### PR TITLE
Add iss and aud claims to access tokens

### DIFF
--- a/compute_space/compute_space/core/auth.py
+++ b/compute_space/compute_space/core/auth.py
@@ -117,9 +117,7 @@ def decode_access_token(token: str) -> dict[str, Any] | None:
         if _public_key is None:
             raise RuntimeError("public key not loaded")
         zone = _zone_audience()
-        return jwt.decode(
-            token, _public_key, algorithms=["RS256"], audience=zone, issuer=zone
-        )
+        return jwt.decode(token, _public_key, algorithms=["RS256"], audience=zone, issuer=zone)
     except jwt.InvalidTokenError:
         return None
 

--- a/compute_space/compute_space/core/auth.py
+++ b/compute_space/compute_space/core/auth.py
@@ -84,14 +84,22 @@ def get_public_key_pem() -> str:
     return _public_key
 
 
+def _zone_audience() -> str:
+    """Return the audience/issuer identifier for this zone."""
+    return get_config().zone_domain or "localhost"
+
+
 def create_access_token(username: str) -> str:
     """Create a signed RS256 JWT."""
     if _private_key is None:
         raise RuntimeError("Keys not loaded. Call load_keys() first.")
     now = datetime.now(UTC)
+    zone = _zone_audience()
     payload = {
         "sub": username,
         "username": username,
+        "iss": zone,
+        "aud": zone,
         "iat": now,
         "exp": now + timedelta(seconds=ACCESS_TOKEN_EXPIRY),
     }
@@ -108,7 +116,10 @@ def decode_access_token(token: str) -> dict[str, Any] | None:
     try:
         if _public_key is None:
             raise RuntimeError("public key not loaded")
-        return jwt.decode(token, _public_key, algorithms=["RS256"])
+        zone = _zone_audience()
+        return jwt.decode(
+            token, _public_key, algorithms=["RS256"], audience=zone, issuer=zone
+        )
     except jwt.InvalidTokenError:
         return None
 
@@ -121,10 +132,13 @@ def decode_access_token_allow_expired(token: str) -> dict[str, Any] | None:
     try:
         if _public_key is None:
             raise RuntimeError("public key not loaded")
+        zone = _zone_audience()
         return jwt.decode(
             token,
             _public_key,
             algorithms=["RS256"],
+            audience=zone,
+            issuer=zone,
             leeway=REFRESH_GRACE_PERIOD,
         )
     except jwt.InvalidTokenError:

--- a/compute_space/tests/test_auth.py
+++ b/compute_space/tests/test_auth.py
@@ -1,0 +1,96 @@
+"""Unit tests for JWT access token iss/aud claims."""
+
+from pathlib import Path
+from unittest.mock import patch
+
+import jwt as pyjwt
+import pytest
+
+from compute_space.config import DefaultConfig
+from compute_space.core import auth
+
+
+@pytest.fixture(autouse=True)
+def _setup_keys(tmp_path: Path) -> None:
+    """Load keys and set zone_domain config for each test."""
+    auth.load_keys(str(tmp_path / "keys"))
+    cfg = DefaultConfig(
+        host="127.0.0.1",
+        data_root_dir=str(tmp_path),
+        zone_domain="myzone.example.com",
+        tls_enabled=False,
+        start_caddy=False,
+    )
+    cfg.make_all_dirs()
+    with patch("compute_space.core.auth.get_config", return_value=cfg):
+        yield
+
+
+def _decode_raw(token: str) -> dict:
+    """Decode without verification to inspect raw claims."""
+    return pyjwt.decode(token, options={"verify_signature": False}, algorithms=["RS256"])
+
+
+def test_access_token_contains_iss_and_aud(tmp_path: Path) -> None:
+    cfg = DefaultConfig(
+        host="127.0.0.1",
+        data_root_dir=str(tmp_path),
+        zone_domain="myzone.example.com",
+        tls_enabled=False,
+        start_caddy=False,
+    )
+    with patch("compute_space.core.auth.get_config", return_value=cfg):
+        token = auth.create_access_token("alice")
+    claims = _decode_raw(token)
+    assert claims["iss"] == "myzone.example.com"
+    assert claims["aud"] == "myzone.example.com"
+    assert claims["sub"] == "alice"
+    assert claims["username"] == "alice"
+
+
+def test_decode_verifies_aud_and_iss(tmp_path: Path) -> None:
+    cfg = DefaultConfig(
+        host="127.0.0.1",
+        data_root_dir=str(tmp_path),
+        zone_domain="myzone.example.com",
+        tls_enabled=False,
+        start_caddy=False,
+    )
+    with patch("compute_space.core.auth.get_config", return_value=cfg):
+        token = auth.create_access_token("alice")
+        # Same zone decodes fine
+        assert auth.decode_access_token(token) is not None
+
+    # Different zone rejects token
+    cfg_other = DefaultConfig(
+        host="127.0.0.1",
+        data_root_dir=str(tmp_path),
+        zone_domain="other.example.com",
+        tls_enabled=False,
+        start_caddy=False,
+    )
+    with patch("compute_space.core.auth.get_config", return_value=cfg_other):
+        assert auth.decode_access_token(token) is None
+
+
+def test_decode_allow_expired_verifies_aud_and_iss(tmp_path: Path) -> None:
+    cfg = DefaultConfig(
+        host="127.0.0.1",
+        data_root_dir=str(tmp_path),
+        zone_domain="myzone.example.com",
+        tls_enabled=False,
+        start_caddy=False,
+    )
+    with patch("compute_space.core.auth.get_config", return_value=cfg):
+        token = auth.create_access_token("alice")
+        assert auth.decode_access_token_allow_expired(token) is not None
+
+    cfg_other = DefaultConfig(
+        host="127.0.0.1",
+        data_root_dir=str(tmp_path),
+        zone_domain="other.example.com",
+        tls_enabled=False,
+        start_caddy=False,
+    )
+    with patch("compute_space.core.auth.get_config", return_value=cfg_other):
+        assert auth.decode_access_token_allow_expired(token) is None

--- a/compute_space/tests/test_auth.py
+++ b/compute_space/tests/test_auth.py
@@ -9,88 +9,52 @@ import pytest
 from compute_space.config import DefaultConfig
 from compute_space.core import auth
 
+# Tests use this as the zone_domain; update _setup_keys if changed.
+ZONE = "myzone.example.com"
+OTHER_ZONE = "other.example.com"
 
-@pytest.fixture(autouse=True)
-def _setup_keys(tmp_path: Path) -> None:
-    """Load keys and set zone_domain config for each test."""
-    auth.load_keys(str(tmp_path / "keys"))
-    cfg = DefaultConfig(
+
+def _make_cfg(tmp_path: Path, zone_domain: str = ZONE) -> DefaultConfig:
+    return DefaultConfig(
         host="127.0.0.1",
         data_root_dir=str(tmp_path),
-        zone_domain="myzone.example.com",
+        zone_domain=zone_domain,
         tls_enabled=False,
         start_caddy=False,
     )
+
+
+@pytest.fixture(autouse=True)
+def _setup_keys(tmp_path: Path) -> None:
+    """Load keys and patch get_config for each test."""
+    auth.load_keys(str(tmp_path / "keys"))
+    cfg = _make_cfg(tmp_path)
     cfg.make_all_dirs()
     with patch("compute_space.core.auth.get_config", return_value=cfg):
         yield
 
 
-def _decode_raw(token: str) -> dict:
-    """Decode without verification to inspect raw claims."""
-    return pyjwt.decode(token, options={"verify_signature": False}, algorithms=["RS256"])
-
-
-def test_access_token_contains_iss_and_aud(tmp_path: Path) -> None:
-    cfg = DefaultConfig(
-        host="127.0.0.1",
-        data_root_dir=str(tmp_path),
-        zone_domain="myzone.example.com",
-        tls_enabled=False,
-        start_caddy=False,
-    )
-    with patch("compute_space.core.auth.get_config", return_value=cfg):
-        token = auth.create_access_token("alice")
-    claims = _decode_raw(token)
-    assert claims["iss"] == "myzone.example.com"
-    assert claims["aud"] == "myzone.example.com"
+def test_access_token_contains_iss_and_aud() -> None:
+    token = auth.create_access_token("alice")
+    claims = pyjwt.decode(token, options={"verify_signature": False}, algorithms=["RS256"])
+    assert claims["iss"] == ZONE
+    assert claims["aud"] == ZONE
     assert claims["sub"] == "alice"
     assert claims["username"] == "alice"
 
 
 def test_decode_verifies_aud_and_iss(tmp_path: Path) -> None:
-    cfg = DefaultConfig(
-        host="127.0.0.1",
-        data_root_dir=str(tmp_path),
-        zone_domain="myzone.example.com",
-        tls_enabled=False,
-        start_caddy=False,
-    )
-    with patch("compute_space.core.auth.get_config", return_value=cfg):
-        token = auth.create_access_token("alice")
-        # Same zone decodes fine
-        assert auth.decode_access_token(token) is not None
+    token = auth.create_access_token("alice")
+    assert auth.decode_access_token(token) is not None
 
     # Different zone rejects token
-    cfg_other = DefaultConfig(
-        host="127.0.0.1",
-        data_root_dir=str(tmp_path),
-        zone_domain="other.example.com",
-        tls_enabled=False,
-        start_caddy=False,
-    )
-    with patch("compute_space.core.auth.get_config", return_value=cfg_other):
+    with patch("compute_space.core.auth.get_config", return_value=_make_cfg(tmp_path, OTHER_ZONE)):
         assert auth.decode_access_token(token) is None
 
 
 def test_decode_allow_expired_verifies_aud_and_iss(tmp_path: Path) -> None:
-    cfg = DefaultConfig(
-        host="127.0.0.1",
-        data_root_dir=str(tmp_path),
-        zone_domain="myzone.example.com",
-        tls_enabled=False,
-        start_caddy=False,
-    )
-    with patch("compute_space.core.auth.get_config", return_value=cfg):
-        token = auth.create_access_token("alice")
-        assert auth.decode_access_token_allow_expired(token) is not None
+    token = auth.create_access_token("alice")
+    assert auth.decode_access_token_allow_expired(token) is not None
 
-    cfg_other = DefaultConfig(
-        host="127.0.0.1",
-        data_root_dir=str(tmp_path),
-        zone_domain="other.example.com",
-        tls_enabled=False,
-        start_caddy=False,
-    )
-    with patch("compute_space.core.auth.get_config", return_value=cfg_other):
+    with patch("compute_space.core.auth.get_config", return_value=_make_cfg(tmp_path, OTHER_ZONE)):
         assert auth.decode_access_token_allow_expired(token) is None

--- a/compute_space/tests/test_integration.py
+++ b/compute_space/tests/test_integration.py
@@ -408,6 +408,8 @@ class TestRouterCore:
         expired_payload = {
             "sub": "owner",
             "username": "owner",
+            "iss": "testzone.local",
+            "aud": "testzone.local",
             "iat": now - timedelta(hours=2),
             "exp": now - timedelta(hours=1),
         }


### PR DESCRIPTION
## Summary
- Access tokens now include `iss` and `aud` claims set to `zone_domain`, preventing cross-zone token replay
- `decode_access_token` and `decode_access_token_allow_expired` verify both claims on decode
- Added unit tests covering claim presence and cross-zone rejection
- Fixed integration test `test_expired_token_refresh` to include iss/aud in handcrafted token
- Reduced test_auth.py boilerplate with shared config helper

## Test plan
- [x] New unit tests pass (`test_auth.py`)
- [x] All 115 existing tests pass (0 failures)
- [ ] Integration test: verify login still works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)