### PR TITLE
Fine-grained filesystem access flags for app manifests

### DIFF
--- a/compute_space/compute_space/core/containers.py
+++ b/compute_space/compute_space/core/containers.py
@@ -15,6 +15,71 @@ _ANSI_RE = re.compile(r"\x1b\[[0-9;]*[a-zA-Z]|\x1b\([AB0-9]|\x1b[=>]|\x0f|\r")
 _CACHE_CORRUPT_RE = re.compile(r"content digest sha256:[0-9a-f]+: not found")
 
 
+def compute_data_mounts(
+    manifest: AppManifest,
+    app_name: str,
+    data_dir: str,
+    temp_data_dir: str,
+) -> list[tuple[str, str, str | None]]:
+    """Return the list of data-volume mounts implied by a manifest.
+
+    Each tuple is ``(host_path, container_path, options)`` where
+    ``options`` is the Docker mount options string (``"ro"``) or ``None``
+    for a default read/write bind. The caller is expected to pass these
+    into ``docker run -v``.
+
+    Resolution rules (each category is independent — any combination of
+    the three ``access_all_apps_*`` / ``access_vm_data*`` fields can be
+    requested):
+
+    * For app_data and app_temp_data, a broad (parent-directory) mount
+      shadows the scoped (single-app) mount; only the broader mount is
+      emitted since the scoped path would be a subpath of it anyway.
+    * For vm_data, the manifest guarantees at most one of RO / RW is
+      active: parsing rejects ``access_vm_data`` (RO) together with
+      either ``access_vm_data_rw`` or the legacy ``access_all_data``
+      shorthand (both of which imply RW). This function just emits
+      whichever mount was requested.
+    """
+    app_data_dir = os.path.join(data_dir, "app_data", app_name)
+    app_temp_dir = os.path.join(temp_data_dir, "app_temp_data", app_name)
+    vm_data_dir = os.path.join(data_dir, "vm_data")
+    c_app_data = f"{CONTAINER_ROOT}/app_data/{app_name}"
+    c_app_temp = f"{CONTAINER_ROOT}/app_temp_data/{app_name}"
+    c_vm_data = f"{CONTAINER_ROOT}/vm_data"
+
+    mounts: list[tuple[str, str, str | None]] = []
+
+    if manifest.wants_all_apps_data:
+        mounts.append(
+            (
+                os.path.join(data_dir, "app_data"),
+                f"{CONTAINER_ROOT}/app_data",
+                None,
+            )
+        )
+    elif manifest.wants_own_app_data:
+        mounts.append((app_data_dir, c_app_data, None))
+
+    if manifest.wants_all_apps_temp_data:
+        mounts.append(
+            (
+                os.path.join(temp_data_dir, "app_temp_data"),
+                f"{CONTAINER_ROOT}/app_temp_data",
+                None,
+            )
+        )
+    elif manifest.wants_own_app_temp_data:
+        mounts.append((app_temp_dir, c_app_temp, None))
+
+    if manifest.wants_vm_data_rw:
+        mounts.append((vm_data_dir, c_vm_data, None))
+    elif manifest.wants_vm_data_ro:
+        mounts.append((vm_data_dir, c_vm_data, "ro"))
+
+    return mounts
+
+
 def _log_path(app_name: str, temp_data_dir: str) -> str:
     """Return the path to the build/deploy log file for an app (in temp data)."""
     return os.path.join(temp_data_dir, "app_temp_data", app_name, "docker.log")
@@ -105,19 +170,14 @@ def run_container(
 ) -> str:
     """Run a Docker container. Returns the container ID."""
     app_data_dir = os.path.join(data_dir, "app_data", app_name)
-    app_temp_dir = os.path.join(temp_data_dir, "app_temp_data", app_name)
     vm_data_dir = os.path.join(data_dir, "vm_data")
     container_name = f"openhost-{app_name}"
 
-    # Check which data access the app has (sqlite implies app_data)
-    has_app_data = manifest.app_data or manifest.sqlite_dbs or manifest.access_all_data
-    has_app_temp = manifest.app_temp_data or manifest.access_all_data
-    has_vm_data = manifest.access_vm_data or manifest.access_all_data
-
-    # Container paths follow the logical structure under CONTAINER_ROOT
+    # Container paths follow the logical structure under CONTAINER_ROOT.
+    # Only the ones used for env-var translation below are computed
+    # here; ``compute_data_mounts`` owns the mount-side path layout.
     c_app_data = f"{CONTAINER_ROOT}/app_data/{app_name}"
     c_app_temp = f"{CONTAINER_ROOT}/app_temp_data/{app_name}"
-    c_vm_data = f"{CONTAINER_ROOT}/vm_data"
 
     # Translate host paths to container paths in env vars
     container_env = {}
@@ -146,26 +206,21 @@ def run_container(
         "--add-host=host.docker.internal:host-gateway",
     ]
 
-    # Mount data volumes following the logical structure from docs/data.md
-    if manifest.access_all_data:
-        # Full access: mount parent dirs so the app sees all apps' data
-        cmd.extend(["-v", f"{os.path.join(data_dir, 'app_data')}:{CONTAINER_ROOT}/app_data"])
-        cmd.extend(
-            [
-                "-v",
-                f"{os.path.join(temp_data_dir, 'app_temp_data')}:{CONTAINER_ROOT}/app_temp_data",
-            ]
-        )
+    # Mount data volumes following the logical structure from docs/data.md.
+    # See ``compute_data_mounts`` for the permission-resolution rules.
+    # The vm_data dir is shared among apps and may not exist yet on a
+    # fresh install, so create it on demand if the manifest asks for it.
+    # Detecting that by host path is more robust than by container path,
+    # since the container-path scheme is defined inside
+    # ``compute_data_mounts`` and could drift.
+    mounts = compute_data_mounts(manifest, app_name, data_dir, temp_data_dir)
+    if any(host == vm_data_dir for host, _container, _opts in mounts):
         os.makedirs(vm_data_dir, exist_ok=True)
-        cmd.extend(["-v", f"{vm_data_dir}:{c_vm_data}"])
-    else:
-        if has_app_data:
-            cmd.extend(["-v", f"{app_data_dir}:{c_app_data}"])
-        if has_app_temp:
-            cmd.extend(["-v", f"{app_temp_dir}:{c_app_temp}"])
-        if has_vm_data:
-            os.makedirs(vm_data_dir, exist_ok=True)
-            cmd.extend(["-v", f"{vm_data_dir}:{c_vm_data}:ro"])
+    for host_path, container_path, options in mounts:
+        spec = f"{host_path}:{container_path}"
+        if options:
+            spec += f":{options}"
+        cmd.extend(["-v", spec])
 
     # Structured port mappings: bind TCP+UDP on 0.0.0.0
     if port_mappings:

--- a/compute_space/compute_space/core/containers.py
+++ b/compute_space/compute_space/core/containers.py
@@ -15,6 +15,41 @@ _ANSI_RE = re.compile(r"\x1b\[[0-9;]*[a-zA-Z]|\x1b\([AB0-9]|\x1b[=>]|\x0f|\r")
 _CACHE_CORRUPT_RE = re.compile(r"content digest sha256:[0-9a-f]+: not found")
 
 
+def _openhost_state_host_path(data_dir: str) -> str:
+    """Single source of truth for where the router's state dir lives on
+    the host. Used both by ``compute_data_mounts`` (to emit the mount)
+    and by ``_ensure_mount_host_dirs`` (to decide which mounts get
+    auto-created).
+    """
+    return os.path.join(data_dir, "openhost")
+
+
+def _ensure_mount_host_dirs(
+    mounts: list[tuple[str, str, str | None]], data_dir: str
+) -> None:
+    """Create the host side of each bind mount on demand, with one
+    exception: the router's own state directory is never auto-created.
+
+    For app-lifecycle paths (app_data, app_temp_data, vm_data) we
+    create the host directory on demand so a fresh install doesn't
+    fail the Docker bind-mount. Those paths are owned by the
+    app-lifecycle code and creating them empty is semantically
+    correct.
+
+    The openhost state directory is owned by the router and should
+    already exist (``Config.make_all_dirs`` creates it at router
+    startup). If it's missing, Docker's bind-mount will fail, which is
+    the right behaviour — silently creating an empty dir would let a
+    backup tool produce an empty backup instead of surfacing the
+    misconfiguration.
+    """
+    openhost_state_dir = _openhost_state_host_path(data_dir)
+    for host_path, _container_path, _options in mounts:
+        if host_path == openhost_state_dir:
+            continue
+        os.makedirs(host_path, exist_ok=True)
+
+
 def compute_data_mounts(
     manifest: AppManifest,
     app_name: str,
@@ -28,25 +63,31 @@ def compute_data_mounts(
     for a default read/write bind. The caller is expected to pass these
     into ``docker run -v``.
 
-    Resolution rules (each category is independent — any combination of
-    the three ``access_all_apps_*`` / ``access_vm_data*`` fields can be
-    requested):
+    This function doesn't validate the manifest — that happens at parse
+    time in ``parse_manifest_from_string``. It only interprets the
+    already-resolved ``wants_*`` properties on the manifest and emits
+    the corresponding mount tuples.
+
+    Emission rules:
 
     * For app_data and app_temp_data, a broad (parent-directory) mount
       shadows the scoped (single-app) mount; only the broader mount is
       emitted since the scoped path would be a subpath of it anyway.
-    * For vm_data, the manifest guarantees at most one of RO / RW is
-      active: parsing rejects ``access_vm_data`` (RO) together with
-      either ``access_vm_data_rw`` or the legacy ``access_all_data``
-      shorthand (both of which imply RW). This function just emits
-      whichever mount was requested.
+    * For vm_data, at most one of RO / RW is emitted. Simultaneous
+      RO+RW requests can't occur because the parser rejects them.
+    * ``access_openhost_state_ro`` emits a separate read-only mount
+      for the router's own state directory (SQLite DB, TLS material,
+      etc.). Writes to router state go through the router itself, not
+      through a mounted volume.
     """
     app_data_dir = os.path.join(data_dir, "app_data", app_name)
     app_temp_dir = os.path.join(temp_data_dir, "app_temp_data", app_name)
     vm_data_dir = os.path.join(data_dir, "vm_data")
+    openhost_state_dir = _openhost_state_host_path(data_dir)
     c_app_data = f"{CONTAINER_ROOT}/app_data/{app_name}"
     c_app_temp = f"{CONTAINER_ROOT}/app_temp_data/{app_name}"
     c_vm_data = f"{CONTAINER_ROOT}/vm_data"
+    c_openhost_state = f"{CONTAINER_ROOT}/openhost"
 
     mounts: list[tuple[str, str, str | None]] = []
 
@@ -76,6 +117,9 @@ def compute_data_mounts(
         mounts.append((vm_data_dir, c_vm_data, None))
     elif manifest.wants_vm_data_ro:
         mounts.append((vm_data_dir, c_vm_data, "ro"))
+
+    if manifest.wants_openhost_state_ro:
+        mounts.append((openhost_state_dir, c_openhost_state, "ro"))
 
     return mounts
 
@@ -169,8 +213,11 @@ def run_container(
     port_mappings: list[PortMapping] | None = None,
 ) -> str:
     """Run a Docker container. Returns the container ID."""
+    # app_data_dir is retained for env-var path translation below
+    # (OPENHOST_SQLITE_* variables that come in as host paths and need
+    # to be rewritten to the in-container layout). All mount host-path
+    # bookkeeping lives in ``compute_data_mounts``.
     app_data_dir = os.path.join(data_dir, "app_data", app_name)
-    vm_data_dir = os.path.join(data_dir, "vm_data")
     container_name = f"openhost-{app_name}"
 
     # Container paths follow the logical structure under CONTAINER_ROOT.
@@ -208,14 +255,8 @@ def run_container(
 
     # Mount data volumes following the logical structure from docs/data.md.
     # See ``compute_data_mounts`` for the permission-resolution rules.
-    # The vm_data dir is shared among apps and may not exist yet on a
-    # fresh install, so create it on demand if the manifest asks for it.
-    # Detecting that by host path is more robust than by container path,
-    # since the container-path scheme is defined inside
-    # ``compute_data_mounts`` and could drift.
     mounts = compute_data_mounts(manifest, app_name, data_dir, temp_data_dir)
-    if any(host == vm_data_dir for host, _container, _opts in mounts):
-        os.makedirs(vm_data_dir, exist_ok=True)
+    _ensure_mount_host_dirs(mounts, data_dir)
     for host_path, container_path, options in mounts:
         spec = f"{host_path}:{container_path}"
         if options:

--- a/compute_space/compute_space/core/data.py
+++ b/compute_space/compute_space/core/data.py
@@ -21,19 +21,22 @@ def provision_data(
     """Create data directories for an app based on manifest permissions.
     Returns a dict of environment variable name -> value.
 
-    Apps only get filesystem access to directories they explicitly request
-    via app_data and app_temp_data flags in [data]. SQLite entries
-    implicitly enable app_data.
+    Apps only get filesystem access to directories they explicitly
+    request in the manifest ``[data]`` section. This covers the scoped
+    flags (``app_data``, ``app_temp_data``, ``sqlite`` entries) and the
+    broad flags (``access_all_apps_data``, ``access_all_apps_temp_data``,
+    legacy ``access_all_data``) — any of which imply the app also wants
+    its own scoped directory and the associated env-var injection. See
+    ``AppManifest`` for the helper properties (``wants_own_app_data``,
+    ``wants_own_app_temp_data``) that fold these together.
     """
     app_data_dir = os.path.join(data_dir, "app_data", app_name)
     app_temp_dir = os.path.join(temp_data_dir, "app_temp_data", app_name)
     env_vars = {}
 
-    # Determine if permanent data dir is needed:
-    # explicitly requested, has sqlite entries, or access_all_data
-    needs_app_data = manifest.app_data or manifest.sqlite_dbs or manifest.access_all_data
-
-    if needs_app_data:
+    # Permission expansion (including the legacy ``access_all_data``
+    # shorthand) happens on the manifest itself — see AppManifest.
+    if manifest.wants_own_app_data:
         os.makedirs(app_data_dir, exist_ok=True)
         os.chmod(app_data_dir, 0o777)
         env_vars["OPENHOST_APP_DATA_DIR"] = app_data_dir
@@ -48,7 +51,7 @@ def provision_data(
             env_key = f"OPENHOST_SQLITE_{db_name}"
             env_vars[env_key] = db_path
 
-    if manifest.app_temp_data or manifest.access_all_data:
+    if manifest.wants_own_app_temp_data:
         os.makedirs(app_temp_dir, exist_ok=True)
         env_vars["OPENHOST_APP_TEMP_DIR"] = app_temp_dir
 

--- a/compute_space/compute_space/core/manifest.py
+++ b/compute_space/compute_space/core/manifest.py
@@ -58,15 +58,22 @@ class AppManifest:
     app_temp_data: bool = False
     # Read-only access to the shared VM data directory:
     access_vm_data: bool = False
-    # Broad access to all apps' data. Each of these three fields can be
-    # requested independently — you can, for example, grant an app the
-    # ability to read every app's permanent data without also granting it
-    # access to temp data or to vm_data. ``access_all_data`` is kept as
-    # legacy shorthand that implies all three of the ``access_all_*``
-    # fields below plus a read/write mount of ``vm_data``.
+    # Broad access to all apps' data / VM-level shared state. Each of
+    # these three fields can be requested independently — e.g. grant an
+    # app access to every other app's permanent data without also
+    # granting access to temp data or to vm_data. ``access_all_data``
+    # is kept as legacy shorthand equivalent to setting all three.
     access_all_apps_data: bool = False
     access_all_apps_temp_data: bool = False
     access_vm_data_rw: bool = False
+    # Read-only access to the OpenHost router's own state directory
+    # (``{persistent_data_dir}/openhost/``: router.db, TLS cert + key,
+    # Corefile, Caddyfile, signing keys, claim token). Intended for
+    # full-instance backup/inspection tools. NOT implied by
+    # ``access_all_data`` because existing manifests using that flag do
+    # not expect router-state exposure; apps that want it must opt in
+    # explicitly.
+    access_openhost_state_ro: bool = False
     access_all_data: bool = False
 
     # [services]
@@ -135,6 +142,17 @@ class AppManifest:
     def wants_vm_data_rw(self) -> bool:
         """Read/write access to ``/data/vm_data``."""
         return bool(self.access_all_data or self.access_vm_data_rw)
+
+    @property
+    def wants_openhost_state_ro(self) -> bool:
+        """Read-only access to ``{persistent_data_dir}/openhost/``.
+
+        Intended for full-instance inspection / backup tools that need
+        to read the router's SQLite DB, TLS material, and other
+        control-plane state. Not implied by ``access_all_data``: apps
+        must opt in explicitly via ``access_openhost_state_ro = true``.
+        """
+        return bool(self.access_openhost_state_ro)
 
 
 def _parse_ports(ports_list: list[Any]) -> list[PortMapping]:
@@ -210,6 +228,9 @@ def parse_manifest_from_string(raw_text: str) -> AppManifest:
             "access_all_apps_temp_data", False
         ),
         access_vm_data_rw=data_section.get("access_vm_data_rw", False),
+        access_openhost_state_ro=data_section.get(
+            "access_openhost_state_ro", False
+        ),
         access_all_data=data_section.get("access_all_data", False),
         raw_toml=raw_text,
     )

--- a/compute_space/compute_space/core/manifest.py
+++ b/compute_space/compute_space/core/manifest.py
@@ -53,9 +53,20 @@ class AppManifest:
 
     # [data]
     sqlite_dbs: list[str] = field(default_factory=list)
+    # Scoped-to-this-app access:
     app_data: bool = False
     app_temp_data: bool = False
+    # Read-only access to the shared VM data directory:
     access_vm_data: bool = False
+    # Broad access to all apps' data. Each of these three fields can be
+    # requested independently — you can, for example, grant an app the
+    # ability to read every app's permanent data without also granting it
+    # access to temp data or to vm_data. ``access_all_data`` is kept as
+    # legacy shorthand that implies all three of the ``access_all_*``
+    # fields below plus a read/write mount of ``vm_data``.
+    access_all_apps_data: bool = False
+    access_all_apps_temp_data: bool = False
+    access_vm_data_rw: bool = False
     access_all_data: bool = False
 
     # [services]
@@ -67,6 +78,63 @@ class AppManifest:
     hidden: bool = False
 
     raw_toml: str = ""
+
+    # ------------------------------------------------------------------
+    # Effective-permission helpers
+    # ------------------------------------------------------------------
+    #
+    # ``access_all_data`` is legacy shorthand meaning "give me everything".
+    # Rather than have every caller re-implement the "a or b or
+    # access_all_data" expansion, these helpers return the resolved
+    # permission set once so callers can consume them uniformly.
+
+    @property
+    def wants_own_app_data(self) -> bool:
+        """True if the app should see its own ``/data/app_data/<app>`` dir.
+
+        Requesting any of ``app_data``, ``sqlite`` entries, or the broad
+        shorthands (``access_all_apps_data``, ``access_all_data``) all
+        imply the app wants access to its own scoped permanent-data
+        directory. This is independent of the app's other filesystem
+        permissions — for example, an app with only ``app_temp_data``
+        set has no permanent-data access but can still see its scoped
+        temp directory.
+        """
+        return bool(
+            self.app_data
+            or self.sqlite_dbs
+            or self.access_all_data
+            or self.access_all_apps_data
+        )
+
+    @property
+    def wants_own_app_temp_data(self) -> bool:
+        """App's own ``/data/app_temp_data/<app>`` dir."""
+        return bool(
+            self.app_temp_data
+            or self.access_all_data
+            or self.access_all_apps_temp_data
+        )
+
+    @property
+    def wants_all_apps_data(self) -> bool:
+        """Parent ``/data/app_data`` dir, exposing every app's permanent data."""
+        return bool(self.access_all_data or self.access_all_apps_data)
+
+    @property
+    def wants_all_apps_temp_data(self) -> bool:
+        """Parent ``/data/app_temp_data`` dir, exposing every app's temp data."""
+        return bool(self.access_all_data or self.access_all_apps_temp_data)
+
+    @property
+    def wants_vm_data_ro(self) -> bool:
+        """Read-only access to ``/data/vm_data``."""
+        return bool(self.access_vm_data and not self.wants_vm_data_rw)
+
+    @property
+    def wants_vm_data_rw(self) -> bool:
+        """Read/write access to ``/data/vm_data``."""
+        return bool(self.access_all_data or self.access_vm_data_rw)
 
 
 def _parse_ports(ports_list: list[Any]) -> list[PortMapping]:
@@ -137,9 +205,27 @@ def parse_manifest_from_string(raw_text: str) -> AppManifest:
         app_data=data_section.get("app_data", False),
         app_temp_data=data_section.get("app_temp_data", False),
         access_vm_data=data_section.get("access_vm_data", False),
+        access_all_apps_data=data_section.get("access_all_apps_data", False),
+        access_all_apps_temp_data=data_section.get(
+            "access_all_apps_temp_data", False
+        ),
+        access_vm_data_rw=data_section.get("access_vm_data_rw", False),
         access_all_data=data_section.get("access_all_data", False),
         raw_toml=raw_text,
     )
+
+    # Reject obviously-contradictory combinations so manifests fail
+    # fast at parse time instead of producing surprising mount layouts.
+    # ``access_all_data`` implies RW on vm_data, so it conflicts with
+    # the RO form just like ``access_vm_data_rw`` does.
+    if manifest.access_vm_data and (
+        manifest.access_vm_data_rw or manifest.access_all_data
+    ):
+        raise ValueError(
+            "[data] access_vm_data (read-only) is mutually exclusive "
+            "with access_vm_data_rw and access_all_data (which imply "
+            "read-write access). Use one or the other."
+        )
 
     # Parse [services] section
     services = data.get("services", {})

--- a/compute_space/compute_space/web/templates/add_app.html
+++ b/compute_space/compute_space/web/templates/add_app.html
@@ -179,16 +179,31 @@ function renderManifest(m, url) {
     row('SQLite databases', m.sqlite_dbs.map(esc).join(', '));
   }
 
-  const hasFs = m.app_data || m.app_temp_data || m.access_vm_data || m.access_all_data || m.sqlite_dbs.length;
+  const hasFs = m.app_data || m.app_temp_data || m.access_vm_data
+    || m.access_vm_data_rw || m.access_all_apps_data
+    || m.access_all_apps_temp_data || m.access_all_data
+    || m.sqlite_dbs.length;
   if (hasFs) {
     section('Filesystem Permissions', '#fff3cd');
+    // access_all_data is the legacy "full power" shorthand; surface it
+    // explicitly so the user sees the aggregate they're granting.
     if (m.access_all_data) {
-      row('Full data access', 'Read/write to all permanent data, temporary data, and VM data');
+      row('Full data access', "Read/write to every app's permanent data and temporary data, plus read/write to VM shared data");
     } else {
+      // Scoped access — this app's own directory only.
       if (m.app_data || m.sqlite_dbs.length)
-        row('Permanent data', "Read/write to app's own permanent data directory");
-      if (m.app_temp_data) row('Temporary data', "Read/write to app's own temporary data directory");
-      if (m.access_vm_data) row('VM data', 'Read-only access to VM shared data');
+        row('Permanent data', "Read/write to this app's own permanent data directory");
+      if (m.app_temp_data)
+        row('Temporary data', "Read/write to this app's own temporary data directory");
+      // Broad access — parent mounts exposing every app's data.
+      if (m.access_all_apps_data)
+        row('All apps\u2019 permanent data', "Read/write to every app's permanent data directory");
+      if (m.access_all_apps_temp_data)
+        row('All apps\u2019 temporary data', "Read/write to every app's temporary data directory");
+      // VM data — read-only and read/write are mutually exclusive at
+      // manifest parse time, so at most one of these is ever true.
+      if (m.access_vm_data) row('VM data (read-only)', 'Read-only access to VM shared data');
+      if (m.access_vm_data_rw) row('VM data (read/write)', 'Read/write access to VM shared data');
     }
   }
 

--- a/compute_space/compute_space/web/templates/add_app.html
+++ b/compute_space/compute_space/web/templates/add_app.html
@@ -182,11 +182,14 @@ function renderManifest(m, url) {
   const hasFs = m.app_data || m.app_temp_data || m.access_vm_data
     || m.access_vm_data_rw || m.access_all_apps_data
     || m.access_all_apps_temp_data || m.access_all_data
+    || m.access_openhost_state_ro
     || m.sqlite_dbs.length;
   if (hasFs) {
     section('Filesystem Permissions', '#fff3cd');
-    // access_all_data is the legacy "full power" shorthand; surface it
-    // explicitly so the user sees the aggregate they're granting.
+    // access_all_data is the legacy "full power" shorthand for the
+    // three data categories (app_data / app_temp_data / vm_data).
+    // It does NOT imply access_openhost_state_ro — that's an
+    // independent opt-in for full-instance tools.
     if (m.access_all_data) {
       row('Full data access', "Read/write to every app's permanent data and temporary data, plus read/write to VM shared data");
     } else {
@@ -205,6 +208,10 @@ function renderManifest(m, url) {
       if (m.access_vm_data) row('VM data (read-only)', 'Read-only access to VM shared data');
       if (m.access_vm_data_rw) row('VM data (read/write)', 'Read/write access to VM shared data');
     }
+    // Surfaced regardless of access_all_data since it's an independent flag.
+    if (m.access_openhost_state_ro)
+      row('Router state (read-only)',
+          "Read-only access to the OpenHost router's own state directory (router.db, TLS material, signing keys). Intended for full-instance backup/inspection tools. Grants visibility into all apps' API tokens and the owner password hash.");
   }
 
   if (m.public_paths.length) {

--- a/compute_space/tests/test_containers_mounts.py
+++ b/compute_space/tests/test_containers_mounts.py
@@ -159,6 +159,98 @@ class TestLegacyAccessAllData:
         assert legacy == fine
 
 
+class TestOpenhostStateMount:
+    def test_access_openhost_state_ro_alone(self):
+        # Asking for router-state access only — no data mounts at all.
+        mounts = _mounts(access_openhost_state_ro=True)
+        assert mounts == [("/host/data/openhost", "/data/openhost", "ro")]
+
+    def test_access_openhost_state_ro_with_access_all_data(self):
+        # Stacks cleanly on top of the legacy shorthand. Order: the
+        # three data-category mounts first, then openhost last.
+        mounts = _mounts(access_all_data=True, access_openhost_state_ro=True)
+        assert mounts == [
+            ("/host/data/app_data", "/data/app_data", None),
+            ("/host/temp/app_temp_data", "/data/app_temp_data", None),
+            ("/host/data/vm_data", "/data/vm_data", None),
+            ("/host/data/openhost", "/data/openhost", "ro"),
+        ]
+
+    def test_access_all_data_alone_does_not_mount_openhost_state(self):
+        # Guarantees the backward-compat invariant at the mount layer:
+        # existing manifests using only access_all_data must never
+        # expose /data/openhost.
+        mounts = _mounts(access_all_data=True)
+        assert all(m[1] != "/data/openhost" for m in mounts)
+
+    def test_openhost_state_host_path_helper_matches_mount(self):
+        # The host-side path for the router state dir is computed in
+        # two places (compute_data_mounts emits it into the mount
+        # tuple; run_container uses it as a sentinel for the
+        # no-autocreate guard). The shared helper exists specifically
+        # so these two places can never drift — pin that here.
+        from compute_space.core.containers import _openhost_state_host_path
+
+        mounts = _mounts(access_openhost_state_ro=True)
+        assert mounts[0][0] == _openhost_state_host_path("/host/data")
+
+
+class TestEnsureMountHostDirs:
+    """``_ensure_mount_host_dirs`` creates all requested host paths
+    except the router's own state dir, which is intentionally left
+    alone so a missing router dir fails loudly rather than silently
+    producing an empty backup."""
+
+    def test_creates_app_data_and_vm_data_dirs(self, tmp_path):
+        from compute_space.core.containers import _ensure_mount_host_dirs
+
+        data_dir = str(tmp_path / "data")
+        temp_dir = str(tmp_path / "temp")
+        mounts = [
+            (f"{data_dir}/app_data/testapp", "/data/app_data/testapp", None),
+            (f"{data_dir}/vm_data", "/data/vm_data", None),
+            (f"{temp_dir}/app_temp_data/testapp", "/data/app_temp_data/testapp", None),
+        ]
+        _ensure_mount_host_dirs(mounts, data_dir)
+        import os as _os
+
+        for host, _c, _o in mounts:
+            assert _os.path.isdir(host), f"{host} should have been created"
+
+    def test_does_not_create_openhost_state_dir(self, tmp_path):
+        """Even if the openhost mount is requested, the host dir
+        is not auto-created. Docker will fail the bind-mount on its
+        own if the dir is missing — that's the intended behaviour."""
+        from compute_space.core.containers import _ensure_mount_host_dirs
+
+        data_dir = str(tmp_path / "data")
+        mounts = [
+            (f"{data_dir}/openhost", "/data/openhost", "ro"),
+        ]
+        _ensure_mount_host_dirs(mounts, data_dir)
+        import os as _os
+
+        # Still absent.
+        assert not _os.path.exists(f"{data_dir}/openhost")
+
+    def test_creates_others_even_if_openhost_requested_too(self, tmp_path):
+        from compute_space.core.containers import _ensure_mount_host_dirs
+
+        data_dir = str(tmp_path / "data")
+        mounts = [
+            (f"{data_dir}/app_data", "/data/app_data", None),
+            (f"{data_dir}/vm_data", "/data/vm_data", None),
+            (f"{data_dir}/openhost", "/data/openhost", "ro"),
+        ]
+        _ensure_mount_host_dirs(mounts, data_dir)
+        import os as _os
+
+        assert _os.path.isdir(f"{data_dir}/app_data")
+        assert _os.path.isdir(f"{data_dir}/vm_data")
+        # openhost specifically skipped.
+        assert not _os.path.exists(f"{data_dir}/openhost")
+
+
 class TestManifestRejection:
     def test_vm_data_ro_and_rw_rejected_at_parse_time(self):
         toml = MINIMAL + "\n[data]\naccess_vm_data = true\naccess_vm_data_rw = true\n"

--- a/compute_space/tests/test_containers_mounts.py
+++ b/compute_space/tests/test_containers_mounts.py
@@ -1,0 +1,173 @@
+"""Unit tests for the container data-mount resolver.
+
+Exercises the permission-resolution rules in
+``compute_space.core.containers.compute_data_mounts`` without actually
+running Docker. These are complementary to ``test_manifest.py``, which
+covers the manifest fields in isolation.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from compute_space.core.containers import compute_data_mounts
+from compute_space.core.manifest import parse_manifest_from_string
+
+MINIMAL = """\
+[app]
+name = "testapp"
+version = "0.1.0"
+
+[runtime.container]
+image = "Dockerfile"
+port = 8080
+"""
+
+
+def _mounts(**flags):
+    """Build a manifest from flags and return the resolved mounts list."""
+    lines = ["[data]"]
+    for k, v in flags.items():
+        if isinstance(v, list):
+            lines.append(f"{k} = {v!r}".replace("'", '"'))
+        else:
+            lines.append(f"{k} = {str(v).lower()}")
+    toml = MINIMAL + "\n" + "\n".join(lines) + "\n"
+    manifest = parse_manifest_from_string(toml)
+    return compute_data_mounts(
+        manifest, "testapp", data_dir="/host/data", temp_data_dir="/host/temp"
+    )
+
+
+class TestDefaultNoAccess:
+    def test_no_data_section_produces_no_mounts(self):
+        manifest = parse_manifest_from_string(MINIMAL)
+        mounts = compute_data_mounts(manifest, "testapp", "/host/data", "/host/temp")
+        assert mounts == []
+
+
+class TestScopedMounts:
+    def test_app_data_only(self):
+        mounts = _mounts(app_data=True)
+        assert mounts == [
+            ("/host/data/app_data/testapp", "/data/app_data/testapp", None)
+        ]
+
+    def test_app_temp_data_only(self):
+        mounts = _mounts(app_temp_data=True)
+        assert mounts == [
+            ("/host/temp/app_temp_data/testapp", "/data/app_temp_data/testapp", None)
+        ]
+
+    def test_both_scoped(self):
+        mounts = _mounts(app_data=True, app_temp_data=True)
+        assert mounts == [
+            ("/host/data/app_data/testapp", "/data/app_data/testapp", None),
+            ("/host/temp/app_temp_data/testapp", "/data/app_temp_data/testapp", None),
+        ]
+
+
+class TestVmDataMounts:
+    def test_vm_data_ro(self):
+        mounts = _mounts(access_vm_data=True)
+        assert mounts == [("/host/data/vm_data", "/data/vm_data", "ro")]
+
+    def test_vm_data_rw(self):
+        mounts = _mounts(access_vm_data_rw=True)
+        assert mounts == [("/host/data/vm_data", "/data/vm_data", None)]
+
+
+class TestBroadMounts:
+    def test_all_apps_data_only(self):
+        mounts = _mounts(access_all_apps_data=True)
+        # Parent mount; no scoped mount, no temp, no vm_data.
+        assert mounts == [("/host/data/app_data", "/data/app_data", None)]
+
+    def test_all_apps_data_shadows_scoped(self):
+        # Requesting both broad + scoped results in only the broad mount
+        # (the scoped path would be shadowed anyway).
+        mounts = _mounts(access_all_apps_data=True, app_data=True)
+        assert mounts == [("/host/data/app_data", "/data/app_data", None)]
+
+    def test_all_apps_temp_data_only(self):
+        mounts = _mounts(access_all_apps_temp_data=True)
+        assert mounts == [
+            ("/host/temp/app_temp_data", "/data/app_temp_data", None)
+        ]
+
+    def test_all_apps_temp_data_shadows_scoped(self):
+        # Symmetric to the app_data shadowing test above.
+        mounts = _mounts(access_all_apps_temp_data=True, app_temp_data=True)
+        assert mounts == [
+            ("/host/temp/app_temp_data", "/data/app_temp_data", None)
+        ]
+
+
+class TestSqliteImpliesAppData:
+    def test_sqlite_alone_enables_scoped_mount(self):
+        # Requesting ``sqlite`` entries is a shorthand for ``app_data``;
+        # it must produce the same scoped mount as requesting app_data
+        # directly.
+        mounts = _mounts(sqlite=["main"])
+        assert mounts == [
+            ("/host/data/app_data/testapp", "/data/app_data/testapp", None)
+        ]
+
+
+class TestIndependentCombinations:
+    def test_all_apps_data_plus_vm_ro(self):
+        # Classic "inspect the host" permission set: see every app's
+        # permanent data + read-only vm_data, nothing else.
+        mounts = _mounts(access_all_apps_data=True, access_vm_data=True)
+        assert mounts == [
+            ("/host/data/app_data", "/data/app_data", None),
+            ("/host/data/vm_data", "/data/vm_data", "ro"),
+        ]
+
+    def test_all_apps_temp_data_plus_vm_rw(self):
+        mounts = _mounts(
+            access_all_apps_temp_data=True, access_vm_data_rw=True
+        )
+        assert mounts == [
+            ("/host/temp/app_temp_data", "/data/app_temp_data", None),
+            ("/host/data/vm_data", "/data/vm_data", None),
+        ]
+
+    def test_all_three_broad(self):
+        mounts = _mounts(
+            access_all_apps_data=True,
+            access_all_apps_temp_data=True,
+            access_vm_data_rw=True,
+        )
+        assert mounts == [
+            ("/host/data/app_data", "/data/app_data", None),
+            ("/host/temp/app_temp_data", "/data/app_temp_data", None),
+            ("/host/data/vm_data", "/data/vm_data", None),
+        ]
+
+
+class TestLegacyAccessAllData:
+    def test_access_all_data_equivalent_to_all_three_broad(self):
+        # The legacy shorthand should produce the same mount set as
+        # requesting all three fine-grained flags independently.
+        legacy = _mounts(access_all_data=True)
+        fine = _mounts(
+            access_all_apps_data=True,
+            access_all_apps_temp_data=True,
+            access_vm_data_rw=True,
+        )
+        assert legacy == fine
+
+
+class TestManifestRejection:
+    def test_vm_data_ro_and_rw_rejected_at_parse_time(self):
+        toml = MINIMAL + "\n[data]\naccess_vm_data = true\naccess_vm_data_rw = true\n"
+        with pytest.raises(ValueError, match="mutually exclusive"):
+            parse_manifest_from_string(toml)
+
+    def test_vm_data_ro_plus_access_all_data_rejected_at_parse_time(self):
+        # Parse-time contradiction even though ``access_all_data`` grants
+        # vm_data via a different flag (implicit RW).
+        toml = MINIMAL + "\n[data]\naccess_vm_data = true\naccess_all_data = true\n"
+        with pytest.raises(ValueError, match="mutually exclusive"):
+            parse_manifest_from_string(toml)

--- a/compute_space/tests/test_integration.py
+++ b/compute_space/tests/test_integration.py
@@ -74,6 +74,90 @@ def test_sqlite_provisioning():
         assert not os.path.exists(env_vars["OPENHOST_SQLITE_cache"])
 
 
+def _provision(tmp_path, **manifest_kwargs):
+    """Run provision_data against pytest-managed temp dirs and return
+    ``(env_vars, data_dir, temp_dir)`` for assertions.
+
+    ``tmp_path`` is pytest's per-test tempdir fixture, which pytest
+    cleans up automatically — that's the whole reason this helper takes
+    it as an argument rather than calling ``tempfile.mkdtemp`` itself.
+    """
+    data_dir = str(tmp_path / "data")
+    temp_dir = str(tmp_path / "temp")
+    os.makedirs(data_dir, exist_ok=True)
+    os.makedirs(temp_dir, exist_ok=True)
+    manifest = AppManifest(
+        name="testapp",
+        version="0.1.0",
+        container_image="alpine:latest",
+        container_port=8080,
+        **manifest_kwargs,
+    )
+    env_vars = provision_data(
+        "testapp",
+        manifest,
+        data_dir,
+        temp_dir,
+        my_openhost_redirect_domain="my.test.example.com",
+        zone_domain="test.example.com",
+        port=manifest.container_port,
+    )
+    return env_vars, data_dir, temp_dir
+
+
+def test_provision_data_scoped_app_data(tmp_path):
+    """``app_data = true`` provisions the scoped dir and sets the env var."""
+    env_vars, data_dir, _temp_dir = _provision(tmp_path, app_data=True)
+    scoped = os.path.join(data_dir, "app_data", "testapp")
+    assert os.path.isdir(scoped)
+    assert env_vars["OPENHOST_APP_DATA_DIR"] == scoped
+    assert "OPENHOST_APP_TEMP_DIR" not in env_vars
+
+
+def test_provision_data_scoped_app_temp_data(tmp_path):
+    env_vars, _data_dir, temp_dir = _provision(tmp_path, app_temp_data=True)
+    scoped = os.path.join(temp_dir, "app_temp_data", "testapp")
+    assert os.path.isdir(scoped)
+    assert env_vars["OPENHOST_APP_TEMP_DIR"] == scoped
+    assert "OPENHOST_APP_DATA_DIR" not in env_vars
+
+
+def test_provision_data_access_all_apps_data_creates_scoped_dir(tmp_path):
+    """Requesting broad access also creates the scoped dir + env var so
+    the app can write to its own namespace via the familiar path."""
+    env_vars, data_dir, _ = _provision(tmp_path, access_all_apps_data=True)
+    scoped = os.path.join(data_dir, "app_data", "testapp")
+    assert os.path.isdir(scoped)
+    assert env_vars["OPENHOST_APP_DATA_DIR"] == scoped
+
+
+def test_provision_data_access_all_apps_temp_data_creates_scoped_dir(tmp_path):
+    env_vars, _data_dir, temp_dir = _provision(
+        tmp_path, access_all_apps_temp_data=True
+    )
+    scoped = os.path.join(temp_dir, "app_temp_data", "testapp")
+    assert os.path.isdir(scoped)
+    assert env_vars["OPENHOST_APP_TEMP_DIR"] == scoped
+    # Symmetric to test_provision_data_scoped_app_temp_data: granting
+    # temp-only broad access must NOT implicitly grant permanent-data
+    # access.
+    assert "OPENHOST_APP_DATA_DIR" not in env_vars
+
+
+def test_provision_data_legacy_access_all_data_provisions_both(tmp_path):
+    env_vars, data_dir, temp_dir = _provision(tmp_path, access_all_data=True)
+    assert os.path.isdir(os.path.join(data_dir, "app_data", "testapp"))
+    assert os.path.isdir(os.path.join(temp_dir, "app_temp_data", "testapp"))
+    assert "OPENHOST_APP_DATA_DIR" in env_vars
+    assert "OPENHOST_APP_TEMP_DIR" in env_vars
+
+
+def test_provision_data_no_data_section_emits_no_data_env_vars(tmp_path):
+    env_vars, _data_dir, _temp_dir = _provision(tmp_path)
+    assert "OPENHOST_APP_DATA_DIR" not in env_vars
+    assert "OPENHOST_APP_TEMP_DIR" not in env_vars
+
+
 def test_pre_setup_security_audit(tmp_path):
     """Security audit via /health returns valid results before owner setup."""
     ROUTER_PORT = 18084

--- a/compute_space/tests/test_integration.py
+++ b/compute_space/tests/test_integration.py
@@ -158,6 +158,26 @@ def test_provision_data_no_data_section_emits_no_data_env_vars(tmp_path):
     assert "OPENHOST_APP_TEMP_DIR" not in env_vars
 
 
+def test_provision_data_access_openhost_state_ro_is_a_noop(tmp_path):
+    """Router state is owned by the router — provision_data must NOT
+    create the /data/openhost dir or inject env vars for it."""
+    env_vars, data_dir, _temp_dir = _provision(
+        tmp_path, access_openhost_state_ro=True
+    )
+    # No app_data env var — this flag doesn't imply scoped app_data access.
+    assert "OPENHOST_APP_DATA_DIR" not in env_vars
+    # (app_temp_dir is always created by provision_data for internal
+    # use — build logs, repo clones — even when the app has no data
+    # permissions, so we don't assert it doesn't exist here.)
+    #
+    # The /data/openhost dir is the router's own path and
+    # provision_data must not pre-create it.
+    assert not os.path.exists(os.path.join(data_dir, "openhost"))
+    # No OPENHOST_OPENHOST_STATE_DIR or similar spurious env var.
+    for k in env_vars:
+        assert "openhost_state" not in k.lower()
+
+
 def test_pre_setup_security_audit(tmp_path):
     """Security audit via /health returns valid results before owner setup."""
     ROUTER_PORT = 18084

--- a/compute_space/tests/test_manifest.py
+++ b/compute_space/tests/test_manifest.py
@@ -51,6 +51,7 @@ class TestDefaults:
         assert manifest.access_all_apps_data is False
         assert manifest.access_all_apps_temp_data is False
         assert manifest.access_vm_data_rw is False
+        assert manifest.access_openhost_state_ro is False
 
     def test_sqlite_default_empty(self):
         manifest = parse_manifest_from_string(MINIMAL)
@@ -468,3 +469,27 @@ class TestFineGrainedDataAccess:
         assert m.wants_all_apps_data is False
         assert m.wants_all_apps_temp_data is True
         assert m.wants_vm_data_rw is True
+
+    # ----- access_openhost_state_ro -----
+
+    def test_access_openhost_state_ro_parsed(self):
+        m = parse_manifest_from_string(self._with_data(access_openhost_state_ro=True))
+        assert m.access_openhost_state_ro is True
+        assert m.wants_openhost_state_ro is True
+
+    def test_access_all_data_does_NOT_imply_openhost_state(self):
+        # Key backward-compatibility guarantee: existing manifests that
+        # set access_all_data must not silently gain access to the
+        # router's state directory. That permission is always opt-in.
+        m = parse_manifest_from_string(self._with_data(access_all_data=True))
+        assert m.wants_openhost_state_ro is False
+
+    def test_openhost_state_ro_composes_with_other_permissions(self):
+        # It's a standalone flag, so pair it with anything and both
+        # should resolve independently.
+        m = parse_manifest_from_string(
+            self._with_data(access_all_data=True, access_openhost_state_ro=True)
+        )
+        assert m.wants_all_apps_data is True
+        assert m.wants_vm_data_rw is True
+        assert m.wants_openhost_state_ro is True

--- a/compute_space/tests/test_manifest.py
+++ b/compute_space/tests/test_manifest.py
@@ -48,6 +48,9 @@ class TestDefaults:
         assert manifest.app_temp_data is False
         assert manifest.access_vm_data is False
         assert manifest.access_all_data is False
+        assert manifest.access_all_apps_data is False
+        assert manifest.access_all_apps_temp_data is False
+        assert manifest.access_vm_data_rw is False
 
     def test_sqlite_default_empty(self):
         manifest = parse_manifest_from_string(MINIMAL)
@@ -340,3 +343,128 @@ class TestValidation:
         toml = '[app]\nname = "x"\nversion = "1"\n[runtime.container]\nimage = "Dockerfile"\n'
         with pytest.raises(ValueError, match="port"):
             parse_manifest_from_string(toml)
+
+
+class TestFineGrainedDataAccess:
+    """Verify the independently-requestable data access flags."""
+
+    def _with_data(self, **flags):
+        """Build a minimal manifest with a [data] section."""
+        lines = ["[data]"]
+        for k, v in flags.items():
+            lines.append(f"{k} = {str(v).lower()}")
+        return MINIMAL + "\n" + "\n".join(lines) + "\n"
+
+    # ----- parsing -----
+
+    def test_access_all_apps_data_parsed(self):
+        m = parse_manifest_from_string(self._with_data(access_all_apps_data=True))
+        assert m.access_all_apps_data is True
+        assert m.access_all_apps_temp_data is False
+        assert m.access_vm_data_rw is False
+        assert m.access_all_data is False
+
+    def test_access_all_apps_temp_data_parsed(self):
+        m = parse_manifest_from_string(self._with_data(access_all_apps_temp_data=True))
+        assert m.access_all_apps_temp_data is True
+
+    def test_access_vm_data_rw_parsed(self):
+        m = parse_manifest_from_string(self._with_data(access_vm_data_rw=True))
+        assert m.access_vm_data_rw is True
+
+    def test_vm_data_ro_and_rw_mutually_exclusive(self):
+        toml = self._with_data(access_vm_data=True, access_vm_data_rw=True)
+        with pytest.raises(ValueError, match="mutually exclusive"):
+            parse_manifest_from_string(toml)
+
+    def test_vm_data_ro_and_access_all_data_mutually_exclusive(self):
+        # access_all_data implies RW on vm_data, so combining it with
+        # an explicit RO request is contradictory.
+        toml = self._with_data(access_vm_data=True, access_all_data=True)
+        with pytest.raises(ValueError, match="mutually exclusive"):
+            parse_manifest_from_string(toml)
+
+    def test_vm_data_rw_and_access_all_data_is_accepted_as_redundant(self):
+        # Documented in manifest_spec.md as "redundant but accepted":
+        # both flags imply RW on vm_data, so there's no contradiction,
+        # and the effective permissions are identical to either alone.
+        m = parse_manifest_from_string(
+            self._with_data(access_vm_data_rw=True, access_all_data=True)
+        )
+        assert m.wants_vm_data_rw is True
+        assert m.wants_vm_data_ro is False
+
+    # ----- effective-permission helpers -----
+
+    def test_wants_own_app_data_defaults_false(self):
+        m = parse_manifest_from_string(MINIMAL)
+        assert m.wants_own_app_data is False
+        assert m.wants_own_app_temp_data is False
+        assert m.wants_all_apps_data is False
+        assert m.wants_all_apps_temp_data is False
+        assert m.wants_vm_data_ro is False
+        assert m.wants_vm_data_rw is False
+
+    def test_app_data_enables_own_app_data(self):
+        m = parse_manifest_from_string(self._with_data(app_data=True))
+        assert m.wants_own_app_data is True
+        assert m.wants_all_apps_data is False
+
+    def test_app_temp_data_enables_own_app_temp_data(self):
+        m = parse_manifest_from_string(self._with_data(app_temp_data=True))
+        assert m.wants_own_app_temp_data is True
+        assert m.wants_own_app_data is False
+        assert m.wants_all_apps_temp_data is False
+
+    def test_sqlite_enables_own_app_data(self):
+        toml = MINIMAL + '\n[data]\nsqlite = ["main"]\n'
+        m = parse_manifest_from_string(toml)
+        assert m.wants_own_app_data is True
+
+    def test_access_all_apps_data_enables_both_own_and_parent(self):
+        # Parent-level access implicitly covers the app's own dir — but
+        # the mount layout in containers.py will shadow the scoped mount
+        # with the parent.
+        m = parse_manifest_from_string(self._with_data(access_all_apps_data=True))
+        assert m.wants_own_app_data is True
+        assert m.wants_all_apps_data is True
+
+    def test_access_all_data_is_shorthand_for_everything(self):
+        m = parse_manifest_from_string(self._with_data(access_all_data=True))
+        assert m.wants_own_app_data is True
+        assert m.wants_own_app_temp_data is True
+        assert m.wants_all_apps_data is True
+        assert m.wants_all_apps_temp_data is True
+        assert m.wants_vm_data_rw is True
+        # RO is suppressed because RW wins.
+        assert m.wants_vm_data_ro is False
+
+    def test_vm_data_ro_only(self):
+        m = parse_manifest_from_string(self._with_data(access_vm_data=True))
+        assert m.wants_vm_data_ro is True
+        assert m.wants_vm_data_rw is False
+
+    def test_vm_data_rw_suppresses_ro(self):
+        m = parse_manifest_from_string(self._with_data(access_vm_data_rw=True))
+        assert m.wants_vm_data_ro is False
+        assert m.wants_vm_data_rw is True
+
+    def test_independent_combination_all_apps_data_plus_vm_ro(self):
+        # "I want to inspect every app's permanent data + read vm_data.
+        # I do NOT want to touch temp data or modify vm_data."
+        m = parse_manifest_from_string(
+            self._with_data(access_all_apps_data=True, access_vm_data=True)
+        )
+        assert m.wants_all_apps_data is True
+        assert m.wants_all_apps_temp_data is False
+        assert m.wants_vm_data_ro is True
+        assert m.wants_vm_data_rw is False
+
+    def test_independent_combination_temp_data_plus_vm_rw(self):
+        # Another arbitrary combination — all three categories independent.
+        m = parse_manifest_from_string(
+            self._with_data(access_all_apps_temp_data=True, access_vm_data_rw=True)
+        )
+        assert m.wants_all_apps_data is False
+        assert m.wants_all_apps_temp_data is True
+        assert m.wants_vm_data_rw is True

--- a/docs/creating_an_app.md
+++ b/docs/creating_an_app.md
@@ -102,19 +102,27 @@ The router injects these environment variables into your app:
 | `OPENHOST_ROUTER_URL` | `http://host.docker.internal:8080` | internal URL of the router, used for constructing service requests                                              |
 | `OPENHOST_ZONE_DOMAIN` | `user.host.imbue.com` | The compute space's domain                                                                                      |
 | `OPENHOST_MY_REDIRECT_DOMAIN` | `my.selfhost.imbue.com` | The shared `my.*` OAuth redirect domain. This hosts a browser-local page that redirects the user to their zone. |
-| `OPENHOST_APP_DATA_DIR` | `/data/app_data/my-app` | Path to the app's persistent data directory. Set when `app_data`, `sqlite`, or `access_all_data` is requested   |
-| `OPENHOST_APP_TEMP_DIR` | `/data/app_temp_data/my-app` | Path to the app's temporary data directory. Set when `app_temp_data` or `access_all_data` is requested          |
+| `OPENHOST_APP_DATA_DIR` | `/data/app_data/my-app` | Path to the app's persistent data directory. Set when `app_data`, `sqlite`, `access_all_apps_data`, or `access_all_data` is requested |
+| `OPENHOST_APP_TEMP_DIR` | `/data/app_temp_data/my-app` | Path to the app's temporary data directory. Set when `app_temp_data`, `access_all_apps_temp_data`, or `access_all_data` is requested  |
 | `OPENHOST_SQLITE_<NAME>` | `/data/app_data/my-app/sqlite/main.db` (for `sqlite = ["main"]`) | Path to a provisioned SQLite database file. Set once per entry in `sqlite`                                      |
 
 ### Data storage
 
-Apps have no filesystem access by default. Request what you need in the `[data]` section of your manifest:
+Apps have no filesystem access by default. Request what you need in the `[data]` section of your manifest. Categories are independent — any combination is valid.
 
-- **`sqlite = ["db_name"]`** — Provisions a SQLite database. Access the file at `OPENHOST_SQLITE_<NAME>`.
-- **`app_data = true`** — mounts a persistent directory at `/data/app_data/{app_name}/`. Backed up.
-- **`app_temp_data = true`** — mounts a temporary directory at `/data/app_temp_data/{app_name}/`. Not backed up, can be recreated.
-- **`access_vm_data = true`** — read-only access to the VM's shared data at `/data/vm_data/`.
-- **`access_all_data = true`** — full access to all data directories (all apps' data + VM data).
+Scoped to just this app:
+
+- **`sqlite = ["db_name"]`** — provisions a SQLite database file. Implies `app_data`.
+- **`app_data = true`** — mounts `/data/app_data/{app_name}/` inside the container. Backed up.
+- **`app_temp_data = true`** — mounts `/data/app_temp_data/{app_name}/`. Not backed up.
+
+Broad access to all apps' data or the VM's shared state (use sparingly):
+
+- **`access_all_apps_data = true`** — read/write mount of `/data/app_data/` (every app's persistent data).
+- **`access_all_apps_temp_data = true`** — read/write mount of `/data/app_temp_data/` (every app's temp data).
+- **`access_vm_data = true`** — read-only mount of `/data/vm_data/`.
+- **`access_vm_data_rw = true`** — read/write mount of `/data/vm_data/`. Mutually exclusive with `access_vm_data`.
+- **`access_all_data = true`** — legacy shorthand for all three broad flags (`access_all_apps_data` + `access_all_apps_temp_data` + `access_vm_data_rw`).
 
 The host operator can optionally set `storage_min_free_mb` in the OpenHost config to require a minimum amount of free persistent storage. When free space drops below this threshold, running apps are stopped until space is freed. The storage guard can be temporarily paused from the dashboard to allow starting a file-browser app for cleanup.
 

--- a/docs/creating_an_app.md
+++ b/docs/creating_an_app.md
@@ -122,7 +122,8 @@ Broad access to all apps' data or the VM's shared state (use sparingly):
 - **`access_all_apps_temp_data = true`** — read/write mount of `/data/app_temp_data/` (every app's temp data).
 - **`access_vm_data = true`** — read-only mount of `/data/vm_data/`.
 - **`access_vm_data_rw = true`** — read/write mount of `/data/vm_data/`. Mutually exclusive with `access_vm_data`.
-- **`access_all_data = true`** — legacy shorthand for all three broad flags (`access_all_apps_data` + `access_all_apps_temp_data` + `access_vm_data_rw`).
+- **`access_openhost_state_ro = true`** — read-only mount of the router's own state directory (`/data/openhost/`: `router.db`, TLS material, signing keys). Intended for full-instance backup or inspection tools. Not implied by `access_all_data`.
+- **`access_all_data = true`** — legacy shorthand for the three data-category broad flags (`access_all_apps_data` + `access_all_apps_temp_data` + `access_vm_data_rw`). Does **not** include router state; request `access_openhost_state_ro` separately if you need it.
 
 The host operator can optionally set `storage_min_free_mb` in the OpenHost config to require a minimum amount of free persistent storage. When free space drops below this threshold, running apps are stopped until space is freed. The storage guard can be temporarily paused from the dashboard to allow starting a file-browser app for cleanup.
 

--- a/docs/manifest_spec.md
+++ b/docs/manifest_spec.md
@@ -51,33 +51,72 @@ Declares additional port mappings for the container. Each entry binds a containe
 
 ### `[data]` — optional
 
+Apps must explicitly request filesystem access. Each category (permanent
+data, temporary data, VM data) can be requested for this app alone
+(scoped) or for every app on the host (broad). Any combination is
+allowed.
+
+#### Scoped access — just this app
+
 | Field | Type | Required | Default | Description |
 |-------|------|----------|---------|-------------|
-| `app_data` | boolean | no | false | Request access to permanent filesystem directory (backed up) |
-| `app_temp_data` | boolean | no | false | Request access to temporary filesystem directory (not backed up) |
-| `sqlite` | string[] | no | [] | SQLite database names to provision (implicitly enables `app_data`) |
-| `access_vm_data` | boolean | no | false | Whether the app can access the VM's shared data directory |
-| `access_all_data` | boolean | no | false | Full access to permanent data, temp data, and vm data |
+| `app_data` | boolean | no | false | Mount this app's permanent data directory at `/data/app_data/<app>` (backed up) |
+| `app_temp_data` | boolean | no | false | Mount this app's temporary directory at `/data/app_temp_data/<app>` (not backed up) |
+| `sqlite` | string[] | no | `[]` | SQLite database names to provision (implicitly enables `app_data`) |
+
+#### Broad access — every app's data / shared state
+
+Use these to write apps that manage or inspect state across the whole
+host (backup/restore, file browsers, debugging tools). All three can be
+requested independently.
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `access_all_apps_data` | boolean | no | false | Read/write mount of `/data/app_data` (every app's permanent data) |
+| `access_all_apps_temp_data` | boolean | no | false | Read/write mount of `/data/app_temp_data` (every app's temporary data) |
+| `access_vm_data` | boolean | no | false | Read-only mount of `/data/vm_data` (router DB, shared state) |
+| `access_vm_data_rw` | boolean | no | false | Read/write mount of `/data/vm_data`. Mutually exclusive with `access_vm_data` (RO). Combining with `access_all_data` is redundant but accepted, since the legacy shorthand already grants RW. |
+
+#### Legacy shorthand
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `access_all_data` | boolean | no | false | Shorthand equivalent to `access_all_apps_data = true`, `access_all_apps_temp_data = true`, and `access_vm_data_rw = true`. |
 
 ## Data Directory Structure
 
-Apps have two storage areas on separate disks. **By default, apps have no filesystem access.** Each must be explicitly requested:
+Apps have two storage areas on separate disks. **By default, apps have
+no filesystem access.** Each must be explicitly requested:
 
-- **Permanent data** (`/data/app_data/{app_name}/`) — backed up, user-visible. Enabled by `app_data = true` or by requesting `sqlite` entries.
-- **Temporary data** (`/data/app_temp_data/{app_name}/`) — not backed up, recreatable. Enabled by `app_temp_data = true`.
-- **VM data** (`/data/vm_data/`) — router database and VM-level shared data. Only accessible if `access_vm_data = true`.
+- **Permanent data** (`/data/app_data/{app_name}/`) — backed up,
+  user-visible. Enabled by `app_data = true` or by requesting `sqlite`
+  entries.
+- **Temporary data** (`/data/app_temp_data/{app_name}/`) — not backed
+  up, recreatable. Enabled by `app_temp_data = true`.
+- **VM data** (`/data/vm_data/`) — router database and VM-level shared
+  data. Enabled by `access_vm_data = true` (RO) or
+  `access_vm_data_rw = true` (RW).
 
-The host operator can optionally set `storage_min_free_mb` in the OpenHost config to require a minimum amount of free persistent storage. When free space drops below this threshold, the storage guard stops running apps until space is freed.
+The broad-access flags mount the **parent** directory instead of the
+scoped subdir, so your container sees every app's data at
+`/data/app_data/<other-app>/`, `/data/app_temp_data/<other-app>/`, etc.
 
-All data dirs live under `/data/` in the container. All apps see the same path structure regardless of permissions — only the dirs they have access to are mounted. With `access_all_data`, the parent dirs are mounted instead (`/data/app_data/`, `/data/app_temp_data/`) so the app can see all apps' data.
+The host operator can optionally set `storage_min_free_mb` in the
+OpenHost config to require a minimum amount of free persistent storage.
+When free space drops below this threshold, the storage guard stops
+running apps until space is freed.
+
+All data dirs live under `/data/` in the container. All apps see the
+same path structure regardless of permissions — only the dirs they have
+access to are mounted.
 
 ## Environment Variable Injection
 
 The host provisions requested data services and injects connection info as environment variables:
 
 - `OPENHOST_SQLITE_<name>` — filesystem path to the named sqlite database (only if `sqlite` entries requested)
-- `OPENHOST_APP_DATA_DIR` — `/data/app_data/{app_name}` (only if app_data access granted)
-- `OPENHOST_APP_TEMP_DIR` — `/data/app_temp_data/{app_name}` (only if app_temp_data access granted)
+- `OPENHOST_APP_DATA_DIR` — `/data/app_data/{app_name}` (set when any permission that implies scoped permanent-data access is granted: `app_data`, `sqlite`, `access_all_apps_data`, or `access_all_data`)
+- `OPENHOST_APP_TEMP_DIR` — `/data/app_temp_data/{app_name}` (set when `app_temp_data`, `access_all_apps_temp_data`, or `access_all_data` is granted)
 - `OPENHOST_AUTH_PUBLIC_KEY` — PEM-encoded JWT public key for token verification (only if signing keys are available)
 - `OPENHOST_ROUTER_URL` — URL of the router's HTTP server (e.g., `http://host.docker.internal:<port>`)
 

--- a/docs/manifest_spec.md
+++ b/docs/manifest_spec.md
@@ -52,9 +52,11 @@ Declares additional port mappings for the container. Each entry binds a containe
 ### `[data]` — optional
 
 Apps must explicitly request filesystem access. Each category (permanent
-data, temporary data, VM data) can be requested for this app alone
-(scoped) or for every app on the host (broad). Any combination is
-allowed.
+data, temporary data, VM data, router state) can be requested for this
+app alone (scoped) or for every app on the host (broad). Most
+combinations are allowed; the exceptions are noted in the field
+descriptions (e.g. `access_vm_data` read-only cannot be combined with
+any flag that grants `vm_data` read/write access).
 
 #### Scoped access — just this app
 
@@ -67,21 +69,22 @@ allowed.
 #### Broad access — every app's data / shared state
 
 Use these to write apps that manage or inspect state across the whole
-host (backup/restore, file browsers, debugging tools). All three can be
+host (backup/restore, file browsers, debugging tools). All can be
 requested independently.
 
 | Field | Type | Required | Default | Description |
 |-------|------|----------|---------|-------------|
 | `access_all_apps_data` | boolean | no | false | Read/write mount of `/data/app_data` (every app's permanent data) |
 | `access_all_apps_temp_data` | boolean | no | false | Read/write mount of `/data/app_temp_data` (every app's temporary data) |
-| `access_vm_data` | boolean | no | false | Read-only mount of `/data/vm_data` (router DB, shared state) |
+| `access_vm_data` | boolean | no | false | Read-only mount of `/data/vm_data` (VM-level shared data, e.g. signing keys used by multiple apps). Mutually exclusive with `access_vm_data_rw` and `access_all_data`, both of which grant RW access to the same directory. |
 | `access_vm_data_rw` | boolean | no | false | Read/write mount of `/data/vm_data`. Mutually exclusive with `access_vm_data` (RO). Combining with `access_all_data` is redundant but accepted, since the legacy shorthand already grants RW. |
+| `access_openhost_state_ro` | boolean | no | false | Read-only mount of the OpenHost router's own state directory (`router.db`, TLS cert + key, Corefile, Caddyfile, signing keys, claim token). Intended for full-instance inspection / backup tools. **Not** implied by `access_all_data` — apps must opt in explicitly. Grants visibility into all apps' API tokens and the owner password hash. |
 
 #### Legacy shorthand
 
 | Field | Type | Required | Default | Description |
 |-------|------|----------|---------|-------------|
-| `access_all_data` | boolean | no | false | Shorthand equivalent to `access_all_apps_data = true`, `access_all_apps_temp_data = true`, and `access_vm_data_rw = true`. |
+| `access_all_data` | boolean | no | false | Shorthand equivalent to `access_all_apps_data = true`, `access_all_apps_temp_data = true`, and `access_vm_data_rw = true`. Does **not** include `access_openhost_state_ro` — for backward compatibility, existing manifests using this flag do not silently gain access to router state. |
 
 ## Data Directory Structure
 
@@ -89,13 +92,21 @@ Apps have two storage areas on separate disks. **By default, apps have
 no filesystem access.** Each must be explicitly requested:
 
 - **Permanent data** (`/data/app_data/{app_name}/`) — backed up,
-  user-visible. Enabled by `app_data = true` or by requesting `sqlite`
-  entries.
+  user-visible. Enabled by `app_data = true`, by requesting `sqlite`
+  entries, or by any of the broader flags that imply app_data access
+  (`access_all_apps_data`, `access_all_data`).
 - **Temporary data** (`/data/app_temp_data/{app_name}/`) — not backed
-  up, recreatable. Enabled by `app_temp_data = true`.
-- **VM data** (`/data/vm_data/`) — router database and VM-level shared
-  data. Enabled by `access_vm_data = true` (RO) or
-  `access_vm_data_rw = true` (RW).
+  up, recreatable. Enabled by `app_temp_data = true` or by any flag
+  that implies temp-data access (`access_all_apps_temp_data`,
+  `access_all_data`).
+- **VM data** (`/data/vm_data/`) — VM-level shared data (e.g. signing
+  keys used by multiple apps). Enabled by `access_vm_data = true` (RO)
+  or `access_vm_data_rw = true` (RW). This does **not** contain the
+  router's own SQLite DB — that lives separately, see below.
+- **OpenHost router state** (`/data/openhost/`) — the router's own
+  `router.db`, TLS material, and related control-plane files. Enabled
+  only by `access_openhost_state_ro = true` (RO). Not implied by
+  `access_all_data`.
 
 The broad-access flags mount the **parent** directory instead of the
 scoped subdir, so your container sees every app's data at


### PR DESCRIPTION
Splits the monolithic access_all_data manifest flag into three independent fields so apps can request exactly the filesystem access they need.

New [data] fields:
- access_all_apps_data — RW mount of /data/app_data (every app)
- access_all_apps_temp_data — RW mount of /data/app_temp_data (every app)
- access_vm_data_rw — RW mount of /data/vm_data (access_vm_data stays RO)

Any combination is valid. access_all_data is kept as legacy shorthand for all three of the new flags.

Manifest rejects access_vm_data (RO) combined with either access_vm_data_rw or access_all_data at parse time.

AppManifest gains wants_* properties that centralise the resolution of scoped + broad + legacy flags. containers.compute_data_mounts is extracted as a pure helper returning docker mount tuples; run_container consumes it. provision_data uses the same helpers. 72 unit tests + 7 provision_data cases cover the new behavior.