### PR TITLE
Drop redundant username claim from JWT payload

### DIFF
--- a/compute_space/compute_space/core/auth.py
+++ b/compute_space/compute_space/core/auth.py
@@ -91,7 +91,6 @@ def create_access_token(username: str) -> str:
     now = datetime.now(UTC)
     payload = {
         "sub": username,
-        "username": username,
         "iat": now,
         "exp": now + timedelta(seconds=ACCESS_TOKEN_EXPIRY),
     }
@@ -223,7 +222,7 @@ def _validate_api_token(token: str) -> dict[str, str] | None:
     owner = db.execute("SELECT username FROM owner WHERE id = 1").fetchone()
     if not owner:
         return None
-    return {"sub": owner["username"], "username": owner["username"]}
+    return {"sub": owner["username"]}
 
 
 def get_current_user_from_request(request: Request) -> dict[str, Any] | None:

--- a/compute_space/tests/test_integration.py
+++ b/compute_space/tests/test_integration.py
@@ -407,7 +407,6 @@ class TestRouterCore:
         now = datetime.now(UTC)
         expired_payload = {
             "sub": "owner",
-            "username": "owner",
             "iat": now - timedelta(hours=2),
             "exp": now - timedelta(hours=1),
         }


### PR DESCRIPTION
## Summary
- Remove duplicated `username` claim from JWT payload in `create_access_token` and the API-token identity path. Standard `sub` claim already carries the same value.
- Update integration test payload accordingly.

No code reads `username` from claims (verified with grep), so this is safe.

## Test plan
- [ ] `uv run --group dev pytest compute_space/tests/ -v`

🤖 Generated with [Claude Code](https://claude.com/claude-code)