### PR TITLE
oh: add SSH commands to instance management

### DIFF
--- a/compute_space_cli/compute_space_cli/config.py
+++ b/compute_space_cli/compute_space_cli/config.py
@@ -41,6 +41,7 @@ class Instance:
     hostname: str = attr.ib()
     token: str = attr.ib()
     alias: str | None = attr.ib(default=None)
+    ssh_key: str | None = attr.ib(default=None)
 
     @property
     def url(self) -> str:
@@ -69,6 +70,8 @@ class MultiConfig:
             entry: dict[str, object] = {"token": inst.token}
             if inst.alias:
                 entry["alias"] = inst.alias
+            if inst.ssh_key:
+                entry["ssh_key"] = inst.ssh_key
             instances_raw[hostname] = entry
         if instances_raw:
             raw["instances"] = instances_raw
@@ -96,6 +99,7 @@ class MultiConfig:
                         hostname=hostname,
                         token=raw_inst["token"],
                         alias=raw_inst.get("alias"),
+                        ssh_key=raw_inst.get("ssh_key"),
                     )
                 raw_default = data.get("default_instance")
                 if raw_default is not None and not isinstance(raw_default, str):

--- a/compute_space_cli/compute_space_cli/main.py
+++ b/compute_space_cli/compute_space_cli/main.py
@@ -4,6 +4,7 @@ import shutil
 import subprocess
 import sys
 import time
+from pathlib import Path
 from typing import Annotated
 
 import attrs
@@ -443,6 +444,70 @@ class InstanceCmd:
     ) -> None:
         """Print the stored API token for an instance."""
         print(cfg.token)
+
+    @cappa.command(name="configure-ssh-key")
+    def configure_ssh_key(
+        self,
+        name: Annotated[str, cappa.Arg(help="Hostname or alias")],
+        key_path: Annotated[str, cappa.Arg(help="Path to SSH private key")],
+    ) -> None:
+        """Store an SSH key path for an instance."""
+        resolved = Path(key_path).expanduser().resolve()
+        if not resolved.exists():
+            print(f"Key file not found: {resolved}", file=sys.stderr)
+            raise SystemExit(1)
+
+        multi = _load_or_exit()
+        try:
+            hostname = multi._resolve_name(name)
+        except config.InstanceNotFoundError as e:
+            print(str(e), file=sys.stderr)
+            raise SystemExit(1) from None
+        old = multi.instances[hostname]
+        updated = config.Instance(
+            hostname=old.hostname,
+            token=old.token,
+            alias=old.alias,
+            ssh_key=str(resolved),
+        )
+        multi.upsert_instance(updated).save()
+        print(f"SSH key for {hostname} set to {resolved}")
+
+    @cappa.command(name="ssh")
+    def ssh(
+        self,
+        cfg: Annotated[config.Instance, Dep(resolve_instance)],
+        args: Annotated[list[str] | None, cappa.Arg(num_args=-1, help="Extra arguments passed to ssh")] = None,
+    ) -> None:
+        """SSH into an instance as the host user."""
+        ssh_bin = shutil.which("ssh")
+        if not ssh_bin:
+            print("ssh not found on PATH", file=sys.stderr)
+            raise SystemExit(1)
+
+        cmd = [ssh_bin]
+        if cfg.ssh_key:
+            cmd += ["-i", cfg.ssh_key]
+        cmd += [f"host@{cfg.hostname}", *(args or [])]
+        raise SystemExit(subprocess.call(cmd))
+
+    @cappa.command(name="rsync")
+    def rsync(
+        self,
+        cfg: Annotated[config.Instance, Dep(resolve_instance)],
+        args: Annotated[list[str] | None, cappa.Arg(num_args=-1, help="Arguments passed to rsync")] = None,
+    ) -> None:
+        """Run rsync against an instance over SSH."""
+        rsync_bin = shutil.which("rsync")
+        if not rsync_bin:
+            print("rsync not found on PATH", file=sys.stderr)
+            raise SystemExit(1)
+
+        ssh_cmd = "ssh"
+        if cfg.ssh_key:
+            ssh_cmd = f"ssh -i {cfg.ssh_key}"
+        cmd = [rsync_bin, "-e", ssh_cmd, *(args or [])]
+        raise SystemExit(subprocess.call(cmd))
 
 
 @cappa.command(name="curl", help="curl with your OpenHost bearer token injected.")

--- a/compute_space_cli/compute_space_cli/main.py
+++ b/compute_space_cli/compute_space_cli/main.py
@@ -369,6 +369,8 @@ class InstanceCmd:
                 flags.append("default")
             if inst.alias:
                 flags.append(f"alias: {inst.alias}")
+            if inst.ssh_key:
+                flags.append(f"ssh-key: {inst.ssh_key}")
             flag_str = f"  [{', '.join(flags)}]" if flags else ""
             print(f"  {hostname:<{max_name}}{flag_str}")
 
@@ -448,7 +450,7 @@ class InstanceCmd:
     @cappa.command(name="configure-ssh-key")
     def configure_ssh_key(
         self,
-        name: Annotated[str, cappa.Arg(help="Hostname or alias")],
+        cfg: Annotated[config.Instance, Dep(resolve_instance)],
         key_path: Annotated[str, cappa.Arg(help="Path to SSH private key")],
     ) -> None:
         """Store an SSH key path for an instance."""
@@ -458,20 +460,14 @@ class InstanceCmd:
             raise SystemExit(1)
 
         multi = _load_or_exit()
-        try:
-            hostname = multi._resolve_name(name)
-        except config.InstanceNotFoundError as e:
-            print(str(e), file=sys.stderr)
-            raise SystemExit(1) from None
-        old = multi.instances[hostname]
         updated = config.Instance(
-            hostname=old.hostname,
-            token=old.token,
-            alias=old.alias,
+            hostname=cfg.hostname,
+            token=cfg.token,
+            alias=cfg.alias,
             ssh_key=str(resolved),
         )
         multi.upsert_instance(updated).save()
-        print(f"SSH key for {hostname} set to {resolved}")
+        print(f"SSH key for {cfg.hostname} set to {resolved}")
 
     @cappa.command(name="ssh")
     def ssh(
@@ -544,7 +540,7 @@ class Oh:
     subcommand: cappa.Subcommands[Status | AppCmd | TokensCmd | LogsCmd | InstanceCmd | Curl]
     instance: Annotated[
         str | None,
-        cappa.Arg(long=True, default=None, help="Target a specific named instance"),
+        cappa.Arg(long=True, default=None, propagate=True, help="Target a specific named instance"),
     ] = None
 
 


### PR DESCRIPTION
## Summary
- Add `oh instance configure-ssh-key NAME KEY_PATH` to store an SSH key path for an instance
- Add `oh instance ssh` to SSH into an instance as `host@hostname`, with passthrough args
- Add `oh instance rsync` to rsync over SSH against an instance, with passthrough args
- Add `ssh_key` field to `Instance` config (persisted in TOML)

## Test plan
- [x] All 37 existing CLI tests pass
- [ ] Manual: `oh instance configure-ssh-key <name> ~/.ssh/id_ed25519`
- [ ] Manual: `oh instance ssh` opens SSH session
- [ ] Manual: `oh instance ssh -- ls /tmp` passes args through
- [ ] Manual: `oh instance rsync ./local host@hostname:/remote`

🤖 Generated with [Claude Code](https://claude.com/claude-code)