### PR TITLE
Introduce ContainerRuntime abstraction

### DIFF
--- a/compute_space/compute_space/config.py
+++ b/compute_space/compute_space/config.py
@@ -43,6 +43,10 @@ class Config:
     port_range_start: int
     port_range_end: int
 
+    # Container runtime: which runtime manages app containers.
+    # Supported values are defined in compute_space.core.runtimes.factory.
+    container_runtime: str
+
     def evolve(self, **kwargs: Any) -> Self:
         return attr.evolve(self, **kwargs)
 
@@ -159,6 +163,9 @@ class DefaultConfig(Config):
     # Ports
     port_range_start: int = 9000
     port_range_end: int = 9999
+
+    # Container runtime
+    container_runtime: str = "docker"
 
 
 def load_config() -> Config:

--- a/compute_space/compute_space/core/containers.py
+++ b/compute_space/compute_space/core/containers.py
@@ -1,39 +1,40 @@
+"""Thin, runtime-neutral API for container lifecycle.
+
+Every function here delegates to the ``ContainerRuntime`` selected by router
+config.  Callers should import these functions (not runtime classes) so the
+choice of runtime stays a single decision made in one place.
+
+The implementation moved to ``compute_space.core.runtimes`` in the container
+runtime abstraction refactor.  The module-level functions below are kept as
+a stable import surface so we can add more runtimes (notably rootless Podman)
+without touching every call site.
+"""
+
+from __future__ import annotations
+
 import os
-import re
 import sqlite3
-import subprocess
 
 from compute_space.core.logging import logger
 from compute_space.core.manifest import AppManifest
 from compute_space.core.manifest import PortMapping
+from compute_space.core.runtimes import get_runtime
 
-# Container mount root — all data dirs live under this prefix so the
-# container filesystem stays clean (no data dirs mixed with /bin, /etc, etc).
+# Prefix used on RuntimeError messages raised by any runtime when the failure
+# is specifically a corrupted local build cache.  The HTTP API uses this
+# marker to surface a "drop cache" remediation to the user.
+BUILD_CACHE_CORRUPT_MARKER = "[BUILD_CACHE_CORRUPT]"
+
+# Container mount root — exposed so callers that need to construct container
+# paths (e.g. env-var templating outside the runtime) can share the constant.
 CONTAINER_ROOT = "/data"
 
-_ANSI_RE = re.compile(r"\x1b\[[0-9;]*[a-zA-Z]|\x1b\([AB0-9]|\x1b[=>]|\x0f|\r")
-_CACHE_CORRUPT_RE = re.compile(r"content digest sha256:[0-9a-f]+: not found")
 
-
-def _log_path(app_name: str, temp_data_dir: str) -> str:
-    """Return the path to the build/deploy log file for an app (in temp data)."""
+def _build_log_path(app_name: str, temp_data_dir: str) -> str:
+    """Path to the build/deploy log file for an app."""
+    # Kept in sync with the runtime implementations, which write to this file
+    # during image build and container start-up.
     return os.path.join(temp_data_dir, "app_temp_data", app_name, "docker.log")
-
-
-def _append_log(app_name: str, temp_data_dir: str, text: str) -> None:
-    """Append text to the app's log file."""
-    log_file = _log_path(app_name, temp_data_dir)
-    os.makedirs(os.path.dirname(log_file), exist_ok=True)
-    with open(log_file, "a") as f:
-        f.write(text)
-
-
-def _clear_log(app_name: str, temp_data_dir: str) -> None:
-    """Clear the app's log file (on fresh deploy/reload)."""
-    log_file = _log_path(app_name, temp_data_dir)
-    os.makedirs(os.path.dirname(log_file), exist_ok=True)
-    with open(log_file, "w"):
-        pass
 
 
 def build_image(
@@ -42,55 +43,13 @@ def build_image(
     dockerfile_rel_path: str,
     temp_data_dir: str | None = None,
 ) -> str:
-    """Build a Docker image from the Dockerfile. Returns image tag."""
-    image_tag = f"openhost-{app_name}:latest"
-    dockerfile_path = os.path.join(repo_path, dockerfile_rel_path)
-    cmd = [
-        "docker",
-        "build",
-        "--progress=plain",
-        "-t",
-        image_tag,
-        "-f",
-        dockerfile_path,
+    """Build the image for an app.  Returns the resulting image tag."""
+    return get_runtime().build_image(
+        app_name,
         repo_path,
-    ]
-    logger.info("Building Docker image: %s", " ".join(cmd))
-
-    if temp_data_dir:
-        _append_log(app_name, temp_data_dir, f"=== Building image: {image_tag} ===\n")
-
-    if temp_data_dir:
-        # Stream build output line-by-line so the frontend can show progress
-        proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True)
-        build_output = ""
-        try:
-            assert proc.stdout is not None
-            for line in proc.stdout:
-                build_output += line
-                _append_log(app_name, temp_data_dir, line)
-            proc.wait(timeout=300)
-        except subprocess.TimeoutExpired:
-            proc.kill()
-            raise
-        if proc.returncode != 0:
-            if _CACHE_CORRUPT_RE.search(build_output):
-                raise RuntimeError("[CACHE_CORRUPT] Docker build cache is corrupted.")
-            # Include the tail of build output so the error is visible in
-            # the main router log (the full output is already in the app log).
-            tail = build_output[-2000:] if len(build_output) > 2000 else build_output
-            raise RuntimeError(f"Docker build failed (exit code {proc.returncode}):\n{tail}")
-    else:
-        result = subprocess.run(cmd, capture_output=True, text=True, timeout=300)
-        if result.returncode != 0:
-            if _CACHE_CORRUPT_RE.search(result.stderr):
-                raise RuntimeError("[CACHE_CORRUPT] Docker build cache is corrupted.")
-            raise RuntimeError(f"Docker build failed:\n{result.stderr}")
-
-    if temp_data_dir:
-        _append_log(app_name, temp_data_dir, "=== Build complete ===\n\n")
-
-    return image_tag
+        dockerfile_rel_path,
+        temp_data_dir=temp_data_dir,
+    )
 
 
 def run_container(
@@ -103,120 +62,26 @@ def run_container(
     temp_data_dir: str,
     port_mappings: list[PortMapping] | None = None,
 ) -> str:
-    """Run a Docker container. Returns the container ID."""
-    app_data_dir = os.path.join(data_dir, "app_data", app_name)
-    app_temp_dir = os.path.join(temp_data_dir, "app_temp_data", app_name)
-    vm_data_dir = os.path.join(data_dir, "vm_data")
-    container_name = f"openhost-{app_name}"
-
-    # Check which data access the app has (sqlite implies app_data)
-    has_app_data = manifest.app_data or manifest.sqlite_dbs or manifest.access_all_data
-    has_app_temp = manifest.app_temp_data or manifest.access_all_data
-    has_vm_data = manifest.access_vm_data or manifest.access_all_data
-
-    # Container paths follow the logical structure under CONTAINER_ROOT
-    c_app_data = f"{CONTAINER_ROOT}/app_data/{app_name}"
-    c_app_temp = f"{CONTAINER_ROOT}/app_temp_data/{app_name}"
-    c_vm_data = f"{CONTAINER_ROOT}/vm_data"
-
-    # Translate host paths to container paths in env vars
-    container_env = {}
-    for key, value in env_vars.items():
-        if key.startswith("OPENHOST_SQLITE_"):
-            rel_path = os.path.relpath(value, app_data_dir)
-            container_env[key] = os.path.join(c_app_data, rel_path)
-        elif key == "OPENHOST_APP_DATA_DIR":
-            container_env[key] = c_app_data
-        elif key == "OPENHOST_APP_TEMP_DIR":
-            container_env[key] = c_app_temp
-        else:
-            container_env[key] = value
-
-    cmd = [
-        "docker",
-        "run",
-        "-d",
-        "--name",
-        container_name,
-        "-p",
-        f"127.0.0.1:{local_port}:{manifest.container_port}",
-        f"--memory={manifest.memory_mb}m",
-        f"--cpus={manifest.cpu_millicores / 1000.0}",
-        "--restart=unless-stopped",
-        "--add-host=host.docker.internal:host-gateway",
-    ]
-
-    # Mount data volumes following the logical structure from docs/data.md
-    if manifest.access_all_data:
-        # Full access: mount parent dirs so the app sees all apps' data
-        cmd.extend(["-v", f"{os.path.join(data_dir, 'app_data')}:{CONTAINER_ROOT}/app_data"])
-        cmd.extend(
-            [
-                "-v",
-                f"{os.path.join(temp_data_dir, 'app_temp_data')}:{CONTAINER_ROOT}/app_temp_data",
-            ]
-        )
-        os.makedirs(vm_data_dir, exist_ok=True)
-        cmd.extend(["-v", f"{vm_data_dir}:{c_vm_data}"])
-    else:
-        if has_app_data:
-            cmd.extend(["-v", f"{app_data_dir}:{c_app_data}"])
-        if has_app_temp:
-            cmd.extend(["-v", f"{app_temp_dir}:{c_app_temp}"])
-        if has_vm_data:
-            os.makedirs(vm_data_dir, exist_ok=True)
-            cmd.extend(["-v", f"{vm_data_dir}:{c_vm_data}:ro"])
-
-    # Structured port mappings: bind TCP+UDP on 0.0.0.0
-    if port_mappings:
-        for pm in port_mappings:
-            cmd.extend(["-p", f"0.0.0.0:{pm.host_port}:{pm.container_port}/tcp"])
-            cmd.extend(["-p", f"0.0.0.0:{pm.host_port}:{pm.container_port}/udp"])
-
-    for cap in manifest.capabilities:
-        cmd.extend(["--cap-add", cap])
-
-    for device in manifest.devices:
-        cmd.extend(["--device", device])
-
-    for key, value in container_env.items():
-        cmd.extend(["-e", f"{key}={value}"])
-
-    if manifest.container_command:
-        cmd.append(image_tag)
-        cmd.extend(manifest.container_command.split())
-    else:
-        cmd.append(image_tag)
-
-    logger.info("Running container: %s", " ".join(cmd))
-    _append_log(app_name, temp_data_dir, f"=== Starting container: {container_name} ===\n")
-
-    # Remove any stale container with the same name (e.g. from a previous run
-    # or crash) so docker run doesn't fail with a name conflict.
-    subprocess.run(
-        ["docker", "rm", "-f", container_name],
-        capture_output=True,
-        timeout=30,
+    """Start a detached container for an app.  Returns the container ID."""
+    return get_runtime().run_container(
+        app_name,
+        image_tag,
+        manifest,
+        local_port,
+        env_vars,
+        data_dir,
+        temp_data_dir,
+        port_mappings=port_mappings,
     )
-
-    result = subprocess.run(cmd, capture_output=True, text=True, timeout=60)
-    if result.returncode != 0:
-        _append_log(app_name, temp_data_dir, f"ERROR: {result.stderr}\n")
-        raise RuntimeError(f"Docker run failed:\n{result.stderr}")
-
-    container_id = result.stdout.strip()
-    _append_log(app_name, temp_data_dir, f"Container started: {container_id[:12]}\n\n")
-    return container_id
 
 
 def stop_container(container_id: str) -> None:
-    """Stop and remove a Docker container."""
-    subprocess.run(["docker", "stop", container_id], capture_output=True, timeout=30)
-    subprocess.run(["docker", "rm", "-f", container_id], capture_output=True, timeout=30)
+    """Stop and remove a container by ID or name.  Idempotent."""
+    get_runtime().stop_container(container_id)
 
 
 def stop_app_process(app_row: sqlite3.Row) -> None:
-    """Stop the running process for an app. Does not update DB."""
+    """Stop the running process for an app.  Does not update the database."""
     try:
         if app_row["docker_container_id"]:
             stop_container(app_row["docker_container_id"])
@@ -225,33 +90,23 @@ def stop_app_process(app_row: sqlite3.Row) -> None:
 
 
 def remove_image(app_name: str) -> None:
-    """Remove the Docker image for an app."""
-    image_tag = f"openhost-{app_name}:latest"
-    subprocess.run(["docker", "rmi", image_tag], capture_output=True, timeout=30)
+    """Remove the image built for an app.  Idempotent."""
+    get_runtime().remove_image(app_name)
 
 
 def drop_docker_build_cache() -> str:
-    """Drop Docker build cache and return command output."""
-    cmd = ["docker", "builder", "prune", "--all", "--force"]
-    logger.info("Dropping Docker build cache: %s", " ".join(cmd))
-    result = subprocess.run(cmd, capture_output=True, text=True, timeout=120)
-    output = (result.stdout + result.stderr).strip()
-    if result.returncode != 0:
-        raise RuntimeError(output or "Docker builder prune failed")
-    return output
+    """Drop the container runtime's build cache.  Returns human-readable output.
+
+    Historically named for Docker; kept as the public function name so existing
+    callers and tests continue to work.  Delegates to whichever runtime is
+    active.
+    """
+    return get_runtime().drop_build_cache()
 
 
 def get_container_status(container_id: str) -> str:
-    """Returns 'running', 'exited', or 'unknown'."""
-    result = subprocess.run(
-        ["docker", "inspect", "--format", "{{.State.Status}}", container_id],
-        capture_output=True,
-        text=True,
-        timeout=10,
-    )
-    if result.returncode != 0:
-        return "unknown"
-    return result.stdout.strip()
+    """Return ``"running"``, ``"exited"``, or ``"unknown"``."""
+    return get_runtime().get_container_status(container_id)
 
 
 def get_docker_logs(
@@ -260,15 +115,15 @@ def get_docker_logs(
     container_id: str | None = None,
     tail: int = 10000,
 ) -> str:
-    """Get combined build log + container runtime logs.
+    """Combined build log + recent container logs for an app.
 
-    Returns the build/deploy log file contents followed by recent
-    docker container logs (if the container is running).
+    The build log is read from disk (it was streamed there during
+    ``build_image``); the container logs are fetched from the active runtime.
     """
     parts = []
 
     # Build/deploy log (full, no truncation)
-    log_file = _log_path(app_name, temp_data_dir)
+    log_file = _build_log_path(app_name, temp_data_dir)
     if os.path.exists(log_file):
         try:
             with open(log_file) as f:
@@ -278,18 +133,8 @@ def get_docker_logs(
 
     # Live container logs
     if container_id:
-        try:
-            result = subprocess.run(
-                ["docker", "logs", "--tail", str(tail), container_id],
-                capture_output=True,
-                text=True,
-                timeout=10,
-            )
-            combined = (result.stdout + result.stderr).strip()
-            if combined:
-                combined = _ANSI_RE.sub("", combined)
-                parts.append("=== Container logs ===\n" + combined)
-        except (subprocess.TimeoutExpired, OSError):
-            pass
+        container_logs = get_runtime().get_container_logs(container_id, tail=tail)
+        if container_logs:
+            parts.append("=== Container logs ===\n" + container_logs)
 
     return "\n".join(parts) if parts else ""

--- a/compute_space/compute_space/core/runtimes/__init__.py
+++ b/compute_space/compute_space/core/runtimes/__init__.py
@@ -1,0 +1,17 @@
+"""Container runtime abstraction.
+
+The router talks to a pluggable ``ContainerRuntime`` for all image build and
+container lifecycle operations.  Today only the Docker runtime is shipped;
+future runtimes (e.g. rootless Podman) will be wired through the same
+interface.
+
+Code outside this package should import the free functions from
+``compute_space.core.containers`` (which delegate to the selected runtime),
+not call runtime classes directly.
+"""
+
+from compute_space.core.runtimes.base import ContainerRuntime
+from compute_space.core.runtimes.docker import DockerRuntime
+from compute_space.core.runtimes.factory import get_runtime
+
+__all__ = ["ContainerRuntime", "DockerRuntime", "get_runtime"]

--- a/compute_space/compute_space/core/runtimes/base.py
+++ b/compute_space/compute_space/core/runtimes/base.py
@@ -1,0 +1,94 @@
+"""ContainerRuntime protocol.
+
+Defines the interface every container runtime implementation must satisfy.
+The router always goes through this interface; runtime-specific details
+(Docker CLI flags, Podman uidmap setup, etc.) live entirely inside each
+implementation.
+"""
+
+from __future__ import annotations
+
+from typing import Protocol
+
+from compute_space.core.manifest import AppManifest
+from compute_space.core.manifest import PortMapping
+
+
+class ContainerRuntime(Protocol):
+    """Interface the router uses to manage containers.
+
+    Implementations are stateless from the caller's perspective — any state
+    (subuid allocations, per-app networks, etc.) is persisted in the runtime
+    itself or in the router's database, not on the runtime object.
+    """
+
+    name: str
+    """Short identifier for the runtime (e.g. ``"docker"``, ``"podman"``).
+
+    Used in log messages and error text so operators can tell which runtime
+    produced a given failure.
+    """
+
+    def build_image(
+        self,
+        app_name: str,
+        repo_path: str,
+        dockerfile_rel_path: str,
+        temp_data_dir: str | None = None,
+    ) -> str:
+        """Build the container image for an app.
+
+        Returns the resulting image tag.  If ``temp_data_dir`` is provided,
+        build output is streamed to the app's build log.
+
+        Raises ``RuntimeError`` on build failure.  The error message should
+        start with ``[BUILD_CACHE_CORRUPT]`` when the failure is specifically
+        a corrupted local build cache (so callers can offer a "drop cache"
+        remediation).
+        """
+        ...
+
+    def run_container(
+        self,
+        app_name: str,
+        image_tag: str,
+        manifest: AppManifest,
+        local_port: int,
+        env_vars: dict[str, str],
+        data_dir: str,
+        temp_data_dir: str,
+        port_mappings: list[PortMapping] | None = None,
+    ) -> str:
+        """Start a detached container for an app.  Returns the container ID."""
+        ...
+
+    def stop_container(self, container_id: str) -> None:
+        """Stop and remove a container by ID or name.  Idempotent."""
+        ...
+
+    def remove_image(self, app_name: str) -> None:
+        """Remove the image built for an app.  Idempotent."""
+        ...
+
+    def get_container_status(self, container_id: str) -> str:
+        """Return ``"running"``, ``"exited"``, or ``"unknown"``."""
+        ...
+
+    def get_container_logs(
+        self,
+        container_id: str,
+        tail: int = 10000,
+    ) -> str:
+        """Return recent stdout/stderr from a container.
+
+        ANSI escape sequences are stripped.  Returns an empty string when
+        logs are unavailable (e.g. container gone, runtime timeout).
+        """
+        ...
+
+    def drop_build_cache(self) -> str:
+        """Drop the runtime's local build cache.  Returns human-readable output.
+
+        Raises ``RuntimeError`` on failure.
+        """
+        ...

--- a/compute_space/compute_space/core/runtimes/docker.py
+++ b/compute_space/compute_space/core/runtimes/docker.py
@@ -1,0 +1,277 @@
+"""Docker implementation of ContainerRuntime.
+
+Shells out to the ``docker`` CLI via ``subprocess``.  Behavior is preserved
+verbatim from the pre-runtime-abstraction ``containers.py`` module; this file
+is a mechanical extraction with no semantic changes.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+
+from compute_space.core.logging import logger
+from compute_space.core.manifest import AppManifest
+from compute_space.core.manifest import PortMapping
+
+# Container mount root — all data dirs live under this prefix so the
+# container filesystem stays clean (no data dirs mixed with /bin, /etc, etc).
+CONTAINER_ROOT = "/data"
+
+_ANSI_RE = re.compile(r"\x1b\[[0-9;]*[a-zA-Z]|\x1b\([AB0-9]|\x1b[=>]|\x0f|\r")
+_CACHE_CORRUPT_RE = re.compile(r"content digest sha256:[0-9a-f]+: not found")
+
+# Prefix on RuntimeError messages that signals a corrupted build cache.
+# Callers strip this prefix before showing the error to users, but the
+# HTTP API uses it to surface a "drop cache" remediation action.  Kept
+# in sync with ``compute_space.core.containers.BUILD_CACHE_CORRUPT_MARKER``
+# (duplicated here to avoid an import cycle).
+_BUILD_CACHE_CORRUPT_MARKER = "[BUILD_CACHE_CORRUPT]"
+
+
+def _build_log_path(app_name: str, temp_data_dir: str) -> str:
+    """Path to the build/deploy log file for an app (in temp data)."""
+    # NOTE: historical filename is "docker.log"; kept for backward compatibility
+    # with already-deployed instances.  Phase 1 of the runtime migration will
+    # rename to "build.log" with a read-side fallback.
+    return os.path.join(temp_data_dir, "app_temp_data", app_name, "docker.log")
+
+
+def _append_log(app_name: str, temp_data_dir: str, text: str) -> None:
+    log_file = _build_log_path(app_name, temp_data_dir)
+    os.makedirs(os.path.dirname(log_file), exist_ok=True)
+    with open(log_file, "a") as f:
+        f.write(text)
+
+
+class DockerRuntime:
+    """``ContainerRuntime`` backed by the Docker CLI."""
+
+    name = "docker"
+
+    # ------------------------------------------------------------------ build
+
+    def build_image(
+        self,
+        app_name: str,
+        repo_path: str,
+        dockerfile_rel_path: str,
+        temp_data_dir: str | None = None,
+    ) -> str:
+        image_tag = f"openhost-{app_name}:latest"
+        dockerfile_path = os.path.join(repo_path, dockerfile_rel_path)
+        cmd = [
+            "docker",
+            "build",
+            "--progress=plain",
+            "-t",
+            image_tag,
+            "-f",
+            dockerfile_path,
+            repo_path,
+        ]
+        logger.info("Building Docker image: %s", " ".join(cmd))
+
+        if temp_data_dir:
+            _append_log(app_name, temp_data_dir, f"=== Building image: {image_tag} ===\n")
+
+        if temp_data_dir:
+            # Stream build output line-by-line so the frontend can show progress
+            proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True)
+            build_output = ""
+            try:
+                assert proc.stdout is not None
+                for line in proc.stdout:
+                    build_output += line
+                    _append_log(app_name, temp_data_dir, line)
+                proc.wait(timeout=300)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+                raise
+            if proc.returncode != 0:
+                if _CACHE_CORRUPT_RE.search(build_output):
+                    raise RuntimeError(f"{_BUILD_CACHE_CORRUPT_MARKER} Docker build cache is corrupted.")
+                # Include the tail of build output so the error is visible in
+                # the main router log (the full output is already in the app log).
+                tail = build_output[-2000:] if len(build_output) > 2000 else build_output
+                raise RuntimeError(f"Docker build failed (exit code {proc.returncode}):\n{tail}")
+        else:
+            result = subprocess.run(cmd, capture_output=True, text=True, timeout=300)
+            if result.returncode != 0:
+                if _CACHE_CORRUPT_RE.search(result.stderr):
+                    raise RuntimeError(f"{_BUILD_CACHE_CORRUPT_MARKER} Docker build cache is corrupted.")
+                raise RuntimeError(f"Docker build failed:\n{result.stderr}")
+
+        if temp_data_dir:
+            _append_log(app_name, temp_data_dir, "=== Build complete ===\n\n")
+
+        return image_tag
+
+    # -------------------------------------------------------------------- run
+
+    def run_container(
+        self,
+        app_name: str,
+        image_tag: str,
+        manifest: AppManifest,
+        local_port: int,
+        env_vars: dict[str, str],
+        data_dir: str,
+        temp_data_dir: str,
+        port_mappings: list[PortMapping] | None = None,
+    ) -> str:
+        app_data_dir = os.path.join(data_dir, "app_data", app_name)
+        app_temp_dir = os.path.join(temp_data_dir, "app_temp_data", app_name)
+        vm_data_dir = os.path.join(data_dir, "vm_data")
+        container_name = f"openhost-{app_name}"
+
+        # Check which data access the app has (sqlite implies app_data)
+        has_app_data = manifest.app_data or manifest.sqlite_dbs or manifest.access_all_data
+        has_app_temp = manifest.app_temp_data or manifest.access_all_data
+        has_vm_data = manifest.access_vm_data or manifest.access_all_data
+
+        # Container paths follow the logical structure under CONTAINER_ROOT
+        c_app_data = f"{CONTAINER_ROOT}/app_data/{app_name}"
+        c_app_temp = f"{CONTAINER_ROOT}/app_temp_data/{app_name}"
+        c_vm_data = f"{CONTAINER_ROOT}/vm_data"
+
+        # Translate host paths to container paths in env vars
+        container_env = {}
+        for key, value in env_vars.items():
+            if key.startswith("OPENHOST_SQLITE_"):
+                rel_path = os.path.relpath(value, app_data_dir)
+                container_env[key] = os.path.join(c_app_data, rel_path)
+            elif key == "OPENHOST_APP_DATA_DIR":
+                container_env[key] = c_app_data
+            elif key == "OPENHOST_APP_TEMP_DIR":
+                container_env[key] = c_app_temp
+            else:
+                container_env[key] = value
+
+        cmd = [
+            "docker",
+            "run",
+            "-d",
+            "--name",
+            container_name,
+            "-p",
+            f"127.0.0.1:{local_port}:{manifest.container_port}",
+            f"--memory={manifest.memory_mb}m",
+            f"--cpus={manifest.cpu_millicores / 1000.0}",
+            "--restart=unless-stopped",
+            "--add-host=host.docker.internal:host-gateway",
+        ]
+
+        # Mount data volumes following the logical structure from docs/data.md
+        if manifest.access_all_data:
+            # Full access: mount parent dirs so the app sees all apps' data
+            cmd.extend(["-v", f"{os.path.join(data_dir, 'app_data')}:{CONTAINER_ROOT}/app_data"])
+            cmd.extend(
+                [
+                    "-v",
+                    f"{os.path.join(temp_data_dir, 'app_temp_data')}:{CONTAINER_ROOT}/app_temp_data",
+                ]
+            )
+            os.makedirs(vm_data_dir, exist_ok=True)
+            cmd.extend(["-v", f"{vm_data_dir}:{c_vm_data}"])
+        else:
+            if has_app_data:
+                cmd.extend(["-v", f"{app_data_dir}:{c_app_data}"])
+            if has_app_temp:
+                cmd.extend(["-v", f"{app_temp_dir}:{c_app_temp}"])
+            if has_vm_data:
+                os.makedirs(vm_data_dir, exist_ok=True)
+                cmd.extend(["-v", f"{vm_data_dir}:{c_vm_data}:ro"])
+
+        # Structured port mappings: bind TCP+UDP on 0.0.0.0
+        if port_mappings:
+            for pm in port_mappings:
+                cmd.extend(["-p", f"0.0.0.0:{pm.host_port}:{pm.container_port}/tcp"])
+                cmd.extend(["-p", f"0.0.0.0:{pm.host_port}:{pm.container_port}/udp"])
+
+        for cap in manifest.capabilities:
+            cmd.extend(["--cap-add", cap])
+
+        for device in manifest.devices:
+            cmd.extend(["--device", device])
+
+        for key, value in container_env.items():
+            cmd.extend(["-e", f"{key}={value}"])
+
+        if manifest.container_command:
+            cmd.append(image_tag)
+            cmd.extend(manifest.container_command.split())
+        else:
+            cmd.append(image_tag)
+
+        logger.info("Running container: %s", " ".join(cmd))
+        _append_log(app_name, temp_data_dir, f"=== Starting container: {container_name} ===\n")
+
+        # Remove any stale container with the same name (e.g. from a previous run
+        # or crash) so docker run doesn't fail with a name conflict.
+        subprocess.run(
+            ["docker", "rm", "-f", container_name],
+            capture_output=True,
+            timeout=30,
+        )
+
+        result = subprocess.run(cmd, capture_output=True, text=True, timeout=60)
+        if result.returncode != 0:
+            _append_log(app_name, temp_data_dir, f"ERROR: {result.stderr}\n")
+            raise RuntimeError(f"Docker run failed:\n{result.stderr}")
+
+        container_id = result.stdout.strip()
+        _append_log(app_name, temp_data_dir, f"Container started: {container_id[:12]}\n\n")
+        return container_id
+
+    # ------------------------------------------------------------- lifecycle
+
+    def stop_container(self, container_id: str) -> None:
+        subprocess.run(["docker", "stop", container_id], capture_output=True, timeout=30)
+        subprocess.run(["docker", "rm", "-f", container_id], capture_output=True, timeout=30)
+
+    def remove_image(self, app_name: str) -> None:
+        image_tag = f"openhost-{app_name}:latest"
+        subprocess.run(["docker", "rmi", image_tag], capture_output=True, timeout=30)
+
+    def get_container_status(self, container_id: str) -> str:
+        result = subprocess.run(
+            ["docker", "inspect", "--format", "{{.State.Status}}", container_id],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        if result.returncode != 0:
+            return "unknown"
+        return result.stdout.strip()
+
+    def get_container_logs(
+        self,
+        container_id: str,
+        tail: int = 10000,
+    ) -> str:
+        try:
+            result = subprocess.run(
+                ["docker", "logs", "--tail", str(tail), container_id],
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
+        except (subprocess.TimeoutExpired, OSError):
+            return ""
+        combined = (result.stdout + result.stderr).strip()
+        if not combined:
+            return ""
+        return _ANSI_RE.sub("", combined)
+
+    # ----------------------------------------------------------------- cache
+
+    def drop_build_cache(self) -> str:
+        cmd = ["docker", "builder", "prune", "--all", "--force"]
+        logger.info("Dropping Docker build cache: %s", " ".join(cmd))
+        result = subprocess.run(cmd, capture_output=True, text=True, timeout=120)
+        output = (result.stdout + result.stderr).strip()
+        if result.returncode != 0:
+            raise RuntimeError(output or "Docker builder prune failed")
+        return output

--- a/compute_space/compute_space/core/runtimes/factory.py
+++ b/compute_space/compute_space/core/runtimes/factory.py
@@ -1,0 +1,52 @@
+"""Factory that picks the container runtime based on router config.
+
+This indirection exists so the rest of the codebase never has to know which
+runtime is in use — it just imports the free functions from
+``compute_space.core.containers`` (which delegate through this factory).
+"""
+
+from __future__ import annotations
+
+from compute_space.config import get_config
+from compute_space.core.runtimes.base import ContainerRuntime
+from compute_space.core.runtimes.docker import DockerRuntime
+
+_SUPPORTED_RUNTIMES: dict[str, type[ContainerRuntime]] = {
+    "docker": DockerRuntime,
+}
+
+_DEFAULT_RUNTIME_NAME = "docker"
+
+
+def _resolve_runtime_name() -> str:
+    """Return the configured runtime name, or the default when no Quart
+    application context is available (e.g. CLI or unit tests).
+    """
+    try:
+        return get_config().container_runtime
+    except RuntimeError:
+        # Outside a Quart application context — fall back to the historical
+        # default so callers don't have to thread a Config object through
+        # every call site.
+        return _DEFAULT_RUNTIME_NAME
+
+
+def get_runtime(runtime_name: str | None = None) -> ContainerRuntime:
+    """Return a ``ContainerRuntime`` instance for the configured runtime.
+
+    If ``runtime_name`` is ``None``, the current Quart app config is consulted
+    (so the runtime selection lives in the same place as every other router
+    config value).  When called outside a request/app context, the historical
+    default runtime is used.
+
+    Raises ``ValueError`` on an unknown runtime name.
+    """
+    if runtime_name is None:
+        runtime_name = _resolve_runtime_name()
+
+    try:
+        cls = _SUPPORTED_RUNTIMES[runtime_name]
+    except KeyError:
+        supported = ", ".join(sorted(_SUPPORTED_RUNTIMES))
+        raise ValueError(f"Unknown container_runtime {runtime_name!r}; supported: {supported}") from None
+    return cls()

--- a/compute_space/compute_space/web/routes/api/apps.py
+++ b/compute_space/compute_space/web/routes/api/apps.py
@@ -23,6 +23,7 @@ from compute_space.core.apps import insert_and_deploy
 from compute_space.core.apps import reload_app_background
 from compute_space.core.apps import start_app_process
 from compute_space.core.apps import validate_manifest
+from compute_space.core.containers import BUILD_CACHE_CORRUPT_MARKER
 from compute_space.core.containers import get_docker_logs
 from compute_space.core.containers import remove_image
 from compute_space.core.containers import stop_app_process
@@ -220,9 +221,11 @@ def app_status(app_name: str) -> ResponseReturnValue:
         return jsonify({"error": "not found"}), 404
     error_msg = app_row["error_message"]
     error_kind = None
-    if error_msg and "[CACHE_CORRUPT]" in error_msg:
-        error_kind = "cache_corrupt"
-        error_msg = "Docker build cache is corrupted."
+    # Accept both the current marker and the legacy one so errors written by
+    # an older router process still surface a usable error kind to the UI.
+    if error_msg and (BUILD_CACHE_CORRUPT_MARKER in error_msg or "[CACHE_CORRUPT]" in error_msg):
+        error_kind = "build_cache_corrupt"
+        error_msg = "Container build cache is corrupted."
     return jsonify({"status": app_row["status"], "error": error_msg, "error_kind": error_kind})
 
 

--- a/compute_space/compute_space/web/static/js/app-detail.js
+++ b/compute_space/compute_space/web/static/js/app-detail.js
@@ -81,8 +81,14 @@ function showToast(message, actions) {
     return toast;
 }
 
+// Accept both the new and legacy error-kind strings so a browser that
+// picked up an older router's JSON response still shows the toast.
+function isCacheCorruptKind(kind) {
+    return kind === 'build_cache_corrupt' || kind === 'cache_corrupt';
+}
+
 function clearCacheAndReload() {
-    showToast('Clearing Docker build cache...', []);
+    showToast('Clearing build cache...', []);
     fetch(config.dropDockerCacheUrl, {method: 'POST', credentials: 'same-origin'})
         .then(function(r) { return r.json(); })
         .then(function(data) {
@@ -123,7 +129,7 @@ function clearCacheAndReload() {
         if (sessionStorage.getItem(toastKey)) return;
         sessionStorage.setItem(toastKey, '1');
         showToast(
-            'Docker build cache is corrupted. Clear it and rebuild?',
+            'Container build cache is corrupted. Clear it and rebuild?',
             [
                 { label: 'Clear Cache & Rebuild', primary: true, onClick: clearCacheAndReload },
                 { label: 'Dismiss', primary: false, onClick: function() {} }
@@ -143,7 +149,7 @@ function clearCacheAndReload() {
                 if (appStatus === 'running' && nextUrl) {
                     window.location.href = nextUrl;
                 }
-                if (appStatus === 'error' && data.error_kind === 'cache_corrupt') {
+                if (appStatus === 'error' && isCacheCorruptKind(data.error_kind)) {
                     showCacheCorruptToast();
                 }
             });
@@ -154,7 +160,7 @@ function clearCacheAndReload() {
         fetch(config.appStatusUrl)
             .then(function(r) { return r.json(); })
             .then(function(data) {
-                if (data.error_kind === 'cache_corrupt') showCacheCorruptToast();
+                if (isCacheCorruptKind(data.error_kind)) showCacheCorruptToast();
             });
     }
 

--- a/compute_space/tests/test_containers_delegation.py
+++ b/compute_space/tests/test_containers_delegation.py
@@ -1,0 +1,106 @@
+"""Tests that the ``containers`` module's free functions correctly delegate
+to the active ``ContainerRuntime``.
+
+The existing ``test_docker_cache`` and integration tests already cover the
+Docker-runtime code path end-to-end; these tests specifically exercise the
+indirection layer added by the runtime abstraction so regressions in it are
+caught without spinning up Docker.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import compute_space.core.runtimes.factory as factory_mod
+from compute_space.core import containers
+from compute_space.core.runtimes.base import ContainerRuntime
+
+
+class _RecordingRuntime:
+    """ContainerRuntime that records every call so tests can assert on it.
+
+    Not a subclass — it just satisfies the Protocol structurally, which is
+    enough given we never call ``isinstance`` in production code.
+    """
+
+    name = "recording"
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, tuple[Any, ...], dict[str, Any]]] = []
+
+    def __getattr__(self, item: str):  # noqa: ANN204 - test helper
+        def _fn(*args: Any, **kwargs: Any) -> str:
+            self.calls.append((item, args, kwargs))
+            # Each method in ContainerRuntime that returns something returns
+            # either a string (image tag / container id / status / logs) or
+            # None, so a string default is always a safe stand-in.
+            return f"recorded:{item}"
+
+        return _fn
+
+
+def _patch_runtime(monkeypatch, runtime: ContainerRuntime) -> None:
+    """Force get_runtime() to return ``runtime`` regardless of config."""
+    monkeypatch.setattr(factory_mod, "get_runtime", lambda name=None: runtime)
+    # containers.py imported get_runtime by name, so patch that binding too.
+    monkeypatch.setattr(containers, "get_runtime", lambda name=None: runtime)
+
+
+def test_build_image_delegates_to_runtime(monkeypatch) -> None:
+    runtime = _RecordingRuntime()
+    _patch_runtime(monkeypatch, runtime)
+
+    result = containers.build_image("myapp", "/repo", "Dockerfile", temp_data_dir="/tmp/t")
+
+    assert result == "recorded:build_image"
+    assert runtime.calls == [
+        ("build_image", ("myapp", "/repo", "Dockerfile"), {"temp_data_dir": "/tmp/t"}),
+    ]
+
+
+def test_stop_container_delegates_to_runtime(monkeypatch) -> None:
+    runtime = _RecordingRuntime()
+    _patch_runtime(monkeypatch, runtime)
+
+    containers.stop_container("abc123")
+
+    assert len(runtime.calls) == 1
+    assert runtime.calls[0][0] == "stop_container"
+    assert runtime.calls[0][1] == ("abc123",)
+
+
+def test_remove_image_delegates_to_runtime(monkeypatch) -> None:
+    runtime = _RecordingRuntime()
+    _patch_runtime(monkeypatch, runtime)
+
+    containers.remove_image("myapp")
+
+    assert runtime.calls[0] == ("remove_image", ("myapp",), {})
+
+
+def test_drop_docker_build_cache_delegates_to_runtime(monkeypatch) -> None:
+    """The public function is still named drop_docker_build_cache for
+    backwards compatibility, but it now dispatches through the runtime."""
+    runtime = _RecordingRuntime()
+    _patch_runtime(monkeypatch, runtime)
+
+    result = containers.drop_docker_build_cache()
+
+    assert result == "recorded:drop_build_cache"
+    assert runtime.calls[0][0] == "drop_build_cache"
+
+
+def test_get_container_status_delegates_to_runtime(monkeypatch) -> None:
+    runtime = _RecordingRuntime()
+    _patch_runtime(monkeypatch, runtime)
+
+    status = containers.get_container_status("abc123")
+
+    assert status == "recorded:get_container_status"
+    assert runtime.calls[0] == ("get_container_status", ("abc123",), {})
+
+
+def test_build_cache_corrupt_marker_is_exported() -> None:
+    """Other modules (notably the HTTP API) rely on this marker to detect
+    build-cache-corruption errors; make sure it stays importable."""
+    assert containers.BUILD_CACHE_CORRUPT_MARKER == "[BUILD_CACHE_CORRUPT]"

--- a/compute_space/tests/test_docker_runtime.py
+++ b/compute_space/tests/test_docker_runtime.py
@@ -1,0 +1,86 @@
+"""Unit tests for DockerRuntime that don't need a running daemon.
+
+These tests mock ``subprocess`` to verify argument construction and error
+handling.  End-to-end Docker tests live under ``@requires_docker`` and need
+``--run-docker``.
+"""
+
+from __future__ import annotations
+
+import subprocess
+
+import pytest
+
+from compute_space.core.runtimes.docker import DockerRuntime
+
+
+class _FakeCompleted:
+    def __init__(self, returncode: int, stdout: str = "", stderr: str = "") -> None:
+        self.returncode = returncode
+        self.stdout = stdout
+        self.stderr = stderr
+
+
+def test_drop_build_cache_runs_builder_prune(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: dict[str, object] = {}
+
+    def fake_run(cmd, capture_output, text, timeout):  # type: ignore[no-untyped-def]
+        calls["cmd"] = cmd
+        return _FakeCompleted(0, stdout="Total reclaimed space: 42MB\n")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    output = DockerRuntime().drop_build_cache()
+
+    assert output == "Total reclaimed space: 42MB"
+    assert calls["cmd"] == ["docker", "builder", "prune", "--all", "--force"]
+
+
+def test_drop_build_cache_raises_on_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fake_run(cmd, capture_output, text, timeout):  # type: ignore[no-untyped-def]
+        return _FakeCompleted(1, stderr="daemon exploded")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    with pytest.raises(RuntimeError, match="daemon exploded"):
+        DockerRuntime().drop_build_cache()
+
+
+def test_build_image_raises_build_cache_corrupt_marker_on_cache_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When the BuildKit cache-corrupt string appears in build output, the
+    runtime must raise a RuntimeError starting with the shared
+    BUILD_CACHE_CORRUPT_MARKER so the HTTP API surfaces the right error kind.
+    """
+
+    def fake_run(cmd, capture_output, text, timeout):  # type: ignore[no-untyped-def]
+        return _FakeCompleted(
+            1,
+            stderr="oh no: content digest sha256:deadbeef: not found",
+        )
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    with pytest.raises(RuntimeError) as exc_info:
+        # temp_data_dir=None selects the non-streaming code path that uses
+        # subprocess.run (easier to mock than the streaming Popen path).
+        DockerRuntime().build_image("myapp", "/repo", "Dockerfile", temp_data_dir=None)
+
+    assert str(exc_info.value).startswith("[BUILD_CACHE_CORRUPT]")
+
+
+def test_get_container_status_returns_unknown_on_runtime_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fake_run(cmd, capture_output, text, timeout):  # type: ignore[no-untyped-def]
+        return _FakeCompleted(1, stderr="no such container")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    assert DockerRuntime().get_container_status("bogus") == "unknown"
+
+
+def test_runtime_name_is_docker() -> None:
+    """Used in log messages and status displays; keep it stable."""
+    assert DockerRuntime().name == "docker"

--- a/compute_space/tests/test_runtime_factory.py
+++ b/compute_space/tests/test_runtime_factory.py
@@ -1,0 +1,29 @@
+"""Tests for the container runtime factory.
+
+The factory is what picks between runtimes based on router config.  Nothing
+else in the codebase should know which runtime is in use.
+"""
+
+import pytest
+
+from compute_space.core.runtimes import DockerRuntime
+from compute_space.core.runtimes import get_runtime
+
+
+def test_get_runtime_returns_docker_when_requested() -> None:
+    runtime = get_runtime("docker")
+    assert isinstance(runtime, DockerRuntime)
+    assert runtime.name == "docker"
+
+
+def test_get_runtime_raises_on_unknown_name() -> None:
+    with pytest.raises(ValueError, match="Unknown container_runtime"):
+        get_runtime("nonexistent-runtime")
+
+
+def test_get_runtime_error_lists_supported_runtimes() -> None:
+    """The error message should name every supported runtime so operators
+    get an actionable hint when they typo the config value."""
+    with pytest.raises(ValueError) as exc_info:
+        get_runtime("typo")
+    assert "docker" in str(exc_info.value)


### PR DESCRIPTION
Phase 0 of the rootless Podman migration. Moves every docker CLI call behind a ContainerRuntime protocol so future runtimes (rootless Podman, gVisor-backed runc, etc.) can slot in without touching callers.

What changed

- New compute_space/core/runtimes/ package with a base Protocol, the extracted DockerRuntime implementation, and a factory keyed off a new container_runtime config option. Default is docker, so behavior on existing deployments is unchanged.
- containers.py keeps its public function surface; each free function delegates to get_runtime().
- Renames the build-cache-corrupt error marker to [BUILD_CACHE_CORRUPT] and the API error_kind to build_cache_corrupt. The UI accepts both the new and legacy values so an upgraded router talking to a cached browser still works.
- Unit tests for the factory, the Docker runtime's subprocess invocations, and the delegation layer.

What is not in this PR

- No DB migration. The docker_container_id column stays untouched. It will be renamed in Phase 2 alongside adding uid_map_base for per-app uidmap allocation.
- No build-log rename. docker.log stays as the filename for this phase.
- No ansible changes.
- No Podman code. This is only the abstraction scaffolding.

Verification

- uv run pytest : 200 passed, 30 skipped (docker/tls-gated).
- uv run ruff check . : clean.
- uv run ruff format --check . : clean.
- uv run mypy : clean.
- vet : clean.