### PR TITLE
Make PortMapping a dataclass so manifests serialize as JSON

### DIFF
--- a/compute_space/compute_space/core/apps.py
+++ b/compute_space/compute_space/core/apps.py
@@ -4,6 +4,7 @@ Extracted from routes/apps.py — no HTTP/Quart dependencies.
 """
 
 import asyncio
+import dataclasses
 import json
 import os
 import re
@@ -15,7 +16,6 @@ import threading
 import time
 import urllib.parse
 
-import attr
 import httpx
 
 import compute_space.core.storage as storage
@@ -225,7 +225,7 @@ def insert_and_deploy(
 
     # Apply port overrides from caller (CLI --port flags, etc.)
     mappings = [
-        attr.evolve(pm, host_port=port_overrides.get(pm.label, pm.host_port)) if port_overrides else pm
+        dataclasses.replace(pm, host_port=port_overrides.get(pm.label, pm.host_port)) if port_overrides else pm
         for pm in manifest.port_mappings
     ]
 
@@ -467,7 +467,7 @@ def _sync_port_mappings(
     to_resolve: list[PortMapping] = []
     for pm in new_mappings:
         if pm.label in existing:
-            to_resolve.append(attr.evolve(pm, host_port=existing[pm.label]["host_port"]))
+            to_resolve.append(dataclasses.replace(pm, host_port=existing[pm.label]["host_port"]))
         else:
             to_resolve.append(pm)
 

--- a/compute_space/compute_space/core/manifest.py
+++ b/compute_space/compute_space/core/manifest.py
@@ -4,14 +4,19 @@ from dataclasses import dataclass
 from dataclasses import field
 from typing import Any
 
-import attr
-
 from compute_space.core.logging import logger
 
 
-@attr.s(auto_attribs=True, frozen=True)
+@dataclass(frozen=True)
 class PortMapping:
-    """A structured port mapping declared in [[ports]]."""
+    """A structured port mapping declared in [[ports]].
+
+    Defined as a dataclass (rather than an attrs class) so that the manifest,
+    which is itself a dataclass, serializes cleanly via ``dataclasses.asdict``.
+    Flask's default JSON encoder cannot serialize attrs instances, which
+    previously caused /api/clone_and_get_app_info to 500 whenever a manifest
+    declared any ``[[ports]]`` entries.
+    """
 
     label: str
     container_port: int

--- a/compute_space/compute_space/core/ports.py
+++ b/compute_space/compute_space/core/ports.py
@@ -1,8 +1,7 @@
+import dataclasses
 import random
 import socket
 import sqlite3
-
-import attr
 
 from compute_space.core.manifest import PortMapping
 from compute_space.db import get_db
@@ -105,7 +104,7 @@ def resolve_port_mappings(
         if pm.host_port == 0:
             assigned = _find_free_host_port(range_start, range_end, db, claimed, exclude_app=exclude_app)
             claimed.add(assigned)
-            resolved.append(attr.evolve(pm, host_port=assigned))
+            resolved.append(dataclasses.replace(pm, host_port=assigned))
 
     return resolved
 

--- a/compute_space/tests/test_manifest.py
+++ b/compute_space/tests/test_manifest.py
@@ -1,5 +1,8 @@
 """Unit tests for the openhost.toml manifest parser."""
 
+import dataclasses
+import json
+
 import pytest
 
 from compute_space.core.manifest import parse_manifest_from_string
@@ -245,6 +248,38 @@ host_port = 0
         toml = MINIMAL + 'extra_ports = ["8081:8081"]\n\n[[ports]]\nlabel = "metrics"\ncontainer_port = 9090\n'
         manifest = parse_manifest_from_string(toml)
         assert len(manifest.port_mappings) == 1
+
+    def test_manifest_with_port_mappings_is_json_serializable(self):
+        """Regression: manifests with [[ports]] must round-trip through
+        ``dataclasses.asdict`` + ``json.dumps`` so that
+        ``/api/clone_and_get_app_info`` can return them. Previously
+        ``PortMapping`` was an attrs class, which ``dataclasses.asdict``
+        leaves as-is, and Flask's default JSON encoder then raises
+        ``TypeError: Object of type PortMapping is not JSON serializable``.
+        """
+        toml = (
+            MINIMAL
+            + """
+[[ports]]
+label = "metrics"
+container_port = 9090
+host_port = 9090
+
+[[ports]]
+label = "debug"
+container_port = 5005
+host_port = 0
+"""
+        )
+        manifest = parse_manifest_from_string(toml)
+        info = dataclasses.asdict(manifest)
+        # Round-trip through JSON; will raise TypeError on regression.
+        payload = json.dumps(info)
+        decoded = json.loads(payload)
+        assert decoded["port_mappings"] == [
+            {"label": "metrics", "container_port": 9090, "host_port": 9090},
+            {"label": "debug", "container_port": 5005, "host_port": 0},
+        ]
 
 
 class TestContainerParsing:


### PR DESCRIPTION
The /api/clone_and_get_app_info endpoint calls dataclasses.asdict(manifest) and returns it via Flask's default JSON encoder. PortMapping was an attrs class, which dataclasses.asdict does not recurse into, so raw PortMapping instances survive in the output and Flask 500s with TypeError: Object of type PortMapping is not JSON serializable for any app that declares [[ports]].

Switching PortMapping to a frozen dataclass is the minimal fix; dataclasses.asdict now recurses and produces plain dicts. The three attr.evolve(pm, ...) call sites are swapped for dataclasses.replace. Added a regression test that round-trips a manifest with [[ports]] through dataclasses.asdict + json.dumps.

Existing unit tests all pass. Ruff and mypy clean.