### PR TITLE
Fix private key file permissions

### DIFF
--- a/compute_space/compute_space/core/auth.py
+++ b/compute_space/compute_space/core/auth.py
@@ -20,6 +20,7 @@ from quart import Response
 
 from compute_space.config import get_config
 from compute_space.core.logging import logger
+from compute_space.core.util import write_restricted
 from compute_space.db import get_db
 
 _private_key: str | None = None
@@ -56,7 +57,7 @@ def _generate_keypair(keys_dir: str) -> tuple[str, str]:
         .decode()
     )
 
-    (keys_path / "private.pem").write_text(private_pem)
+    write_restricted(keys_path / "private.pem", private_pem)
     (keys_path / "public.pem").write_text(public_pem)
 
     return private_pem, public_pem

--- a/compute_space/compute_space/core/identity.py
+++ b/compute_space/compute_space/core/identity.py
@@ -24,6 +24,7 @@ from cryptography.hazmat.primitives.asymmetric import rsa
 
 from compute_space.config import get_config
 from compute_space.core.logging import logger
+from compute_space.core.util import write_restricted
 
 # Identity tokens are short-lived (5 minutes) since they're one-time-use
 IDENTITY_TOKEN_EXPIRY: int = 300
@@ -73,7 +74,7 @@ def load_identity_keys(data_dir: str) -> None:
                 )
                 .decode()
             )
-            priv_path.write_text(_identity_private_key)
+            write_restricted(priv_path, _identity_private_key)
             pub_path.write_text(_identity_public_key)
             logger.info("Generated new persistent identity keys at %s", keys_dir)
     except (OSError, PermissionError, ValueError) as e:

--- a/compute_space/compute_space/core/util.py
+++ b/compute_space/compute_space/core/util.py
@@ -1,8 +1,17 @@
 import asyncio
 import functools
+import os
 from collections.abc import Callable
 from collections.abc import Coroutine
+from pathlib import Path
 from typing import Any
+
+
+def write_restricted(path: Path, content: str) -> None:
+    """Write a file that is only readable by the owner (mode 0o600)."""
+    fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    with os.fdopen(fd, "w") as f:
+        f.write(content)
 
 
 def assert_type[T](value: Any, expected_type: type[T]) -> T:


### PR DESCRIPTION
## Summary
- Private key files (`private.pem`) were written via `Path.write_text()`, which inherits the process umask — potentially leaving them group/world-readable.
- Added `write_restricted()` to `core/util.py` that uses `os.open` with `0o600` mode, so keys are owner-only from creation — no window of exposure.
- Auth and identity key writes both use the shared helper. Public key files unchanged (meant to be readable).

## Test plan
- [x] All 112 compute_space tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)