### PR TITLE
Fix auth key null checks: replace assert with RuntimeError

### DIFF
--- a/compute_space/compute_space/core/auth.py
+++ b/compute_space/compute_space/core/auth.py
@@ -105,7 +105,8 @@ def create_refresh_token() -> str:
 def decode_access_token(token: str) -> dict[str, Any] | None:
     """Verify and decode a JWT. Returns claims dict or None."""
     try:
-        assert _public_key is not None
+        if _public_key is None:
+            raise RuntimeError("public key not loaded")
         return jwt.decode(token, _public_key, algorithms=["RS256"])
     except jwt.InvalidTokenError:
         return None
@@ -114,7 +115,8 @@ def decode_access_token(token: str) -> dict[str, Any] | None:
 def decode_access_token_allow_expired(token: str) -> dict[str, Any] | None:
     """Decode a JWT ignoring expiry -- used during token refresh."""
     try:
-        assert _public_key is not None
+        if _public_key is None:
+            raise RuntimeError("public key not loaded")
         return jwt.decode(
             token,
             _public_key,


### PR DESCRIPTION
## Summary
- Replace `assert _public_key is not None` with `if _public_key is None: raise RuntimeError(...)` in `decode_access_token()` and `decode_access_token_allow_expired()`
- `assert` is stripped by `python -O`, silently removing these safety checks in optimized mode
- Matches existing pattern in `get_public_key_pem()` (line 81)

## Test plan
- [ ] Existing tests pass
- [ ] Verify `RuntimeError` raised when `_public_key` is `None`

🤖 Generated with [Claude Code](https://claude.com/claude-code)