### PR TITLE
Resolve host UID dynamically in the openhost service template

### DIFF
--- a/ansible/tasks/setup_openhost_service.yml
+++ b/ansible/tasks/setup_openhost_service.yml
@@ -16,11 +16,23 @@
     group: host
   register: config_file
 
+# Look up the host user's UID so the service template can reference
+# the right /run/user/<uid> path and user@<uid>.service unit. The
+# host user is created without a fixed UID so the value varies by
+# cloud provider (typically 1000 on GCP, 1001 on EC2 / Hetzner).
+- name: Resolve host user UID
+  getent:
+    database: passwd
+    key: host
+    split: ":"
+
 - name: Install openhost systemd service
   become: yes
   template:
     src: templates/openhost.service.j2
     dest: /etc/systemd/system/openhost.service
+  vars:
+    host_uid: "{{ getent_passwd.host[1] }}"
   register: service_file
 
 - name: Reload systemd

--- a/ansible/templates/openhost.service.j2
+++ b/ansible/templates/openhost.service.j2
@@ -1,12 +1,15 @@
 [Unit]
 Description=OpenHost Compute Space
-# The user-session bus from ``user@1001.service`` must be up before we
-# start, otherwise rootless podman's systemd cgroup manager can't talk
-# to it and builds fail with "Interactive authentication required".
-# Lingering (set in ansible/tasks/podman.yml) ensures that unit exists;
-# this After= makes sure systemd orders us after it's actually running.
-After=network-online.target user@1001.service
-Wants=network-online.target user@1001.service
+# The user-session bus from ``user@{{ host_uid }}.service`` must be up
+# before we start, otherwise rootless podman's systemd cgroup manager
+# can't talk to it and builds fail with "Interactive authentication
+# required". Lingering (set in ansible/tasks/podman.yml) ensures that
+# unit exists; this After= makes sure systemd orders us after it's
+# actually running. ``host_uid`` is resolved dynamically by ansible
+# from the host user's actual UID, since the user is created without
+# a hardcoded UID and the value differs across cloud providers.
+After=network-online.target user@{{ host_uid }}.service
+Wants=network-online.target user@{{ host_uid }}.service
 
 [Service]
 Type=simple
@@ -21,8 +24,8 @@ Environment=OPENHOST_ROUTER_CONFIG=/home/host/.openhost/local_compute_space/conf
 # "Interactive authentication required" when creating the scope.
 # Both paths must be set; the bus address alone isn't enough (the
 # runtime-dir search path anchors on XDG_RUNTIME_DIR too).
-Environment=XDG_RUNTIME_DIR=/run/user/1001
-Environment=DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/1001/bus
+Environment=XDG_RUNTIME_DIR=/run/user/{{ host_uid }}
+Environment=DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/{{ host_uid }}/bus
 ExecStart=/home/host/.pixi/bin/pixi run python -m compute_space
 # Don't auto-restart on crash (can blow through certbot rate limits).
 # RestartForceExitStatus=42 overrides Restart=no for exit code 42 only,


### PR DESCRIPTION
Follow-up to #29: that PR hardcoded UID 1001 in the service template, which broke the GCP e2e because the host user gets UID 1000 there. The merge went through on the back of the EC2 e2e passing before GCP failed.

Look up the host user's UID via the getent module and pass it into the template, so the /run/user/<uid> paths and user@<uid>.service ordering are correct on any provider.