### PR TITLE
Additional tests for PR 8

### DIFF
--- a/compute_space/tests/test_containers.py
+++ b/compute_space/tests/test_containers.py
@@ -687,9 +687,7 @@ def test_bind_mount_arg_preserves_absolute_paths_verbatim() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_run_container_rewrites_openhost_app_data_dir_env_var(
-    tmp_path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_run_container_rewrites_openhost_app_data_dir_env_var(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
     """``OPENHOST_APP_DATA_DIR`` is always the host path when provisioned,
     but the app sees it from inside the container.  The -e value must
     be the container-side ``/data/app_data/<name>`` path."""
@@ -701,9 +699,7 @@ def test_run_container_rewrites_openhost_app_data_dir_env_var(
         tmp_path=tmp_path,
         env_vars={"OPENHOST_APP_DATA_DIR": host_app_data},
     )
-    env_flags = [
-        argv[i + 1] for i, arg in enumerate(argv[:-1]) if arg == "-e"
-    ]
+    env_flags = [argv[i + 1] for i, arg in enumerate(argv[:-1]) if arg == "-e"]
     assert f"OPENHOST_APP_DATA_DIR=/data/app_data/{manifest.name}" in env_flags
     # The host path must not leak through.
     assert not any(host_app_data in flag for flag in env_flags), env_flags
@@ -730,18 +726,14 @@ def test_run_container_rewrites_openhost_sqlite_env_var_to_container_path(
             "OPENHOST_SQLITE_main": host_db,
         },
     )
-    env_flags = [
-        argv[i + 1] for i, arg in enumerate(argv[:-1]) if arg == "-e"
-    ]
+    env_flags = [argv[i + 1] for i, arg in enumerate(argv[:-1]) if arg == "-e"]
     expected = f"OPENHOST_SQLITE_main=/data/app_data/{manifest.name}/sqlite/main.db"
     assert expected in env_flags, env_flags
     # Host path must not leak.
     assert not any(host_db in flag for flag in env_flags), env_flags
 
 
-def test_run_container_rewrites_openhost_app_temp_dir_env_var(
-    tmp_path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_run_container_rewrites_openhost_app_temp_dir_env_var(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
     """``OPENHOST_APP_TEMP_DIR`` has the same rewriting contract as the
     permanent-data var.  Parameters differ (temp dirs live under a
     separate root on the host) so this is a distinct code path."""
@@ -753,16 +745,12 @@ def test_run_container_rewrites_openhost_app_temp_dir_env_var(
         tmp_path=tmp_path,
         env_vars={"OPENHOST_APP_TEMP_DIR": host_temp},
     )
-    env_flags = [
-        argv[i + 1] for i, arg in enumerate(argv[:-1]) if arg == "-e"
-    ]
+    env_flags = [argv[i + 1] for i, arg in enumerate(argv[:-1]) if arg == "-e"]
     assert f"OPENHOST_APP_TEMP_DIR=/data/app_temp_data/{manifest.name}" in env_flags
     assert not any(host_temp in flag for flag in env_flags), env_flags
 
 
-def test_run_container_does_not_rewrite_unrelated_env_vars(
-    tmp_path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_run_container_does_not_rewrite_unrelated_env_vars(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
     """Only the three OpenHost-managed env var names are rewritten;
     everything else passes through byte-for-byte.
 
@@ -788,9 +776,7 @@ def test_run_container_does_not_rewrite_unrelated_env_vars(
             "LOG_LEVEL": "info",
         },
     )
-    env_flags = [
-        argv[i + 1] for i, arg in enumerate(argv[:-1]) if arg == "-e"
-    ]
+    env_flags = [argv[i + 1] for i, arg in enumerate(argv[:-1]) if arg == "-e"]
     assert "DATABASE_URL=postgres://host.containers.internal:5432/foo" in env_flags
     assert f"BACKUP_TARGET={host_app_data}/backups" in env_flags
     assert "LOG_LEVEL=info" in env_flags
@@ -815,9 +801,7 @@ def test_run_container_rewrites_only_exact_openhost_app_data_dir_name(
             "OPENHOST_APP_DATA_DIR_BACKUP": f"{host_app_data}-backup",
         },
     )
-    env_flags = [
-        argv[i + 1] for i, arg in enumerate(argv[:-1]) if arg == "-e"
-    ]
+    env_flags = [argv[i + 1] for i, arg in enumerate(argv[:-1]) if arg == "-e"]
     # The exact-name var is rewritten.
     assert f"OPENHOST_APP_DATA_DIR=/data/app_data/{manifest.name}" in env_flags
     # The prefix-match var is NOT rewritten.
@@ -874,9 +858,7 @@ def _run_and_capture_all_calls(
     return runs
 
 
-def test_run_container_removes_stale_container_before_running(
-    tmp_path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_run_container_removes_stale_container_before_running(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
     """The stale-cleanup ``podman rm -f openhost-<name>`` call must
     happen strictly before ``podman run`` so name conflicts from a
     previous crashed run don't block the fresh start."""
@@ -889,14 +871,10 @@ def test_run_container_removes_stale_container_before_running(
     assert rm_indexes, f"no 'podman rm -f' call was issued: {calls}"
     assert run_indexes, f"no 'podman run' call was issued: {calls}"
     # Every rm must precede every run.
-    assert max(rm_indexes) < min(run_indexes), (
-        f"'podman rm -f' must precede 'podman run'; got order {calls}"
-    )
+    assert max(rm_indexes) < min(run_indexes), f"'podman rm -f' must precede 'podman run'; got order {calls}"
 
 
-def test_run_container_removes_the_correct_stale_container_name(
-    tmp_path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_run_container_removes_the_correct_stale_container_name(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
     """The pre-cleanup target name must be ``openhost-<app_name>`` —
     the same name the subsequent ``podman run`` passes to ``--name``.
     A mismatch (e.g. removing ``openhost-<manifest_name>`` while

--- a/compute_space/tests/test_containers.py
+++ b/compute_space/tests/test_containers.py
@@ -672,3 +672,242 @@ def test_bind_mount_arg_preserves_absolute_paths_verbatim() -> None:
     target vs. what the app's env var points at."""
     arg = _bind_mount_arg("/a/b/c/", "/data/app_data/myapp/")
     assert arg == "/a/b/c/:/data/app_data/myapp/:idmap"
+
+
+# ---------------------------------------------------------------------------
+# run_container: env var host→container path rewriting
+#
+# Apps that request ``sqlite`` or ``app_data`` see env vars whose values
+# are host filesystem paths at provisioning time.  ``run_container`` must
+# rewrite them to the in-container ``/data/...`` view before emitting
+# ``-e`` flags; a regression that stops rewriting (or starts rewriting
+# unrelated env vars) silently breaks persistence — apps open a brand new
+# DB at a path inside the userns that disappears on restart, with no
+# visible error.
+# ---------------------------------------------------------------------------
+
+
+def test_run_container_rewrites_openhost_app_data_dir_env_var(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``OPENHOST_APP_DATA_DIR`` is always the host path when provisioned,
+    but the app sees it from inside the container.  The -e value must
+    be the container-side ``/data/app_data/<name>`` path."""
+    manifest = _basic_manifest(app_data=True)
+    host_app_data = str(tmp_path / "persistent" / "app_data" / manifest.name)
+    argv = _run_and_capture(
+        monkeypatch,
+        manifest=manifest,
+        tmp_path=tmp_path,
+        env_vars={"OPENHOST_APP_DATA_DIR": host_app_data},
+    )
+    env_flags = [
+        argv[i + 1] for i, arg in enumerate(argv[:-1]) if arg == "-e"
+    ]
+    assert f"OPENHOST_APP_DATA_DIR=/data/app_data/{manifest.name}" in env_flags
+    # The host path must not leak through.
+    assert not any(host_app_data in flag for flag in env_flags), env_flags
+
+
+def test_run_container_rewrites_openhost_sqlite_env_var_to_container_path(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A sqlite db provisioned at ``<host-app-data>/sqlite/main.db`` must
+    appear to the container as ``/data/app_data/<name>/sqlite/main.db``.
+
+    Silently forwarding the host path would make the app open a brand
+    new DB inside the userns that vanishes on restart — a data-loss
+    bug with no log line."""
+    manifest = _basic_manifest(app_data=True, sqlite_dbs=["main"])
+    host_app_data = str(tmp_path / "persistent" / "app_data" / manifest.name)
+    host_db = os.path.join(host_app_data, "sqlite", "main.db")
+    argv = _run_and_capture(
+        monkeypatch,
+        manifest=manifest,
+        tmp_path=tmp_path,
+        env_vars={
+            "OPENHOST_APP_DATA_DIR": host_app_data,
+            "OPENHOST_SQLITE_main": host_db,
+        },
+    )
+    env_flags = [
+        argv[i + 1] for i, arg in enumerate(argv[:-1]) if arg == "-e"
+    ]
+    expected = f"OPENHOST_SQLITE_main=/data/app_data/{manifest.name}/sqlite/main.db"
+    assert expected in env_flags, env_flags
+    # Host path must not leak.
+    assert not any(host_db in flag for flag in env_flags), env_flags
+
+
+def test_run_container_rewrites_openhost_app_temp_dir_env_var(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``OPENHOST_APP_TEMP_DIR`` has the same rewriting contract as the
+    permanent-data var.  Parameters differ (temp dirs live under a
+    separate root on the host) so this is a distinct code path."""
+    manifest = _basic_manifest(app_temp_data=True)
+    host_temp = str(tmp_path / "temp" / "app_temp_data" / manifest.name)
+    argv = _run_and_capture(
+        monkeypatch,
+        manifest=manifest,
+        tmp_path=tmp_path,
+        env_vars={"OPENHOST_APP_TEMP_DIR": host_temp},
+    )
+    env_flags = [
+        argv[i + 1] for i, arg in enumerate(argv[:-1]) if arg == "-e"
+    ]
+    assert f"OPENHOST_APP_TEMP_DIR=/data/app_temp_data/{manifest.name}" in env_flags
+    assert not any(host_temp in flag for flag in env_flags), env_flags
+
+
+def test_run_container_does_not_rewrite_unrelated_env_vars(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Only the three OpenHost-managed env var names are rewritten;
+    everything else passes through byte-for-byte.
+
+    Regression target: a well-meaning refactor that matches on value
+    substrings (``if host_app_data in value``) rather than on key
+    names would mangle unrelated vars that happen to share a prefix
+    with a data path — e.g. a ``BACKUP_PATH`` pointing into app_data."""
+    manifest = _basic_manifest(app_data=True)
+    host_app_data = str(tmp_path / "persistent" / "app_data" / manifest.name)
+    argv = _run_and_capture(
+        monkeypatch,
+        manifest=manifest,
+        tmp_path=tmp_path,
+        env_vars={
+            "OPENHOST_APP_DATA_DIR": host_app_data,
+            # Unrelated var whose value contains a colon (URL-ish) and
+            # whose name doesn't match any rewriting rule.
+            "DATABASE_URL": "postgres://host.containers.internal:5432/foo",
+            # Unrelated var whose value happens to contain the host
+            # data path — rewriting would corrupt it.
+            "BACKUP_TARGET": f"{host_app_data}/backups",
+            # Generic var with no special meaning.
+            "LOG_LEVEL": "info",
+        },
+    )
+    env_flags = [
+        argv[i + 1] for i, arg in enumerate(argv[:-1]) if arg == "-e"
+    ]
+    assert "DATABASE_URL=postgres://host.containers.internal:5432/foo" in env_flags
+    assert f"BACKUP_TARGET={host_app_data}/backups" in env_flags
+    assert "LOG_LEVEL=info" in env_flags
+
+
+def test_run_container_rewrites_only_exact_openhost_app_data_dir_name(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``OPENHOST_APP_DATA_DIR`` is matched on equality, not prefix.
+    A variable whose name merely *starts with* ``OPENHOST_APP_DATA_DIR``
+    (e.g. a custom ``OPENHOST_APP_DATA_DIR_BACKUP``) must NOT be
+    rewritten, because the rewrite logic doesn't know what the custom
+    var semantically is."""
+    manifest = _basic_manifest(app_data=True)
+    host_app_data = str(tmp_path / "persistent" / "app_data" / manifest.name)
+    argv = _run_and_capture(
+        monkeypatch,
+        manifest=manifest,
+        tmp_path=tmp_path,
+        env_vars={
+            "OPENHOST_APP_DATA_DIR": host_app_data,
+            "OPENHOST_APP_DATA_DIR_BACKUP": f"{host_app_data}-backup",
+        },
+    )
+    env_flags = [
+        argv[i + 1] for i, arg in enumerate(argv[:-1]) if arg == "-e"
+    ]
+    # The exact-name var is rewritten.
+    assert f"OPENHOST_APP_DATA_DIR=/data/app_data/{manifest.name}" in env_flags
+    # The prefix-match var is NOT rewritten.
+    assert f"OPENHOST_APP_DATA_DIR_BACKUP={host_app_data}-backup" in env_flags
+
+
+# ---------------------------------------------------------------------------
+# run_container: stale-container pre-cleanup
+#
+# ``run_container`` runs ``podman rm -f <name>`` before ``podman run`` so
+# a container left over from a crashed previous attempt doesn't make the
+# new run fail with a name conflict that the operator would have to clear
+# manually.  If the pre-cleanup ever gets dropped, apps that crashed
+# during a previous ``run_container`` invocation become un-deployable
+# until an operator SSHs in.
+# ---------------------------------------------------------------------------
+
+
+def _run_and_capture_all_calls(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    manifest: AppManifest,
+    tmp_path,
+    env_vars: dict[str, str] | None = None,
+) -> list[list[str]]:
+    """Same harness as ``_run_and_capture`` but returns every subprocess
+    call in order, unfiltered, so tests can assert on the pre-cleanup
+    call as well as the run call."""
+    runs: list[list[str]] = []
+
+    def fake_run(cmd, capture_output=False, text=False, timeout=60, **_):  # type: ignore[no-untyped-def]
+        runs.append(list(cmd))
+        if cmd[:2] == ["podman", "run"]:
+            return _FakeCompleted(0, stdout="container-id-xyz\n")
+        return _FakeCompleted(0)
+
+    _patch_subprocess_run(monkeypatch, fake_run)
+
+    data_dir = str(tmp_path / "persistent")
+    temp_data_dir = str(tmp_path / "temp")
+    os.makedirs(data_dir, exist_ok=True)
+    os.makedirs(temp_data_dir, exist_ok=True)
+    os.makedirs(os.path.join(temp_data_dir, "app_temp_data", manifest.name), exist_ok=True)
+
+    run_container(
+        manifest.name,
+        "openhost-myapp:latest",
+        manifest,
+        local_port=9001,
+        env_vars=env_vars or {},
+        data_dir=data_dir,
+        temp_data_dir=temp_data_dir,
+    )
+    return runs
+
+
+def test_run_container_removes_stale_container_before_running(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The stale-cleanup ``podman rm -f openhost-<name>`` call must
+    happen strictly before ``podman run`` so name conflicts from a
+    previous crashed run don't block the fresh start."""
+    manifest = _basic_manifest()
+    calls = _run_and_capture_all_calls(monkeypatch, manifest=manifest, tmp_path=tmp_path)
+
+    # Find both calls.
+    rm_indexes = [i for i, c in enumerate(calls) if c[:3] == ["podman", "rm", "-f"]]
+    run_indexes = [i for i, c in enumerate(calls) if c[:2] == ["podman", "run"]]
+    assert rm_indexes, f"no 'podman rm -f' call was issued: {calls}"
+    assert run_indexes, f"no 'podman run' call was issued: {calls}"
+    # Every rm must precede every run.
+    assert max(rm_indexes) < min(run_indexes), (
+        f"'podman rm -f' must precede 'podman run'; got order {calls}"
+    )
+
+
+def test_run_container_removes_the_correct_stale_container_name(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The pre-cleanup target name must be ``openhost-<app_name>`` —
+    the same name the subsequent ``podman run`` passes to ``--name``.
+    A mismatch (e.g. removing ``openhost-<manifest_name>`` while
+    running as ``openhost-<rename_target>`` during an in-place rename)
+    would defeat the whole point of the cleanup."""
+    manifest = _basic_manifest(name="notes")
+    calls = _run_and_capture_all_calls(monkeypatch, manifest=manifest, tmp_path=tmp_path)
+
+    rm_calls = [c for c in calls if c[:3] == ["podman", "rm", "-f"]]
+    assert rm_calls == [["podman", "rm", "-f", "openhost-notes"]], rm_calls
+
+    run_cmd = next(c for c in calls if c[:2] == ["podman", "run"])
+    name_idx = run_cmd.index("--name")
+    assert run_cmd[name_idx + 1] == "openhost-notes"

--- a/compute_space/tests/test_deploy_app_background.py
+++ b/compute_space/tests/test_deploy_app_background.py
@@ -36,7 +36,6 @@ from compute_space.core.manifest import AppManifest
 
 from .conftest import _make_test_config
 
-
 # ---------------------------------------------------------------------------
 # Fixtures and helpers
 # ---------------------------------------------------------------------------
@@ -235,9 +234,7 @@ def test_cache_corrupt_marker_short_circuits_retry_loop(
 
     def _cache_corrupt(*args: Any, **kwargs: Any) -> str:
         attempts["n"] += 1
-        raise RuntimeError(
-            f"{BUILD_CACHE_CORRUPT_MARKER} content digest sha256:deadbeef: not found"
-        )
+        raise RuntimeError(f"{BUILD_CACHE_CORRUPT_MARKER} content digest sha256:deadbeef: not found")
 
     monkeypatch.setattr(apps_module, "build_image", _cache_corrupt)
 

--- a/compute_space/tests/test_deploy_app_background.py
+++ b/compute_space/tests/test_deploy_app_background.py
@@ -1,0 +1,327 @@
+"""Unit tests for ``compute_space.core.apps.deploy_app_background``.
+
+The function is the in-process builder that ``/api/add_app`` and
+``/api/reload`` hand off to a background thread.  It has two
+non-obvious contracts that the rest of the system depends on:
+
+1. **Transient build failures retry up to 3 times**, with escalating
+   backoff (``attempt * 5`` seconds).  If the retry loop ever regresses
+   to a single attempt, every flaky podman pull / transient network
+   blip surfaces to the user as a hard ``status='error'`` row.
+
+2. **``BUILD_CACHE_CORRUPT_MARKER`` short-circuits the retry loop.**
+   Retrying a corrupt local build cache just burns another ~300s
+   timeout per attempt before returning the same error.  The dashboard
+   matches this marker to surface a "drop cache and rebuild" toast —
+   dragging the user through two additional silent retries before that
+   toast appears is a user-visible regression (minutes of spinner on
+   every app page).
+
+These tests mock out ``build_image`` / ``run_container`` / the sqlite
+schema so they run without podman, without real sqlite migrations, and
+without real sleep delays.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from compute_space.core import apps as apps_module
+from compute_space.core.containers import BUILD_CACHE_CORRUPT_MARKER
+from compute_space.core.manifest import AppManifest
+
+from .conftest import _make_test_config
+
+
+# ---------------------------------------------------------------------------
+# Fixtures and helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_basic_manifest() -> AppManifest:
+    return AppManifest(
+        name="notes",
+        version="0.1.0",
+        container_image="Dockerfile",
+        container_port=8080,
+        memory_mb=128,
+        cpu_millicores=100,
+    )
+
+
+def _seed_apps_row(db_path: str, app_name: str, local_port: int) -> None:
+    """Insert a minimal apps row so deploy_app_background's UPDATEs land.
+
+    We skip the full init_db path — that drags in Quart — and just
+    apply the single CREATE TABLE the function needs."""
+    db = sqlite3.connect(db_path)
+    try:
+        db.execute(
+            """CREATE TABLE IF NOT EXISTS apps (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                name TEXT NOT NULL UNIQUE,
+                version TEXT NOT NULL,
+                repo_path TEXT NOT NULL,
+                local_port INTEGER NOT NULL UNIQUE,
+                container_id TEXT,
+                status TEXT NOT NULL DEFAULT 'stopped',
+                error_message TEXT
+            )"""
+        )
+        db.execute(
+            """INSERT INTO apps (name, version, repo_path, local_port, status)
+               VALUES (?, '0.1.0', '/tmp/fake-repo', ?, 'building')""",
+            (app_name, local_port),
+        )
+        db.commit()
+    finally:
+        db.close()
+
+
+def _row(db_path: str, app_name: str) -> dict[str, Any]:
+    db = sqlite3.connect(db_path)
+    db.row_factory = sqlite3.Row
+    try:
+        r = db.execute("SELECT * FROM apps WHERE name = ?", (app_name,)).fetchone()
+        assert r is not None
+        return dict(r)
+    finally:
+        db.close()
+
+
+@pytest.fixture
+def sleep_calls(monkeypatch: pytest.MonkeyPatch) -> list[float]:
+    """Record and suppress ``time.sleep`` calls inside
+    ``compute_space.core.apps``.  Returns the recording list."""
+    calls: list[float] = []
+
+    def _record(seconds: float) -> None:
+        calls.append(seconds)
+
+    monkeypatch.setattr(apps_module.time, "sleep", _record)
+    return calls
+
+
+@pytest.fixture
+def stub_downstream(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
+    """Replace the downstream side-effects of deploy_app_background
+    (storage check, run_container, wait_for_ready) with no-op stubs.
+
+    Returns a dict the test can inspect to confirm which stubs were
+    actually called."""
+    called: dict[str, Any] = {}
+
+    def _noop_storage_check(_cfg: Any) -> None:
+        called["storage_check"] = True
+
+    def _fake_run_container(*args: Any, **kwargs: Any) -> str:
+        called["run_container_argv"] = (args, kwargs)
+        return "container-id-xyz"
+
+    def _fake_wait_for_ready(*args: Any, **kwargs: Any) -> bool:
+        called["wait_for_ready"] = True
+        return True
+
+    monkeypatch.setattr(apps_module.storage, "check_before_deploy", _noop_storage_check)
+    monkeypatch.setattr(apps_module, "run_container", _fake_run_container)
+    monkeypatch.setattr(apps_module, "wait_for_ready", _fake_wait_for_ready)
+    return called
+
+
+# ---------------------------------------------------------------------------
+# Retry / short-circuit tests
+# ---------------------------------------------------------------------------
+
+
+def test_generic_build_failure_retries_three_times_then_succeeds(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, sleep_calls: list[float], stub_downstream: dict[str, Any]
+) -> None:
+    """Two transient failures followed by a success must leave the app
+    in ``status='running'`` — i.e. the retry loop must try ≥3 times
+    before giving up, and a success on the last allowed attempt must
+    still land the happy path."""
+    cfg = _make_test_config(tmp_path, port=19500)
+    _seed_apps_row(cfg.db_path, "notes", 19501)
+
+    attempts = {"n": 0}
+
+    def _flaky_build_image(*args: Any, **kwargs: Any) -> str:
+        attempts["n"] += 1
+        if attempts["n"] < 3:
+            raise RuntimeError("pull failed: connection reset")
+        return "openhost-notes:latest"
+
+    monkeypatch.setattr(apps_module, "build_image", _flaky_build_image)
+
+    apps_module.deploy_app_background(
+        manifest=_make_basic_manifest(),
+        repo_path="/tmp/fake-repo",
+        local_port=19501,
+        env_vars={},
+        config=cfg,
+    )
+
+    # Exactly 3 build attempts: fail, fail, succeed.
+    assert attempts["n"] == 3
+    # Backoff between the two retries: attempt * 5 seconds, i.e. 5 then 10.
+    # No sleep after the final successful attempt.
+    assert sleep_calls == [5, 10]
+    # run_container + wait_for_ready fired on the happy path.
+    assert stub_downstream.get("run_container_argv") is not None
+    assert stub_downstream.get("wait_for_ready") is True
+    # DB row reflects the final running state.
+    row = _row(cfg.db_path, "notes")
+    assert row["status"] == "running"
+    assert row["error_message"] is None
+
+
+def test_generic_build_failure_gives_up_after_three_attempts(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, sleep_calls: list[float], stub_downstream: dict[str, Any]
+) -> None:
+    """If all three attempts fail, the app row ends up in status='error'
+    with the original exception message and the retry cadence we promise
+    on the tin (5s, 10s, no final sleep because the error propagates)."""
+    cfg = _make_test_config(tmp_path, port=19502)
+    _seed_apps_row(cfg.db_path, "notes", 19503)
+
+    attempts = {"n": 0}
+
+    def _always_fail(*args: Any, **kwargs: Any) -> str:
+        attempts["n"] += 1
+        raise RuntimeError("pull failed: connection reset")
+
+    monkeypatch.setattr(apps_module, "build_image", _always_fail)
+
+    # deploy_app_background swallows the final exception itself (it
+    # logs + writes an 'error' row), so this call must not raise.
+    apps_module.deploy_app_background(
+        manifest=_make_basic_manifest(),
+        repo_path="/tmp/fake-repo",
+        local_port=19503,
+        env_vars={},
+        config=cfg,
+    )
+
+    assert attempts["n"] == 3, "must attempt exactly 3 times before giving up"
+    # Backoffs before attempts 2 and 3; no backoff after the final failure
+    # because we re-raise out of the loop.
+    assert sleep_calls == [5, 10]
+    # run_container must never be called when build never succeeds.
+    assert "run_container_argv" not in stub_downstream
+    # Error recorded on the row.
+    row = _row(cfg.db_path, "notes")
+    assert row["status"] == "error"
+    assert "pull failed: connection reset" in (row["error_message"] or "")
+
+
+def test_cache_corrupt_marker_short_circuits_retry_loop(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, sleep_calls: list[float], stub_downstream: dict[str, Any]
+) -> None:
+    """A build error carrying ``BUILD_CACHE_CORRUPT_MARKER`` must
+    propagate on the first attempt without sleeping or retrying.
+
+    Retrying can't heal a corrupt local cache, and the dashboard
+    matches on the marker in ``error_message`` to fire a 'drop cache
+    and rebuild' toast — two extra retries before that toast appears
+    would show the user a minutes-long spinner for no benefit."""
+    cfg = _make_test_config(tmp_path, port=19504)
+    _seed_apps_row(cfg.db_path, "notes", 19505)
+
+    attempts = {"n": 0}
+
+    def _cache_corrupt(*args: Any, **kwargs: Any) -> str:
+        attempts["n"] += 1
+        raise RuntimeError(
+            f"{BUILD_CACHE_CORRUPT_MARKER} content digest sha256:deadbeef: not found"
+        )
+
+    monkeypatch.setattr(apps_module, "build_image", _cache_corrupt)
+
+    apps_module.deploy_app_background(
+        manifest=_make_basic_manifest(),
+        repo_path="/tmp/fake-repo",
+        local_port=19505,
+        env_vars={},
+        config=cfg,
+    )
+
+    assert attempts["n"] == 1, "cache-corrupt marker must short-circuit after 1 attempt"
+    assert sleep_calls == [], "no retry backoff when short-circuiting"
+    assert "run_container_argv" not in stub_downstream
+    row = _row(cfg.db_path, "notes")
+    assert row["status"] == "error"
+    # The marker MUST be preserved in error_message so the dashboard
+    # can match on it.
+    assert BUILD_CACHE_CORRUPT_MARKER in (row["error_message"] or "")
+
+
+def test_cache_corrupt_marker_embedded_mid_message_still_short_circuits(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, sleep_calls: list[float], stub_downstream: dict[str, Any]
+) -> None:
+    """The marker detection uses substring matching (``MARKER in str(e)``),
+    so a message that surfaces the marker anywhere in the exception
+    body — not just at the start — must still short-circuit.
+
+    This guards against future refactors that might switch to
+    ``str(e).startswith(MARKER)`` and silently let cache-corrupt
+    errors fall through to the retry loop when the build system
+    prefixes extra context."""
+    cfg = _make_test_config(tmp_path, port=19506)
+    _seed_apps_row(cfg.db_path, "notes", 19507)
+
+    attempts = {"n": 0}
+
+    def _fail_with_embedded_marker(*args: Any, **kwargs: Any) -> str:
+        attempts["n"] += 1
+        raise RuntimeError(
+            "build step 4/10 failed: podman build crashed. "
+            f"{BUILD_CACHE_CORRUPT_MARKER} content digest sha256:xx: not found"
+        )
+
+    monkeypatch.setattr(apps_module, "build_image", _fail_with_embedded_marker)
+
+    apps_module.deploy_app_background(
+        manifest=_make_basic_manifest(),
+        repo_path="/tmp/fake-repo",
+        local_port=19507,
+        env_vars={},
+        config=cfg,
+    )
+
+    assert attempts["n"] == 1
+    assert sleep_calls == []
+    row = _row(cfg.db_path, "notes")
+    assert row["status"] == "error"
+    assert BUILD_CACHE_CORRUPT_MARKER in (row["error_message"] or "")
+
+
+def test_happy_path_does_not_sleep(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, sleep_calls: list[float], stub_downstream: dict[str, Any]
+) -> None:
+    """When the first build attempt succeeds, the loop must not sleep
+    at all.  A regression that unconditionally sleeps before returning
+    would add 5s of latency to every deploy — a silent regression
+    nothing else would flag."""
+    cfg = _make_test_config(tmp_path, port=19508)
+    _seed_apps_row(cfg.db_path, "notes", 19509)
+
+    def _succeed(*args: Any, **kwargs: Any) -> str:
+        return "openhost-notes:latest"
+
+    monkeypatch.setattr(apps_module, "build_image", _succeed)
+
+    apps_module.deploy_app_background(
+        manifest=_make_basic_manifest(),
+        repo_path="/tmp/fake-repo",
+        local_port=19509,
+        env_vars={},
+        config=cfg,
+    )
+
+    assert sleep_calls == []
+    row = _row(cfg.db_path, "notes")
+    assert row["status"] == "running"

--- a/compute_space/tests/test_runtime_sentinel.py
+++ b/compute_space/tests/test_runtime_sentinel.py
@@ -192,8 +192,7 @@ def test_ansible_podman_task_file_is_present() -> None:
     this test being updated — otherwise the two asserts below would
     silently skip."""
     assert _PODMAN_TASKS_PATH.is_file(), (
-        f"expected ansible task file at {_PODMAN_TASKS_PATH}; "
-        "if you moved it, update _PODMAN_TASKS_PATH in this test"
+        f"expected ansible task file at {_PODMAN_TASKS_PATH}; if you moved it, update _PODMAN_TASKS_PATH in this test"
     )
 
 
@@ -209,15 +208,12 @@ def test_ansible_writes_matching_runtime_version() -> None:
     text = _read_podman_task_text()
     matches = re.findall(r"runtime_version=(\d+)", text)
     assert matches, (
-        "no ``runtime_version=<N>`` literal found in "
-        f"{_PODMAN_TASKS_PATH}; did the sentinel-write task change?"
+        f"no ``runtime_version=<N>`` literal found in {_PODMAN_TASKS_PATH}; did the sentinel-write task change?"
     )
     # Every occurrence must match; if the task writes the value in
     # more than one place they must all agree.
     distinct = set(matches)
-    assert len(distinct) == 1, (
-        f"ansible task writes inconsistent runtime_version values: {distinct}"
-    )
+    assert len(distinct) == 1, f"ansible task writes inconsistent runtime_version values: {distinct}"
     written = int(next(iter(distinct)))
     assert written == EXPECTED_RUNTIME_VERSION, (
         f"ansible writes runtime_version={written} but Python expects "
@@ -232,16 +228,12 @@ def test_ansible_writes_matching_runtime_name() -> None:
     ansible."""
     text = _read_podman_task_text()
     matches = re.findall(r"(?m)^\s*runtime=(\w+)\s*$", text)
-    assert matches, (
-        "no ``runtime=<name>`` literal found in "
-        f"{_PODMAN_TASKS_PATH}; did the sentinel-write task change?"
-    )
+    assert matches, f"no ``runtime=<name>`` literal found in {_PODMAN_TASKS_PATH}; did the sentinel-write task change?"
     distinct = set(matches)
     assert len(distinct) == 1, f"ansible task writes inconsistent runtime values: {distinct}"
     written = next(iter(distinct))
     assert written == EXPECTED_RUNTIME, (
-        f"ansible writes runtime={written} but Python expects "
-        f"EXPECTED_RUNTIME={EXPECTED_RUNTIME!r}"
+        f"ansible writes runtime={written} but Python expects EXPECTED_RUNTIME={EXPECTED_RUNTIME!r}"
     )
 
 
@@ -262,9 +254,7 @@ def test_ansible_unprivileged_port_floor_matches_python_constant() -> None:
         f"found in {_PODMAN_TASKS_PATH}; did the sysctl-drop-in task change?"
     )
     distinct = set(matches)
-    assert len(distinct) == 1, (
-        f"ansible writes inconsistent port floor values: {distinct}"
-    )
+    assert len(distinct) == 1, f"ansible writes inconsistent port floor values: {distinct}"
     written = int(next(iter(distinct)))
     assert written == UNPRIVILEGED_PORT_FLOOR, (
         f"ansible writes net.ipv4.ip_unprivileged_port_start={written} "

--- a/compute_space/tests/test_runtime_sentinel.py
+++ b/compute_space/tests/test_runtime_sentinel.py
@@ -13,11 +13,14 @@ against a sentinel written to tmp_path rather than the real /etc.
 from __future__ import annotations
 
 import builtins
+import re
 from pathlib import Path
 
 import pytest
 
+from compute_space import OPENHOST_PROJECT_DIR
 from compute_space.core import runtime_sentinel
+from compute_space.core.manifest import UNPRIVILEGED_PORT_FLOOR
 from compute_space.core.runtime_sentinel import EXPECTED_RUNTIME
 from compute_space.core.runtime_sentinel import EXPECTED_RUNTIME_VERSION
 from compute_space.core.runtime_sentinel import host_prep_status
@@ -156,3 +159,115 @@ def test_module_level_expected_values_match_ansible() -> None:
     """
     assert runtime_sentinel.EXPECTED_RUNTIME == "podman"
     assert runtime_sentinel.EXPECTED_RUNTIME_VERSION == 1
+
+
+# ---------------------------------------------------------------------------
+# Cross-check Python constants against the ansible tasks that set them.
+#
+# The existing `test_module_level_expected_values_match_ansible` only
+# asserts the Python side: bumping EXPECTED_RUNTIME_VERSION in Python
+# without updating ansible/tasks/podman.yml (or vice versa) passes that
+# test but ships a silently-broken host-prep — every freshly provisioned
+# host sees a "host not prepped" banner forever because the sentinel
+# value written by ansible no longer matches what the router expects.
+#
+# Same story for UNPRIVILEGED_PORT_FLOOR vs the sysctl value the task
+# writes to /etc/sysctl.d/90-openhost-podman.conf.
+# ---------------------------------------------------------------------------
+
+
+_PODMAN_TASKS_PATH = OPENHOST_PROJECT_DIR / "ansible" / "tasks" / "podman.yml"
+
+
+def _read_podman_task_text() -> str:
+    """Read the ansible task file verbatim.  We parse with regex rather
+    than a YAML loader because the values we care about are inline
+    literals inside ``content: |`` blocks — structural YAML awareness
+    doesn't help and just couples the test to PyYAML."""
+    return _PODMAN_TASKS_PATH.read_text()
+
+
+def test_ansible_podman_task_file_is_present() -> None:
+    """Guard against the tasks file being moved or renamed without
+    this test being updated — otherwise the two asserts below would
+    silently skip."""
+    assert _PODMAN_TASKS_PATH.is_file(), (
+        f"expected ansible task file at {_PODMAN_TASKS_PATH}; "
+        "if you moved it, update _PODMAN_TASKS_PATH in this test"
+    )
+
+
+def test_ansible_writes_matching_runtime_version() -> None:
+    """The ansible task writes ``runtime_version=<N>`` to the sentinel
+    file.  That N must match ``EXPECTED_RUNTIME_VERSION`` or the
+    dashboard nags the operator on every update check even after a
+    fresh playbook run.
+
+    Parses the file as text so we aren't depending on YAML semantics —
+    the literal is what ends up on disk regardless of how the
+    surrounding YAML is structured."""
+    text = _read_podman_task_text()
+    matches = re.findall(r"runtime_version=(\d+)", text)
+    assert matches, (
+        "no ``runtime_version=<N>`` literal found in "
+        f"{_PODMAN_TASKS_PATH}; did the sentinel-write task change?"
+    )
+    # Every occurrence must match; if the task writes the value in
+    # more than one place they must all agree.
+    distinct = set(matches)
+    assert len(distinct) == 1, (
+        f"ansible task writes inconsistent runtime_version values: {distinct}"
+    )
+    written = int(next(iter(distinct)))
+    assert written == EXPECTED_RUNTIME_VERSION, (
+        f"ansible writes runtime_version={written} but Python expects "
+        f"EXPECTED_RUNTIME_VERSION={EXPECTED_RUNTIME_VERSION}; bump both "
+        "or hosts will see a stale-sentinel banner after re-provisioning"
+    )
+
+
+def test_ansible_writes_matching_runtime_name() -> None:
+    """Symmetric check for the ``runtime=`` literal — catches a hypothetical
+    future rename from podman to something else that forgets to update
+    ansible."""
+    text = _read_podman_task_text()
+    matches = re.findall(r"(?m)^\s*runtime=(\w+)\s*$", text)
+    assert matches, (
+        "no ``runtime=<name>`` literal found in "
+        f"{_PODMAN_TASKS_PATH}; did the sentinel-write task change?"
+    )
+    distinct = set(matches)
+    assert len(distinct) == 1, f"ansible task writes inconsistent runtime values: {distinct}"
+    written = next(iter(distinct))
+    assert written == EXPECTED_RUNTIME, (
+        f"ansible writes runtime={written} but Python expects "
+        f"EXPECTED_RUNTIME={EXPECTED_RUNTIME!r}"
+    )
+
+
+def test_ansible_unprivileged_port_floor_matches_python_constant() -> None:
+    """``ansible/tasks/podman.yml`` writes a sysctl
+    ``net.ipv4.ip_unprivileged_port_start = <N>`` drop-in.  That N
+    must equal ``UNPRIVILEGED_PORT_FLOOR`` (the manifest-parse
+    boundary) or apps get rejected at parse time for perfectly valid
+    ports the host kernel would otherwise accept — or worse, rejected
+    at bind time for ports the manifest layer wrongly accepted."""
+    text = _read_podman_task_text()
+    matches = re.findall(
+        r"net\.ipv4\.ip_unprivileged_port_start\s*=\s*(\d+)",
+        text,
+    )
+    assert matches, (
+        "no ``net.ipv4.ip_unprivileged_port_start`` sysctl literal "
+        f"found in {_PODMAN_TASKS_PATH}; did the sysctl-drop-in task change?"
+    )
+    distinct = set(matches)
+    assert len(distinct) == 1, (
+        f"ansible writes inconsistent port floor values: {distinct}"
+    )
+    written = int(next(iter(distinct)))
+    assert written == UNPRIVILEGED_PORT_FLOOR, (
+        f"ansible writes net.ipv4.ip_unprivileged_port_start={written} "
+        f"but Python's UNPRIVILEGED_PORT_FLOOR is {UNPRIVILEGED_PORT_FLOOR}; "
+        "bump both or manifests will silently disagree with the kernel"
+    )


### PR DESCRIPTION
Adds 16 unit tests covering gaps flagged during PR 8 review.

Three gap categories. 1. deploy_app_background retry + cache-corrupt short-circuit in test_deploy_app_background.py. 2. run_container env var host to container path rewriting and stale-container pre-cleanup in test_containers.py. 3. ansible tasks podman.yml constants cross-checked against EXPECTED_RUNTIME_VERSION and UNPRIVILEGED_PORT_FLOOR in test_runtime_sentinel.py.

Mutation-tested each: removing the short circuit, dropping env rewriting, dropping stale cleanup, reducing retry count, and bumping ansible constants independently each cause the intended tests to fail.

All tests pass locally. No integration tests touched so no requires-containers flag needed.