### PR TITLE
oh: add 'curl' subcommand

### DIFF
--- a/compute_space/compute_space/core/apps.py
+++ b/compute_space/compute_space/core/apps.py
@@ -4,7 +4,6 @@ Extracted from routes/apps.py — no HTTP/Quart dependencies.
 """
 
 import asyncio
-import dataclasses
 import hashlib
 import json
 import os
@@ -17,6 +16,7 @@ import threading
 import time
 import urllib.parse
 
+import attr
 import httpx
 
 import compute_space.core.storage as storage
@@ -228,7 +228,7 @@ def insert_and_deploy(
 
     # Apply port overrides from caller (CLI --port flags, etc.)
     mappings = [
-        dataclasses.replace(pm, host_port=port_overrides.get(pm.label, pm.host_port)) if port_overrides else pm
+        attr.evolve(pm, host_port=port_overrides.get(pm.label, pm.host_port)) if port_overrides else pm
         for pm in manifest.port_mappings
     ]
 
@@ -474,7 +474,7 @@ def _sync_port_mappings(
     to_resolve: list[PortMapping] = []
     for pm in new_mappings:
         if pm.label in existing:
-            to_resolve.append(dataclasses.replace(pm, host_port=existing[pm.label]["host_port"]))
+            to_resolve.append(attr.evolve(pm, host_port=existing[pm.label]["host_port"]))
         else:
             to_resolve.append(pm)
 

--- a/compute_space/compute_space/core/data.py
+++ b/compute_space/compute_space/core/data.py
@@ -25,7 +25,16 @@ def rmtree_with_sudo_fallback(path: str, *, raise_on_failure: bool = False) -> N
         return
 
     def _make_writable_and_retry(func, err_path, _exc):  # type: ignore[no-untyped-def]
+        # Unlinking a file needs write perms on the parent directory, not
+        # the file itself — so chmod both.  Git clones leave read-only
+        # dirs as well as read-only files.
         os.chmod(err_path, stat.S_IRWXU)
+        parent = os.path.dirname(err_path)
+        if parent and parent != err_path:
+            try:
+                os.chmod(parent, stat.S_IRWXU)
+            except OSError:
+                pass
         func(err_path)
 
     try:

--- a/compute_space/compute_space/core/manifest.py
+++ b/compute_space/compute_space/core/manifest.py
@@ -1,8 +1,8 @@
 import os
 import tomllib
-from dataclasses import dataclass
-from dataclasses import field
 from typing import Any
+
+import attr
 
 from compute_space.core.logging import logger
 
@@ -67,29 +67,22 @@ SAFE_DEVICE_PATHS: frozenset[str] = frozenset(
 )
 
 
-@dataclass(frozen=True)
+@attr.s(auto_attribs=True, frozen=True)
 class PortMapping:
-    """A structured port mapping declared in [[ports]].
-
-    Defined as a dataclass (rather than an attrs class) so that the manifest,
-    which is itself a dataclass, serializes cleanly via ``dataclasses.asdict``.
-    Flask's default JSON encoder cannot serialize attrs instances, which
-    previously caused /api/clone_and_get_app_info to 500 whenever a manifest
-    declared any ``[[ports]]`` entries.
-    """
+    """A structured port mapping declared in [[ports]]."""
 
     label: str
     container_port: int
     host_port: int = 0  # 0 = auto-assign
 
 
-@dataclass
+@attr.s(auto_attribs=True)
 class AppManifest:
     # [app]
     name: str
     version: str
     description: str = ""
-    authors: list[str] = field(default_factory=list)
+    authors: list[str] = attr.Factory(list)
 
     # [runtime]
     runtime_type: str = "serverfull"
@@ -98,13 +91,13 @@ class AppManifest:
     container_image: str = ""
     container_port: int = 0
     container_command: str | None = None
-    port_mappings: list[PortMapping] = field(default_factory=list)
-    capabilities: list[str] = field(default_factory=list)
-    devices: list[str] = field(default_factory=list)
+    port_mappings: list[PortMapping] = attr.Factory(list)
+    capabilities: list[str] = attr.Factory(list)
+    devices: list[str] = attr.Factory(list)
 
     # [routing]
     health_check: str | None = None
-    public_paths: list[str] = field(default_factory=list)
+    public_paths: list[str] = attr.Factory(list)
 
     # [resources]
     memory_mb: int = 128
@@ -112,15 +105,15 @@ class AppManifest:
     gpu: bool = False
 
     # [data]
-    sqlite_dbs: list[str] = field(default_factory=list)
+    sqlite_dbs: list[str] = attr.Factory(list)
     app_data: bool = False
     app_temp_data: bool = False
     access_vm_data: bool = False
     access_all_data: bool = False
 
     # [services]
-    provides_services: list[str] = field(default_factory=list)
-    requires_services: dict[str, list[dict[str, Any]]] = field(default_factory=dict)
+    provides_services: list[str] = attr.Factory(list)
+    requires_services: dict[str, list[dict[str, Any]]] = attr.Factory(dict)
     # requires_services example: {"secrets": [{"key": "DB_URL", "reason": "...", "required": True}]}
 
     # [app] metadata

--- a/compute_space/compute_space/core/ports.py
+++ b/compute_space/compute_space/core/ports.py
@@ -1,7 +1,8 @@
-import dataclasses
 import random
 import socket
 import sqlite3
+
+import attr
 
 from compute_space.core.manifest import PortMapping
 from compute_space.db import get_db
@@ -104,7 +105,7 @@ def resolve_port_mappings(
         if pm.host_port == 0:
             assigned = _find_free_host_port(range_start, range_end, db, claimed, exclude_app=exclude_app)
             claimed.add(assigned)
-            resolved.append(dataclasses.replace(pm, host_port=assigned))
+            resolved.append(attr.evolve(pm, host_port=assigned))
 
     return resolved
 

--- a/compute_space/compute_space/web/routes/api/apps.py
+++ b/compute_space/compute_space/web/routes/api/apps.py
@@ -1,10 +1,10 @@
 import asyncio
-import dataclasses
 import os
 import re
 import shutil
 import threading
 
+import attr
 from quart import Blueprint
 from quart import jsonify
 from quart import redirect
@@ -75,7 +75,7 @@ async def clone_and_get_app_info() -> ResponseReturnValue:
         raise RuntimeError("manifest unexpectedly None after successful clone")
     db = get_db()
     validation_error = validate_manifest(manifest, db)
-    info = dataclasses.asdict(manifest)
+    info = attr.asdict(manifest)
     info.pop("raw_toml", None)
     return jsonify(
         {

--- a/compute_space/tests/test_manifest.py
+++ b/compute_space/tests/test_manifest.py
@@ -1,8 +1,8 @@
 """Unit tests for the openhost.toml manifest parser."""
 
-import dataclasses
 import json
 
+import attr
 import pytest
 
 from compute_space.core.manifest import SAFE_CAPABILITIES
@@ -254,11 +254,8 @@ host_port = 0
 
     def test_manifest_with_port_mappings_is_json_serializable(self):
         """Regression: manifests with [[ports]] must round-trip through
-        ``dataclasses.asdict`` + ``json.dumps`` so that
-        ``/api/clone_and_get_app_info`` can return them. Previously
-        ``PortMapping`` was an attrs class, which ``dataclasses.asdict``
-        leaves as-is, and Flask's default JSON encoder then raises
-        ``TypeError: Object of type PortMapping is not JSON serializable``.
+        ``attr.asdict`` + ``json.dumps`` so that
+        ``/api/clone_and_get_app_info`` can return them.
         """
         toml = (
             MINIMAL
@@ -275,7 +272,7 @@ host_port = 0
 """
         )
         manifest = parse_manifest_from_string(toml)
-        info = dataclasses.asdict(manifest)
+        info = attr.asdict(manifest)
         # Round-trip through JSON; will raise TypeError on regression.
         payload = json.dumps(info)
         decoded = json.loads(payload)

--- a/compute_space_cli/compute_space_cli/main.py
+++ b/compute_space_cli/compute_space_cli/main.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import shutil
+import subprocess
 import sys
 import time
 from typing import Annotated
@@ -402,10 +404,38 @@ class InstanceCmd:
         print(f"Default instance set to '{name}'")
 
 
+@cappa.command(name="curl", help="curl with your OpenHost bearer token injected.")
+@attrs.define
+class Curl:
+    args: Annotated[
+        list[str],
+        cappa.Arg(num_args=-1, help="Arguments passed to curl"),
+    ] = attrs.Factory(list)
+
+    def __call__(self, cfg: Annotated[config.Instance, Dep(resolve_instance)]) -> None:
+        curl = shutil.which("curl")
+        if not curl:
+            print("curl not found on PATH", file=sys.stderr)
+            raise SystemExit(1)
+
+        url_args = []
+        remaining = list(self.args)
+        for arg in remaining:
+            if not arg.startswith("-"):
+                if "://" not in arg:
+                    arg = f"{cfg.url.rstrip('/')}/{arg.lstrip('/')}"
+                url_args.append(arg)
+            else:
+                url_args.append(arg)
+
+        cmd = [curl, "-H", f"Authorization: Bearer {cfg.token}", *url_args]
+        raise SystemExit(subprocess.call(cmd))
+
+
 @cappa.command(name="oh", help="OpenHost compute space CLI — manage things in your compute space.")
 @attrs.define
 class Oh:
-    subcommand: cappa.Subcommands[Status | Login | AppCmd | TokensCmd | LogsCmd | InstanceCmd]
+    subcommand: cappa.Subcommands[Status | Login | AppCmd | TokensCmd | LogsCmd | InstanceCmd | Curl]
     instance: Annotated[
         str | None,
         cappa.Arg(long=True, default=None, help="Target a specific named instance"),


### PR DESCRIPTION
## Summary
- Adds \`oh curl\` — curl wrapper that injects the active instance's URL and bearer token.
- Bare paths get the instance URL prepended (\`oh curl /api/apps\`); absolute URLs pass through.

## Stacked-PR context
PR #3 in the 6-PR stack splitting \`zack/new_services_interface\`. Stacks on #32.

## Test plan
- [x] \`compute_space_cli/\` tests still pass (38 passed).
- [ ] Manual smoke: \`oh curl /api/apps\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)