### PR TITLE
oh: make CLI pip-installable from a git URL

### DIFF
--- a/compute_space_cli/pyproject.toml
+++ b/compute_space_cli/pyproject.toml
@@ -1,0 +1,26 @@
+[project]
+name = "oh"
+version = "0.1.0"
+description = "OpenHost CLI — manage apps on your compute space"
+requires-python = ">=3.12"
+dependencies = [
+    "attrs",
+    "cappa",
+    "httpx",
+    "tomli-w",
+]
+
+[project.scripts]
+oh = "compute_space_cli.main:main"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/compute_space_cli"]
+
+[tool.uv]
+# Don't manage this subproject with uv — it ships standalone via
+# `pip install git+https://.../openhost.git#subdirectory=compute_space_cli`.
+managed = false

--- a/compute_space_cli/pyproject.toml
+++ b/compute_space_cli/pyproject.toml
@@ -21,6 +21,7 @@ build-backend = "hatchling.build"
 packages = ["src/compute_space_cli"]
 
 [tool.uv]
-# Don't manage this subproject with uv — it ships standalone via
-# `pip install git+https://.../openhost.git#subdirectory=compute_space_cli`.
+# Don't manage this subproject with uv; the pyproject.toml is just to make it installable via pip with a git URL.
+# otherwise since we rarely run uv from this subdir, the lockfile is liable to get out of date.
+# ideally we'd use some sort of proper workspace management but we don't now.
 managed = false


### PR DESCRIPTION
## Summary
Re-adds `compute_space_cli/pyproject.toml` (deleted in 82987be when the subproject pyprojects were collapsed into the root). The CLI now ships standalone again so users can install just `oh` without cloning the whole repo:

\`\`\`
pip install git+https://github.com/imbue-openhost/openhost.git#subdirectory=compute_space_cli
\`\`\`

\`[tool.uv] managed = false\` tells uv to leave this subproject alone — no \`uv.lock\` is generated here; locking still happens at the root workspace.

## Test plan
- [x] \`pip install <subdirectory>\` into a fresh venv resolves and installs the \`oh\` script
- [x] \`oh --help\` and \`oh status\` work from the standalone install
- [x] \`oh\` from the root uv env still works (\`uv run oh --help\`)
- [x] No \`compute_space_cli/uv.lock\` gets generated by either flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)