### PR TITLE
Add packaging to root pyproject.toml dependencies

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -94,6 +94,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/3c/2e/8d0c2ab90a8c1d9a24f0399058ab8519a3279d1bd4289511d74e909f060e/markupsafe-3.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/27/1a/1f68f9ba0c207934b35b86a8ca3aad8395a3d6dd7921c0686e23853ff5a9/mccabe-0.7.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/9e/c9/b2622292ea83fbb4ec318f5b9ab867d0a28ab43c5717bb85b0a5f6b3b0a4/networkx-3.6.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c0/db/61efa0d08a99f897ef98256b03e563092d36cc38dc4ebe4a85020fe40b31/pbr-7.0.3-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/5e/5f/82c8074f7e84978129347c2c6ec8b6c59f3584ff1a20bc3c940a3e061790/priority-2.0.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b1/90/a998c550d0ddd07e38605bb5c455d00fcc177a800ff9cc3dafdcb3dd7b56/pycodestyle-2.11.1-py2.py3-none-any.whl
@@ -998,7 +999,7 @@ packages:
 - pypi: ./
   name: openhost
   version: 0.1.0
-  sha256: 96324b884ee9f367d87c713aff4f689c135a207b75486b6d82699757556f7352
+  sha256: 9fcaed1139cb304ff715db28ac72f27962080818f6894ae4ae42a9941513ecad
   requires_dist:
   - pyjwt[crypto]
   - acme>=5.4.0
@@ -1015,6 +1016,7 @@ packages:
   - hypercorn
   - josepy
   - loguru
+  - packaging
   - quart
   - tomli-w
   - typed-settings>=25.3.0
@@ -1033,6 +1035,11 @@ packages:
   purls: []
   size: 3167099
   timestamp: 1775587756857
+- pypi: https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl
+  name: packaging
+  version: '26.2'
+  sha256: 5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e
+  requires_python: '>=3.8'
 - pypi: https://files.pythonhosted.org/packages/c0/db/61efa0d08a99f897ef98256b03e563092d36cc38dc4ebe4a85020fe40b31/pbr-7.0.3-py2.py3-none-any.whl
   name: pbr
   version: 7.0.3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ dependencies = [
     "hypercorn",
     "josepy",
     "loguru",
+    "packaging",
     "quart",
     "tomli-w",
     "typed-settings>=25.3.0",

--- a/uv.lock
+++ b/uv.lock
@@ -3,7 +3,7 @@ revision = 3
 requires-python = "==3.12.*"
 
 [options]
-exclude-newer = "2026-04-18T07:00:49.799168Z"
+exclude-newer = "2026-04-20T20:56:22.485613Z"
 exclude-newer-span = "P1W"
 
 [[package]]
@@ -888,6 +888,7 @@ dependencies = [
     { name = "hypercorn" },
     { name = "josepy" },
     { name = "loguru" },
+    { name = "packaging" },
     { name = "pyjwt", extra = ["crypto"] },
     { name = "quart" },
     { name = "tomli-w" },
@@ -925,6 +926,7 @@ requires-dist = [
     { name = "hypercorn" },
     { name = "josepy" },
     { name = "loguru" },
+    { name = "packaging" },
     { name = "pyjwt", extras = ["crypto"] },
     { name = "quart" },
     { name = "tomli-w" },


### PR DESCRIPTION
## Summary
- `compute_space/core/services_v2.py` imports `packaging` (added in #35) but the dep was only declared in `compute_space/pyproject.toml`, not the root `pyproject.toml` that `pixi install` uses on deployed servers
- This causes `ModuleNotFoundError: No module named 'packaging'` at openhost startup in e2e CI on every branch since #35 merged
- Adds `packaging` to root `[project].dependencies` and re-locks `pixi.lock` + `uv.lock`

## Test plan
- [x] `uv run --group dev pytest -x compute_space/tests/` passes locally
- [ ] e2e (ec2) and e2e (gcp) jobs pass on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)