### PR TITLE
Deploy via git clone instead of rsync

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -37,6 +37,7 @@ jobs:
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       AWS_DEFAULT_REGION: us-east-1
       SKIP_APT_UPGRADE: "1"
+      OPENHOST_COMMIT: ${{ github.sha }}
       # GCP-specific
       GCP_PROJECT: ${{ secrets.GCP_PROJECT_ID }}
       GCP_ZONE: ${{ vars.GCP_ZONE || 'us-central1-a' }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -37,7 +37,7 @@ jobs:
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       AWS_DEFAULT_REGION: us-east-1
       SKIP_APT_UPGRADE: "1"
-      OPENHOST_COMMIT: ${{ github.sha }}
+      OPENHOST_COMMIT: ${{ github.event.pull_request.head.sha || github.sha }}
       # GCP-specific
       GCP_PROJECT: ${{ secrets.GCP_PROJECT_ID }}
       GCP_ZONE: ${{ vars.GCP_ZONE || 'us-central1-a' }}

--- a/ansible/deploy.yml
+++ b/ansible/deploy.yml
@@ -1,6 +1,7 @@
 ---
-# Fast re-deploy: sync code and restart the service.
+# Fast re-deploy: clone/update code from GitHub and restart the service.
 # Usage: ansible-playbook ansible/deploy.yml -i <IP>, -e domain=<domain>
+# Optional: -e openhost_commit=<sha> to deploy a specific commit (defaults to main)
 
 - name: Deploy OpenHost
   hosts: all

--- a/ansible/setup.yml
+++ b/ansible/setup.yml
@@ -5,8 +5,9 @@
 # Example: ansible-playbook ansible/setup.yml -i 65.21.1.2, -e domain=host.example.com
 #
 # Optional variables:
-#   -e public_ip=1.2.3.4   (defaults to target IP)
-#   -e initial_user=ubuntu  (defaults to root)
+#   -e public_ip=1.2.3.4         (defaults to target IP)
+#   -e initial_user=ubuntu        (defaults to root)
+#   -e openhost_commit=<sha>      (git commit to deploy; defaults to main)
 
 - name: Bootstrap host user
   hosts: all

--- a/ansible/tasks/sync_code.yml
+++ b/ansible/tasks/sync_code.yml
@@ -1,16 +1,13 @@
 ---
-# Rsync repo code and ACME key to server.
+# Clone repo from GitHub and optionally checkout a specific commit.
+# Pass -e openhost_commit=<sha> to pin a specific version.
 
-# TODO: maybe change this to a git clone, so the updater will work out of the box.
-# could also sync the .git dir, but i'd worry about leaking something by accident.
-- name: Sync repo code
-  synchronize:
-    src: "{{ playbook_dir }}/../"
-    dest: /home/host/openhost/
-    rsync_opts:
-      - "--exclude=.git"
-      - "--exclude=.pixi"
-      - "--filter=':- .gitignore'"
+- name: Clone or update openhost repo
+  ansible.builtin.git:
+    repo: https://github.com/imbue-openhost/openhost.git
+    dest: /home/host/openhost
+    version: "{{ openhost_commit | default('main') }}"
+    force: true
 
 - name: Copy ACME account key
   copy:

--- a/tests/common.sh
+++ b/tests/common.sh
@@ -143,7 +143,8 @@ EOF
 #   $4 - SSH user on the instance (initial user, e.g., ubuntu)
 #
 # Environment:
-#   SKIP_APT_UPGRADE=1  — skip apt dist-upgrade (speeds up ephemeral CI instances)
+#   SKIP_APT_UPGRADE=1    — skip apt dist-upgrade (speeds up ephemeral CI instances)
+#   OPENHOST_COMMIT=<sha> — deploy a specific git commit (defaults to main)
 run_ansible_setup() {
     local ip="$1" ssh_key="$2" domain="$3" ssh_user="${4:-ubuntu}"
     local repo_dir
@@ -151,9 +152,6 @@ run_ansible_setup() {
 
     echo ""
     echo "--- Deploying OpenHost via ansible ---"
-
-    # Ensure git submodules are populated (ansible syncs the whole repo)
-    git -C "$repo_dir" submodule update --init --recursive 2>/dev/null || true
 
     # Build extra vars.
     local extra_vars=()
@@ -163,6 +161,10 @@ run_ansible_setup() {
     if [ "${SKIP_APT_UPGRADE:-0}" = "1" ]; then
         extra_vars+=(-e "skip_apt_upgrade=true")
         echo "  (skipping apt dist-upgrade)"
+    fi
+    if [ -n "${OPENHOST_COMMIT:-}" ]; then
+        extra_vars+=(-e "openhost_commit=$OPENHOST_COMMIT")
+        echo "  (deploying commit $OPENHOST_COMMIT)"
     fi
 
     # Run the full setup playbook.


### PR DESCRIPTION
## Summary
- Ansible deploys now clone from `https://github.com/imbue-openhost/openhost` instead of rsyncing local files
- Optional `-e openhost_commit=<sha>` extra var pins a specific commit (defaults to `main`)
- CI e2e workflow passes `github.sha` so tests deploy the exact commit under test

## Test plan
- [ ] e2e tests pass on GCP and EC2 (this PR triggers them)

🤖 Generated with [Claude Code](https://claude.com/claude-code)