### PR TITLE
oh: restructure instance management CLI

### DIFF
--- a/compute_space_cli/README.md
+++ b/compute_space_cli/README.md
@@ -57,20 +57,23 @@ The CLI supports managing multiple named instances.
 ```bash
 oh instance login                            # interactive login (saves as domain name)
 oh instance list                             # list all instances
-oh instance add prod https://prod.host.com TOKEN
-oh instance remove staging
-oh instance set-default prod
+oh instance add user.host.com TOKEN          # add non-interactively
+oh instance alias user.host.com dev          # set a short alias
+oh instance set-default dev                  # set default (by hostname or alias)
+oh instance remove dev                       # remove (by hostname or alias)
 oh instance token                            # print stored token for current instance
 ```
 
 ### Targeting instances
 
 ```bash
-oh --instance staging app list               # target a specific instance
-OH_INSTANCE=staging oh app list              # same, via env var
+oh --instance dev app list                   # target by alias
+oh --instance user.host.com app list         # target by hostname
+OH_INSTANCE=dev oh app list                  # same, via env var
 ```
 
 Resolution order: `--instance` flag > `OH_INSTANCE` env var > default instance.
+Names are resolved as hostnames first, then aliases.
 
 ## Update
 

--- a/compute_space_cli/README.md
+++ b/compute_space_cli/README.md
@@ -11,11 +11,11 @@ uv tool install "oh @ git+https://github.com/imbue-ai/openhost.git#subdirectory=
 ## Setup
 
 ```bash
-oh login                     # add default instance
-oh login --name staging      # add a named instance
+oh instance login                    # add an instance interactively
+oh instance set-default x.host.com   # set it as default
 ```
 
-This will prompt you for your compute space URL and walk you through creating an API token. Credentials are saved to `~/.openhost/compute_space_cli.toml`.
+This will prompt you for your compute space URL and walk you through creating an API token. The instance is saved under its domain name (e.g. `x.host.com`) to `~/.openhost/compute_space_cli.toml`.
 
 For development, use an editable install so changes take effect immediately:
 
@@ -55,11 +55,12 @@ The CLI supports managing multiple named instances.
 ### Instance management
 
 ```bash
+oh instance login                            # interactive login (saves as domain name)
 oh instance list                             # list all instances
-oh instance add prod https://prod.host.com TOKEN --set-default
-oh instance add staging https://s.host.com TOKEN
+oh instance add prod https://prod.host.com TOKEN
 oh instance remove staging
 oh instance set-default prod
+oh instance token                            # print stored token for current instance
 ```
 
 ### Targeting instances
@@ -69,7 +70,7 @@ oh --instance staging app list               # target a specific instance
 OH_INSTANCE=staging oh app list              # same, via env var
 ```
 
-Resolution order: `--instance` flag > `OH_INSTANCE` env var > default instance. If none of these are set and only one instance is configured, it is selected automatically.
+Resolution order: `--instance` flag > `OH_INSTANCE` env var > default instance.
 
 ## Update
 

--- a/compute_space_cli/compute_space_cli/config.py
+++ b/compute_space_cli/compute_space_cli/config.py
@@ -110,12 +110,11 @@ class MultiConfig:
         """Return a new config with the given instance added or replaced.
 
         If *set_default* is True, the new instance becomes the default.
-        Otherwise the existing default is preserved (or set to *name* if
-        there is no default yet).
+        Otherwise the existing default is preserved.
         """
         instances = dict(self.instances)
         instances[name] = inst
-        default = name if set_default else (self.default_instance or name)
+        default = name if set_default else self.default_instance
         return self.evolve(instances=instances, default_instance=default)
 
     def remove_instance(self, name: str) -> Self:
@@ -146,8 +145,6 @@ class MultiConfig:
         """Resolve which instance to use.
 
         Priority: explicit name > OH_INSTANCE env var > default_instance.
-        If none of these are set and only one instance is configured, it is
-        selected automatically.
         """
         name = instance_name
         if not name:
@@ -156,13 +153,13 @@ class MultiConfig:
             name = self.default_instance
 
         if not name:
-            if len(self.instances) == 1:
-                name = next(iter(self.instances))
-            else:
-                raise InstanceNotFoundError(
-                    f"No instance specified. Use --instance, OH_INSTANCE env var, or set "
-                    f"default_instance in config. Available: {self._available_names}"
-                )
+            if not self.instances:
+                raise InstanceNotFoundError("No instances configured. Run 'oh instance login' first.")
+            raise InstanceNotFoundError(
+                "No default instance set. Use --instance <name>, or set a default with:\n"
+                "  oh instance set-default <name>\n"
+                "Run 'oh instance list' to see configured instances."
+            )
 
         return self.get_instance(name)
 

--- a/compute_space_cli/compute_space_cli/config.py
+++ b/compute_space_cli/compute_space_cli/config.py
@@ -5,7 +5,6 @@ from typing import Any
 from typing import Self
 
 import attr
-import cattrs
 import tomli_w
 
 CONFIG_DIR = Path.home() / ".openhost"
@@ -31,17 +30,21 @@ def normalize_url(url: str) -> str:
     return url
 
 
-def _validate_url(instance: object, attribute: object, value: str) -> None:
-    if not value.startswith(("http://", "https://")):
-        raise ValueError(f"URL must include protocol (http:// or https://): {value}")
+def hostname_from_url(url: str) -> str:
+    return url.replace("https://", "").replace("http://", "").rstrip("/")
 
 
 @attr.s(auto_attribs=True, frozen=True)
 class Instance:
     """A single OpenHost compute-space instance."""
 
-    url: str = attr.ib(validator=_validate_url)
+    hostname: str = attr.ib()
     token: str = attr.ib()
+    alias: str | None = attr.ib(default=None)
+
+    @property
+    def url(self) -> str:
+        return f"https://{self.hostname}"
 
 
 @attr.s(auto_attribs=True, frozen=True)
@@ -62,9 +65,11 @@ class MultiConfig:
         if self.default_instance:
             raw["default_instance"] = self.default_instance
         instances_raw: dict[str, object] = {}
-        for name, inst in self.instances.items():
-            entry: dict[str, object] = {"url": inst.url, "token": inst.token}
-            instances_raw[name] = entry
+        for hostname, inst in self.instances.items():
+            entry: dict[str, object] = {"token": inst.token}
+            if inst.alias:
+                entry["alias"] = inst.alias
+            instances_raw[hostname] = entry
         if instances_raw:
             raw["instances"] = instances_raw
         with open(path, "wb") as f:
@@ -84,62 +89,59 @@ class MultiConfig:
         try:
             if "instances" in data:
                 instances: dict[str, Instance] = {}
-                for name, raw_inst in data["instances"].items():
-                    instances[name] = cattrs.structure(raw_inst, Instance)
+                for hostname, raw_inst in data["instances"].items():
+                    if not isinstance(raw_inst, dict):
+                        raise TypeError(f"Instance '{hostname}' must be a table")
+                    instances[hostname] = Instance(
+                        hostname=hostname,
+                        token=raw_inst["token"],
+                        alias=raw_inst.get("alias"),
+                    )
                 raw_default = data.get("default_instance")
                 if raw_default is not None and not isinstance(raw_default, str):
                     raise TypeError(f"default_instance must be a string, got {type(raw_default).__name__}")
-                return cls(
-                    instances=instances,
-                    default_instance=raw_default,
-                )
+                return cls(instances=instances, default_instance=raw_default)
 
+            # Legacy format: bare url + token at top level.
             if "url" in data and "token" in data:
-                inst = cattrs.structure(data, Instance)
-                return cls(
-                    instances={"default": inst},
-                    default_instance="default",
-                )
-        except (cattrs.ClassValidationError, ValueError, TypeError, AttributeError) as e:
+                hostname = hostname_from_url(data["url"])
+                inst = Instance(hostname=hostname, token=data["token"])
+                return cls(instances={hostname: inst}, default_instance=hostname)
+        except (KeyError, ValueError, TypeError, AttributeError) as e:
             raise ConfigInvalidError(f"Config file at {path} is malformed: {e}") from None
 
-        # Empty or unrecognized config — return empty MultiConfig.
         return cls()
 
-    def upsert_instance(self, name: str, inst: Instance, *, set_default: bool = False) -> Self:
-        """Return a new config with the given instance added or replaced.
-
-        If *set_default* is True, the new instance becomes the default.
-        Otherwise the existing default is preserved.
-        """
+    def upsert_instance(self, inst: Instance, *, set_default: bool = False) -> Self:
+        """Return a new config with the given instance added or replaced."""
         instances = dict(self.instances)
-        instances[name] = inst
-        default = name if set_default else self.default_instance
+        instances[inst.hostname] = inst
+        default = inst.hostname if set_default else self.default_instance
         return self.evolve(instances=instances, default_instance=default)
 
     def remove_instance(self, name: str) -> Self:
-        """Return a new config with the named instance removed.
-
-        Raises *InstanceNotFoundError* if the name does not exist.
-        If the removed instance was the default, the first remaining instance
-        becomes the new default (or ``None`` if no instances remain).
-        """
-        self.get_instance(name)  # raises InstanceNotFoundError if missing
-        instances = {k: v for k, v in self.instances.items() if k != name}
+        """Return a new config with the named instance removed."""
+        hostname = self._resolve_name(name)
+        instances = {k: v for k, v in self.instances.items() if k != hostname}
         default = self.default_instance
-        if default == name:
-            default = next(iter(instances), None)
+        if default == hostname:
+            default = None
         return self.evolve(instances=instances, default_instance=default)
 
-    @property
-    def _available_names(self) -> str:
-        return ", ".join(sorted(self.instances)) or "(none)"
+    def _resolve_name(self, name: str) -> str:
+        """Resolve a name (hostname or alias) to a hostname. Raises if not found."""
+        if name in self.instances:
+            return name
+        for hostname, inst in self.instances.items():
+            if inst.alias == name:
+                return hostname
+        raise InstanceNotFoundError(
+            f"Instance '{name}' not found. Run 'oh instance list' to see configured instances."
+        )
 
     def get_instance(self, name: str) -> Instance:
-        """Return a named instance or raise."""
-        if name not in self.instances:
-            raise InstanceNotFoundError(f"Instance '{name}' not found. Available: {self._available_names}")
-        return self.instances[name]
+        """Return an instance by hostname or alias."""
+        return self.instances[self._resolve_name(name)]
 
     def resolve(self, instance_name: str | None = None) -> Instance:
         """Resolve which instance to use.

--- a/compute_space_cli/compute_space_cli/main.py
+++ b/compute_space_cli/compute_space_cli/main.py
@@ -21,7 +21,7 @@ def _load_or_exit() -> config.MultiConfig:
     try:
         return config.get_multi_config()
     except config.ConfigFileNotFoundError:
-        print("No config file. Run 'oh login' first.", file=sys.stderr)
+        print("No config file. Run 'oh instance login' first.", file=sys.stderr)
         raise SystemExit(1) from None
     except config.ConfigInvalidError as e:
         print(f"Invalid config file: {e}", file=sys.stderr)
@@ -64,49 +64,9 @@ class Status:
             raise SystemExit(1) from None
 
 
-@cappa.command(name="login", help="Log in to your compute space.")
-@attrs.define
-class Login:
-    name: Annotated[
-        str,
-        cappa.Arg(long=True, help="Instance name (used in multi-instance config)"),
-    ] = "default"
-
-    def __call__(self) -> None:
-        url = input("Compute space URL (eg username.host.imbue.com/): ").strip().rstrip("/")
-        if not url:
-            print("No URL provided.", file=sys.stderr)
-            raise SystemExit(1)
-        url = config.normalize_url(url)
-
-        print("\nOpen this link and create an API token:")
-        print(f"  {url}")
-        print()
-
-        token = input("Paste your API token here: ").strip()
-        if not token:
-            print("No token provided.", file=sys.stderr)
-            raise SystemExit(1)
-
-        print("\nVerifying...", end=" ", flush=True)
-        try:
-            resp = httpx.get(
-                f"{url}/dashboard",
-                headers={"Authorization": f"Bearer {token}"},
-                timeout=10,
-                follow_redirects=False,
-            )
-            if resp.status_code != 200:
-                print("failed (invalid token or unreachable)", file=sys.stderr)
-                raise SystemExit(1)
-        except (httpx.ConnectError, httpx.TimeoutException) as e:
-            print(f"failed ({e})", file=sys.stderr)
-            raise SystemExit(1) from None
-        print("ok")
-
-        inst = config.Instance(url=url, token=token)
-        _load_or_create().upsert_instance(self.name, inst).save()
-        print(f"Saved instance '{self.name}'. Compute space: {url}")
+def _instance_name_from_url(url: str) -> str:
+    """Derive a short instance name from a URL, e.g. 'https://user.host.imbue.com' → 'user.host.imbue.com'."""
+    return url.replace("https://", "").replace("http://", "").rstrip("/")
 
 
 @cappa.command(name="app", help="Manage apps.")
@@ -341,6 +301,56 @@ class LogsCmd:
 @cappa.command(name="instance", help="Manage configured instances.")
 @attrs.define
 class InstanceCmd:
+    @cappa.command(name="login")
+    def login(self) -> None:
+        """Log in to an instance interactively."""
+        url = input("Compute space URL (eg username.host.imbue.com/): ").strip().rstrip("/")
+        if not url:
+            print("No URL provided.", file=sys.stderr)
+            raise SystemExit(1)
+        url = config.normalize_url(url)
+
+        print("\nOpen this link and create an API token:")
+        print(f"  {url}")
+        print()
+
+        token = input("Paste your API token here: ").strip()
+        if not token:
+            print("No token provided.", file=sys.stderr)
+            raise SystemExit(1)
+
+        print("\nVerifying...", end=" ", flush=True)
+        try:
+            resp = httpx.get(
+                f"{url}/dashboard",
+                headers={"Authorization": f"Bearer {token}"},
+                timeout=10,
+                follow_redirects=False,
+            )
+            if resp.status_code != 200:
+                print("failed (invalid token or unreachable)", file=sys.stderr)
+                raise SystemExit(1)
+        except (httpx.ConnectError, httpx.TimeoutException) as e:
+            print(f"failed ({e})", file=sys.stderr)
+            raise SystemExit(1) from None
+        print("ok")
+
+        name = _instance_name_from_url(url)
+        multi = _load_or_create()
+        inst = config.Instance(url=url, token=token)
+        multi.upsert_instance(name, inst).save()
+
+        print(f"\nSaved as '{name}'.")
+        if not multi.default_instance:
+            answer = input(f"Set '{name}' as default instance? [Y/n] ").strip().lower()
+            if answer != "n":
+                _load_or_exit().evolve(default_instance=name).save()
+                print(f"Default instance set to '{name}'")
+            else:
+                print(f"Use with: oh --instance {name} <command>")
+        else:
+            print(f"Use with: oh --instance {name} <command>")
+
     @cappa.command(name="list")
     def list_instances(self) -> None:
         """List all configured instances."""
@@ -435,7 +445,7 @@ class Curl:
 @cappa.command(name="oh", help="OpenHost compute space CLI — manage things in your compute space.")
 @attrs.define
 class Oh:
-    subcommand: cappa.Subcommands[Status | Login | AppCmd | TokensCmd | LogsCmd | InstanceCmd | Curl]
+    subcommand: cappa.Subcommands[Status | AppCmd | TokensCmd | LogsCmd | InstanceCmd | Curl]
     instance: Annotated[
         str | None,
         cappa.Arg(long=True, default=None, help="Target a specific named instance"),

--- a/compute_space_cli/compute_space_cli/main.py
+++ b/compute_space_cli/compute_space_cli/main.py
@@ -64,11 +64,6 @@ class Status:
             raise SystemExit(1) from None
 
 
-def _instance_name_from_url(url: str) -> str:
-    """Derive a short instance name from a URL, e.g. 'https://user.host.imbue.com' → 'user.host.imbue.com'."""
-    return url.replace("https://", "").replace("http://", "").rstrip("/")
-
-
 @cappa.command(name="app", help="Manage apps.")
 @attrs.define
 class AppCmd:
@@ -309,6 +304,7 @@ class InstanceCmd:
             print("No URL provided.", file=sys.stderr)
             raise SystemExit(1)
         url = config.normalize_url(url)
+        hostname = config.hostname_from_url(url)
 
         print("\nOpen this link and create an API token:")
         print(f"  {url}")
@@ -335,21 +331,26 @@ class InstanceCmd:
             raise SystemExit(1) from None
         print("ok")
 
-        name = _instance_name_from_url(url)
+        alias = input(f"\nAlias for '{hostname}' (optional, press Enter to skip): ").strip() or None
+        inst = config.Instance(hostname=hostname, token=token, alias=alias)
         multi = _load_or_create()
-        inst = config.Instance(url=url, token=token)
-        multi.upsert_instance(name, inst).save()
+        multi.upsert_instance(inst).save()
 
-        print(f"\nSaved as '{name}'.")
-        if not multi.default_instance:
-            answer = input(f"Set '{name}' as default instance? [Y/n] ").strip().lower()
-            if answer != "n":
-                _load_or_exit().evolve(default_instance=name).save()
-                print(f"Default instance set to '{name}'")
-            else:
-                print(f"Use with: oh --instance {name} <command>")
+        display_name = alias or hostname
+        print(f"\nSaved as '{hostname}'.", end="")
+        if alias:
+            print(f" Alias: '{alias}'.")
         else:
-            print(f"Use with: oh --instance {name} <command>")
+            print()
+        if not multi.default_instance:
+            answer = input(f"Set '{display_name}' as default instance? [Y/n] ").strip().lower()
+            if answer != "n":
+                _load_or_exit().evolve(default_instance=hostname).save()
+                print(f"Default instance set to '{display_name}'")
+            else:
+                print(f"Use with: oh --instance {display_name} <command>")
+        else:
+            print(f"Use with: oh --instance {display_name} <command>")
 
     @cappa.command(name="list")
     def list_instances(self) -> None:
@@ -360,34 +361,38 @@ class InstanceCmd:
             print("No instances configured.")
             return
 
-        max_name = max(len(n) for n in multi.instances)
-        for name, inst in sorted(multi.instances.items()):
+        max_name = max(len(h) for h in multi.instances)
+        for hostname, inst in sorted(multi.instances.items()):
             flags: list[str] = []
-            if name == multi.default_instance:
+            if hostname == multi.default_instance:
                 flags.append("default")
+            if inst.alias:
+                flags.append(f"alias: {inst.alias}")
             flag_str = f"  [{', '.join(flags)}]" if flags else ""
-            print(f"  {name:<{max_name}}  {inst.url}{flag_str}")
+            print(f"  {hostname:<{max_name}}{flag_str}")
 
     @cappa.command(name="add")
     def add(
         self,
-        name: Annotated[str, cappa.Arg(help="Instance name")],
-        url: Annotated[str, cappa.Arg(help="Instance URL")],
+        url: Annotated[str, cappa.Arg(help="Instance URL or hostname")],
         token: Annotated[str, cappa.Arg(help="API token")],
+        alias: Annotated[str | None, cappa.Arg(long=True, help="Short alias")] = None,
         set_default: Annotated[bool, cappa.Arg(long=True, help="Set as default instance")] = False,
     ) -> None:
         """Add a new instance to the config."""
-        url = config.normalize_url(url)
-        inst = config.Instance(url=url, token=token)
-        _load_or_create().upsert_instance(name, inst, set_default=set_default).save()
-        print(f"Added instance '{name}' ({url})")
+        hostname = config.hostname_from_url(config.normalize_url(url))
+        inst = config.Instance(hostname=hostname, token=token, alias=alias)
+        _load_or_create().upsert_instance(inst, set_default=set_default).save()
+        print(f"Added instance '{hostname}'")
+        if alias:
+            print(f"  alias: {alias}")
         if set_default:
             print("  set as default")
 
     @cappa.command(name="remove")
     def remove(
         self,
-        name: Annotated[str, cappa.Arg(help="Instance name to remove")],
+        name: Annotated[str, cappa.Arg(help="Hostname or alias")],
     ) -> None:
         """Remove an instance from the config."""
         multi = _load_or_exit()
@@ -401,17 +406,43 @@ class InstanceCmd:
     @cappa.command(name="set-default")
     def set_default(
         self,
-        name: Annotated[str, cappa.Arg(help="Instance name")],
+        name: Annotated[str, cappa.Arg(help="Hostname or alias")],
     ) -> None:
         """Set the default instance."""
         multi = _load_or_exit()
         try:
-            multi.get_instance(name)
+            hostname = multi._resolve_name(name)
         except config.InstanceNotFoundError as e:
             print(str(e), file=sys.stderr)
             raise SystemExit(1) from None
-        multi.evolve(default_instance=name).save()
+        multi.evolve(default_instance=hostname).save()
         print(f"Default instance set to '{name}'")
+
+    @cappa.command(name="alias")
+    def alias(
+        self,
+        name: Annotated[str, cappa.Arg(help="Hostname or current alias")],
+        new_alias: Annotated[str, cappa.Arg(help="Alias to set")],
+    ) -> None:
+        """Set or update an alias for an instance."""
+        multi = _load_or_exit()
+        try:
+            hostname = multi._resolve_name(name)
+        except config.InstanceNotFoundError as e:
+            print(str(e), file=sys.stderr)
+            raise SystemExit(1) from None
+        old = multi.instances[hostname]
+        updated = config.Instance(hostname=old.hostname, token=old.token, alias=new_alias)
+        multi.upsert_instance(updated).save()
+        print(f"Alias '{new_alias}' set for {hostname}")
+
+    @cappa.command(name="token")
+    def token(
+        self,
+        cfg: Annotated[config.Instance, Dep(resolve_instance)],
+    ) -> None:
+        """Print the stored API token for an instance."""
+        print(cfg.token)
 
 
 @cappa.command(name="curl", help="curl with your OpenHost bearer token injected.")

--- a/compute_space_cli/tests/test_config.py
+++ b/compute_space_cli/tests/test_config.py
@@ -153,22 +153,12 @@ class TestMultiConfigResolve:
         )
         assert multi.resolve().url == "https://a.com"
 
-    def test_single_instance_auto_select(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_no_default_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.delenv("OH_INSTANCE", raising=False)
         multi = _make_multi(
             instances={"only": Instance(url="https://only.com", token="t")},
         )
-        assert multi.resolve().url == "https://only.com"
-
-    def test_multiple_no_default_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.delenv("OH_INSTANCE", raising=False)
-        multi = _make_multi(
-            instances={
-                "a": Instance(url="https://a.com", token="t"),
-                "b": Instance(url="https://b.com", token="t"),
-            },
-        )
-        with pytest.raises(InstanceNotFoundError, match="No instance specified"):
+        with pytest.raises(InstanceNotFoundError, match="No default instance set"):
             multi.resolve()
 
     def test_nonexistent_name_raises(self) -> None:
@@ -224,11 +214,11 @@ class TestMultiConfigEvolve:
 
 
 class TestUpsertInstance:
-    def test_add_to_empty_sets_default(self) -> None:
+    def test_add_to_empty_no_default(self) -> None:
         multi = _make_multi()
         result = multi.upsert_instance("a", Instance(url="https://a.com", token="t"))
         assert "a" in result.instances
-        assert result.default_instance == "a"
+        assert result.default_instance is None
 
     def test_set_default_true(self) -> None:
         multi = _make_multi(

--- a/compute_space_cli/tests/test_config.py
+++ b/compute_space_cli/tests/test_config.py
@@ -18,34 +18,34 @@ def tmp_config(tmp_path: Path) -> Path:
     return tmp_path / "config.toml"
 
 
+def _inst(hostname: str = "a.com", token: str = "t", alias: str | None = None) -> Instance:
+    return Instance(hostname=hostname, token=token, alias=alias)
+
+
 def _make_multi(
     instances: dict[str, Instance] | None = None,
     default: str | None = None,
 ) -> MultiConfig:
-    return MultiConfig(
-        instances=instances or {},
-        default_instance=default,
-    )
+    return MultiConfig(instances=instances or {}, default_instance=default)
 
 
 class TestInstance:
-    def test_valid_https(self) -> None:
-        inst = Instance(url="https://example.com", token="tok")
-        assert inst.url == "https://example.com"
+    def test_fields(self) -> None:
+        inst = _inst("example.com", "tok", "ex")
+        assert inst.hostname == "example.com"
         assert inst.token == "tok"
+        assert inst.alias == "ex"
 
-    def test_valid_http(self) -> None:
-        inst = Instance(url="http://localhost:8080", token="tok")
-        assert inst.url == "http://localhost:8080"
+    def test_url_property(self) -> None:
+        assert _inst("example.com").url == "https://example.com"
 
-    def test_missing_protocol_raises(self) -> None:
-        with pytest.raises(ValueError, match="URL must include protocol"):
-            Instance(url="example.com", token="tok")
+    def test_alias_defaults_none(self) -> None:
+        assert _inst("a.com").alias is None
 
     def test_frozen(self) -> None:
-        inst = Instance(url="https://a.com", token="t")
+        inst = _inst()
         with pytest.raises(AttributeError):
-            inst.url = "https://b.com"  # type: ignore[misc]
+            inst.hostname = "b.com"  # type: ignore[misc]
 
 
 class TestNormalizeUrl:
@@ -63,25 +63,27 @@ class TestMultiConfigSaveLoad:
     def test_roundtrip(self, tmp_config: Path) -> None:
         original = _make_multi(
             instances={
-                "a": Instance(url="https://a.com", token="tok-a"),
-                "b": Instance(url="https://b.com", token="tok-b"),
+                "a.com": _inst("a.com", "tok-a", alias="a"),
+                "b.com": _inst("b.com", "tok-b"),
             },
-            default="a",
+            default="a.com",
         )
         original.save(tmp_config)
         loaded = MultiConfig.load(tmp_config)
-        assert loaded.default_instance == "a"
+        assert loaded.default_instance == "a.com"
         assert len(loaded.instances) == 2
-        assert loaded.instances["a"].url == "https://a.com"
-        assert loaded.instances["b"].token == "tok-b"
+        assert loaded.instances["a.com"].url == "https://a.com"
+        assert loaded.instances["a.com"].alias == "a"
+        assert loaded.instances["b.com"].token == "tok-b"
+        assert loaded.instances["b.com"].alias is None
 
     def test_load_legacy_format(self, tmp_config: Path) -> None:
         with open(tmp_config, "wb") as f:
             tomli_w.dump({"url": "https://old.com", "token": "old-tok"}, f)
         loaded = MultiConfig.load(tmp_config)
-        assert loaded.default_instance == "default"
-        assert loaded.instances["default"].url == "https://old.com"
-        assert loaded.instances["default"].token == "old-tok"
+        assert loaded.default_instance == "old.com"
+        assert loaded.instances["old.com"].url == "https://old.com"
+        assert loaded.instances["old.com"].token == "old-tok"
 
     def test_load_missing_file(self, tmp_config: Path) -> None:
         with pytest.raises(ConfigFileNotFoundError, match="not found"):
@@ -112,215 +114,149 @@ class TestMultiConfigSaveLoad:
 
     def test_save_creates_parent_dirs(self, tmp_path: Path) -> None:
         path = tmp_path / "nested" / "dir" / "config.toml"
-        _make_multi(
-            instances={"x": Instance(url="https://x.com", token="t")},
-            default="x",
-        ).save(path)
+        _make_multi(instances={"x.com": _inst("x.com")}, default="x.com").save(path)
         loaded = MultiConfig.load(path)
-        assert loaded.instances["x"].url == "https://x.com"
+        assert loaded.instances["x.com"].hostname == "x.com"
 
 
 class TestMultiConfigResolve:
     def test_explicit_name(self) -> None:
         multi = _make_multi(
-            instances={
-                "a": Instance(url="https://a.com", token="t"),
-                "b": Instance(url="https://b.com", token="t"),
-            },
-            default="a",
+            instances={"a.com": _inst("a.com"), "b.com": _inst("b.com")},
+            default="a.com",
         )
-        assert multi.resolve(instance_name="b").url == "https://b.com"
+        assert multi.resolve(instance_name="b.com").url == "https://b.com"
+
+    def test_resolve_by_alias(self) -> None:
+        multi = _make_multi(
+            instances={"a.com": _inst("a.com", alias="dev")},
+            default="a.com",
+        )
+        assert multi.resolve(instance_name="dev").hostname == "a.com"
 
     def test_env_var(self, monkeypatch: pytest.MonkeyPatch) -> None:
         multi = _make_multi(
-            instances={
-                "a": Instance(url="https://a.com", token="t"),
-                "b": Instance(url="https://b.com", token="t"),
-            },
-            default="a",
+            instances={"a.com": _inst("a.com"), "b.com": _inst("b.com")},
+            default="a.com",
         )
-        monkeypatch.setenv("OH_INSTANCE", "b")
+        monkeypatch.setenv("OH_INSTANCE", "b.com")
         assert multi.resolve().url == "https://b.com"
 
     def test_default_instance(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.delenv("OH_INSTANCE", raising=False)
         multi = _make_multi(
-            instances={
-                "a": Instance(url="https://a.com", token="t"),
-                "b": Instance(url="https://b.com", token="t"),
-            },
-            default="a",
+            instances={"a.com": _inst("a.com"), "b.com": _inst("b.com")},
+            default="a.com",
         )
         assert multi.resolve().url == "https://a.com"
 
     def test_no_default_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.delenv("OH_INSTANCE", raising=False)
-        multi = _make_multi(
-            instances={"only": Instance(url="https://only.com", token="t")},
-        )
+        multi = _make_multi(instances={"only.com": _inst("only.com")})
         with pytest.raises(InstanceNotFoundError, match="No default instance set"):
             multi.resolve()
 
     def test_nonexistent_name_raises(self) -> None:
-        multi = _make_multi(
-            instances={"a": Instance(url="https://a.com", token="t")},
-            default="a",
-        )
+        multi = _make_multi(instances={"a.com": _inst("a.com")}, default="a.com")
         with pytest.raises(InstanceNotFoundError, match="not found"):
             multi.resolve(instance_name="nope")
 
     def test_explicit_overrides_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
         multi = _make_multi(
-            instances={
-                "a": Instance(url="https://a.com", token="t"),
-                "b": Instance(url="https://b.com", token="t"),
-            },
-            default="a",
+            instances={"a.com": _inst("a.com"), "b.com": _inst("b.com")},
+            default="a.com",
         )
-        monkeypatch.setenv("OH_INSTANCE", "a")
-        assert multi.resolve(instance_name="b").url == "https://b.com"
+        monkeypatch.setenv("OH_INSTANCE", "a.com")
+        assert multi.resolve(instance_name="b.com").url == "https://b.com"
 
     def test_env_overrides_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
         multi = _make_multi(
-            instances={
-                "a": Instance(url="https://a.com", token="t"),
-                "b": Instance(url="https://b.com", token="t"),
-            },
-            default="a",
+            instances={"a.com": _inst("a.com"), "b.com": _inst("b.com")},
+            default="a.com",
         )
-        monkeypatch.setenv("OH_INSTANCE", "b")
+        monkeypatch.setenv("OH_INSTANCE", "b.com")
         assert multi.resolve().url == "https://b.com"
-
-
-class TestMultiConfigEvolve:
-    def test_evolve_default(self) -> None:
-        multi = _make_multi(
-            instances={"a": Instance(url="https://a.com", token="t")},
-            default="a",
-        )
-        evolved = multi.evolve(default_instance="b")
-        assert evolved.default_instance == "b"
-        assert multi.default_instance == "a"  # original unchanged
-
-    def test_evolve_instances(self) -> None:
-        multi = _make_multi(
-            instances={"a": Instance(url="https://a.com", token="t")},
-        )
-        new_instances = dict(multi.instances)
-        new_instances["b"] = Instance(url="https://b.com", token="t2")
-        evolved = multi.evolve(instances=new_instances)
-        assert "b" in evolved.instances
-        assert "b" not in multi.instances  # original unchanged
 
 
 class TestUpsertInstance:
     def test_add_to_empty_no_default(self) -> None:
-        multi = _make_multi()
-        result = multi.upsert_instance("a", Instance(url="https://a.com", token="t"))
-        assert "a" in result.instances
+        result = _make_multi().upsert_instance(_inst("a.com"))
+        assert "a.com" in result.instances
         assert result.default_instance is None
 
     def test_set_default_true(self) -> None:
-        multi = _make_multi(
-            instances={"a": Instance(url="https://a.com", token="t")},
-            default="a",
-        )
-        result = multi.upsert_instance("b", Instance(url="https://b.com", token="t"), set_default=True)
-        assert result.default_instance == "b"
+        multi = _make_multi(instances={"a.com": _inst("a.com")}, default="a.com")
+        result = multi.upsert_instance(_inst("b.com"), set_default=True)
+        assert result.default_instance == "b.com"
 
     def test_preserves_existing_default(self) -> None:
-        multi = _make_multi(
-            instances={"a": Instance(url="https://a.com", token="t")},
-            default="a",
-        )
-        result = multi.upsert_instance("b", Instance(url="https://b.com", token="t"))
-        assert result.default_instance == "a"
-        assert "b" in result.instances
+        multi = _make_multi(instances={"a.com": _inst("a.com")}, default="a.com")
+        result = multi.upsert_instance(_inst("b.com"))
+        assert result.default_instance == "a.com"
+        assert "b.com" in result.instances
 
     def test_replaces_existing_instance(self) -> None:
-        multi = _make_multi(
-            instances={"a": Instance(url="https://a.com", token="old")},
-            default="a",
-        )
-        result = multi.upsert_instance("a", Instance(url="https://a.com", token="new"))
-        assert result.instances["a"].token == "new"
+        multi = _make_multi(instances={"a.com": _inst("a.com", "old")}, default="a.com")
+        result = multi.upsert_instance(_inst("a.com", "new"))
+        assert result.instances["a.com"].token == "new"
 
     def test_original_unchanged(self) -> None:
         multi = _make_multi()
-        multi.upsert_instance("a", Instance(url="https://a.com", token="t"))
-        assert "a" not in multi.instances
+        multi.upsert_instance(_inst("a.com"))
+        assert "a.com" not in multi.instances
 
 
 class TestRemoveInstance:
     def test_remove_non_default(self) -> None:
         multi = _make_multi(
-            instances={
-                "a": Instance(url="https://a.com", token="t"),
-                "b": Instance(url="https://b.com", token="t"),
-            },
-            default="a",
+            instances={"a.com": _inst("a.com"), "b.com": _inst("b.com")},
+            default="a.com",
         )
-        result = multi.remove_instance("b")
-        assert "b" not in result.instances
-        assert result.default_instance == "a"
+        result = multi.remove_instance("b.com")
+        assert "b.com" not in result.instances
+        assert result.default_instance == "a.com"
 
-    def test_remove_default_auto_selects_new(self) -> None:
+    def test_remove_default_clears(self) -> None:
         multi = _make_multi(
-            instances={
-                "a": Instance(url="https://a.com", token="t"),
-                "b": Instance(url="https://b.com", token="t"),
-            },
-            default="a",
+            instances={"a.com": _inst("a.com"), "b.com": _inst("b.com")},
+            default="a.com",
         )
-        result = multi.remove_instance("a")
-        assert "a" not in result.instances
-        assert result.default_instance == "b"
+        result = multi.remove_instance("a.com")
+        assert "a.com" not in result.instances
+        assert result.default_instance is None
+
+    def test_remove_by_alias(self) -> None:
+        multi = _make_multi(instances={"a.com": _inst("a.com", alias="dev")})
+        result = multi.remove_instance("dev")
+        assert "a.com" not in result.instances
 
     def test_remove_last_instance(self) -> None:
-        multi = _make_multi(
-            instances={"only": Instance(url="https://only.com", token="t")},
-            default="only",
-        )
-        result = multi.remove_instance("only")
+        multi = _make_multi(instances={"only.com": _inst("only.com")}, default="only.com")
+        result = multi.remove_instance("only.com")
         assert len(result.instances) == 0
         assert result.default_instance is None
 
     def test_remove_nonexistent_raises(self) -> None:
-        multi = _make_multi(
-            instances={"a": Instance(url="https://a.com", token="t")},
-        )
+        multi = _make_multi(instances={"a.com": _inst("a.com")})
         with pytest.raises(InstanceNotFoundError, match="nope"):
             multi.remove_instance("nope")
 
     def test_original_unchanged(self) -> None:
-        multi = _make_multi(
-            instances={"a": Instance(url="https://a.com", token="t")},
-            default="a",
-        )
-        multi.remove_instance("a")
-        assert "a" in multi.instances
+        multi = _make_multi(instances={"a.com": _inst("a.com")}, default="a.com")
+        multi.remove_instance("a.com")
+        assert "a.com" in multi.instances
 
 
 class TestGetInstance:
-    def test_found(self) -> None:
-        multi = _make_multi(
-            instances={"a": Instance(url="https://a.com", token="t")},
-        )
-        assert multi.get_instance("a").url == "https://a.com"
+    def test_by_hostname(self) -> None:
+        multi = _make_multi(instances={"a.com": _inst("a.com")})
+        assert multi.get_instance("a.com").hostname == "a.com"
+
+    def test_by_alias(self) -> None:
+        multi = _make_multi(instances={"a.com": _inst("a.com", alias="dev")})
+        assert multi.get_instance("dev").hostname == "a.com"
 
     def test_not_found(self) -> None:
-        multi = _make_multi(
-            instances={"a": Instance(url="https://a.com", token="t")},
-        )
+        multi = _make_multi(instances={"a.com": _inst("a.com")})
         with pytest.raises(InstanceNotFoundError, match="nope"):
-            multi.get_instance("nope")
-
-    def test_not_found_lists_available(self) -> None:
-        multi = _make_multi(
-            instances={
-                "alpha": Instance(url="https://a.com", token="t"),
-                "beta": Instance(url="https://b.com", token="t"),
-            },
-        )
-        with pytest.raises(InstanceNotFoundError, match="alpha, beta"):
             multi.get_instance("nope")

--- a/docs/creating_an_app.md
+++ b/docs/creating_an_app.md
@@ -124,7 +124,7 @@ Apps have no filesystem access by default. Request what you need in the `[data]`
 - **`access_vm_data = true`** — read-only access to the VM's shared data at `/data/vm_data/`.
 - **`access_all_data = true`** — full access to all data directories (all apps' data + VM data).
 
-The host operator can optionally set `storage_min_free_mb` in the OpenHost config to require a minimum amount of free disk space. When free space drops below this threshold, running apps are stopped until space is freed. The storage guard can be temporarily paused from the dashboard to allow starting a file-browser app for cleanup.
+The host operator can optionally set `storage_min_free_mb` in the OpenHost config to require a minimum amount of free persistent storage. When free space drops below this threshold, running apps are stopped until space is freed. The storage guard can be temporarily paused from the dashboard to allow starting a file-browser app for cleanup.
 
 See the [manifest spec](manifest_spec.md) for the full reference.
 
@@ -167,7 +167,7 @@ or if not,
 ```bash
 uv tool install "oh @ git+https://github.com/imbue-ai/openhost.git#subdirectory=compute_space_cli"
 ```
-Run `oh login` to login to your compute space.
+Run `oh instance login` to login to your compute space.
 
 ## AI Agent Development
 


### PR DESCRIPTION
## Summary
- Move `oh login` to `oh instance login`; remove auto-default behavior so the user explicitly chooses their default
- Restructure `Instance` to store `hostname`, `token`, and optional `alias` (keyed by hostname in config)
- Add `oh instance alias`, `oh instance token`, and resolution by alias across all subcommands
- Update README and docs to match

## Test plan
- [ ] `oh instance login` — interactive flow saves by hostname, prompts for alias
- [ ] `oh instance alias` — sets/updates alias
- [ ] `oh instance token` — prints token for resolved instance
- [ ] `oh instance remove` — removes by hostname or alias, clears default if needed
- [ ] `oh --instance <alias> app list` — alias resolution works
- [ ] Existing config files with legacy format still load correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)