### PR TITLE
Fix ws_proxy: dont emit empty Sec-WebSocket-Protocol header

### DIFF
--- a/compute_space/compute_space/web/proxy.py
+++ b/compute_space/compute_space/web/proxy.py
@@ -1,4 +1,5 @@
 import asyncio
+from typing import Any
 
 import httpx
 import websockets
@@ -176,15 +177,23 @@ async def ws_proxy(
     # the handshake completes and both send/receive are immediately usable.
     await client_ws.accept()
 
+    # Only pass `subprotocols` if the client actually negotiated some.
+    # Passing an empty list causes the `websockets` client to emit an
+    # empty `Sec-WebSocket-Protocol:` header, which strict backends
+    # (including `websockets`' own server, as used by Selkies / the
+    # linuxserver webtop image) reject with
+    # `InvalidHeaderFormat: expected token at 0 in`.
+    ws_kwargs: dict[str, Any] = {
+        "additional_headers": extra_headers,
+        "compression": None,  # avoid permessage-deflate mismatches with backend
+        "open_timeout": 10,
+        "close_timeout": 5,
+    }
+    if subprotocols:
+        ws_kwargs["subprotocols"] = subprotocols
+
     try:
-        async with websockets.connect(
-            target_url,
-            additional_headers=extra_headers,
-            subprotocols=subprotocols,  # type: ignore[arg-type]
-            compression=None,  # avoid permessage-deflate mismatches with backend
-            open_timeout=10,
-            close_timeout=5,
-        ) as backend:
+        async with websockets.connect(target_url, **ws_kwargs) as backend:
 
             async def backend_to_client() -> None:
                 try:


### PR DESCRIPTION
When the client does not negotiate a subprotocol, ws_proxy left the local subprotocols list empty and forwarded it to websockets.connect(..., subprotocols=[]). The websockets client library emits an empty Sec-WebSocket-Protocol: header on the backend connection, which the websockets server library parses strictly and rejects with InvalidHeaderFormat: expected token at 0 in.

This reproduces consistently with apps whose backend uses a strict WebSocket server (e.g. the linuxserver webtop / Selkies image): the browser handshake succeeds at the OpenHost proxy but the proxy-to-backend handshake fails, so the client sees attempting to reconnect websocket disconnected forever.

The fix builds the websockets.connect kwargs conditionally so subprotocols is only passed when the client actually negotiated one. Client-initiated subprotocols still round-trip to the backend; an absent negotiation now results in no Sec-WebSocket-Protocol header on the backend hop, matching the behavior the client would see without the proxy in the middle.