### PR TITLE
Hash refresh tokens and app tokens at rest

### DIFF
--- a/compute_space/compute_space/core/apps.py
+++ b/compute_space/compute_space/core/apps.py
@@ -5,6 +5,7 @@ Extracted from routes/apps.py — no HTTP/Quart dependencies.
 
 import asyncio
 import dataclasses
+import hashlib
 import json
 import os
 import re
@@ -283,9 +284,10 @@ def insert_and_deploy(
         )
     app_token = env_vars.get("OPENHOST_APP_TOKEN")
     if app_token:
+        app_token_hash = hashlib.sha256(app_token.encode()).hexdigest()
         db.execute(
-            "INSERT OR REPLACE INTO app_tokens (app_name, token) VALUES (?, ?)",
-            (app_name, app_token),
+            "INSERT OR REPLACE INTO app_tokens (app_name, token_hash) VALUES (?, ?)",
+            (app_name, app_token_hash),
         )
 
     for svc_name in manifest.provides_services:
@@ -507,9 +509,10 @@ def start_app_process(app_name: str, db: sqlite3.Connection, config: Config) -> 
 
     app_token = env_vars.get("OPENHOST_APP_TOKEN")
     if app_token:
+        app_token_hash = hashlib.sha256(app_token.encode()).hexdigest()
         db.execute(
-            "INSERT OR REPLACE INTO app_tokens (app_name, token) VALUES (?, ?)",
-            (app_name, app_token),
+            "INSERT OR REPLACE INTO app_tokens (app_name, token_hash) VALUES (?, ?)",
+            (app_name, app_token_hash),
         )
 
     db.execute("DELETE FROM service_providers WHERE app_name = ?", (app_name,))

--- a/compute_space/compute_space/db/migrations.py
+++ b/compute_space/compute_space/db/migrations.py
@@ -1,3 +1,4 @@
+import hashlib
 import os
 import re
 import sqlite3
@@ -178,3 +179,60 @@ def migrate(db: sqlite3.Connection) -> None:
     )
     db.execute("CREATE UNIQUE INDEX IF NOT EXISTS idx_port_mappings_host_port ON app_port_mappings(host_port)")
     db.commit()
+
+    # Migrate refresh_tokens: rename token -> token_hash and hash existing values.
+    # Can't use _recreate_table because column name changes (token -> token_hash).
+    rt_cols = {row[1] for row in db.execute("PRAGMA table_info(refresh_tokens)").fetchall()}
+    if "token" in rt_cols and "token_hash" not in rt_cols:
+        db.execute("PRAGMA foreign_keys=OFF")
+        try:
+            db.execute("DROP TABLE IF EXISTS refresh_tokens_new")
+            db.execute(
+                """CREATE TABLE refresh_tokens_new (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    token_hash TEXT UNIQUE NOT NULL,
+                    expires_at TEXT NOT NULL,
+                    revoked INTEGER NOT NULL DEFAULT 0
+                )"""
+            )
+            db.execute(
+                "INSERT INTO refresh_tokens_new (id, token_hash, expires_at, revoked) "
+                "SELECT id, token, expires_at, revoked FROM refresh_tokens"
+            )
+            db.execute("DROP TABLE refresh_tokens")
+            db.execute("ALTER TABLE refresh_tokens_new RENAME TO refresh_tokens")
+            # Hash the plaintext values now in token_hash column
+            rows = db.execute("SELECT id, token_hash FROM refresh_tokens").fetchall()
+            for row in rows:
+                hashed = hashlib.sha256(row[1].encode()).hexdigest()
+                db.execute("UPDATE refresh_tokens SET token_hash = ? WHERE id = ?", (hashed, row[0]))
+            db.commit()
+        finally:
+            db.execute("PRAGMA foreign_keys=ON")
+
+    # Migrate app_tokens: rename token -> token_hash and hash existing values
+    at_cols = {row[1] for row in db.execute("PRAGMA table_info(app_tokens)").fetchall()}
+    if "token" in at_cols and "token_hash" not in at_cols:
+        db.execute("PRAGMA foreign_keys=OFF")
+        try:
+            db.execute("DROP TABLE IF EXISTS app_tokens_new")
+            db.execute(
+                """CREATE TABLE app_tokens_new (
+                    app_name TEXT PRIMARY KEY,
+                    token_hash TEXT NOT NULL UNIQUE,
+                    FOREIGN KEY (app_name) REFERENCES apps(name) ON DELETE CASCADE
+                )"""
+            )
+            db.execute(
+                "INSERT INTO app_tokens_new (app_name, token_hash) "
+                "SELECT app_name, token FROM app_tokens"
+            )
+            db.execute("DROP TABLE app_tokens")
+            db.execute("ALTER TABLE app_tokens_new RENAME TO app_tokens")
+            rows = db.execute("SELECT app_name, token_hash FROM app_tokens").fetchall()
+            for row in rows:
+                hashed = hashlib.sha256(row[1].encode()).hexdigest()
+                db.execute("UPDATE app_tokens SET token_hash = ? WHERE app_name = ?", (hashed, row[0]))
+            db.commit()
+        finally:
+            db.execute("PRAGMA foreign_keys=ON")

--- a/compute_space/compute_space/db/migrations.py
+++ b/compute_space/compute_space/db/migrations.py
@@ -65,7 +65,7 @@ def _recover_temp_tables(db: sqlite3.Connection) -> None:
     the ``<name>_new`` temp table.  Detect this and rename it back so
     the subsequent migration sees a valid table.
     """
-    for table_name in ("apps", "owner"):
+    for table_name in ("apps", "owner", "refresh_tokens", "app_tokens"):
         tmp_name = f"{table_name}_new"
         orig_exists = db.execute(
             "SELECT 1 FROM sqlite_master WHERE type='table' AND name=?",
@@ -180,59 +180,40 @@ def migrate(db: sqlite3.Connection) -> None:
     db.execute("CREATE UNIQUE INDEX IF NOT EXISTS idx_port_mappings_host_port ON app_port_mappings(host_port)")
     db.commit()
 
-    # Migrate refresh_tokens: rename token -> token_hash and hash existing values.
-    # Can't use _recreate_table because column name changes (token -> token_hash).
+    # Migrate refresh_tokens: add token_hash column with hashed values, then
+    # drop the plaintext token column via _recreate_table.
     rt_cols = {row[1] for row in db.execute("PRAGMA table_info(refresh_tokens)").fetchall()}
     if "token" in rt_cols and "token_hash" not in rt_cols:
+        db.execute("ALTER TABLE refresh_tokens ADD COLUMN token_hash TEXT")
+        rows = db.execute("SELECT id, token FROM refresh_tokens").fetchall()
+        for row in rows:
+            hashed = hashlib.sha256(row[1].encode()).hexdigest()
+            db.execute("UPDATE refresh_tokens SET token_hash = ? WHERE id = ?", (hashed, row[0]))
+        db.commit()
+    # Drop the old plaintext token column if it still exists.
+    rt_cols = {row[1] for row in db.execute("PRAGMA table_info(refresh_tokens)").fetchall()}
+    if "token" in rt_cols:
         db.execute("PRAGMA foreign_keys=OFF")
         try:
-            db.execute("DROP TABLE IF EXISTS refresh_tokens_new")
-            db.execute(
-                """CREATE TABLE refresh_tokens_new (
-                    id INTEGER PRIMARY KEY AUTOINCREMENT,
-                    token_hash TEXT UNIQUE NOT NULL,
-                    expires_at TEXT NOT NULL,
-                    revoked INTEGER NOT NULL DEFAULT 0
-                )"""
-            )
-            db.execute(
-                "INSERT INTO refresh_tokens_new (id, token_hash, expires_at, revoked) "
-                "SELECT id, token, expires_at, revoked FROM refresh_tokens"
-            )
-            db.execute("DROP TABLE refresh_tokens")
-            db.execute("ALTER TABLE refresh_tokens_new RENAME TO refresh_tokens")
-            # Hash the plaintext values now in token_hash column
-            rows = db.execute("SELECT id, token_hash FROM refresh_tokens").fetchall()
-            for row in rows:
-                hashed = hashlib.sha256(row[1].encode()).hexdigest()
-                db.execute("UPDATE refresh_tokens SET token_hash = ? WHERE id = ?", (hashed, row[0]))
-            db.commit()
+            _recreate_table(db, "refresh_tokens", [c for c in rt_cols if c != "token"])
         finally:
             db.execute("PRAGMA foreign_keys=ON")
 
-    # Migrate app_tokens: rename token -> token_hash and hash existing values
+    # Migrate app_tokens: add token_hash column with hashed values, then
+    # drop the plaintext token column via _recreate_table.
     at_cols = {row[1] for row in db.execute("PRAGMA table_info(app_tokens)").fetchall()}
     if "token" in at_cols and "token_hash" not in at_cols:
+        db.execute("ALTER TABLE app_tokens ADD COLUMN token_hash TEXT")
+        rows = db.execute("SELECT app_name, token FROM app_tokens").fetchall()
+        for row in rows:
+            hashed = hashlib.sha256(row[1].encode()).hexdigest()
+            db.execute("UPDATE app_tokens SET token_hash = ? WHERE app_name = ?", (hashed, row[0]))
+        db.commit()
+    # Drop the old plaintext token column if it still exists.
+    at_cols = {row[1] for row in db.execute("PRAGMA table_info(app_tokens)").fetchall()}
+    if "token" in at_cols:
         db.execute("PRAGMA foreign_keys=OFF")
         try:
-            db.execute("DROP TABLE IF EXISTS app_tokens_new")
-            db.execute(
-                """CREATE TABLE app_tokens_new (
-                    app_name TEXT PRIMARY KEY,
-                    token_hash TEXT NOT NULL UNIQUE,
-                    FOREIGN KEY (app_name) REFERENCES apps(name) ON DELETE CASCADE
-                )"""
-            )
-            db.execute(
-                "INSERT INTO app_tokens_new (app_name, token_hash) "
-                "SELECT app_name, token FROM app_tokens"
-            )
-            db.execute("DROP TABLE app_tokens")
-            db.execute("ALTER TABLE app_tokens_new RENAME TO app_tokens")
-            rows = db.execute("SELECT app_name, token_hash FROM app_tokens").fetchall()
-            for row in rows:
-                hashed = hashlib.sha256(row[1].encode()).hexdigest()
-                db.execute("UPDATE app_tokens SET token_hash = ? WHERE app_name = ?", (hashed, row[0]))
-            db.commit()
+            _recreate_table(db, "app_tokens", [c for c in at_cols if c != "token"])
         finally:
             db.execute("PRAGMA foreign_keys=ON")

--- a/compute_space/compute_space/db/schema.sql
+++ b/compute_space/compute_space/db/schema.sql
@@ -56,12 +56,12 @@ CREATE TABLE IF NOT EXISTS owner (
 -- Auth: refresh tokens for self-hosted JWT auth
 CREATE TABLE IF NOT EXISTS refresh_tokens (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
-    token TEXT UNIQUE NOT NULL,
+    token_hash TEXT UNIQUE NOT NULL,
     expires_at TEXT NOT NULL,
     revoked INTEGER NOT NULL DEFAULT 0
 );
 
-CREATE INDEX IF NOT EXISTS idx_refresh_tokens_token ON refresh_tokens(token);
+CREATE INDEX IF NOT EXISTS idx_refresh_tokens_token_hash ON refresh_tokens(token_hash);
 
 -- API tokens: long-lived bearer tokens that grant owner-level access
 CREATE TABLE IF NOT EXISTS api_tokens (
@@ -75,7 +75,7 @@ CREATE TABLE IF NOT EXISTS api_tokens (
 -- Cross-app services: app authentication tokens
 CREATE TABLE IF NOT EXISTS app_tokens (
     app_name TEXT PRIMARY KEY,
-    token TEXT NOT NULL UNIQUE,
+    token_hash TEXT NOT NULL UNIQUE,
     FOREIGN KEY (app_name) REFERENCES apps(name) ON DELETE CASCADE
 );
 

--- a/compute_space/compute_space/web/middleware.py
+++ b/compute_space/compute_space/web/middleware.py
@@ -1,3 +1,4 @@
+import hashlib
 import inspect
 from collections.abc import Awaitable
 from collections.abc import Callable
@@ -52,10 +53,11 @@ def _try_refresh() -> dict[str, Any] | None:
     if expired_claims is None:
         return None
 
+    refresh_tok_hash = hashlib.sha256(refresh_tok.encode()).hexdigest()
     db = get_db()
     rt = db.execute(
-        "SELECT * FROM refresh_tokens WHERE token = ? AND revoked = 0",
-        (refresh_tok,),
+        "SELECT * FROM refresh_tokens WHERE token_hash = ? AND revoked = 0",
+        (refresh_tok_hash,),
     ).fetchone()
     if rt is None:
         return None

--- a/compute_space/compute_space/web/routes/pages/auth.py
+++ b/compute_space/compute_space/web/routes/pages/auth.py
@@ -1,3 +1,4 @@
+import hashlib
 import os
 import secrets
 from datetime import UTC
@@ -113,12 +114,13 @@ async def setup() -> ResponseReturnValue:
 
     access_token = auth.create_access_token("owner")
     refresh_token = secrets.token_urlsafe(48)
+    refresh_token_hash = hashlib.sha256(refresh_token.encode()).hexdigest()
     expires_at = datetime.now(UTC) + timedelta(
         seconds=auth.REFRESH_TOKEN_EXPIRY,
     )
     db.execute(
-        "INSERT INTO refresh_tokens (token, expires_at) VALUES (?, ?)",
-        (refresh_token, expires_at.isoformat()),
+        "INSERT INTO refresh_tokens (token_hash, expires_at) VALUES (?, ?)",
+        (refresh_token_hash, expires_at.isoformat()),
     )
     db.commit()
 
@@ -166,12 +168,13 @@ async def login() -> ResponseReturnValue:
 
     access_token = auth.create_access_token("owner")
     refresh_token = secrets.token_urlsafe(48)
+    refresh_token_hash = hashlib.sha256(refresh_token.encode()).hexdigest()
     expires_at = datetime.now(UTC) + timedelta(
         seconds=auth.REFRESH_TOKEN_EXPIRY,
     )
     db.execute(
-        "INSERT INTO refresh_tokens (token, expires_at) VALUES (?, ?)",
-        (refresh_token, expires_at.isoformat()),
+        "INSERT INTO refresh_tokens (token_hash, expires_at) VALUES (?, ?)",
+        (refresh_token_hash, expires_at.isoformat()),
     )
     db.commit()
 
@@ -184,10 +187,11 @@ async def login() -> ResponseReturnValue:
 def logout() -> ResponseReturnValue:
     refresh_tok = request.cookies.get(auth.COOKIE_REFRESH)
     if refresh_tok:
+        refresh_tok_hash = hashlib.sha256(refresh_tok.encode()).hexdigest()
         db = get_db()
         db.execute(
-            "UPDATE refresh_tokens SET revoked = 1 WHERE token = ?",
-            (refresh_tok,),
+            "UPDATE refresh_tokens SET revoked = 1 WHERE token_hash = ?",
+            (refresh_tok_hash,),
         )
         db.commit()
 

--- a/compute_space/compute_space/web/routes/services.py
+++ b/compute_space/compute_space/web/routes/services.py
@@ -1,3 +1,4 @@
+import hashlib
 import json
 from urllib.parse import urlparse
 
@@ -60,7 +61,8 @@ def _authenticate_and_resolve_consumer_app() -> str | None:
     auth_header = request.headers.get("Authorization", "")
     if auth_header.startswith("Bearer "):
         token = auth_header[7:]
-        token_row = db.execute("SELECT app_name FROM app_tokens WHERE token = ?", (token,)).fetchone()
+        token_hash = hashlib.sha256(token.encode()).hexdigest()
+        token_row = db.execute("SELECT app_name FROM app_tokens WHERE token_hash = ?", (token_hash,)).fetchone()
         return token_row["app_name"] if token_row else None
 
     # Browser auth: verify JWT cookie, derive app from Origin

--- a/compute_space/tests/test_migrations.py
+++ b/compute_space/tests/test_migrations.py
@@ -435,6 +435,110 @@ class TestRouterMigrations:
         assert row["updated_at"] is not None
 
 
+    def test_migrate_hashes_refresh_tokens(self, tmp_path):
+        """Migration renames token -> token_hash and hashes existing plaintext values."""
+        import hashlib
+
+        db_path = str(tmp_path / "test.db")
+        db = sqlite3.connect(db_path)
+        db.executescript(_OLDEST_ROUTER_SCHEMA)
+        # Insert plaintext refresh tokens
+        db.execute(
+            "INSERT INTO refresh_tokens (token, expires_at) VALUES ('plaintext-refresh-1', '2099-01-01T00:00:00')"
+        )
+        db.execute(
+            "INSERT INTO refresh_tokens (token, expires_at) VALUES ('plaintext-refresh-2', '2099-01-01T00:00:00')"
+        )
+        db.commit()
+        db.close()
+
+        _run_init_db(db_path)
+
+        db = sqlite3.connect(db_path)
+        db.row_factory = sqlite3.Row
+        cols = {row[1] for row in db.execute("PRAGMA table_info(refresh_tokens)").fetchall()}
+        assert "token_hash" in cols
+        assert "token" not in cols
+
+        rows = db.execute("SELECT token_hash FROM refresh_tokens ORDER BY id").fetchall()
+        assert len(rows) == 2
+        expected_1 = hashlib.sha256(b"plaintext-refresh-1").hexdigest()
+        expected_2 = hashlib.sha256(b"plaintext-refresh-2").hexdigest()
+        assert rows[0]["token_hash"] == expected_1
+        assert rows[1]["token_hash"] == expected_2
+        # Must not be the original plaintext
+        assert rows[0]["token_hash"] != "plaintext-refresh-1"
+        db.close()
+
+    def test_migrate_hashes_app_tokens(self, tmp_path):
+        """Migration renames token -> token_hash and hashes existing plaintext values in app_tokens."""
+        import hashlib
+
+        db_path = str(tmp_path / "test.db")
+        db = sqlite3.connect(db_path)
+        db.executescript(_OLDEST_ROUTER_SCHEMA)
+        # Need an app row for the FK
+        db.execute(
+            "INSERT INTO apps (name, base_path, subdomain, version, runtime_type, repo_path, local_port) "
+            "VALUES ('myapp', '/myapp', 'myapp', '1.0', 'serverfull', '/repo', 9000)"
+        )
+        # app_tokens table doesn't exist in oldest schema, create it with old column name
+        db.execute(
+            "CREATE TABLE IF NOT EXISTS app_tokens ("
+            "app_name TEXT PRIMARY KEY, token TEXT NOT NULL UNIQUE, "
+            "FOREIGN KEY (app_name) REFERENCES apps(name) ON DELETE CASCADE)"
+        )
+        db.execute("INSERT INTO app_tokens (app_name, token) VALUES ('myapp', 'plaintext-app-token')")
+        db.commit()
+        db.close()
+
+        _run_init_db(db_path)
+
+        db = sqlite3.connect(db_path)
+        db.row_factory = sqlite3.Row
+        cols = {row[1] for row in db.execute("PRAGMA table_info(app_tokens)").fetchall()}
+        assert "token_hash" in cols
+        assert "token" not in cols
+
+        row = db.execute("SELECT token_hash FROM app_tokens WHERE app_name = 'myapp'").fetchone()
+        expected = hashlib.sha256(b"plaintext-app-token").hexdigest()
+        assert row["token_hash"] == expected
+        assert row["token_hash"] != "plaintext-app-token"
+        db.close()
+
+    def test_token_hash_migration_idempotent(self, tmp_path):
+        """Running init_db twice doesn't double-hash tokens."""
+        import hashlib
+
+        db_path = str(tmp_path / "test.db")
+        db = sqlite3.connect(db_path)
+        db.executescript(_OLDEST_ROUTER_SCHEMA)
+        db.execute(
+            "INSERT INTO refresh_tokens (token, expires_at) VALUES ('my-token', '2099-01-01T00:00:00')"
+        )
+        db.commit()
+        db.close()
+
+        _run_init_db(db_path)
+
+        db = sqlite3.connect(db_path)
+        db.row_factory = sqlite3.Row
+        hash_after_first = db.execute("SELECT token_hash FROM refresh_tokens").fetchone()["token_hash"]
+        db.close()
+
+        # Run again — should be no-op since column is already token_hash
+        _run_init_db(db_path)
+
+        db = sqlite3.connect(db_path)
+        db.row_factory = sqlite3.Row
+        hash_after_second = db.execute("SELECT token_hash FROM refresh_tokens").fetchone()["token_hash"]
+        db.close()
+
+        expected = hashlib.sha256(b"my-token").hexdigest()
+        assert hash_after_first == expected
+        assert hash_after_second == expected
+
+
 class TestCrashRecovery:
     """Verify that _recreate_table recovers from a prior crash that left the
     database in an intermediate state (original table dropped, temp table

--- a/compute_space/tests/test_migrations.py
+++ b/compute_space/tests/test_migrations.py
@@ -4,6 +4,7 @@ identical to a fresh database created by schema.sql, and that data is
 preserved correctly through each migration path.
 """
 
+import hashlib
 import os
 import sqlite3
 
@@ -437,8 +438,6 @@ class TestRouterMigrations:
 
     def test_migrate_hashes_refresh_tokens(self, tmp_path):
         """Migration renames token -> token_hash and hashes existing plaintext values."""
-        import hashlib
-
         db_path = str(tmp_path / "test.db")
         db = sqlite3.connect(db_path)
         db.executescript(_OLDEST_ROUTER_SCHEMA)
@@ -472,8 +471,6 @@ class TestRouterMigrations:
 
     def test_migrate_hashes_app_tokens(self, tmp_path):
         """Migration renames token -> token_hash and hashes existing plaintext values in app_tokens."""
-        import hashlib
-
         db_path = str(tmp_path / "test.db")
         db = sqlite3.connect(db_path)
         db.executescript(_OLDEST_ROUTER_SCHEMA)
@@ -508,8 +505,6 @@ class TestRouterMigrations:
 
     def test_token_hash_migration_idempotent(self, tmp_path):
         """Running init_db twice doesn't double-hash tokens."""
-        import hashlib
-
         db_path = str(tmp_path / "test.db")
         db = sqlite3.connect(db_path)
         db.executescript(_OLDEST_ROUTER_SCHEMA)

--- a/compute_space/tests/test_migrations.py
+++ b/compute_space/tests/test_migrations.py
@@ -435,7 +435,6 @@ class TestRouterMigrations:
         assert row["created_at"] is not None
         assert row["updated_at"] is not None
 
-
     def test_migrate_hashes_refresh_tokens(self, tmp_path):
         """Migration renames token -> token_hash and hashes existing plaintext values."""
         db_path = str(tmp_path / "test.db")
@@ -508,9 +507,7 @@ class TestRouterMigrations:
         db_path = str(tmp_path / "test.db")
         db = sqlite3.connect(db_path)
         db.executescript(_OLDEST_ROUTER_SCHEMA)
-        db.execute(
-            "INSERT INTO refresh_tokens (token, expires_at) VALUES ('my-token', '2099-01-01T00:00:00')"
-        )
+        db.execute("INSERT INTO refresh_tokens (token, expires_at) VALUES ('my-token', '2099-01-01T00:00:00')")
         db.commit()
         db.close()
 

--- a/compute_space/tests/test_token_hashing.py
+++ b/compute_space/tests/test_token_hashing.py
@@ -3,8 +3,6 @@
 import hashlib
 import sqlite3
 
-import pytest
-
 from compute_space.db.connection import init_db
 
 

--- a/compute_space/tests/test_token_hashing.py
+++ b/compute_space/tests/test_token_hashing.py
@@ -1,0 +1,143 @@
+"""Tests that refresh tokens and app tokens are stored as SHA-256 hashes, not plaintext."""
+
+import hashlib
+import sqlite3
+
+import pytest
+
+from compute_space.db.connection import init_db
+
+
+class _FakeApp:
+    def __init__(self, db_path: str):
+        self.config = {"DB_PATH": db_path}
+
+
+def _init_test_db(tmp_path) -> str:
+    db_path = str(tmp_path / "test.db")
+    init_db(_FakeApp(db_path))
+    return db_path
+
+
+class TestRefreshTokenHashing:
+    """Verify refresh tokens are hashed before storage."""
+
+    def test_stored_hash_differs_from_raw_token(self, tmp_path):
+        """After inserting a refresh token via the same pattern as auth.py,
+        the stored token_hash should be the SHA-256 hex digest, not the raw value."""
+        db_path = _init_test_db(tmp_path)
+        db = sqlite3.connect(db_path)
+        db.row_factory = sqlite3.Row
+
+        raw_token = "test-refresh-token-abc123"
+        token_hash = hashlib.sha256(raw_token.encode()).hexdigest()
+
+        db.execute(
+            "INSERT INTO refresh_tokens (token_hash, expires_at) VALUES (?, ?)",
+            (token_hash, "2099-01-01T00:00:00"),
+        )
+        db.commit()
+
+        row = db.execute("SELECT token_hash FROM refresh_tokens").fetchone()
+        assert row["token_hash"] != raw_token
+        assert row["token_hash"] == token_hash
+        assert len(row["token_hash"]) == 64  # SHA-256 hex digest length
+        db.close()
+
+    def test_lookup_by_hash(self, tmp_path):
+        """Lookup by hashed value finds the correct row."""
+        db_path = _init_test_db(tmp_path)
+        db = sqlite3.connect(db_path)
+        db.row_factory = sqlite3.Row
+
+        raw_token = "lookup-test-token"
+        token_hash = hashlib.sha256(raw_token.encode()).hexdigest()
+
+        db.execute(
+            "INSERT INTO refresh_tokens (token_hash, expires_at, revoked) VALUES (?, ?, 0)",
+            (token_hash, "2099-01-01T00:00:00"),
+        )
+        db.commit()
+
+        # Simulate middleware lookup: hash the raw cookie value, then query
+        lookup_hash = hashlib.sha256(raw_token.encode()).hexdigest()
+        row = db.execute(
+            "SELECT * FROM refresh_tokens WHERE token_hash = ? AND revoked = 0",
+            (lookup_hash,),
+        ).fetchone()
+        assert row is not None
+
+        # Raw token should NOT match
+        row_raw = db.execute(
+            "SELECT * FROM refresh_tokens WHERE token_hash = ?",
+            (raw_token,),
+        ).fetchone()
+        assert row_raw is None
+        db.close()
+
+
+class TestAppTokenHashing:
+    """Verify app tokens are hashed before storage."""
+
+    def test_stored_hash_differs_from_raw_token(self, tmp_path):
+        """After inserting an app token, the stored token_hash is SHA-256, not plaintext."""
+        db_path = _init_test_db(tmp_path)
+        db = sqlite3.connect(db_path)
+        db.row_factory = sqlite3.Row
+
+        # Need an app row for the FK
+        db.execute(
+            "INSERT INTO apps (name, version, runtime_type, repo_path, local_port) "
+            "VALUES ('testapp', '1.0', 'serverfull', '/repo', 9000)"
+        )
+
+        raw_token = "test-app-token-xyz789"
+        token_hash = hashlib.sha256(raw_token.encode()).hexdigest()
+
+        db.execute(
+            "INSERT INTO app_tokens (app_name, token_hash) VALUES (?, ?)",
+            ("testapp", token_hash),
+        )
+        db.commit()
+
+        row = db.execute("SELECT token_hash FROM app_tokens WHERE app_name = 'testapp'").fetchone()
+        assert row["token_hash"] != raw_token
+        assert row["token_hash"] == token_hash
+        assert len(row["token_hash"]) == 64
+        db.close()
+
+    def test_lookup_by_hash(self, tmp_path):
+        """Lookup by hashed bearer token finds the correct app."""
+        db_path = _init_test_db(tmp_path)
+        db = sqlite3.connect(db_path)
+        db.row_factory = sqlite3.Row
+
+        db.execute(
+            "INSERT INTO apps (name, version, runtime_type, repo_path, local_port) "
+            "VALUES ('myapp', '1.0', 'serverfull', '/repo', 9001)"
+        )
+
+        raw_token = "bearer-app-token"
+        token_hash = hashlib.sha256(raw_token.encode()).hexdigest()
+        db.execute(
+            "INSERT INTO app_tokens (app_name, token_hash) VALUES (?, ?)",
+            ("myapp", token_hash),
+        )
+        db.commit()
+
+        # Simulate services.py lookup: hash bearer token, then query
+        lookup_hash = hashlib.sha256(raw_token.encode()).hexdigest()
+        row = db.execute(
+            "SELECT app_name FROM app_tokens WHERE token_hash = ?",
+            (lookup_hash,),
+        ).fetchone()
+        assert row is not None
+        assert row["app_name"] == "myapp"
+
+        # Raw token should NOT match
+        row_raw = db.execute(
+            "SELECT app_name FROM app_tokens WHERE token_hash = ?",
+            (raw_token,),
+        ).fetchone()
+        assert row_raw is None
+        db.close()


### PR DESCRIPTION
## Summary

- Store SHA-256 hashes instead of plaintext bearer tokens in `refresh_tokens` and `app_tokens` tables, matching existing `api_tokens` pattern
- Migration detects old `token` column, renames to `token_hash`, and hashes existing plaintext values in place
- All write paths (setup, login, app deploy/start) hash before INSERT; all read paths (refresh, logout, service auth) hash before query

## Test plan

- [x] Migration correctly hashes old plaintext refresh_tokens rows
- [x] Migration correctly hashes old plaintext app_tokens rows
- [x] Migration is idempotent (double init_db doesn't double-hash)
- [x] Stored token_hash != raw token value (SHA-256 hex digest)
- [x] Lookup by hashed value finds correct row
- [x] Raw plaintext token does not match any row
- [x] All existing tests pass (119 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)