### PR TITLE
Wire openhost service to the host user's systemd session for rootless podman

### DIFF
--- a/ansible/templates/openhost.service.j2
+++ b/ansible/templates/openhost.service.j2
@@ -1,7 +1,12 @@
 [Unit]
 Description=OpenHost Compute Space
-After=network-online.target
-Wants=network-online.target
+# The user-session bus from ``user@1001.service`` must be up before we
+# start, otherwise rootless podman's systemd cgroup manager can't talk
+# to it and builds fail with "Interactive authentication required".
+# Lingering (set in ansible/tasks/podman.yml) ensures that unit exists;
+# this After= makes sure systemd orders us after it's actually running.
+After=network-online.target user@1001.service
+Wants=network-online.target user@1001.service
 
 [Service]
 Type=simple
@@ -9,6 +14,15 @@ User=host
 WorkingDirectory=/home/host/openhost
 Environment=PATH=/home/host/.pixi/bin:/home/host/openhost/.pixi/envs/default/bin:/usr/local/bin:/usr/bin:/bin
 Environment=OPENHOST_ROUTER_CONFIG=/home/host/.openhost/local_compute_space/config.toml
+# Rootless podman needs to reach the host user's systemd manager +
+# session DBus so it can create transient scope units for each
+# container's cgroup. Without these, podman falls back to cgroupfs
+# but runc still contacts systemd directly and fails with
+# "Interactive authentication required" when creating the scope.
+# Both paths must be set; the bus address alone isn't enough (the
+# runtime-dir search path anchors on XDG_RUNTIME_DIR too).
+Environment=XDG_RUNTIME_DIR=/run/user/1001
+Environment=DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/1001/bus
 ExecStart=/home/host/.pixi/bin/pixi run python -m compute_space
 # Don't auto-restart on crash (can blow through certbot rate limits).
 # RestartForceExitStatus=42 overrides Restart=no for exit code 42 only,


### PR DESCRIPTION
Rootless podman builds fail on a clean systemd-started openhost service with 'Interactive authentication required' because the service has no XDG_RUNTIME_DIR / DBUS_SESSION_BUS_ADDRESS set. Lingering is enabled in the playbook so the user's systemd manager is up — but without these env vars, the service can't reach it, runc's systemd cgroup delegation fails, and every build's first RUN step errors out.

Adds both env vars to the unit and orders it After=user@1001.service so systemd guarantees the user bus is running before openhost starts.

Confirmed on a live instance that the fix unblocks podman builds end-to-end.