### PR TITLE
data: chmod parent dir in rmtree onexc hook

### DIFF
--- a/compute_space/compute_space/core/data.py
+++ b/compute_space/compute_space/core/data.py
@@ -25,7 +25,16 @@ def rmtree_with_sudo_fallback(path: str, *, raise_on_failure: bool = False) -> N
         return
 
     def _make_writable_and_retry(func, err_path, _exc):  # type: ignore[no-untyped-def]
+        # Unlinking a file needs write perms on the parent directory, not
+        # the file itself — so chmod both.  Git clones leave read-only
+        # dirs as well as read-only files.
         os.chmod(err_path, stat.S_IRWXU)
+        parent = os.path.dirname(err_path)
+        if parent and parent != err_path:
+            try:
+                os.chmod(parent, stat.S_IRWXU)
+            except OSError:
+                pass
         func(err_path)
 
     try:


### PR DESCRIPTION
## Summary
- `_make_writable_and_retry` only chmodded the offending file, but unlinking a file needs write perms on the **parent directory**. Git clones leave both files and dirs read-only, so the rmtree fast path was falling through to `sudo rm -rf` on local dev.
- Now chmod both the file and its parent dir (best-effort) before retrying.

## Stacked-PR context
First in a 6-PR stack splitting `zack/new_services_interface`:
1. **this PR** — rmtree fix
2. manifest dataclass → attrs
3. `oh curl`
4. apps/secrets → apps/secrets_v2
5. services_v2 + oauth app
6. secrets_v2 / oauth full-stack tests

## Test plan
- [x] `compute_space/tests/test_data_rmtree.py` — `test_rmtree_onexc_hook_chmods_readonly_files` was failing on main, now passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)