### PR TITLE
ci: remove test exclusions from test-podman job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,9 +25,7 @@ jobs:
       - uses: astral-sh/setup-uv@v6
       - run: uv run pytest
 
-  # Rootless-podman test suites.  Re-runs compute_space and full-stack tests
-  # on a runner with rootless podman installed, so any suite that shells out
-  # to podman (even via mocks) gets an honest environment.
+  # Runs full test suite, including containerized tests.
   test-podman:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
       - run: uv run pytest
 
   # Runs full test suite, including containerized tests.
-  test-podman:
+  test-containers:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
       - uses: astral-sh/setup-uv@v6
       - run: uv run pytest
 
-  # Runs full test suite, including containerized tests.
+  # Runs full unit test suite, including containerized tests.
   test-containers:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,13 +25,9 @@ jobs:
       - uses: astral-sh/setup-uv@v6
       - run: uv run pytest
 
-  # Rootless-podman unit suites.  Re-runs the same compute_space tests as the
-  # ``test`` job above, but on a runner with rootless podman installed, so any
-  # suite that shells out to podman (even via mocks) gets an honest environment.
-  # ``compute_space/tests/test_integration.py`` and ``tests/test_full_stack.py``
-  # are intentionally excluded: their ``@requires_containers``-marked classes
-  # need ``:idmap`` on the workspace bind mount, which GitHub's overlayfs
-  # runners don't reliably support; those run in the e2e workflow on real VMs.
+  # Rootless-podman test suites.  Re-runs compute_space and full-stack tests
+  # on a runner with rootless podman installed, so any suite that shells out
+  # to podman (even via mocks) gets an honest environment.
   test-podman:
     runs-on: ubuntu-latest
     steps:
@@ -46,7 +42,6 @@ jobs:
       - name: Verify rootless podman works
         run: |
           podman info --format '{{.Host.Security.Rootless}}' | grep -qx true
-      - name: Run compute_space unit tests (excluding idmap-dependent ones)
+      - name: Run compute_space and full-stack tests
         run: |
-          uv run --group dev pytest compute_space/tests/ -v \
-            --ignore=compute_space/tests/test_integration.py
+          uv run --group dev pytest compute_space/tests/ tests/test_full_stack.py -v


### PR DESCRIPTION
## Summary
- Remove `--ignore=compute_space/tests/test_integration.py` from the `test-podman` CI job
- Add `tests/test_full_stack.py` to the podman test run
- These were previously excluded due to idmap/overlayfs concerns on GitHub runners

## Test plan
- [ ] Watch `test-podman` CI job pass with the previously-excluded tests included

🤖 Generated with [Claude Code](https://claude.com/claude-code)