### PR TITLE
Fix apps.py null checks: replace assert with RuntimeError

### DIFF
--- a/compute_space/compute_space/web/routes/api/apps.py
+++ b/compute_space/compute_space/web/routes/api/apps.py
@@ -80,7 +80,8 @@ async def clone_and_get_app_info() -> ResponseReturnValue:
     if error:
         return jsonify({"error": error}), 400
 
-    assert manifest is not None
+    if manifest is None:
+        raise RuntimeError("manifest unexpectedly None after successful clone")
     db = get_db()
     validation_error = validate_manifest(manifest, db)
     info = dataclasses.asdict(manifest)
@@ -141,7 +142,8 @@ async def api_add_app() -> ResponseReturnValue:
         if error:
             return jsonify({"error": error}), 400
 
-    assert clone_dir is not None
+    if clone_dir is None:
+        raise RuntimeError("clone_dir unexpectedly None after successful clone")
     if manifest is None:
         try:
             manifest = parse_manifest(clone_dir)


### PR DESCRIPTION
## Summary
- Replace `assert manifest is not None` and `assert clone_dir is not None` in `apps.py` with explicit `RuntimeError` raises
- `assert` stripped by `python -O`, silently removing these guards in optimized mode
- Follow-up to #12 which fixed the same pattern in `auth.py`

## Test plan
- [ ] Existing tests pass
- [ ] Pre-commit (ruff/mypy) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)