### PR TITLE
Fix logout CSRF: restrict /logout to POST-only

### DIFF
--- a/compute_space/compute_space/web/routes/pages/auth.py
+++ b/compute_space/compute_space/web/routes/pages/auth.py
@@ -180,7 +180,7 @@ async def login() -> ResponseReturnValue:
     return response
 
 
-@auth_bp.route("/logout", methods=["GET", "POST"])
+@auth_bp.route("/logout", methods=["POST"])
 def logout() -> ResponseReturnValue:
     refresh_tok = request.cookies.get(auth.COOKIE_REFRESH)
     if refresh_tok:

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -437,7 +437,7 @@ class TestSelfHost:
         assert r.status_code == 200
 
         # Logout
-        r = s.get(f"{router_url}/logout", allow_redirects=False, timeout=10)
+        r = s.post(f"{router_url}/logout", allow_redirects=False, timeout=10)
         assert r.status_code == 302
 
         # Dashboard should no longer be accessible

--- a/tests/test_full_stack.py
+++ b/tests/test_full_stack.py
@@ -485,7 +485,7 @@ class TestLoginLogout:
         assert r.status_code == 200
 
         # Log out
-        r = s.get(f"{router_url}/logout", allow_redirects=False, timeout=10)
+        r = s.post(f"{router_url}/logout", allow_redirects=False, timeout=10)
         assert r.status_code == 302
 
         # Dashboard should no longer be accessible


### PR DESCRIPTION
## Summary
- Removed GET from `/logout` route — POST-only now. Prevents CSRF via `<img src="/logout">` or similar GET-triggering tags.
- Updated e2e and full-stack tests to use `s.post()` for logout.

## Test plan
- [ ] Existing logout tests pass with POST
- [ ] GET `/logout` returns 405

🤖 Generated with [Claude Code](https://claude.com/claude-code)