### PR TITLE
Add app_archive storage tier with optional JuiceFS-on-S3 backing

### DIFF
--- a/ansible/setup.yml
+++ b/ansible/setup.yml
@@ -47,4 +47,9 @@
   tasks:
     - import_tasks: tasks/sync_code.yml
     - import_tasks: tasks/pixi.yml
+    # JuiceFS must be installed + mounted BEFORE the openhost service
+    # is enabled, since openhost.service has Requires=juicefs-mount.service
+    # when juicefs_enabled is true.
+    - import_tasks: tasks/juicefs.yml
+      when: juicefs_enabled | default(false) | bool
     - import_tasks: tasks/setup_openhost_service.yml

--- a/ansible/tasks/juicefs.yml
+++ b/ansible/tasks/juicefs.yml
@@ -106,6 +106,18 @@
     group: host
     mode: "0750"
 
+# /var/log is root-owned, so the host user can't write juicefs's
+# mount log there directly.  Pre-create a dedicated subdir owned
+# by host so the systemd unit can write without sudo.
+- name: Create juicefs log dir
+  become: yes
+  file:
+    path: /var/log/juicefs
+    state: directory
+    owner: host
+    group: host
+    mode: "0750"
+
 - name: Create juicefs config dir
   become: yes
   file:
@@ -115,8 +127,9 @@
     group: host
     mode: "0750"
 
-# Secrets go to a 0600 EnvironmentFile read by the systemd unit;
-# they are NOT passed on the juicefs argv (which is visible in ps).
+# Secrets go to a 0640 root:host EnvironmentFile read by the systemd
+# unit (which runs as User=host so it needs group-read).  They are
+# NOT passed on the juicefs argv, which would be visible in ``ps``.
 - name: Write juicefs S3 credentials
   become: yes
   copy:

--- a/ansible/tasks/juicefs.yml
+++ b/ansible/tasks/juicefs.yml
@@ -1,0 +1,225 @@
+---
+# Install JuiceFS, format the volume (idempotent), and mount it via
+# systemd at /data/app_archive_juicefs/.  When this role runs,
+# ``setup_openhost_service.yml`` renders ``archive_dir_override`` into
+# the openhost config so app_archive bind-mounts land on the JuiceFS
+# mount.
+#
+# Gated behind ``juicefs_enabled`` so existing zones are unaffected.
+# When enabled, requires:
+#   juicefs_s3_bucket
+#   juicefs_s3_region          (default: us-east-1)
+#   juicefs_s3_access_key
+#   juicefs_s3_secret_key
+# Optional:
+#   juicefs_volume_name        (default: openhost)
+#   juicefs_s3_endpoint        (default: empty -> AWS S3)
+#
+# Metadata engine is SQLite at /var/lib/juicefs/meta.db.  This is
+# single-host but matches the openhost-core architecture (one VM
+# per zone).  The metadata file is dumped daily by a systemd timer
+# to ``<persistent_data_dir>/openhost/juicefs-metadata-dump.json``
+# so the existing restic-based ``openhost-backup`` app picks it up
+# for off-VM disaster-recovery.
+
+- name: Validate juicefs required variables
+  assert:
+    that:
+      - juicefs_s3_bucket | default('') | length > 0
+      - juicefs_s3_access_key | default('') | length > 0
+      - juicefs_s3_secret_key | default('') | length > 0
+    fail_msg: >-
+      juicefs_enabled=true requires juicefs_s3_bucket,
+      juicefs_s3_access_key, and juicefs_s3_secret_key to be set.
+      Pass them via -e or a vars file.
+
+- name: Resolve juicefs binary architecture
+  set_fact:
+    _juicefs_arch: "{{ 'arm64' if ansible_architecture == 'aarch64' else 'amd64' }}"
+
+# Pinning version + sha256 keeps the install reproducible and
+# defends against a compromised release page swapping the tarball.
+- name: Set juicefs version and checksums
+  set_fact:
+    _juicefs_version: "1.3.1"
+    _juicefs_sha256_amd64: "eb67a7be5d174b420cb3734d441971b3a462ab522b78ad2a6ed993e7deddcd44"
+    _juicefs_sha256_arm64: "c29bff8f609366011cee03b9abcc76c11a06308b2c314364b8c340a2bfbc6c48"
+
+- name: Pick juicefs sha256 for current arch
+  set_fact:
+    _juicefs_sha256: >-
+      {{ _juicefs_sha256_arm64 if _juicefs_arch == 'arm64' else _juicefs_sha256_amd64 }}
+
+- name: Check installed juicefs version
+  command: /usr/local/bin/juicefs version
+  register: _juicefs_installed
+  failed_when: false
+  changed_when: false
+
+- name: Download juicefs release tarball
+  become: yes
+  get_url:
+    url: "https://github.com/juicedata/juicefs/releases/download/v{{ _juicefs_version }}/juicefs-{{ _juicefs_version }}-linux-{{ _juicefs_arch }}.tar.gz"
+    dest: "/tmp/juicefs-{{ _juicefs_version }}-linux-{{ _juicefs_arch }}.tar.gz"
+    checksum: "sha256:{{ _juicefs_sha256 }}"
+    mode: "0644"
+  when: _juicefs_installed.rc != 0 or _juicefs_version not in (_juicefs_installed.stdout | default(''))
+
+- name: Extract juicefs binary
+  become: yes
+  unarchive:
+    src: "/tmp/juicefs-{{ _juicefs_version }}-linux-{{ _juicefs_arch }}.tar.gz"
+    dest: /usr/local/bin
+    remote_src: yes
+    extra_opts:
+      - --no-same-owner
+    creates: "/usr/local/bin/juicefs-{{ _juicefs_version }}-marker"
+  when: _juicefs_installed.rc != 0 or _juicefs_version not in (_juicefs_installed.stdout | default(''))
+
+# unarchive lays down ``juicefs`` plus a few extras (LICENSE, README).
+# Drop a per-version marker so the unarchive ``creates:`` short-circuits
+# subsequent runs without depending on the binary path (which could be
+# present from an older download).
+- name: Touch juicefs version marker
+  become: yes
+  file:
+    path: "/usr/local/bin/juicefs-{{ _juicefs_version }}-marker"
+    state: touch
+    mode: "0644"
+  when: _juicefs_installed.rc != 0 or _juicefs_version not in (_juicefs_installed.stdout | default(''))
+  changed_when: false
+
+- name: Ensure juicefs binary is executable
+  become: yes
+  file:
+    path: /usr/local/bin/juicefs
+    mode: "0755"
+    owner: root
+    group: root
+
+- name: Create juicefs metadata dir
+  become: yes
+  file:
+    path: /var/lib/juicefs
+    state: directory
+    owner: host
+    group: host
+    mode: "0750"
+
+- name: Create juicefs config dir
+  become: yes
+  file:
+    path: /etc/openhost/juicefs
+    state: directory
+    owner: root
+    group: host
+    mode: "0750"
+
+# Secrets go to a 0600 EnvironmentFile read by the systemd unit;
+# they are NOT passed on the juicefs argv (which is visible in ps).
+- name: Write juicefs S3 credentials
+  become: yes
+  copy:
+    dest: /etc/openhost/juicefs/s3.env
+    content: |
+      ACCESS_KEY={{ juicefs_s3_access_key }}
+      SECRET_KEY={{ juicefs_s3_secret_key }}
+    owner: root
+    group: host
+    mode: "0640"
+  no_log: true
+
+- name: Create juicefs mount point
+  become: yes
+  file:
+    path: /data/app_archive_juicefs
+    state: directory
+    owner: host
+    group: host
+    mode: "0755"
+
+# Format-once guard.  ``juicefs format`` is destructive when called
+# with different storage args than the existing volume; the sentinel
+# file makes the role idempotent across reruns.  Running it twice
+# with the SAME args is harmless (juicefs detects existing volume),
+# but skipping is cheaper and avoids needing the secret-key arg in
+# the rerun path.
+- name: Check juicefs format sentinel
+  become: yes
+  stat:
+    path: /var/lib/juicefs/.formatted
+  register: _juicefs_format_sentinel
+
+- name: Format juicefs volume
+  become: yes
+  become_user: host
+  shell: |
+    set -eu
+    . /etc/openhost/juicefs/s3.env
+    /usr/local/bin/juicefs format \
+      --storage s3 \
+      --bucket "{{ _juicefs_bucket_url }}" \
+      --access-key "$ACCESS_KEY" \
+      --secret-key "$SECRET_KEY" \
+      "sqlite3:///var/lib/juicefs/meta.db" \
+      "{{ juicefs_volume_name | default('openhost') }}"
+  vars:
+    _juicefs_bucket_url: >-
+      {%- if juicefs_s3_endpoint | default('') -%}
+        {{ juicefs_s3_endpoint }}/{{ juicefs_s3_bucket }}
+      {%- else -%}
+        https://{{ juicefs_s3_bucket }}.s3.{{ juicefs_s3_region | default('us-east-1') }}.amazonaws.com
+      {%- endif -%}
+  args:
+    executable: /bin/bash
+  when: not _juicefs_format_sentinel.stat.exists
+  no_log: true
+
+- name: Mark juicefs volume as formatted
+  become: yes
+  file:
+    path: /var/lib/juicefs/.formatted
+    state: touch
+    owner: host
+    group: host
+    mode: "0644"
+  when: not _juicefs_format_sentinel.stat.exists
+
+- name: Install juicefs systemd mount unit
+  become: yes
+  template:
+    src: templates/juicefs-mount.service.j2
+    dest: /etc/systemd/system/juicefs-mount.service
+    mode: "0644"
+  register: _juicefs_unit
+
+- name: Install juicefs metadata-dump service + timer
+  become: yes
+  template:
+    src: "{{ item.src }}"
+    dest: "{{ item.dest }}"
+    mode: "0644"
+  loop:
+    - { src: "templates/juicefs-meta-dump.service.j2", dest: "/etc/systemd/system/juicefs-meta-dump.service" }
+    - { src: "templates/juicefs-meta-dump.timer.j2", dest: "/etc/systemd/system/juicefs-meta-dump.timer" }
+  register: _juicefs_meta_units
+
+- name: Reload systemd for juicefs units
+  become: yes
+  systemd:
+    daemon_reload: yes
+  when: _juicefs_unit.changed or _juicefs_meta_units.changed
+
+- name: Enable and start juicefs mount
+  become: yes
+  systemd:
+    name: juicefs-mount.service
+    enabled: yes
+    state: started
+
+- name: Enable juicefs metadata-dump timer
+  become: yes
+  systemd:
+    name: juicefs-meta-dump.timer
+    enabled: yes
+    state: started

--- a/ansible/templates/config.toml.j2
+++ b/ansible/templates/config.toml.j2
@@ -9,3 +9,9 @@ public_ip = "{{ public_ip | default(inventory_hostname) }}"
 start_caddy = true
 data_root_dir = "/home/host/.openhost/local_compute_space"
 apps_dir_override = "/home/host/openhost/apps"
+{% if juicefs_enabled | default(false) | bool %}
+# JuiceFS-backed app_archive tier.  Apps that opt into ``[data]
+# app_archive`` get bind-mounts under this path instead of local
+# disk.  See ansible/tasks/juicefs.yml for the mount setup.
+archive_dir_override = "/data/app_archive_juicefs"
+{% endif %}

--- a/ansible/templates/juicefs-meta-dump.service.j2
+++ b/ansible/templates/juicefs-meta-dump.service.j2
@@ -12,12 +12,17 @@ Group=host
 #   1. ``juicefs format`` against the SAME bucket
 #   2. ``juicefs load`` the dump
 # The dump itself is small (KBs to a few MBs); restic dedup makes
-# storing it daily cheap.  Lands inside persistent_data_dir so the
-# backup app's existing rules already cover it.
+# storing it daily cheap.  Lands inside persistent_data_dir/openhost/
+# so the backup app's existing rules already cover it.
+#
+# The path is parameterised on ``juicefs_dump_dir`` so an operator
+# who has overridden ``data_root_dir`` in their config gets the dump
+# in the matching location; the default matches the standard
+# ansible-deployed path.
 ExecStart=/bin/bash -c '\
     set -eu; \
     /usr/local/bin/juicefs dump \
         "sqlite3:///var/lib/juicefs/meta.db" \
-        /home/host/.openhost/local_compute_space/persistent_data/openhost/juicefs-metadata-dump.json.tmp; \
-    mv /home/host/.openhost/local_compute_space/persistent_data/openhost/juicefs-metadata-dump.json.tmp \
-       /home/host/.openhost/local_compute_space/persistent_data/openhost/juicefs-metadata-dump.json'
+        {{ juicefs_dump_dir | default("/home/host/.openhost/local_compute_space/persistent_data/openhost") }}/juicefs-metadata-dump.json.tmp; \
+    mv {{ juicefs_dump_dir | default("/home/host/.openhost/local_compute_space/persistent_data/openhost") }}/juicefs-metadata-dump.json.tmp \
+       {{ juicefs_dump_dir | default("/home/host/.openhost/local_compute_space/persistent_data/openhost") }}/juicefs-metadata-dump.json'

--- a/ansible/templates/juicefs-meta-dump.service.j2
+++ b/ansible/templates/juicefs-meta-dump.service.j2
@@ -1,0 +1,23 @@
+[Unit]
+Description=Daily JuiceFS metadata dump for restic backup
+After=juicefs-mount.service
+Requires=juicefs-mount.service
+
+[Service]
+Type=oneshot
+User=host
+Group=host
+# ``juicefs dump`` walks the SQLite metadata and writes a JSON blob
+# capturing every inode + chunk pointer.  Restoring is two steps:
+#   1. ``juicefs format`` against the SAME bucket
+#   2. ``juicefs load`` the dump
+# The dump itself is small (KBs to a few MBs); restic dedup makes
+# storing it daily cheap.  Lands inside persistent_data_dir so the
+# backup app's existing rules already cover it.
+ExecStart=/bin/bash -c '\
+    set -eu; \
+    /usr/local/bin/juicefs dump \
+        "sqlite3:///var/lib/juicefs/meta.db" \
+        /home/host/.openhost/local_compute_space/persistent_data/openhost/juicefs-metadata-dump.json.tmp; \
+    mv /home/host/.openhost/local_compute_space/persistent_data/openhost/juicefs-metadata-dump.json.tmp \
+       /home/host/.openhost/local_compute_space/persistent_data/openhost/juicefs-metadata-dump.json'

--- a/ansible/templates/juicefs-meta-dump.timer.j2
+++ b/ansible/templates/juicefs-meta-dump.timer.j2
@@ -1,0 +1,15 @@
+[Unit]
+Description=Daily JuiceFS metadata dump for restic backup
+
+[Timer]
+# Run every 24h with a randomised delay so restores can recover to
+# a known-recent state even if the dump runs at a chaotic time.  An
+# initial run 5 min after boot covers the case where the timer
+# fires before the first periodic invocation.
+OnBootSec=5min
+OnUnitActiveSec=24h
+RandomizedDelaySec=15min
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/ansible/templates/juicefs-mount.service.j2
+++ b/ansible/templates/juicefs-mount.service.j2
@@ -1,0 +1,38 @@
+[Unit]
+Description=JuiceFS mount for OpenHost app_archive tier
+# The mount must be up before openhost-core starts any apps; the
+# ordering is set on openhost.service via After=juicefs-mount.service
+# (see openhost.service.j2).  Failing here surfaces as a refusal to
+# start the openhost service rather than apps silently writing to a
+# local-disk shadow path.
+After=network-online.target
+Wants=network-online.target
+Before=openhost.service
+RequiresMountsFor=/var/lib/juicefs
+
+[Service]
+Type=forking
+User=host
+Group=host
+# Secrets-only env file (0640 root:host).  ACCESS_KEY/SECRET_KEY are
+# NOT passed on argv, so ``ps`` doesn't leak them.
+EnvironmentFile=/etc/openhost/juicefs/s3.env
+# JuiceFS reads ACCESS_KEY/SECRET_KEY from environment when --access-key
+# isn't passed; ``mount`` itself has no creds-on-argv option that's
+# safer than the env path, so this is the canonical pattern.
+ExecStart=/usr/local/bin/juicefs mount \
+    --background \
+    --log /var/log/juicefs-mount.log \
+    --no-usage-report \
+    "sqlite3:///var/lib/juicefs/meta.db" \
+    /data/app_archive_juicefs
+ExecStop=/usr/local/bin/juicefs umount /data/app_archive_juicefs || /bin/umount -l /data/app_archive_juicefs
+# A failed mount must NOT silently fall through to local disk: if the
+# mount drops, apps that wrote to /data/app_archive_juicefs/<app>/
+# would start hitting the underlying empty mount point.  Restart loops
+# would surface the issue but the safer behaviour is fail-loud.
+Restart=on-failure
+RestartSec=10
+
+[Install]
+WantedBy=multi-user.target

--- a/ansible/templates/juicefs-mount.service.j2
+++ b/ansible/templates/juicefs-mount.service.j2
@@ -1,10 +1,11 @@
 [Unit]
 Description=JuiceFS mount for OpenHost app_archive tier
-# The mount must be up before openhost-core starts any apps; the
-# ordering is set on openhost.service via After=juicefs-mount.service
-# (see openhost.service.j2).  Failing here surfaces as a refusal to
-# start the openhost service rather than apps silently writing to a
-# local-disk shadow path.
+# openhost.service declares both After= AND Requires= on this unit
+# when JuiceFS is enabled (see openhost.service.j2).  The Requires=
+# is intentional and stronger than ordering: if this unit fails or
+# stops, systemd refuses to start openhost.service, so apps can never
+# silently write to the underlying empty mount-point and have those
+# writes shadowed once the mount comes back.
 After=network-online.target
 Wants=network-online.target
 Before=openhost.service
@@ -22,11 +23,15 @@ EnvironmentFile=/etc/openhost/juicefs/s3.env
 # safer than the env path, so this is the canonical pattern.
 ExecStart=/usr/local/bin/juicefs mount \
     --background \
-    --log /var/log/juicefs-mount.log \
+    --log /var/log/juicefs/mount.log \
     --no-usage-report \
     "sqlite3:///var/lib/juicefs/meta.db" \
     /data/app_archive_juicefs
-ExecStop=/usr/local/bin/juicefs umount /data/app_archive_juicefs || /bin/umount -l /data/app_archive_juicefs
+# systemd doesn't run ExecStop through a shell, so a bare ``||`` would
+# be passed as literal argv to ``juicefs umount``.  Wrap explicitly so
+# the ``-l`` fallback runs when the clean unmount fails (e.g. because
+# a container still has the FS busy and we're tearing the host down).
+ExecStop=/bin/bash -c '/usr/local/bin/juicefs umount /data/app_archive_juicefs || /bin/umount -l /data/app_archive_juicefs'
 # A failed mount must NOT silently fall through to local disk: if the
 # mount drops, apps that wrote to /data/app_archive_juicefs/<app>/
 # would start hitting the underlying empty mount point.  Restart loops

--- a/ansible/templates/openhost.service.j2
+++ b/ansible/templates/openhost.service.j2
@@ -8,8 +8,17 @@ Description=OpenHost Compute Space
 # actually running. ``host_uid`` is resolved dynamically by ansible
 # from the host user's actual UID, since the user is created without
 # a hardcoded UID and the value differs across cloud providers.
-After=network-online.target user@{{ host_uid }}.service
+After=network-online.target user@{{ host_uid }}.service{% if juicefs_enabled | default(false) | bool %} juicefs-mount.service{% endif %}
+
 Wants=network-online.target user@{{ host_uid }}.service
+{% if juicefs_enabled | default(false) | bool %}
+# When the app_archive tier is JuiceFS-backed, the mount must be live
+# before openhost starts any apps; otherwise apps that opt into
+# app_archive write to the underlying empty mount-point, which gets
+# shadowed once the mount comes up.  Requires= forces openhost to
+# fail-loud if the mount is dead.
+Requires=juicefs-mount.service
+{% endif %}
 
 [Service]
 Type=simple

--- a/compute_space/compute_space/config.py
+++ b/compute_space/compute_space/config.py
@@ -36,6 +36,16 @@ class Config:
     data_root_dir: str
     apps_dir_override: str | None
 
+    # Optional override for where ``app_archive`` bind mounts are
+    # backed.  When unset, the archive tier defaults to a local-disk
+    # subdirectory under ``persistent_data_dir`` — same backing as
+    # ``app_data``, just a separate dir.  When the operator sets up
+    # JuiceFS (or any other host-mounted POSIX filesystem) and points
+    # this at the mount path, every app that opts into ``app_archive``
+    # gets bind-mounts into that filesystem instead.  The app sees the
+    # same in-container path either way; only the backing changes.
+    archive_dir_override: str | None
+
     # Minimum free disk space in MB (0 = no enforcement)
     storage_min_free_mb: int
 
@@ -67,6 +77,19 @@ class Config:
     @property
     def temporary_data_dir(self) -> str:
         return os.path.join(self.data_root_dir, "temporary_data")
+
+    @property
+    def app_archive_dir(self) -> str:
+        # Where every app's ``/data/app_archive/<name>/`` bind-mount
+        # source lives.  Operator override (e.g. a JuiceFS mount path)
+        # takes priority; otherwise we fall back to a local-disk
+        # subdirectory of ``persistent_data_dir`` so apps that opt
+        # into ``app_archive`` work even on instances with no
+        # JuiceFS configured — they just don't get the elastic-S3
+        # benefit.
+        if self.archive_dir_override:
+            return self.archive_dir_override
+        return os.path.join(self.persistent_data_dir, "app_archive")
 
     @property
     def apps_dir(self) -> str:
@@ -121,6 +144,13 @@ class Config:
         assert os.path.exists(self.data_root_dir)
         os.makedirs(self.persistent_data_dir, exist_ok=True)
         os.makedirs(self.temporary_data_dir, exist_ok=True)
+        # ``app_archive_dir`` may resolve to an external mount the
+        # operator already set up (e.g. JuiceFS); we don't try to
+        # mkdir it in that case because we likely lack permission and
+        # the mount itself was already created by ansible.  Only
+        # create it when it's pointing at the local fallback.
+        if not self.archive_dir_override:
+            os.makedirs(self.app_archive_dir, exist_ok=True)
         os.makedirs(self.apps_dir, exist_ok=True)
         os.makedirs(self.openhost_data_path, exist_ok=True)
         os.makedirs(self.keys_dir, exist_ok=True)
@@ -152,6 +182,7 @@ class DefaultConfig(Config):
     # Data
     data_root_dir: str = "/opt/openhost"
     apps_dir_override: str | None = None  # if None, defaults to data_root_dir/apps
+    archive_dir_override: str | None = None  # if None, defaults to persistent_data_dir/app_archive
 
     # Minimum free disk space in MB (0 = no enforcement)
     storage_min_free_mb: int = 0

--- a/compute_space/compute_space/core/apps.py
+++ b/compute_space/compute_space/core/apps.py
@@ -240,6 +240,7 @@ def insert_and_deploy(
         manifest,
         config.persistent_data_dir,
         config.temporary_data_dir,
+        config.app_archive_dir,
         port=config.port,
         zone_domain=config.zone_domain,
         my_openhost_redirect_domain=config.my_openhost_redirect_domain,
@@ -397,6 +398,7 @@ def deploy_app_background(
             env_vars,
             config.persistent_data_dir,
             config.temporary_data_dir,
+            config.app_archive_dir,
             port_mappings=port_mappings,
         )
         db.execute(
@@ -518,6 +520,7 @@ def start_app_process(app_name: str, db: sqlite3.Connection, config: Config) -> 
         manifest,
         config.persistent_data_dir,
         config.temporary_data_dir,
+        config.app_archive_dir,
         port=config.port,
         zone_domain=config.zone_domain,
         my_openhost_redirect_domain=config.my_openhost_redirect_domain,
@@ -563,6 +566,7 @@ def start_app_process(app_name: str, db: sqlite3.Connection, config: Config) -> 
         env_vars,
         config.persistent_data_dir,
         config.temporary_data_dir,
+        config.app_archive_dir,
         port_mappings=port_mappings,
     )
     db.execute(

--- a/compute_space/compute_space/core/containers.py
+++ b/compute_space/compute_space/core/containers.py
@@ -205,20 +205,33 @@ def run_container(
     env_vars: dict[str, str],
     data_dir: str,
     temp_data_dir: str,
+    archive_dir: str,
     port_mappings: list[PortMapping] | None = None,
 ) -> str:
-    """Start a detached container for an app.  Returns the container ID."""
+    """Start a detached container for an app.  Returns the container ID.
+
+    ``archive_dir`` is the host-side root for the ``app_archive`` tier;
+    its backing is operator-selected (local disk by default; can be a
+    JuiceFS mount path).  Apps that opt into ``[data] app_archive``
+    get a per-app subdir bind-mounted from there into
+    ``/data/app_archive/<name>/`` inside the container.  The
+    in-container path is the same regardless of backing so apps don't
+    have to know whether their archive tier is on local disk or on S3.
+    """
     app_data_dir = os.path.join(data_dir, "app_data", app_name)
     app_temp_dir = os.path.join(temp_data_dir, "app_temp_data", app_name)
+    app_archive_dir = os.path.join(archive_dir, app_name)
     vm_data_dir = os.path.join(data_dir, "vm_data")
     container_name = f"openhost-{app_name}"
 
     has_app_data = manifest.app_data or manifest.sqlite_dbs or manifest.access_all_data
     has_app_temp = manifest.app_temp_data or manifest.access_all_data
+    has_app_archive = manifest.app_archive or manifest.access_all_data
     has_vm_data = manifest.access_vm_data or manifest.access_all_data
 
     c_app_data = f"{CONTAINER_ROOT}/app_data/{app_name}"
     c_app_temp = f"{CONTAINER_ROOT}/app_temp_data/{app_name}"
+    c_app_archive = f"{CONTAINER_ROOT}/app_archive/{app_name}"
     c_vm_data = f"{CONTAINER_ROOT}/vm_data"
 
     # Translate host paths in env vars to their in-container equivalents.
@@ -231,6 +244,8 @@ def run_container(
             container_env[key] = c_app_data
         elif key == "OPENHOST_APP_TEMP_DIR":
             container_env[key] = c_app_temp
+        elif key == "OPENHOST_APP_ARCHIVE_DIR":
+            container_env[key] = c_app_archive
         else:
             container_env[key] = value
 
@@ -266,6 +281,10 @@ def run_container(
                 ),
             ]
         )
+        # Archive parent mount.  Same rationale as the app_data parent
+        # mount above: an access_all_data app sees the entire archive
+        # namespace, not just its own subdir.
+        cmd.extend(["-v", _bind_mount_arg(archive_dir, f"{CONTAINER_ROOT}/app_archive")])
         os.makedirs(vm_data_dir, exist_ok=True)
         cmd.extend(["-v", _bind_mount_arg(vm_data_dir, c_vm_data)])
     else:
@@ -273,6 +292,8 @@ def run_container(
             cmd.extend(["-v", _bind_mount_arg(app_data_dir, c_app_data)])
         if has_app_temp:
             cmd.extend(["-v", _bind_mount_arg(app_temp_dir, c_app_temp)])
+        if has_app_archive:
+            cmd.extend(["-v", _bind_mount_arg(app_archive_dir, c_app_archive)])
         if has_vm_data:
             os.makedirs(vm_data_dir, exist_ok=True)
             cmd.extend(["-v", _bind_mount_arg(vm_data_dir, c_vm_data, read_only=True)])

--- a/compute_space/compute_space/core/data.py
+++ b/compute_space/compute_space/core/data.py
@@ -77,6 +77,7 @@ def provision_data(
     manifest: AppManifest,
     data_dir: str,
     temp_data_dir: str,
+    archive_dir: str,
     my_openhost_redirect_domain: str,
     zone_domain: str,
     port: int,
@@ -85,11 +86,19 @@ def provision_data(
     Returns a dict of environment variable name -> value.
 
     Apps only get filesystem access to directories they explicitly request
-    via app_data and app_temp_data flags in [data]. SQLite entries
-    implicitly enable app_data.
+    via app_data, app_temp_data, and app_archive flags in [data].  SQLite
+    entries implicitly enable app_data.
+
+    ``archive_dir`` is the host-side root for the ``app_archive`` tier.
+    Apps that opt in get a per-app subdirectory under it bind-mounted
+    into the container at ``/data/app_archive/<name>/``.  The backing
+    is operator-selected at the host config level (defaults to local
+    disk under ``persistent_data_dir/app_archive``; can point at a
+    JuiceFS-on-S3 mount, etc.).
     """
     app_data_dir = os.path.join(data_dir, "app_data", app_name)
     app_temp_dir = os.path.join(temp_data_dir, "app_temp_data", app_name)
+    app_archive_dir = os.path.join(archive_dir, app_name)
     env_vars = {}
 
     # Determine if permanent data dir is needed:
@@ -113,6 +122,18 @@ def provision_data(
     if manifest.app_temp_data or manifest.access_all_data:
         os.makedirs(app_temp_dir, exist_ok=True)
         env_vars["OPENHOST_APP_TEMP_DIR"] = app_temp_dir
+
+    if manifest.app_archive or manifest.access_all_data:
+        # When the archive root is operator-overridden (e.g. a JuiceFS
+        # mount), the directory itself was created by ansible at host
+        # setup time.  We still ``makedirs(..., exist_ok=True)`` for
+        # the per-app subdir — that's a normal mkdir on whatever FS
+        # backs the root, and works on JuiceFS the same way it works
+        # on local disk.  The parent ``archive_dir`` is NOT created
+        # here when it's operator-overridden; that's the operator's
+        # job and is handled in Config.make_all_dirs.
+        os.makedirs(app_archive_dir, exist_ok=True)
+        env_vars["OPENHOST_APP_ARCHIVE_DIR"] = app_archive_dir
 
     # Always create temp dir for internal use (repo clone, logs) even if
     # the app doesn't get access to it
@@ -144,7 +165,21 @@ def deprovision_temp_data(app_name: str, temp_data_dir: str) -> None:
     rmtree_with_sudo_fallback(os.path.join(temp_data_dir, "app_temp_data", app_name))
 
 
-def deprovision_data(app_name: str, data_dir: str, temp_data_dir: str) -> None:
-    """Remove all data for an app from both permanent and temp disks."""
+def deprovision_data(
+    app_name: str,
+    data_dir: str,
+    temp_data_dir: str,
+    archive_dir: str,
+) -> None:
+    """Remove all data for an app from local-persistent, archive, and
+    local-temp disks.
+
+    ``archive_dir`` is the host-side root for the ``app_archive`` tier
+    (see ``provision_data``).  The same rmtree-with-sudo-fallback path
+    works for both local-disk and JuiceFS backings — JuiceFS handles
+    chunk cleanup in its metadata engine and async-deletes blocks
+    from S3 when the per-app subdir is removed.
+    """
     rmtree_with_sudo_fallback(os.path.join(data_dir, "app_data", app_name))
+    rmtree_with_sudo_fallback(os.path.join(archive_dir, app_name))
     deprovision_temp_data(app_name, temp_data_dir)

--- a/compute_space/compute_space/core/data.py
+++ b/compute_space/compute_space/core/data.py
@@ -124,14 +124,34 @@ def provision_data(
         env_vars["OPENHOST_APP_TEMP_DIR"] = app_temp_dir
 
     if manifest.app_archive or manifest.access_all_data:
-        # When the archive root is operator-overridden (e.g. a JuiceFS
-        # mount), the directory itself was created by ansible at host
-        # setup time.  We still ``makedirs(..., exist_ok=True)`` for
-        # the per-app subdir — that's a normal mkdir on whatever FS
-        # backs the root, and works on JuiceFS the same way it works
-        # on local disk.  The parent ``archive_dir`` is NOT created
-        # here when it's operator-overridden; that's the operator's
-        # job and is handled in Config.make_all_dirs.
+        # ``archive_dir`` itself must already exist by the time we
+        # provision an app.  For the local-fallback path it was
+        # created by ``Config.make_all_dirs``; for an operator-
+        # overridden path (e.g. a JuiceFS mount) it was created by
+        # ansible during host setup and the mount must already be
+        # attached.
+        #
+        # We deliberately do NOT use ``os.makedirs(app_archive_dir,
+        # exist_ok=True)`` here — that would silently create the
+        # override path on local disk if the JuiceFS mount hasn't
+        # come up yet, and apps would then write to a local-disk
+        # ghost path that gets shadowed once JuiceFS attaches,
+        # losing those writes.  Instead, refuse to provision if the
+        # archive root doesn't exist; the systemd unit ordering
+        # makes openhost-core boot-fail when the mount fails, so
+        # this branch should only fire on a misconfigured zone.
+        if not os.path.isdir(archive_dir):
+            raise RuntimeError(
+                f"archive_dir {archive_dir!r} does not exist or is not a "
+                f"directory.  If JuiceFS is configured, check that the "
+                f"mount is attached; otherwise check that "
+                f"Config.make_all_dirs() ran on startup."
+            )
+        # mkdir only the per-app leaf, not parents — exist_ok=True
+        # for redeploy idempotency.  ``os.mkdir`` would fail if
+        # ``app_archive_dir`` already exists; we use ``makedirs``
+        # with the parent existence-check above guaranteeing the
+        # parent is real.
         os.makedirs(app_archive_dir, exist_ok=True)
         env_vars["OPENHOST_APP_ARCHIVE_DIR"] = app_archive_dir
 

--- a/compute_space/compute_space/core/manifest.py
+++ b/compute_space/compute_space/core/manifest.py
@@ -309,13 +309,22 @@ def parse_manifest_from_string(raw_text: str) -> AppManifest:
     # its own would invite that corruption — every meaningful app
     # needs SOME local state (at least a sqlite session db, even if
     # the bulk content is archive-resident).
-    if data_section.get("app_archive") and not (
-        data_section.get("app_data") or data_section.get("sqlite")
-    ):
+    #
+    # ``access_all_data`` is the catch-all permission that grants
+    # every tier including the local-disk one, so it satisfies the
+    # invariant on its own — an access_all_data app gets app_data
+    # access regardless of whether the manifest names the field.
+    has_local_tier = (
+        data_section.get("app_data")
+        or data_section.get("sqlite")
+        or data_section.get("access_all_data")
+    )
+    if data_section.get("app_archive") and not has_local_tier:
         raise ValueError(
-            "[data].app_archive requires [data].app_data (or [data].sqlite). "
-            "The archive tier is for bulk content; working state and "
-            "embedded databases must live in the local-disk app_data tier."
+            "[data].app_archive requires [data].app_data (or [data].sqlite, "
+            "or [data].access_all_data).  The archive tier is for bulk "
+            "content; working state and embedded databases must live in "
+            "the local-disk app_data tier."
         )
 
     return AppManifest(

--- a/compute_space/compute_space/core/manifest.py
+++ b/compute_space/compute_space/core/manifest.py
@@ -123,6 +123,18 @@ class AppManifest:
     sqlite_dbs: list[str] = attr.Factory(list)
     app_data: bool = False
     app_temp_data: bool = False
+    # ``app_archive`` opts the app into an additional bind mount at
+    # ``/data/app_archive/<name>/`` whose host backing is operator-
+    # selected: a JuiceFS-on-S3 mount when the operator has configured
+    # one, otherwise a local-disk subdirectory under
+    # ``persistent_data_dir``.  The app sees the same POSIX path either
+    # way.  Intended for bulk content (videos, photos, attachments) —
+    # things that need elastic storage but tolerate the higher latency
+    # of a network FS.  ``app_data`` remains the right place for
+    # SQLite, working state, and anything that requires strict POSIX
+    # consistency (close-to-open semantics over a network FS would
+    # corrupt SQLite WAL).
+    app_archive: bool = False
     access_vm_data: bool = False
     access_all_data: bool = False
 
@@ -289,6 +301,23 @@ def parse_manifest_from_string(raw_text: str) -> AppManifest:
             app_name,
         )
 
+    # Reject ``app_archive`` without ``app_data``.  The archive tier is
+    # for bulk content (videos, photos, attachments); SQLite + working
+    # state must live in the local-disk app_data tier because the
+    # archive tier may be backed by a network FS with close-to-open
+    # consistency that corrupts SQLite WAL.  Allowing app_archive on
+    # its own would invite that corruption — every meaningful app
+    # needs SOME local state (at least a sqlite session db, even if
+    # the bulk content is archive-resident).
+    if data_section.get("app_archive") and not (
+        data_section.get("app_data") or data_section.get("sqlite")
+    ):
+        raise ValueError(
+            "[data].app_archive requires [data].app_data (or [data].sqlite). "
+            "The archive tier is for bulk content; working state and "
+            "embedded databases must live in the local-disk app_data tier."
+        )
+
     return AppManifest(
         name=app_name,
         version=app_section["version"],
@@ -310,6 +339,7 @@ def parse_manifest_from_string(raw_text: str) -> AppManifest:
         sqlite_dbs=data_section.get("sqlite", []),
         app_data=data_section.get("app_data", False),
         app_temp_data=data_section.get("app_temp_data", False),
+        app_archive=data_section.get("app_archive", False),
         access_vm_data=data_section.get("access_vm_data", False),
         access_all_data=data_section.get("access_all_data", False),
         provides_services=services.get("provides", []),

--- a/compute_space/compute_space/web/routes/api/apps.py
+++ b/compute_space/compute_space/web/routes/api/apps.py
@@ -13,6 +13,7 @@ from quart import request
 from quart import url_for
 from quart.typing import ResponseReturnValue
 
+from compute_space.config import Config
 from compute_space.config import get_config
 from compute_space.core.apps import RESERVED_PATHS
 from compute_space.core.apps import app_log_path
@@ -400,7 +401,7 @@ async def remove_app(app_name: str) -> ResponseReturnValue:
     return jsonify({"ok": True})
 
 
-def _rename_app_storage_dirs(config, old_name: str, new_name: str) -> str | None:
+def _rename_app_storage_dirs(config: Config, old_name: str, new_name: str) -> str | None:
     """Rename per-app subdirs across the three storage tiers, with
     best-effort rollback on partial failure.
 

--- a/compute_space/compute_space/web/routes/api/apps.py
+++ b/compute_space/compute_space/web/routes/api/apps.py
@@ -2,6 +2,7 @@ import asyncio
 import os
 import re
 import shutil
+import sqlite3
 import threading
 
 import attr
@@ -428,7 +429,9 @@ async def rename_app(app_name: str) -> ResponseReturnValue:
     if conflict:
         return jsonify({"error": f"Name already in use by '{conflict['name']}'"}), 409
 
-    was_running = app_row["status"] in ("running", "starting", "building")
+    prior_status = app_row["status"]
+    prior_container_id = app_row["container_id"]
+    was_running = prior_status in ("running", "starting", "building")
     stop_app_process(app_row)
     db.execute(
         "UPDATE apps SET status = 'stopped', container_id = NULL WHERE name = ?",
@@ -479,6 +482,20 @@ async def rename_app(app_name: str) -> ResponseReturnValue:
                     old_dir,
                     rollback_exc,
                 )
+        # Restore the prior status + container_id so the dashboard
+        # shows the app the same way it did before the failed rename.
+        # ``stop_app_process`` already terminated the process, so a
+        # ``running`` state will reconcile via the supervisor's
+        # crashed-app path on the next health-check tick rather than
+        # leaving a permanently-stuck ``stopped`` row.
+        try:
+            db.execute(
+                "UPDATE apps SET status = ?, container_id = ? WHERE name = ?",
+                (prior_status, prior_container_id, app_name),
+            )
+            db.commit()
+        except sqlite3.Error as db_exc:
+            logger.error("Failed to restore status during rename rollback: %s", db_exc)
         return jsonify({"error": f"Failed to rename app data directories: {exc}"}), 500
 
     db.execute("PRAGMA foreign_keys=OFF")

--- a/compute_space/compute_space/web/routes/api/apps.py
+++ b/compute_space/compute_space/web/routes/api/apps.py
@@ -400,6 +400,53 @@ async def remove_app(app_name: str) -> ResponseReturnValue:
     return jsonify({"ok": True})
 
 
+def _rename_app_storage_dirs(config, old_name: str, new_name: str) -> str | None:
+    """Rename per-app subdirs across the three storage tiers, with
+    best-effort rollback on partial failure.
+
+    Returns ``None`` on success, or an error message string on failure
+    (callers convert that to a 500 response).  Pure-sync helper so the
+    blocking ``os.rename`` calls — which can take tens-to-hundreds of
+    ms on a JuiceFS-backed archive tier — don't run on the asyncio
+    event loop.
+
+    Each per-tier rename stays within its own parent dir (jfs->jfs or
+    local->local), so cross-device EXDEV is not an issue, but a
+    transient mount drop or permissions blip on the archive tier
+    still could fail.  When that happens, undo the renames we already
+    did so the on-disk state matches what's still in the DB; if the
+    rollback rename itself ALSO fails, log it and continue — the
+    operator-visible state is wedged for that tier and only manual
+    reconciliation can fix it.
+    """
+    rename_parents = [
+        os.path.join(config.persistent_data_dir, "app_data"),
+        os.path.join(config.temporary_data_dir, "app_temp_data"),
+        config.app_archive_dir,
+    ]
+    renamed: list[tuple[str, str]] = []
+    try:
+        for parent in rename_parents:
+            old_dir = os.path.join(parent, old_name)
+            new_dir = os.path.join(parent, new_name)
+            if os.path.exists(old_dir) and not os.path.exists(new_dir):
+                os.rename(old_dir, new_dir)
+                renamed.append((old_dir, new_dir))
+    except OSError as exc:
+        for old_dir, new_dir in reversed(renamed):
+            try:
+                os.rename(new_dir, old_dir)
+            except OSError as rollback_exc:
+                logger.error(
+                    "Rollback of partial rename %s -> %s failed: %s",
+                    new_dir,
+                    old_dir,
+                    rollback_exc,
+                )
+        return str(exc)
+    return None
+
+
 @api_apps_bp.route("/rename_app/<app_name>", methods=["POST"])
 @login_required
 async def rename_app(app_name: str) -> ResponseReturnValue:
@@ -444,44 +491,18 @@ async def rename_app(app_name: str) -> ResponseReturnValue:
     # archive tier here would orphan its contents under the old
     # name; the next provision_data on the renamed app would create
     # a fresh empty archive subdir, silently abandoning whatever
-    # was there.
-    #
-    # ``config.app_archive_dir`` may resolve to a JuiceFS mount
-    # path.  Each per-tier rename stays within its own parent dir
-    # (jfs->jfs or local->local), so cross-device EXDEV is not an
-    # issue, but a transient mount drop or permissions blip on the
-    # archive tier still could.  If anything fails, roll back the
-    # tiers we already renamed so the on-disk and DB state stay
-    # consistent — apps would otherwise come back up under the new
-    # name with their archive contents still under the old.
-    rename_parents = [
-        os.path.join(config.persistent_data_dir, "app_data"),
-        os.path.join(config.temporary_data_dir, "app_temp_data"),
-        config.app_archive_dir,
-    ]
-    renamed: list[tuple[str, str]] = []
-    try:
-        for parent in rename_parents:
-            old_dir = os.path.join(parent, app_name)
-            new_dir = os.path.join(parent, new_name)
-            if os.path.exists(old_dir) and not os.path.exists(new_dir):
-                os.rename(old_dir, new_dir)
-                renamed.append((old_dir, new_dir))
-    except OSError as exc:
-        # Best-effort rollback.  If a rollback rename itself fails
-        # (e.g. the underlying filesystem is gone) we surface the
-        # original error and let the operator reconcile manually
-        # from the logs.
-        for old_dir, new_dir in reversed(renamed):
-            try:
-                os.rename(new_dir, old_dir)
-            except OSError as rollback_exc:
-                logger.error(
-                    "Rollback of partial rename %s -> %s failed: %s",
-                    new_dir,
-                    old_dir,
-                    rollback_exc,
-                )
+    # was there.  ``_rename_app_storage_dirs`` runs in a worker
+    # thread because ``config.app_archive_dir`` may resolve to a
+    # JuiceFS mount with tens-to-hundreds-of-ms rename latency,
+    # which would otherwise stall the event loop and block other
+    # requests for the duration of the rename.
+    rename_error = await asyncio.to_thread(
+        _rename_app_storage_dirs,
+        config,
+        app_name,
+        new_name,
+    )
+    if rename_error is not None:
         # Restore the prior status + container_id so the dashboard
         # shows the app the same way it did before the failed rename.
         # ``stop_app_process`` already terminated the process, so a
@@ -496,7 +517,7 @@ async def rename_app(app_name: str) -> ResponseReturnValue:
             db.commit()
         except sqlite3.Error as db_exc:
             logger.error("Failed to restore status during rename rollback: %s", db_exc)
-        return jsonify({"error": f"Failed to rename app data directories: {exc}"}), 500
+        return jsonify({"error": f"Failed to rename app data directories: {rename_error}"}), 500
 
     db.execute("PRAGMA foreign_keys=OFF")
     db.execute(

--- a/compute_space/compute_space/web/routes/api/apps.py
+++ b/compute_space/compute_space/web/routes/api/apps.py
@@ -382,7 +382,13 @@ async def remove_app(app_name: str) -> ResponseReturnValue:
         if keep_data:
             await asyncio.to_thread(deprovision_temp_data, app_name, config.temporary_data_dir)
         else:
-            await asyncio.to_thread(deprovision_data, app_name, config.persistent_data_dir, config.temporary_data_dir)
+            await asyncio.to_thread(
+                deprovision_data,
+                app_name,
+                config.persistent_data_dir,
+                config.temporary_data_dir,
+                config.app_archive_dir,
+            )
     except Exception as e:
         logger.warning("Failed to deprovision data for %s: %s", app_name, e)
 

--- a/compute_space/compute_space/web/routes/api/apps.py
+++ b/compute_space/compute_space/web/routes/api/apps.py
@@ -444,18 +444,42 @@ async def rename_app(app_name: str) -> ResponseReturnValue:
     # was there.
     #
     # ``config.app_archive_dir`` may resolve to a JuiceFS mount
-    # path; the rename is just a directory rename within the
-    # mount, which JuiceFS handles atomically via its metadata
-    # engine.
-    for parent in [
+    # path.  Each per-tier rename stays within its own parent dir
+    # (jfs->jfs or local->local), so cross-device EXDEV is not an
+    # issue, but a transient mount drop or permissions blip on the
+    # archive tier still could.  If anything fails, roll back the
+    # tiers we already renamed so the on-disk and DB state stay
+    # consistent — apps would otherwise come back up under the new
+    # name with their archive contents still under the old.
+    rename_parents = [
         os.path.join(config.persistent_data_dir, "app_data"),
         os.path.join(config.temporary_data_dir, "app_temp_data"),
         config.app_archive_dir,
-    ]:
-        old_dir = os.path.join(parent, app_name)
-        new_dir = os.path.join(parent, new_name)
-        if os.path.exists(old_dir) and not os.path.exists(new_dir):
-            os.rename(old_dir, new_dir)
+    ]
+    renamed: list[tuple[str, str]] = []
+    try:
+        for parent in rename_parents:
+            old_dir = os.path.join(parent, app_name)
+            new_dir = os.path.join(parent, new_name)
+            if os.path.exists(old_dir) and not os.path.exists(new_dir):
+                os.rename(old_dir, new_dir)
+                renamed.append((old_dir, new_dir))
+    except OSError as exc:
+        # Best-effort rollback.  If a rollback rename itself fails
+        # (e.g. the underlying filesystem is gone) we surface the
+        # original error and let the operator reconcile manually
+        # from the logs.
+        for old_dir, new_dir in reversed(renamed):
+            try:
+                os.rename(new_dir, old_dir)
+            except OSError as rollback_exc:
+                logger.error(
+                    "Rollback of partial rename %s -> %s failed: %s",
+                    new_dir,
+                    old_dir,
+                    rollback_exc,
+                )
+        return jsonify({"error": f"Failed to rename app data directories: {exc}"}), 500
 
     db.execute("PRAGMA foreign_keys=OFF")
     db.execute(

--- a/compute_space/compute_space/web/routes/api/apps.py
+++ b/compute_space/compute_space/web/routes/api/apps.py
@@ -436,9 +436,21 @@ async def rename_app(app_name: str) -> ResponseReturnValue:
     )
     db.commit()
 
+    # Rename every per-app subdirectory across each storage tier
+    # (local-persistent, local-scratch, archive).  Missing the
+    # archive tier here would orphan its contents under the old
+    # name; the next provision_data on the renamed app would create
+    # a fresh empty archive subdir, silently abandoning whatever
+    # was there.
+    #
+    # ``config.app_archive_dir`` may resolve to a JuiceFS mount
+    # path; the rename is just a directory rename within the
+    # mount, which JuiceFS handles atomically via its metadata
+    # engine.
     for parent in [
         os.path.join(config.persistent_data_dir, "app_data"),
         os.path.join(config.temporary_data_dir, "app_temp_data"),
+        config.app_archive_dir,
     ]:
         old_dir = os.path.join(parent, app_name)
         new_dir = os.path.join(parent, new_name)

--- a/compute_space/tests/test_ansible_templates.py
+++ b/compute_space/tests/test_ansible_templates.py
@@ -228,6 +228,38 @@ def test_juicefs_mount_restart_on_failure(templates_env: Environment) -> None:
     assert "Restart=on-failure" in rendered
 
 
+def test_juicefs_mount_execstop_uses_shell(templates_env: Environment) -> None:
+    """systemd does NOT execute ExecStop= via a shell.  Earlier this unit
+    had ``... umount X || /bin/umount -l X`` directly on the line, which
+    would have been passed as literal argv to ``juicefs umount`` and
+    silently failed the lazy-umount fallback.  Pin the shell wrap.
+    """
+    rendered = templates_env.get_template("juicefs-mount.service.j2").render()
+    exec_stop = next(line for line in rendered.splitlines() if line.startswith("ExecStop="))
+    # Either /bin/sh or /bin/bash with -c is acceptable; the key
+    # invariant is "shell is in the loop", not "specific shell".
+    assert re.search(r"^ExecStop=/bin/(?:ba)?sh\s+-c\s+", exec_stop), exec_stop
+
+
+def test_juicefs_mount_log_path_is_host_writable(templates_env: Environment) -> None:
+    """juicefs writes to ``--log <path>`` from inside the unit running
+    as ``User=host``.  The path must NOT be a root-owned dir like
+    ``/var/log`` directly; the role pre-creates ``/var/log/juicefs``
+    owned by host, so the log path must be inside there (or under
+    /home/host).  Anything else will fail-to-start at first boot.
+    """
+    rendered = templates_env.get_template("juicefs-mount.service.j2").render()
+    log_path = re.search(r"--log\s+(\S+)", rendered)
+    assert log_path is not None, rendered
+    p = log_path.group(1)
+    # Accept either the host's home tree or a host-owned /var/log subdir.
+    acceptable = (
+        p.startswith("/home/host/")
+        or p.startswith("/var/log/juicefs/")
+    )
+    assert acceptable, f"juicefs --log path {p!r} must be writable by the host user"
+
+
 # ---------------------------------------------------------------------------
 # juicefs-meta-dump — daily timer + atomic rename
 # ---------------------------------------------------------------------------

--- a/compute_space/tests/test_ansible_templates.py
+++ b/compute_space/tests/test_ansible_templates.py
@@ -229,10 +229,10 @@ def test_juicefs_mount_restart_on_failure(templates_env: Environment) -> None:
 
 
 def test_juicefs_mount_execstop_uses_shell(templates_env: Environment) -> None:
-    """systemd does NOT execute ExecStop= via a shell.  Earlier this unit
-    had ``... umount X || /bin/umount -l X`` directly on the line, which
-    would have been passed as literal argv to ``juicefs umount`` and
-    silently failed the lazy-umount fallback.  Pin the shell wrap.
+    """systemd does not execute ExecStop= via a shell, so a bare ``||``
+    would be passed as literal argv to ``juicefs umount`` and the
+    lazy-umount fallback would silently never run.  The shell wrapper
+    around the umount + fallback is therefore mandatory.
     """
     rendered = templates_env.get_template("juicefs-mount.service.j2").render()
     exec_stop = next(line for line in rendered.splitlines() if line.startswith("ExecStop="))

--- a/compute_space/tests/test_ansible_templates.py
+++ b/compute_space/tests/test_ansible_templates.py
@@ -1,0 +1,265 @@
+"""Render-time tests for the ansible jinja2 templates.
+
+These templates are otherwise tested only by running ansible against a
+real VM, which is too slow to do per-commit.  Here we render them with
+jinja2 directly and assert on the contents — covering the JuiceFS
+toggle, the conditional ``Requires=juicefs-mount.service``, and the
+bind-mount path the systemd unit hands to ``juicefs mount``.
+
+These tests intentionally skip ansible-isms that aren't valid jinja2
+(filters like ``ansible_architecture``) by feeding the templates the
+exact variables they expect.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+from jinja2 import Environment, FileSystemLoader, StrictUndefined
+
+
+def _ansible_bool(value: object) -> bool:
+    """Mimic ansible's ``| bool`` filter for our render-time tests.
+
+    Ansible's ``bool`` accepts python bools, the literal strings
+    ``"true"``/``"false"``/``"yes"``/``"no"``/``"1"``/``"0"`` (case-
+    insensitive), and integers.  We only need the cases the templates
+    actually pass through, so anything else falls back to Python's
+    ``bool()`` for predictability.
+    """
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return value.strip().lower() in {"true", "yes", "y", "1", "on"}
+    return bool(value)
+
+
+@pytest.fixture(scope="module")
+def templates_env() -> Environment:
+    """Jinja2 env pointed at the ansible templates dir.
+
+    StrictUndefined turns any reference to an unset variable into a
+    test failure, so we catch typos in the templates rather than
+    silently rendering them as empty strings.
+
+    Ansible filters that aren't builtin to jinja2 are shimmed in so
+    the templates can render outside of ansible for these tests.
+    """
+    here = Path(__file__).resolve()
+    # compute_space/tests/test_ansible_templates.py -> openhost-core/ansible/templates
+    repo_root = here.parents[2]
+    templates_dir = repo_root / "ansible" / "templates"
+    assert templates_dir.is_dir(), templates_dir
+    env = Environment(
+        loader=FileSystemLoader(str(templates_dir)),
+        undefined=StrictUndefined,
+        keep_trailing_newline=True,
+    )
+    env.filters["bool"] = _ansible_bool
+    return env
+
+
+# ---------------------------------------------------------------------------
+# config.toml.j2 — archive_dir_override only when juicefs_enabled
+# ---------------------------------------------------------------------------
+
+
+def _render_config_toml(env: Environment, **vars_: object) -> str:
+    return env.get_template("config.toml.j2").render(**vars_)
+
+
+def test_config_toml_no_archive_override_by_default(templates_env: Environment) -> None:
+    """JuiceFS off (the default) must not emit ``archive_dir_override``.
+
+    Existing zones reload their config.toml on every deploy; a stray
+    override line would shift their archive root unintentionally.
+    """
+    rendered = _render_config_toml(
+        templates_env,
+        domain="example.selfhost.imbue.com",
+        public_ip="1.2.3.4",
+        juicefs_enabled=False,
+    )
+    assert "archive_dir_override" not in rendered, rendered
+
+
+def test_config_toml_no_archive_override_when_juicefs_unset(templates_env: Environment) -> None:
+    """``juicefs_enabled`` is supplied via -e at deploy time and is
+    absent on existing operator workflows that haven't opted in.  The
+    template must default to off, not error out on the missing var.
+    """
+    rendered = _render_config_toml(
+        templates_env,
+        domain="example.selfhost.imbue.com",
+        public_ip="1.2.3.4",
+        # juicefs_enabled deliberately omitted
+    )
+    assert "archive_dir_override" not in rendered, rendered
+
+
+def test_config_toml_archive_override_when_juicefs_enabled(templates_env: Environment) -> None:
+    rendered = _render_config_toml(
+        templates_env,
+        domain="example.selfhost.imbue.com",
+        public_ip="1.2.3.4",
+        juicefs_enabled=True,
+    )
+    assert 'archive_dir_override = "/data/app_archive_juicefs"' in rendered, rendered
+
+
+def test_config_toml_archive_override_with_string_true(templates_env: Environment) -> None:
+    """Ansible's ``-e juicefs_enabled=true`` arrives as the literal
+    string ``"true"`` (not a bool).  The template's ``| bool`` filter
+    must coerce it correctly so ``-e juicefs_enabled=true`` actually
+    enables the feature.
+    """
+    rendered = _render_config_toml(
+        templates_env,
+        domain="example.selfhost.imbue.com",
+        public_ip="1.2.3.4",
+        juicefs_enabled="true",
+    )
+    assert "archive_dir_override" in rendered, rendered
+
+
+def test_config_toml_archive_override_off_with_string_false(templates_env: Environment) -> None:
+    """Inverse of the above: literal ``"false"`` must NOT enable."""
+    rendered = _render_config_toml(
+        templates_env,
+        domain="example.selfhost.imbue.com",
+        public_ip="1.2.3.4",
+        juicefs_enabled="false",
+    )
+    assert "archive_dir_override" not in rendered, rendered
+
+
+# ---------------------------------------------------------------------------
+# openhost.service.j2 — Requires=juicefs-mount.service when enabled
+# ---------------------------------------------------------------------------
+
+
+def _render_openhost_service(env: Environment, **vars_: object) -> str:
+    return env.get_template("openhost.service.j2").render(host_uid="1001", **vars_)
+
+
+def test_openhost_service_no_juicefs_dep_by_default(templates_env: Environment) -> None:
+    rendered = _render_openhost_service(templates_env, juicefs_enabled=False)
+    # The After= line shouldn't list the juicefs unit when off.
+    after_line = next(line for line in rendered.splitlines() if line.startswith("After="))
+    assert "juicefs-mount.service" not in after_line, after_line
+    assert "Requires=juicefs-mount.service" not in rendered
+
+
+def test_openhost_service_juicefs_dep_when_enabled(templates_env: Environment) -> None:
+    rendered = _render_openhost_service(templates_env, juicefs_enabled=True)
+    # Requires= must be present and the After= line must include the unit.
+    assert "Requires=juicefs-mount.service" in rendered, rendered
+    after_line = next(line for line in rendered.splitlines() if line.startswith("After="))
+    assert "juicefs-mount.service" in after_line, after_line
+
+
+def test_openhost_service_no_dep_when_juicefs_unset(templates_env: Environment) -> None:
+    """An operator who never passes -e juicefs_enabled gets no juicefs deps."""
+    rendered = _render_openhost_service(templates_env)
+    assert "juicefs-mount.service" not in rendered, rendered
+
+
+# ---------------------------------------------------------------------------
+# juicefs-mount.service.j2 — argv shape, no creds on the command line
+# ---------------------------------------------------------------------------
+
+
+def test_juicefs_mount_uses_env_for_creds(templates_env: Environment) -> None:
+    """ACCESS_KEY/SECRET_KEY must come from EnvironmentFile, not argv.
+
+    Putting credentials on argv leaks them via ``ps`` and any process
+    listing.  This test pins down that pattern.
+    """
+    rendered = templates_env.get_template("juicefs-mount.service.j2").render()
+    assert "EnvironmentFile=/etc/openhost/juicefs/s3.env" in rendered
+    # The ExecStart line must NOT carry --access-key / --secret-key:
+    exec_line = next(
+        line for line in rendered.splitlines() if line.startswith("ExecStart=")
+    )
+    # Subsequent continuation lines also need scrutiny.
+    cont_lines = []
+    in_exec = False
+    for line in rendered.splitlines():
+        if line.startswith("ExecStart="):
+            in_exec = True
+            cont_lines.append(line)
+            continue
+        if in_exec:
+            if line.endswith("\\"):
+                cont_lines.append(line)
+            else:
+                cont_lines.append(line)
+                break
+    blob = "\n".join(cont_lines)
+    assert "--access-key" not in blob, blob
+    assert "--secret-key" not in blob, blob
+
+
+def test_juicefs_mount_target_path(templates_env: Environment) -> None:
+    """Mount target must match what config.toml.j2's archive_dir_override
+    points at, and what containers.py expects as the host-side parent
+    of per-app subdirs.
+    """
+    rendered = templates_env.get_template("juicefs-mount.service.j2").render()
+    assert "/data/app_archive_juicefs" in rendered
+
+
+def test_juicefs_mount_orders_before_openhost(templates_env: Environment) -> None:
+    """openhost.service has Requires=juicefs-mount.service when JuiceFS
+    is on, so the mount unit must declare itself ``Before=openhost.service``
+    (or have the corresponding ordering) for systemd to start it first.
+    """
+    rendered = templates_env.get_template("juicefs-mount.service.j2").render()
+    assert "Before=openhost.service" in rendered
+
+
+def test_juicefs_mount_restart_on_failure(templates_env: Environment) -> None:
+    """A dropped mount must surface as a failed unit rather than apps
+    silently writing to the underlying empty mount-point.
+    """
+    rendered = templates_env.get_template("juicefs-mount.service.j2").render()
+    assert "Restart=on-failure" in rendered
+
+
+# ---------------------------------------------------------------------------
+# juicefs-meta-dump — daily timer + atomic rename
+# ---------------------------------------------------------------------------
+
+
+def test_meta_dump_writes_under_persistent_data_dir(templates_env: Environment) -> None:
+    """The dump must land under persistent_data_dir/openhost/ so the
+    existing restic-based openhost-backup app picks it up.
+    """
+    rendered = templates_env.get_template("juicefs-meta-dump.service.j2").render()
+    expected_path = (
+        "/home/host/.openhost/local_compute_space/persistent_data/openhost/"
+        "juicefs-metadata-dump.json"
+    )
+    assert expected_path in rendered, rendered
+
+
+def test_meta_dump_uses_atomic_rename(templates_env: Environment) -> None:
+    """Writing then renaming makes the dump file consistent for any
+    backup snapshot taken concurrent with the timer firing.  A direct
+    overwrite would leave a half-written file readable by restic.
+    """
+    rendered = templates_env.get_template("juicefs-meta-dump.service.j2").render()
+    # ``mv X.tmp X`` must be present.  ``re.DOTALL`` lets the regex span
+    # across the systemd line-continuation backslashes that split the
+    # mv command across two lines.
+    assert re.search(r"mv\s+\S+\.tmp\s.+\S+\.json", rendered, re.DOTALL), rendered
+
+
+def test_meta_dump_timer_runs_daily(templates_env: Environment) -> None:
+    rendered = templates_env.get_template("juicefs-meta-dump.timer.j2").render()
+    assert "OnUnitActiveSec=24h" in rendered
+    # Persistent= covers the case where the VM was off when the timer
+    # was due to fire — systemd runs it at next boot.
+    assert "Persistent=true" in rendered

--- a/compute_space/tests/test_ansible_templates.py
+++ b/compute_space/tests/test_ansible_templates.py
@@ -268,13 +268,33 @@ def test_juicefs_mount_log_path_is_host_writable(templates_env: Environment) -> 
 def test_meta_dump_writes_under_persistent_data_dir(templates_env: Environment) -> None:
     """The dump must land under persistent_data_dir/openhost/ so the
     existing restic-based openhost-backup app picks it up.
+
+    With no override the default is the standard ansible-deployed
+    path, which is the case for the vast majority of zones.
     """
     rendered = templates_env.get_template("juicefs-meta-dump.service.j2").render()
-    expected_path = (
+    expected_default = (
         "/home/host/.openhost/local_compute_space/persistent_data/openhost/"
         "juicefs-metadata-dump.json"
     )
-    assert expected_path in rendered, rendered
+    assert expected_default in rendered, rendered
+
+
+def test_meta_dump_dump_dir_override_honoured(templates_env: Environment) -> None:
+    """Operators who override ``data_root_dir`` via the openhost config
+    must be able to point ``juicefs_dump_dir`` at the matching
+    persistent_data_dir/openhost/ subtree, otherwise the dump silently
+    lands in the wrong place and restic misses it.
+    """
+    rendered = templates_env.get_template("juicefs-meta-dump.service.j2").render(
+        juicefs_dump_dir="/srv/openhost/persistent_data/openhost",
+    )
+    assert (
+        "/srv/openhost/persistent_data/openhost/juicefs-metadata-dump.json" in rendered
+    ), rendered
+    # And the default path must be absent so we know the override
+    # actually replaced it everywhere.
+    assert "/home/host/.openhost" not in rendered, rendered
 
 
 def test_meta_dump_uses_atomic_rename(templates_env: Environment) -> None:

--- a/compute_space/tests/test_app_archive.py
+++ b/compute_space/tests/test_app_archive.py
@@ -163,6 +163,33 @@ def test_provision_data_refuses_when_archive_dir_missing(tmp_path) -> None:
         )
 
 
+def test_provision_data_refuses_when_archive_dir_missing_via_access_all_data(tmp_path) -> None:
+    """The same guard must fire for ``access_all_data`` apps too —
+    they use the archive tier even though they don't set
+    ``app_archive=True`` directly.  Without this branch coverage a
+    refactor that splits the two could regress the guard for one
+    flag and leave the other silently broken.
+    """
+    data_dir = tmp_path / "persistent"
+    temp_dir = tmp_path / "temp"
+    archive_dir = tmp_path / "doesnt-exist"  # NOT created
+    data_dir.mkdir()
+    temp_dir.mkdir()
+
+    manifest = _manifest(access_all_data=True)
+    with pytest.raises(RuntimeError, match="archive_dir"):
+        provision_data(
+            manifest.name,
+            manifest,
+            str(data_dir),
+            str(temp_dir),
+            str(archive_dir),
+            my_openhost_redirect_domain="my.example.com",
+            zone_domain="example.com",
+            port=8080,
+        )
+
+
 def test_provision_data_does_not_fail_when_archive_dir_missing_and_no_archive_opt_in(
     tmp_path,
 ) -> None:

--- a/compute_space/tests/test_app_archive.py
+++ b/compute_space/tests/test_app_archive.py
@@ -13,9 +13,6 @@ These tests cover the manifest opt-in plumbing that flows from
 
 from __future__ import annotations
 
-import os
-import tempfile
-
 import pytest
 
 from compute_space.config import DefaultConfig
@@ -131,6 +128,68 @@ def test_provision_data_archive_subdir_under_access_all_data(tmp_path) -> None:
     # subdir must exist (env var stamped to the in-container path).
     assert (archive_dir / manifest.name).is_dir()
     assert env["OPENHOST_APP_ARCHIVE_DIR"] == str(archive_dir / manifest.name)
+
+
+def test_provision_data_refuses_when_archive_dir_missing(tmp_path) -> None:
+    """When the configured archive root doesn't exist as a directory
+    (e.g. an operator-overridden JuiceFS mount that isn't attached
+    yet), provisioning must fail loudly rather than silently
+    creating a local-disk ghost path that gets shadowed when the
+    mount eventually attaches.
+
+    This is the load-bearing invariant on the operator-side
+    JuiceFS-mount-failure path: systemd ordering makes openhost-
+    core boot-fail when the mount fails, but if the operator
+    bypasses that ordering somehow, this guard turns the failure
+    into a clean error message instead of silent data loss.
+    """
+    data_dir = tmp_path / "persistent"
+    temp_dir = tmp_path / "temp"
+    archive_dir = tmp_path / "doesnt-exist"  # NOT created
+    data_dir.mkdir()
+    temp_dir.mkdir()
+
+    manifest = _manifest(app_data=True, app_archive=True)
+    with pytest.raises(RuntimeError, match="archive_dir"):
+        provision_data(
+            manifest.name,
+            manifest,
+            str(data_dir),
+            str(temp_dir),
+            str(archive_dir),
+            my_openhost_redirect_domain="my.example.com",
+            zone_domain="example.com",
+            port=8080,
+        )
+
+
+def test_provision_data_does_not_fail_when_archive_dir_missing_and_no_archive_opt_in(
+    tmp_path,
+) -> None:
+    """Apps that don't ask for app_archive must NOT fail just
+    because the configured archive_dir doesn't exist.  The whole
+    point of the opt-in is that operators with no JuiceFS (and
+    therefore potentially with a fallback path that hasn't been
+    populated by Config.make_all_dirs yet) can still deploy
+    archive-free apps."""
+    data_dir = tmp_path / "persistent"
+    temp_dir = tmp_path / "temp"
+    archive_dir = tmp_path / "doesnt-exist"  # NOT created
+    data_dir.mkdir()
+    temp_dir.mkdir()
+
+    manifest = _manifest(app_data=True)  # no app_archive
+    # Must not raise.
+    provision_data(
+        manifest.name,
+        manifest,
+        str(data_dir),
+        str(temp_dir),
+        str(archive_dir),
+        my_openhost_redirect_domain="my.example.com",
+        zone_domain="example.com",
+        port=8080,
+    )
 
 
 def test_provision_data_archive_idempotent_on_redeploy(tmp_path) -> None:

--- a/compute_space/tests/test_app_archive.py
+++ b/compute_space/tests/test_app_archive.py
@@ -1,0 +1,292 @@
+"""Tests for the ``app_archive`` storage tier.
+
+The archive tier is a per-app bind mount whose host backing is
+operator-selected: defaults to local disk under ``persistent_data_dir``
+and can be overridden to point at a JuiceFS mount (or any other
+host-mounted POSIX filesystem).  Apps see the same in-container path
+either way.
+
+These tests cover the manifest opt-in plumbing that flows from
+``provision_data`` through ``deprovision_data``, plus the
+``Config.app_archive_dir`` resolution rules.
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+
+import pytest
+
+from compute_space.config import DefaultConfig
+from compute_space.core.data import deprovision_data, provision_data
+from compute_space.core.manifest import AppManifest
+
+
+def _manifest(**kwargs) -> AppManifest:  # type: ignore[no-untyped-def]
+    """Build a minimally-populated AppManifest for tests.
+
+    Mirrors the helper in test_containers.py so the two test files
+    construct equivalent fixtures and a regression that diverges the
+    two surfaces is easier to spot.
+    """
+    base = dict(
+        name="archiveapp",
+        version="0.1.0",
+        container_image="Dockerfile",
+        container_port=8080,
+        memory_mb=128,
+        cpu_millicores=100,
+    )
+    base.update(kwargs)
+    return AppManifest(**base)  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# provision_data
+# ---------------------------------------------------------------------------
+
+
+def test_provision_data_creates_archive_subdir_when_opted_in(tmp_path) -> None:
+    """``app_archive=True`` should produce a per-app subdir under the
+    operator-configured archive root and stamp
+    ``OPENHOST_APP_ARCHIVE_DIR`` on the env-vars dict.
+    """
+    data_dir = tmp_path / "persistent"
+    temp_dir = tmp_path / "temp"
+    archive_dir = tmp_path / "archive"
+    for d in (data_dir, temp_dir, archive_dir):
+        d.mkdir()
+
+    manifest = _manifest(app_data=True, app_archive=True)
+    env = provision_data(
+        manifest.name,
+        manifest,
+        str(data_dir),
+        str(temp_dir),
+        str(archive_dir),
+        my_openhost_redirect_domain="my.example.com",
+        zone_domain="example.com",
+        port=8080,
+    )
+
+    expected = archive_dir / manifest.name
+    assert expected.is_dir()
+    assert env["OPENHOST_APP_ARCHIVE_DIR"] == str(expected)
+
+
+def test_provision_data_skips_archive_when_not_opted_in(tmp_path) -> None:
+    """An app that doesn't ask for ``app_archive`` must NOT get the
+    env var or a subdir created — apps that don't opt in shouldn't
+    surface operator-configured backings to themselves."""
+    data_dir = tmp_path / "persistent"
+    temp_dir = tmp_path / "temp"
+    archive_dir = tmp_path / "archive"
+    for d in (data_dir, temp_dir, archive_dir):
+        d.mkdir()
+
+    manifest = _manifest(app_data=True)  # no app_archive
+    env = provision_data(
+        manifest.name,
+        manifest,
+        str(data_dir),
+        str(temp_dir),
+        str(archive_dir),
+        my_openhost_redirect_domain="my.example.com",
+        zone_domain="example.com",
+        port=8080,
+    )
+
+    assert "OPENHOST_APP_ARCHIVE_DIR" not in env
+    assert not (archive_dir / manifest.name).exists()
+
+
+def test_provision_data_archive_subdir_under_access_all_data(tmp_path) -> None:
+    """``access_all_data`` is the catch-all that grants every tier.
+    Even though the archive bind under access_all_data is the parent
+    directory (handled in run_container), provision_data must still
+    create the per-app subdir so its files have a stable location
+    inside the archive namespace; the parent mount in the container
+    just exposes that subdir under its existing path.
+    """
+    data_dir = tmp_path / "persistent"
+    temp_dir = tmp_path / "temp"
+    archive_dir = tmp_path / "archive"
+    for d in (data_dir, temp_dir, archive_dir):
+        d.mkdir()
+
+    manifest = _manifest(access_all_data=True)
+    env = provision_data(
+        manifest.name,
+        manifest,
+        str(data_dir),
+        str(temp_dir),
+        str(archive_dir),
+        my_openhost_redirect_domain="my.example.com",
+        zone_domain="example.com",
+        port=8080,
+    )
+
+    # access_all_data implies app_archive coverage; the per-app
+    # subdir must exist (env var stamped to the in-container path).
+    assert (archive_dir / manifest.name).is_dir()
+    assert env["OPENHOST_APP_ARCHIVE_DIR"] == str(archive_dir / manifest.name)
+
+
+def test_provision_data_archive_idempotent_on_redeploy(tmp_path) -> None:
+    """Calling provision_data twice (the redeploy path) must succeed
+    without complaining about the archive subdir already existing,
+    and must preserve any data the first deploy wrote.
+
+    Same idempotency contract as app_data and app_temp_data — apps
+    that survive a deploy + restart cycle expect their disks intact.
+    """
+    data_dir = tmp_path / "persistent"
+    temp_dir = tmp_path / "temp"
+    archive_dir = tmp_path / "archive"
+    for d in (data_dir, temp_dir, archive_dir):
+        d.mkdir()
+
+    manifest = _manifest(app_data=True, app_archive=True)
+    provision_data(
+        manifest.name,
+        manifest,
+        str(data_dir),
+        str(temp_dir),
+        str(archive_dir),
+        my_openhost_redirect_domain="my.example.com",
+        zone_domain="example.com",
+        port=8080,
+    )
+    # Drop a marker file under the archive subdir.
+    marker = archive_dir / manifest.name / "marker.txt"
+    marker.write_text("hello")
+
+    # Second provision must not raise nor wipe the marker.
+    provision_data(
+        manifest.name,
+        manifest,
+        str(data_dir),
+        str(temp_dir),
+        str(archive_dir),
+        my_openhost_redirect_domain="my.example.com",
+        zone_domain="example.com",
+        port=8080,
+    )
+    assert marker.read_text() == "hello"
+
+
+# ---------------------------------------------------------------------------
+# deprovision_data
+# ---------------------------------------------------------------------------
+
+
+def test_deprovision_data_removes_archive_subdir(tmp_path) -> None:
+    """A non-keep_data uninstall must remove the app's archive
+    subdirectory along with its app_data and temp dirs.  Without
+    this, a subsequent reinstall of the same app would inherit
+    stale archive contents."""
+    data_dir = tmp_path / "persistent"
+    temp_dir = tmp_path / "temp"
+    archive_dir = tmp_path / "archive"
+    for d in (data_dir, temp_dir, archive_dir):
+        d.mkdir()
+
+    # Pre-populate everything as if an app had run.
+    app_data_dir = data_dir / "app_data" / "myapp"
+    app_temp_dir = temp_dir / "app_temp_data" / "myapp"
+    app_archive_dir = archive_dir / "myapp"
+    for d in (app_data_dir, app_temp_dir, app_archive_dir):
+        d.mkdir(parents=True)
+        (d / "marker.txt").write_text("hi")
+
+    deprovision_data("myapp", str(data_dir), str(temp_dir), str(archive_dir))
+
+    assert not app_data_dir.exists()
+    assert not app_temp_dir.exists()
+    assert not app_archive_dir.exists()
+
+
+def test_deprovision_data_handles_missing_archive_subdir(tmp_path) -> None:
+    """A best-effort deprovision must not raise when the archive
+    subdir doesn't exist (e.g. the app never opted in to
+    app_archive, or the operator wiped the dir manually).
+    Failure to handle this gracefully would block uninstall of
+    every non-archive app on an instance with a misconfigured
+    archive_dir."""
+    data_dir = tmp_path / "persistent"
+    temp_dir = tmp_path / "temp"
+    archive_dir = tmp_path / "archive"
+    for d in (data_dir, temp_dir, archive_dir):
+        d.mkdir()
+
+    # No app_archive subdir exists — deprovision must still succeed.
+    deprovision_data("myapp", str(data_dir), str(temp_dir), str(archive_dir))
+
+
+# ---------------------------------------------------------------------------
+# Config.app_archive_dir
+# ---------------------------------------------------------------------------
+
+
+def _config(**kwargs) -> DefaultConfig:  # type: ignore[no-untyped-def]
+    base = dict(
+        zone_domain="example.com",
+        my_openhost_redirect_domain="my.example.com",
+    )
+    base.update(kwargs)
+    return DefaultConfig(**base)  # type: ignore[arg-type]
+
+
+def test_config_archive_dir_defaults_to_local_subdir() -> None:
+    """When ``archive_dir_override`` is unset, the archive lives
+    on local disk under ``persistent_data_dir``.  Apps still get
+    the bind-mount; they just don't get the elastic-S3 backing.
+    This is the path operators take when they haven't configured
+    JuiceFS yet — apps that opt into app_archive must still
+    deploy."""
+    cfg = _config(data_root_dir="/opt/openhost")
+    assert cfg.archive_dir_override is None
+    expected = "/opt/openhost/persistent_data/app_archive"
+    assert cfg.app_archive_dir == expected
+
+
+def test_config_archive_dir_uses_override_when_set() -> None:
+    """When the operator points ``archive_dir_override`` at a
+    JuiceFS mount (or any other path), the archive tier resolves
+    to that path.  This is the JuiceFS-on-S3 path."""
+    cfg = _config(
+        data_root_dir="/opt/openhost",
+        archive_dir_override="/var/lib/openhost/juicefs/mount/app_archive",
+    )
+    assert cfg.app_archive_dir == "/var/lib/openhost/juicefs/mount/app_archive"
+
+
+def test_config_make_all_dirs_creates_local_archive_dir(tmp_path) -> None:
+    """When the archive backing is local (no override), make_all_dirs
+    must create it.  Without this, the first provision_data on a
+    fresh instance would race against the mkdir."""
+    cfg = _config(data_root_dir=str(tmp_path))
+    cfg.make_all_dirs()
+    assert (tmp_path / "persistent_data" / "app_archive").is_dir()
+
+
+def test_config_make_all_dirs_does_not_create_overridden_archive_dir(
+    tmp_path,
+) -> None:
+    """When ``archive_dir_override`` points at an external mount
+    (e.g. JuiceFS), the operator-side ansible role is responsible
+    for creating it.  Trying to mkdir an external mount path that
+    isn't yet mounted would either fail or — worse — succeed by
+    creating a local-disk path that shadows the mount when it
+    eventually attaches.  Don't.
+    """
+    override = tmp_path / "external" / "archive"
+    # Note: do NOT mkdir(override) — we're asserting that
+    # make_all_dirs DOESN'T create it.
+    cfg = _config(
+        data_root_dir=str(tmp_path),
+        archive_dir_override=str(override),
+    )
+    cfg.make_all_dirs()
+    assert not override.exists()

--- a/compute_space/tests/test_containers.py
+++ b/compute_space/tests/test_containers.py
@@ -315,8 +315,10 @@ def _run_and_capture(
 
     data_dir = str(tmp_path / "persistent")
     temp_data_dir = str(tmp_path / "temp")
+    archive_dir = str(tmp_path / "archive")
     os.makedirs(data_dir, exist_ok=True)
     os.makedirs(temp_data_dir, exist_ok=True)
+    os.makedirs(archive_dir, exist_ok=True)
     os.makedirs(os.path.join(temp_data_dir, "app_temp_data", manifest.name), exist_ok=True)
 
     run_container(
@@ -327,6 +329,7 @@ def _run_and_capture(
         env_vars=env_vars or {},
         data_dir=data_dir,
         temp_data_dir=temp_data_dir,
+        archive_dir=archive_dir,
         port_mappings=port_mappings,
     )
     # The "run" call is the one after the pre-cleanup "rm".
@@ -462,6 +465,88 @@ def test_run_container_access_vm_data_mounts_vm_data_read_only(tmp_path, monkeyp
     vm_mounts = [v for v in volume_args if "/data/vm_data" in v]
     assert len(vm_mounts) == 1, vm_mounts
     assert vm_mounts[0].endswith(":ro,idmap"), vm_mounts[0]
+
+
+def test_run_container_app_archive_mounts_per_app_subdir(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Apps that opt in via [data].app_archive get a per-app bind mount
+    at /data/app_archive/<name>/.  The host source comes from the
+    operator-configured archive_dir (defaulting to a local-disk path
+    under persistent_data_dir; can be overridden to a JuiceFS mount).
+    The container path is the same regardless of backing.
+
+    A regression that mounted the archive parent (instead of the
+    per-app subdir) would expose every app's archive contents to
+    every app — same security concern as the equivalent app_data
+    isolation invariant, pinned here for the new tier.
+    """
+    manifest = _basic_manifest(app_data=True, app_archive=True)
+    argv = _run_and_capture(monkeypatch, manifest=manifest, tmp_path=tmp_path)
+
+    volume_args = [arg for prev, arg in zip(argv, argv[1:], strict=False) if prev == "-v"]
+    archive_mounts = [v for v in volume_args if "/data/app_archive" in v]
+    assert len(archive_mounts) == 1, archive_mounts
+
+    # Per-app subdir, not the parent.
+    assert archive_mounts[0].endswith(f":/data/app_archive/{manifest.name}:idmap"), archive_mounts[0]
+
+    # Source path is the per-app subdir under the configured
+    # archive_dir (here, tmp_path/archive/<name>).
+    assert f"archive/{manifest.name}:" in archive_mounts[0], archive_mounts[0]
+
+
+def test_run_container_app_archive_off_by_default(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Apps that don't opt into app_archive get NO archive bind mount.
+    A regression that always mounted the archive tier would surface
+    operator-configured backings (potentially with stale credentials,
+    a slow JuiceFS, etc.) to apps that never asked for it."""
+    manifest = _basic_manifest(app_data=True)  # no app_archive
+    argv = _run_and_capture(monkeypatch, manifest=manifest, tmp_path=tmp_path)
+
+    volume_args = [arg for prev, arg in zip(argv, argv[1:], strict=False) if prev == "-v"]
+    assert not any("/data/app_archive" in v for v in volume_args)
+
+
+def test_run_container_access_all_data_mounts_archive_parent(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """access_all_data implies access to every app's archive too.
+    The mount is the parent ``/data/app_archive`` directory, not a
+    single per-app subdir, mirroring how app_data is mounted under
+    access_all_data."""
+    manifest = _basic_manifest(access_all_data=True)
+    argv = _run_and_capture(monkeypatch, manifest=manifest, tmp_path=tmp_path)
+
+    volume_args = [arg for prev, arg in zip(argv, argv[1:], strict=False) if prev == "-v"]
+    targets = [v.rsplit(":", 2)[1] for v in volume_args]
+    # Specifically the parent, not a per-app subdir.
+    assert "/data/app_archive" in targets
+    assert f"/data/app_archive/{manifest.name}" not in targets
+
+
+def test_run_container_app_archive_env_var_translated_to_container_path(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``OPENHOST_APP_ARCHIVE_DIR`` in env_vars must be translated from
+    the host path to the in-container path before being stamped on the
+    podman run argv.  The host-vs-container path translation is the
+    same pattern as ``OPENHOST_APP_DATA_DIR`` and
+    ``OPENHOST_APP_TEMP_DIR``; pin the new key follows the same rule."""
+    manifest = _basic_manifest(app_data=True, app_archive=True)
+    # Arbitrary host path; provision_data would normally produce
+    # something like ``<archive_dir>/<name>``.
+    env_vars = {"OPENHOST_APP_ARCHIVE_DIR": "/some/host/archive/myapp"}
+    argv = _run_and_capture(
+        monkeypatch, manifest=manifest, tmp_path=tmp_path, env_vars=env_vars
+    )
+
+    e_values = [arg for prev, arg in zip(argv, argv[1:], strict=False) if prev == "-e"]
+    archive_env = [e for e in e_values if e.startswith("OPENHOST_APP_ARCHIVE_DIR=")]
+    assert len(archive_env) == 1, archive_env
+    assert archive_env[0] == f"OPENHOST_APP_ARCHIVE_DIR=/data/app_archive/{manifest.name}"
 
 
 def test_run_container_port_mappings_bind_tcp_and_udp_on_all_interfaces(

--- a/compute_space/tests/test_integration.py
+++ b/compute_space/tests/test_integration.py
@@ -42,7 +42,7 @@ requires_containers = pytest.mark.requires_containers
 
 def test_sqlite_provisioning():
     """SQLite databases declared in a manifest are provisioned correctly."""
-    with tempfile.TemporaryDirectory() as data_dir, tempfile.TemporaryDirectory() as temp_dir:
+    with tempfile.TemporaryDirectory() as data_dir, tempfile.TemporaryDirectory() as temp_dir, tempfile.TemporaryDirectory() as archive_dir:
         manifest = AppManifest(
             name="testapp",
             version="0.1.0",
@@ -56,6 +56,7 @@ def test_sqlite_provisioning():
             manifest,
             data_dir,
             temp_dir,
+            archive_dir,
             my_openhost_redirect_domain="my.test.example.com",
             zone_domain="test.example.com",
             port=manifest.container_port,

--- a/compute_space/tests/test_manifest.py
+++ b/compute_space/tests/test_manifest.py
@@ -49,6 +49,7 @@ class TestDefaults:
         manifest = parse_manifest_from_string(MINIMAL)
         assert manifest.app_data is False
         assert manifest.app_temp_data is False
+        assert manifest.app_archive is False
         assert manifest.access_vm_data is False
         assert manifest.access_all_data is False
 
@@ -550,3 +551,53 @@ class TestUnprivilegedPortFloor:
         toml = MINIMAL + '\n[[ports]]\nlabel = "auto"\ncontainer_port = 9000\nhost_port = 0\n'
         manifest = parse_manifest_from_string(toml)
         assert manifest.port_mappings[0].host_port == 0
+
+
+class TestAppArchive:
+    """Verify the [data].app_archive opt-in behaves correctly.
+
+    The archive tier is a host-level abstraction backed by either
+    local disk or a JuiceFS-on-S3 mount; the manifest opt-in is
+    backing-agnostic.  These tests pin the manifest-level contract.
+    """
+
+    def test_app_archive_default_is_false(self):
+        manifest = parse_manifest_from_string(MINIMAL)
+        assert manifest.app_archive is False
+
+    def test_app_archive_explicit_true_with_app_data(self):
+        toml = MINIMAL + "\n[data]\napp_data = true\napp_archive = true\n"
+        manifest = parse_manifest_from_string(toml)
+        assert manifest.app_archive is True
+        assert manifest.app_data is True
+
+    def test_app_archive_explicit_true_with_sqlite_only(self):
+        """``app_archive`` is allowed when SQLite implicitly enables
+        the local app_data tier — the validator looks at the raw
+        toml, not the synthesised app_data flag."""
+        toml = MINIMAL + '\n[data]\nsqlite = ["main"]\napp_archive = true\n'
+        manifest = parse_manifest_from_string(toml)
+        assert manifest.app_archive is True
+        assert manifest.sqlite_dbs == ["main"]
+
+    def test_app_archive_without_app_data_rejected(self):
+        """An archive-only app makes no sense.  SQLite + working
+        state must live in the local-disk tier; rejecting the
+        archive-only config at parse time prevents apps from ever
+        getting deployed in that state."""
+        toml = MINIMAL + "\n[data]\napp_archive = true\n"
+        with pytest.raises(ValueError, match="app_archive requires"):
+            parse_manifest_from_string(toml)
+
+    def test_app_archive_with_access_all_data_does_not_crash_validator(self):
+        """access_all_data is the catch-all permission.  It implies
+        access to every tier, but app_archive is still a separate
+        opt-in.  An access_all_data manifest without an explicit
+        app_archive should NOT trip the 'app_archive requires
+        app_data' validator."""
+        toml = MINIMAL + "\n[data]\naccess_all_data = true\n"
+        manifest = parse_manifest_from_string(toml)
+        # access_all_data on its own doesn't toggle app_archive;
+        # apps that want the archive bind must opt in explicitly.
+        assert manifest.app_archive is False
+        assert manifest.access_all_data is True

--- a/compute_space/tests/test_manifest.py
+++ b/compute_space/tests/test_manifest.py
@@ -601,3 +601,14 @@ class TestAppArchive:
         # apps that want the archive bind must opt in explicitly.
         assert manifest.app_archive is False
         assert manifest.access_all_data is True
+
+    def test_app_archive_with_access_all_data_and_no_app_data_accepted(self):
+        """access_all_data implies access to every tier including
+        the local-disk one, so it satisfies the 'app_archive needs
+        local state somewhere' invariant on its own.  An
+        access_all_data manifest that adds app_archive=true must NOT
+        be rejected for missing app_data."""
+        toml = MINIMAL + "\n[data]\naccess_all_data = true\napp_archive = true\n"
+        manifest = parse_manifest_from_string(toml)
+        assert manifest.app_archive is True
+        assert manifest.access_all_data is True

--- a/compute_space/tests/test_rename_app.py
+++ b/compute_space/tests/test_rename_app.py
@@ -64,18 +64,34 @@ async def _post_rename(
     return response.status_code, payload
 
 
-def _seed_app_row(db_path: str, name: str, port: int = 19500) -> None:
+def _seed_app_row(
+    db_path: str, name: str, port: int = 19500, status: str = "stopped"
+) -> None:
     """Insert a minimal apps row that rename_app can target."""
     db = sqlite3.connect(db_path)
     try:
         db.execute(
             """INSERT INTO apps (name, version, repo_path, local_port, status)
-               VALUES (?, '1.0', ?, ?, 'stopped')""",
-            (name, f"/tmp/repo/{name}", port),
+               VALUES (?, '1.0', ?, ?, ?)""",
+            (name, f"/tmp/repo/{name}", port, status),
         )
         db.commit()
     finally:
         db.close()
+
+
+def _tier_parents(cfg) -> dict[str, Path]:
+    """Single source of truth mapping tier name -> host-side parent dir.
+
+    Used both by the setup helper that creates the per-app subdirs
+    and by the assertions that verify their post-rename location, so
+    the two can't drift.
+    """
+    return {
+        "app_data": Path(cfg.persistent_data_dir) / "app_data",
+        "app_temp_data": Path(cfg.temporary_data_dir) / "app_temp_data",
+        "app_archive": Path(cfg.app_archive_dir),
+    }
 
 
 def _make_per_app_dirs(cfg, app_name: str, tiers: list[str]) -> dict[str, Path]:
@@ -83,11 +99,7 @@ def _make_per_app_dirs(cfg, app_name: str, tiers: list[str]) -> dict[str, Path]:
     sentinel file in each so we can verify the rename moved the content
     rather than just creating an empty new dir.
     """
-    parents = {
-        "app_data": Path(cfg.persistent_data_dir) / "app_data",
-        "app_temp_data": Path(cfg.temporary_data_dir) / "app_temp_data",
-        "app_archive": Path(cfg.app_archive_dir),
-    }
+    parents = _tier_parents(cfg)
     out: dict[str, Path] = {}
     for tier in tiers:
         d = parents[tier] / app_name
@@ -118,19 +130,10 @@ async def test_rename_renames_all_three_tiers(tmp_path: Path) -> None:
 
     # Old subdirs gone, new subdirs present, sentinel content preserved
     # so we know we actually moved (not recreated) each tier.
-    for tier, expected_marker in [
-        ("app_data", "app_data"),
-        ("app_temp_data", "app_temp_data"),
-        ("app_archive", "app_archive"),
-    ]:
-        if tier == "app_archive":
-            parent = Path(cfg.app_archive_dir)
-        elif tier == "app_data":
-            parent = Path(cfg.persistent_data_dir) / "app_data"
-        else:
-            parent = Path(cfg.temporary_data_dir) / "app_temp_data"
+    parents = _tier_parents(cfg)
+    for tier, parent in parents.items():
         assert not (parent / "old-name").exists(), tier
-        assert (parent / "new-name" / "sentinel.txt").read_text() == expected_marker
+        assert (parent / "new-name" / "sentinel.txt").read_text() == tier
 
 
 @pytest.mark.asyncio
@@ -166,7 +169,10 @@ async def test_rename_rollback_on_archive_failure(tmp_path: Path) -> None:
     """
     cfg = _make_test_config(tmp_path, port=20202)
     init_db(_FakeApp(cfg.db_path))
-    _seed_app_row(cfg.db_path, "old-name")
+    # Seed the row as ``running`` so the rollback assertion below
+    # actually catches the regression where the status field stays
+    # ``stopped`` after the failed rename.
+    _seed_app_row(cfg.db_path, "old-name", status="running")
     _make_per_app_dirs(cfg, "old-name", ["app_data", "app_temp_data", "app_archive"])
 
     real_rename = os.rename
@@ -187,20 +193,17 @@ async def test_rename_rollback_on_archive_failure(tmp_path: Path) -> None:
     # All three old-name subdirs must be restored; no new-name subdirs
     # in any tier.  Without the rollback, app_data/new-name and
     # app_temp_data/new-name would have leaked through.
-    parents = {
-        "app_data": Path(cfg.persistent_data_dir) / "app_data",
-        "app_temp_data": Path(cfg.temporary_data_dir) / "app_temp_data",
-        "app_archive": Path(cfg.app_archive_dir),
-    }
-    for tier, parent in parents.items():
+    for tier, parent in _tier_parents(cfg).items():
         assert (parent / "old-name").exists(), f"{tier} not rolled back"
         assert not (parent / "new-name").exists(), f"{tier} leaked partial rename"
 
-    # The DB row also stays under the old name so the dashboard doesn't
-    # point at a non-existent rename.
+    # The DB row also stays under the old name AND keeps its prior
+    # status — without restoring status, an app that was running
+    # before the rename would be permanently stuck as ``stopped``
+    # in the DB even though the on-disk state was rolled back.
     db = sqlite3.connect(cfg.db_path)
     try:
-        rows = db.execute("SELECT name FROM apps").fetchall()
+        rows = db.execute("SELECT name, status FROM apps").fetchall()
     finally:
         db.close()
-    assert [r[0] for r in rows] == ["old-name"], rows
+    assert [(r[0], r[1]) for r in rows] == [("old-name", "running")], rows

--- a/compute_space/tests/test_rename_app.py
+++ b/compute_space/tests/test_rename_app.py
@@ -207,3 +207,76 @@ async def test_rename_rollback_on_archive_failure(tmp_path: Path) -> None:
     finally:
         db.close()
     assert [(r[0], r[1]) for r in rows] == [("old-name", "running")], rows
+
+
+@pytest.mark.asyncio
+async def test_rename_rollback_continues_when_a_rollback_rename_itself_fails(
+    tmp_path: Path,
+) -> None:
+    """If a rollback rename ALSO fails (e.g. the underlying filesystem
+    is gone for both forward and reverse), the endpoint must still:
+
+    - Return 500 surfacing the *original* forward-rename failure (not
+      the rollback failure), so operators know the trigger.
+    - Continue rolling back the OTHER renamed tiers — a single bad
+      tier shouldn't abandon the rest as new-name when the operator-
+      visible state needs to be old-name.
+    - Restore the DB status field, since the on-disk + DB-status
+      consistency invariant the route promises is the same regardless
+      of how partial the on-disk rollback turned out.
+    """
+    cfg = _make_test_config(tmp_path, port=20203)
+    init_db(_FakeApp(cfg.db_path))
+    _seed_app_row(cfg.db_path, "old-name", status="running")
+    _make_per_app_dirs(cfg, "old-name", ["app_data", "app_temp_data", "app_archive"])
+
+    real_rename = os.rename
+    archive_root = os.path.realpath(cfg.app_archive_dir)
+    app_temp_root = os.path.realpath(
+        str(Path(cfg.temporary_data_dir) / "app_temp_data")
+    )
+
+    def flaky_rename(src: str, dst: str) -> None:
+        parent = os.path.realpath(os.path.dirname(src))
+        # Forward rename of the archive tier fails (the trigger).
+        if parent == archive_root and os.path.basename(src) == "old-name":
+            raise OSError(28, "simulated transient archive mount failure")
+        # Rollback rename of app_temp_data also fails (the wrinkle).
+        if parent == app_temp_root and os.path.basename(src) == "new-name":
+            raise OSError(5, "simulated rollback rename failure")
+        real_rename(src, dst)
+
+    with mock.patch("os.rename", side_effect=flaky_rename):
+        status, payload = await _post_rename(cfg, cfg.db_path, "old-name", "new-name")
+
+    assert status == 500, payload
+    # The error surfaced must be the original archive-rename failure,
+    # not the rollback failure — operators need the trigger, not the
+    # downstream symptom.
+    assert "transient archive mount failure" in (payload or {}).get("error", ""), payload
+
+    # app_data successfully rolled back to old-name.  app_temp_data
+    # is the wedged tier — its forward rename succeeded but its
+    # rollback rename failed, so it sits at new-name.  This documents
+    # the limitation: the route is best-effort, and the operator log
+    # is the recovery path for cases where rollback also fails.
+    parents = _tier_parents(cfg)
+    assert (parents["app_data"] / "old-name").exists()
+    assert not (parents["app_data"] / "new-name").exists()
+    assert (parents["app_archive"] / "old-name").exists()
+    assert not (parents["app_archive"] / "new-name").exists()
+    # The wedged tier — explicitly assert this rather than glossing
+    # over it, so a future refactor that tries harder to rollback
+    # has a clear signal where to update the test.
+    assert (parents["app_temp_data"] / "new-name").exists()
+    assert not (parents["app_temp_data"] / "old-name").exists()
+
+    # The DB-status restore path runs regardless of partial rollback,
+    # because the operator's dashboard is the only signal they have
+    # without grepping logs.
+    db = sqlite3.connect(cfg.db_path)
+    try:
+        rows = db.execute("SELECT name, status FROM apps").fetchall()
+    finally:
+        db.close()
+    assert [(r[0], r[1]) for r in rows] == [("old-name", "running")], rows

--- a/compute_space/tests/test_rename_app.py
+++ b/compute_space/tests/test_rename_app.py
@@ -1,0 +1,206 @@
+"""Tests for the ``/rename_app/<app>`` endpoint, focused on the
+three-tier directory rename and the partial-failure rollback.
+
+The endpoint renames per-app subdirectories under three storage tiers
+(``app_data``, ``app_temp_data``, ``app_archive``) and then updates a
+small set of related DB rows.  When ``app_archive_dir`` resolves to a
+JuiceFS mount, a transient mount drop or permissions blip during the
+rename loop would otherwise leave the on-disk and DB state in an
+inconsistent state — the archive subdir abandoned under the old name
+while the rest of the world refers to the new one.
+
+These tests exercise the happy path plus the rollback, both directly
+against the route function (no live router process) so they stay
+fast and don't depend on podman.
+"""
+
+from __future__ import annotations
+
+import os
+import sqlite3
+from pathlib import Path
+from unittest import mock
+
+import pytest
+from quart import Quart
+
+import compute_space.web.routes.api.apps as apps_routes
+from compute_space.db.connection import init_db
+
+from .conftest import _FakeApp, _make_test_config
+
+
+async def _post_rename(
+    cfg, db_path: str, app_name: str, new_name: str
+) -> tuple[int, dict | None]:
+    """Drive the unwrapped rename_app route under a Quart context.
+
+    Uses ``app.test_client().post`` rather than ``test_request_context``
+    because the latter doesn't populate ``request.form`` from the
+    ``data=`` kwarg in this version of Quart, leaving the route to
+    400 with "Name is required" before we ever get to the rename
+    logic we're trying to exercise.
+    """
+    app = Quart(__name__)
+    app.config["DB_PATH"] = db_path
+    app.openhost_config = cfg  # type: ignore[attr-defined]
+    # Register the unwrapped view directly so the @login_required
+    # decorator doesn't bounce the request to /login.
+    app.add_url_rule(
+        f"/rename_app/{app_name}",
+        view_func=apps_routes.rename_app.__wrapped__,  # type: ignore[attr-defined]
+        methods=["POST"],
+        defaults={"app_name": app_name},
+    )
+    client = app.test_client()
+    with mock.patch.object(apps_routes, "stop_app_process"):
+        response = await client.post(
+            f"/rename_app/{app_name}", form={"name": new_name}
+        )
+    try:
+        payload = await response.get_json()
+    except Exception:
+        payload = None
+    return response.status_code, payload
+
+
+def _seed_app_row(db_path: str, name: str, port: int = 19500) -> None:
+    """Insert a minimal apps row that rename_app can target."""
+    db = sqlite3.connect(db_path)
+    try:
+        db.execute(
+            """INSERT INTO apps (name, version, repo_path, local_port, status)
+               VALUES (?, '1.0', ?, ?, 'stopped')""",
+            (name, f"/tmp/repo/{name}", port),
+        )
+        db.commit()
+    finally:
+        db.close()
+
+
+def _make_per_app_dirs(cfg, app_name: str, tiers: list[str]) -> dict[str, Path]:
+    """Pre-create the per-app subdirs under each named tier and drop a
+    sentinel file in each so we can verify the rename moved the content
+    rather than just creating an empty new dir.
+    """
+    parents = {
+        "app_data": Path(cfg.persistent_data_dir) / "app_data",
+        "app_temp_data": Path(cfg.temporary_data_dir) / "app_temp_data",
+        "app_archive": Path(cfg.app_archive_dir),
+    }
+    out: dict[str, Path] = {}
+    for tier in tiers:
+        d = parents[tier] / app_name
+        d.mkdir(parents=True, exist_ok=True)
+        (d / "sentinel.txt").write_text(tier)
+        out[tier] = d
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Happy path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_rename_renames_all_three_tiers(tmp_path: Path) -> None:
+    """A rename must move app_data, app_temp_data, AND app_archive
+    subdirectories.  Forgetting the archive tier would orphan its
+    contents under the old name.
+    """
+    cfg = _make_test_config(tmp_path, port=20200)
+    init_db(_FakeApp(cfg.db_path))
+    _seed_app_row(cfg.db_path, "old-name")
+    _make_per_app_dirs(cfg, "old-name", ["app_data", "app_temp_data", "app_archive"])
+
+    status, payload = await _post_rename(cfg, cfg.db_path, "old-name", "new-name")
+    assert status == 200, payload
+
+    # Old subdirs gone, new subdirs present, sentinel content preserved
+    # so we know we actually moved (not recreated) each tier.
+    for tier, expected_marker in [
+        ("app_data", "app_data"),
+        ("app_temp_data", "app_temp_data"),
+        ("app_archive", "app_archive"),
+    ]:
+        if tier == "app_archive":
+            parent = Path(cfg.app_archive_dir)
+        elif tier == "app_data":
+            parent = Path(cfg.persistent_data_dir) / "app_data"
+        else:
+            parent = Path(cfg.temporary_data_dir) / "app_temp_data"
+        assert not (parent / "old-name").exists(), tier
+        assert (parent / "new-name" / "sentinel.txt").read_text() == expected_marker
+
+
+@pytest.mark.asyncio
+async def test_rename_skips_missing_tier_without_error(tmp_path: Path) -> None:
+    """An app that never opted into app_archive has no subdir under the
+    archive tier.  rename_app must skip it cleanly, not fail because
+    the source dir is missing.
+    """
+    cfg = _make_test_config(tmp_path, port=20201)
+    init_db(_FakeApp(cfg.db_path))
+    _seed_app_row(cfg.db_path, "old-name")
+    # Only app_data + app_temp_data exist; app_archive subdir absent.
+    _make_per_app_dirs(cfg, "old-name", ["app_data", "app_temp_data"])
+
+    status, payload = await _post_rename(cfg, cfg.db_path, "old-name", "new-name")
+    assert status == 200, payload
+    # And no spurious archive subdir got created on the way through.
+    assert not (Path(cfg.app_archive_dir) / "new-name").exists()
+
+
+# ---------------------------------------------------------------------------
+# Partial-failure rollback
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_rename_rollback_on_archive_failure(tmp_path: Path) -> None:
+    """If the archive-tier rename fails partway through (e.g. the
+    JuiceFS mount went transiently unhealthy), the previously-renamed
+    app_data and app_temp_data directories must be rolled back so the
+    operator-visible state matches the DB (which still has the old
+    name on disk and in the rows).
+    """
+    cfg = _make_test_config(tmp_path, port=20202)
+    init_db(_FakeApp(cfg.db_path))
+    _seed_app_row(cfg.db_path, "old-name")
+    _make_per_app_dirs(cfg, "old-name", ["app_data", "app_temp_data", "app_archive"])
+
+    real_rename = os.rename
+    archive_root = os.path.realpath(cfg.app_archive_dir)
+
+    def flaky_rename(src: str, dst: str) -> None:
+        # Fail the archive-tier rename specifically; let the others go.
+        if os.path.realpath(os.path.dirname(src)) == archive_root:
+            raise OSError(28, "simulated transient mount failure")
+        real_rename(src, dst)
+
+    with mock.patch("os.rename", side_effect=flaky_rename):
+        status, payload = await _post_rename(cfg, cfg.db_path, "old-name", "new-name")
+
+    # Endpoint must surface the failure rather than swallowing it.
+    assert status == 500, payload
+
+    # All three old-name subdirs must be restored; no new-name subdirs
+    # in any tier.  Without the rollback, app_data/new-name and
+    # app_temp_data/new-name would have leaked through.
+    parents = {
+        "app_data": Path(cfg.persistent_data_dir) / "app_data",
+        "app_temp_data": Path(cfg.temporary_data_dir) / "app_temp_data",
+        "app_archive": Path(cfg.app_archive_dir),
+    }
+    for tier, parent in parents.items():
+        assert (parent / "old-name").exists(), f"{tier} not rolled back"
+        assert not (parent / "new-name").exists(), f"{tier} leaked partial rename"
+
+    # The DB row also stays under the old name so the dashboard doesn't
+    # point at a non-existent rename.
+    db = sqlite3.connect(cfg.db_path)
+    try:
+        rows = db.execute("SELECT name FROM apps").fetchall()
+    finally:
+        db.close()
+    assert [r[0] for r in rows] == ["old-name"], rows

--- a/docs/data.md
+++ b/docs/data.md
@@ -6,11 +6,13 @@
 - each user has a “disk” with folders etc like google drive.
 - there’s some standard structure for the folders
 - apps have permissions to subsets of this drive
-- each app has a permanent and temporary storage area.
-    - permanent is for stuff that needs backed up. it should be legible to users - standard file types. could be exported and imported into a different app relatively easily.
-        - examples: sqlite files. markdown notes. source jpegs for a photo library. etc.
-    - temporary is for app-specific stuff that the user doesn’t need to think about and can get recreated on-demand if needed. caches and whatnot.
-        - examples: low-res thumbnails generated from source photos.
+- each app has three storage areas with different durability + size + latency tradeoffs:
+    - **permanent data (`app_data`)** — local disk, small, fast, backed up, legible to users.  Standard file types, exportable, importable.  This is where SQLite databases and other embedded-DB stores live (LMDB, RocksDB, BoltDB) — the latency profile is right and the strict POSIX consistency keeps WAL fsyncs safe.
+        - examples: sqlite files. markdown notes. JSON config. small assets.
+    - **archive data (`app_archive`)** — operator-selected backing (local-disk fallback by default; can be configured to a JuiceFS-on-S3 mount).  Large, optionally elastic, durability tied to the operator's choice.  Higher latency than `app_data` on uncached reads.  Intended for bulk content the app would otherwise outgrow local disk for.
+        - examples: source jpegs / RAWs in a photo library, original video files, attachment uploads, large model weights.
+    - **temporary data (`app_temp_data`)** — local disk scratch, not backed up, recreatable on demand.
+        - examples: low-res thumbnails generated from source photos, transcoding work files, in-flight upload chunks.
 - there’s also a folder for router-level data, eg the sqlite database used by the router.
 - where do app build artifacts go? probably in app temp data?
 - folder structure (as seen inside containers, mounted at `/data/`)
@@ -19,9 +21,19 @@
             - app_name/
         - app_temp_data/
             - app_name/
+        - app_archive/
+            - app_name/
         - router_data/
             - router.db
-- regardless of permissions, apps should see the same folder structure, just only with folders they have access to. that way the structure doesn't change if the permissions change. without any special permissions, apps will just have basically `/data/app_data/APP_NAME` and `/data/app_temp_data/APP_NAME`.
+- regardless of permissions, apps should see the same folder structure, just only with folders they have access to. that way the structure doesn't change if the permissions change. without any special permissions, apps will just have basically `/data/app_data/APP_NAME` and `/data/app_temp_data/APP_NAME` (and `/data/app_archive/APP_NAME` if requested).
+
+### Why three tiers, not two
+
+`app_data` and `app_archive` look similar from the in-container perspective — both are POSIX directories the app reads/writes — but their host backings have different access patterns and constraints.
+
+`app_data` is local NVMe.  Microsecond random reads, fsync that means something, strict POSIX.  This is where SQLite WAL files have to live: a WAL needs shared-memory mappings the kernel propagates between processes on the same host, and it needs `fsync()` to actually durably commit.  A network FS that gives close-to-open consistency or that buffers writes in a daemon process would corrupt SQLite databases silently.
+
+`app_archive` is the layer where the bytes can spill to S3 (via JuiceFS or similar).  Tens-to-hundreds-of-ms first-touch reads, eventual durability, no shared-memory mmap.  Apps that put the wrong data here — SQLite, anything using `fcntl` advisory locks for correctness — will hit data loss or corruption.  The manifest validator rejects `app_archive = true` without `app_data` (or `sqlite`, or `access_all_data`) so apps always have somewhere safe to put their working state.
 
 ### API
 
@@ -30,8 +42,10 @@
 
 ### Where data actually lives
 
-- persistent data (app_data, router_data) lives in the configured data directory
-- temp data (app_temp_data) lives in a separate subdirectory on the same disk, so that backups can target only the persistent data
+- permanent data (`app_data`) lives on the host's local disk under `persistent_data_dir/app_data/<app>`
+- temp data (`app_temp_data`) lives on a separate subdirectory under `temporary_data_dir`, so that backups can target only the persistent data
+- archive data (`app_archive`) lives at the path the operator configures via `archive_dir_override` in `config.toml`.  When unset (the default), the archive tier falls back to a local-disk subdirectory under `persistent_data_dir/app_archive/`.  Operators who want elastic capacity can point `archive_dir_override` at a JuiceFS mount path and every app's archive bind transparently flows through to S3.
+- the JuiceFS metadata database itself is small and lives on the host's local disk, so a fresh VM restoring from backup has the metadata to reattach to the existing S3 bucket — see the JuiceFS docs for the disaster-recovery runbook.
 
 ### permissions
 

--- a/docs/juicefs.md
+++ b/docs/juicefs.md
@@ -72,8 +72,13 @@ without the metadata you can't reattach.  The metadata-dump timer
 covers this:
 
 1. Provision a fresh openhost VM with `juicefs_enabled=true` and the
-   SAME S3 bucket + same volume name as before.  The format step
-   detects the existing volume in S3 and is a no-op.
+   SAME S3 bucket + same volume name as before.  The ansible role
+   re-runs `juicefs format` (the host-side sentinel file
+   `/var/lib/juicefs/.formatted` doesn't exist on the fresh VM).
+   `juicefs format` is non-destructive when invoked against an
+   already-formatted volume with the same arguments — it just
+   reattaches the local SQLite metadata to the existing S3 layout —
+   so this is safe to run on the recovery VM.
 2. Restore `juicefs-metadata-dump.json` from the most recent restic
    snapshot to its original path.
 3. `sudo -u host juicefs load sqlite3:///var/lib/juicefs/meta.db

--- a/docs/juicefs.md
+++ b/docs/juicefs.md
@@ -8,9 +8,13 @@ whichever backing the operator picked.
 
 Replaces the default local-disk backing for the `app_archive` tier
 with a [JuiceFS](https://juicefs.com/docs/community/introduction)
-mount, which puts every byte under `/data/app_archive/<app>/` on
-the operator's S3 bucket.  Apps see the same in-container path
-either way; only the host-side storage changes.
+mount.  Apps continue to see their archive at the unchanged
+in-container path `/data/app_archive/<app>/`; the host-side bind
+mount source moves from `<persistent_data_dir>/app_archive/<app>/`
+(local disk) to `/data/app_archive_juicefs/<app>/` (the JuiceFS
+mount), and JuiceFS in turn stores the bytes in the operator's S3
+bucket.  The app does not see and does not need to know about that
+indirection.
 
 This is useful when zone storage outgrows the local disk and the
 operator doesn't want to resize the VM.  For most zones the local

--- a/docs/juicefs.md
+++ b/docs/juicefs.md
@@ -77,7 +77,12 @@ covers this:
 2. Restore `juicefs-metadata-dump.json` from the most recent restic
    snapshot to its original path.
 3. `sudo -u host juicefs load sqlite3:///var/lib/juicefs/meta.db
-    /home/host/.openhost/local_compute_space/persistent_data/openhost/juicefs-metadata-dump.json`.
+    "$DUMP_DIR/juicefs-metadata-dump.json"` — where `$DUMP_DIR` is
+    the value of the `juicefs_dump_dir` ansible variable (default:
+    `/home/host/.openhost/local_compute_space/persistent_data/openhost`).
+    Confirm by reading the `ExecStart=` line of
+    `/etc/systemd/system/juicefs-meta-dump.service` on the new VM
+    and using the path baked into it.
 4. `sudo systemctl restart juicefs-mount.service openhost.service`.
 
 The dump runs every 24h (with up-to-15min jitter) so the worst-case

--- a/docs/juicefs.md
+++ b/docs/juicefs.md
@@ -52,8 +52,11 @@ The role:
 1. Installs the pinned JuiceFS binary (`v1.3.1`) with sha256 verify.
 2. `juicefs format` against your bucket, idempotent via a sentinel
    file at `/var/lib/juicefs/.formatted`.
-3. Installs `juicefs-mount.service` ordered before `openhost.service`
-   so apps never see an empty mount-point.
+3. Installs `juicefs-mount.service` and makes `openhost.service` a
+   hard `Requires=` dependent on it (not just ordered after).  If the
+   mount unit fails or dies, systemd refuses to start openhost; apps
+   can never silently write to the underlying empty mount-point and
+   have those writes get shadowed once the mount comes back.
 4. Installs `juicefs-meta-dump.service` + a 24h timer that dumps the
    metadata SQLite to a JSON inside `persistent_data_dir/openhost/`
    so the existing `openhost-backup` (restic) app picks it up.
@@ -81,7 +84,10 @@ timer.
 
 - Secrets live at `/etc/openhost/juicefs/s3.env` mode 0640 root:host;
   they are not visible in `ps`.
-- Mount logs land at `/var/log/juicefs-mount.log`.
+- Mount logs land at `/var/log/juicefs/mount.log`.  The role
+  pre-creates `/var/log/juicefs/` owned by `host` so the unit (which
+  runs as `host`) can write there directly.  `journalctl -u
+  juicefs-mount.service` shows the systemd-side stdout/stderr.
 - `juicefs status sqlite3:///var/lib/juicefs/meta.db` shows volume
   health.  Run as `host`.
 - Disabling JuiceFS later: re-run the playbook with

--- a/docs/juicefs.md
+++ b/docs/juicefs.md
@@ -1,0 +1,92 @@
+# JuiceFS-backed archive tier
+
+This is operator-facing.  App developers don't need to read it; their
+manifest just says `[data] app_archive = true` and the bytes flow to
+whichever backing the operator picked.
+
+## What it does
+
+Replaces the default local-disk backing for the `app_archive` tier
+with a [JuiceFS](https://juicefs.com/docs/community/introduction)
+mount, which puts every byte under `/data/app_archive/<app>/` on
+the operator's S3 bucket.  Apps see the same in-container path
+either way; only the host-side storage changes.
+
+This is useful when zone storage outgrows the local disk and the
+operator doesn't want to resize the VM.  For most zones the local
+fallback is fine.
+
+## What it doesn't do
+
+- Replace `app_data`.  SQLite, advisory-lock-using apps, and
+  anything mmap-shared still lives on local disk.  The manifest
+  validator rejects an `app_archive`-only manifest exactly
+  because of this.
+- Span multiple openhost VMs.  The metadata engine is single-host
+  SQLite.  Multi-host JuiceFS would need Redis or Postgres for
+  metadata; that's not the failure mode this design targets.
+- Encrypt at rest, beyond what S3 server-side encryption provides.
+  Operators who need additional encryption should use
+  `juicefs format --encrypt-rsa-key=…` (not yet wired through the
+  ansible role).
+
+## Enabling it
+
+Pass `juicefs_enabled=true` plus the S3 details to ansible:
+
+```bash
+ansible-playbook ansible/setup.yml -i <ip>, \
+  -e domain=<domain> \
+  -e juicefs_enabled=true \
+  -e juicefs_s3_bucket=my-openhost-archive \
+  -e juicefs_s3_region=us-east-1 \
+  -e juicefs_s3_access_key=AKIA… \
+  -e juicefs_s3_secret_key=… \
+  -e juicefs_volume_name=openhost
+```
+
+Optional: `juicefs_s3_endpoint=https://…` for non-AWS S3
+(MinIO, Backblaze B2, etc.).
+
+The role:
+1. Installs the pinned JuiceFS binary (`v1.3.1`) with sha256 verify.
+2. `juicefs format` against your bucket, idempotent via a sentinel
+   file at `/var/lib/juicefs/.formatted`.
+3. Installs `juicefs-mount.service` ordered before `openhost.service`
+   so apps never see an empty mount-point.
+4. Installs `juicefs-meta-dump.service` + a 24h timer that dumps the
+   metadata SQLite to a JSON inside `persistent_data_dir/openhost/`
+   so the existing `openhost-backup` (restic) app picks it up.
+
+## Disaster recovery
+
+If the openhost VM is lost, the S3 bucket retains the data but
+without the metadata you can't reattach.  The metadata-dump timer
+covers this:
+
+1. Provision a fresh openhost VM with `juicefs_enabled=true` and the
+   SAME S3 bucket + same volume name as before.  The format step
+   detects the existing volume in S3 and is a no-op.
+2. Restore `juicefs-metadata-dump.json` from the most recent restic
+   snapshot to its original path.
+3. `sudo -u host juicefs load sqlite3:///var/lib/juicefs/meta.db
+    /home/host/.openhost/local_compute_space/persistent_data/openhost/juicefs-metadata-dump.json`.
+4. `sudo systemctl restart juicefs-mount.service openhost.service`.
+
+The dump runs every 24h (with up-to-15min jitter) so the worst-case
+loss window is ~24h.  Operators who need tighter RPO can tighten the
+timer.
+
+## Operational notes
+
+- Secrets live at `/etc/openhost/juicefs/s3.env` mode 0640 root:host;
+  they are not visible in `ps`.
+- Mount logs land at `/var/log/juicefs-mount.log`.
+- `juicefs status sqlite3:///var/lib/juicefs/meta.db` shows volume
+  health.  Run as `host`.
+- Disabling JuiceFS later: re-run the playbook with
+  `juicefs_enabled=false`.  The role doesn't run, the
+  `archive_dir_override` line is removed from `config.toml`, and
+  apps fall back to local disk on the next openhost restart.  The
+  S3 bucket's contents stay; reverting per-app data from S3 to
+  local disk is a manual `juicefs sync` operation outside the role.

--- a/docs/manifest_spec.md
+++ b/docs/manifest_spec.md
@@ -57,21 +57,25 @@ Rootless podman can bind ports >= 25 only; `host_port` values below 25 are rejec
 |-------|------|----------|---------|-------------|
 | `app_data` | boolean | no | false | Request access to permanent filesystem directory (backed up) |
 | `app_temp_data` | boolean | no | false | Request access to temporary filesystem directory (not backed up) |
+| `app_archive` | boolean | no | false | Request access to elastic archive directory for bulk content. Backed by local disk by default; can be operator-configured to point at a JuiceFS-on-S3 mount. Requires `app_data` (or `sqlite`, or `access_all_data`) — see Data Directory Structure below for the rationale. |
 | `sqlite` | string[] | no | [] | SQLite database names to provision (implicitly enables `app_data`) |
 | `access_vm_data` | boolean | no | false | Whether the app can access the VM's shared data directory |
-| `access_all_data` | boolean | no | false | Full access to permanent data, temp data, and vm data |
+| `access_all_data` | boolean | no | false | Full access to permanent data, temp data, archive, and vm data |
 
 ## Data Directory Structure
 
-Apps have two storage areas on the same disk. **By default, apps have no filesystem access.** Each must be explicitly requested:
+Apps have three storage areas, each with different durability + size + latency tradeoffs. **By default, apps have no filesystem access.** Each must be explicitly requested:
 
-- **Permanent data** (`/data/app_data/{app_name}/`) — backed up, user-visible. Enabled by `app_data = true` or by requesting `sqlite` entries.
-- **Temporary data** (`/data/app_temp_data/{app_name}/`) — not backed up, recreatable. Enabled by `app_temp_data = true`.
+- **Permanent data** (`/data/app_data/{app_name}/`) — local disk. Small, fast, backed up. Enabled by `app_data = true` or by requesting `sqlite` entries. **SQLite databases must live here**, not in `app_archive`: the archive tier may be backed by a network FS with close-to-open consistency that corrupts SQLite WAL.
+- **Temporary data** (`/data/app_temp_data/{app_name}/`) — local disk scratch. Not backed up, recreatable. Enabled by `app_temp_data = true`.
+- **Archive data** (`/data/app_archive/{app_name}/`) — elastic, optionally backed by JuiceFS-on-S3. Large, higher-latency on uncached reads, durability tied to the operator's S3 provider SLA. Intended for bulk content (videos, photos, attachments) — anything that needs near-unlimited capacity but tolerates network-FS latency. Enabled by `app_archive = true`. Requires the local-data tier (`app_data`, `sqlite`, or `access_all_data`) so working state has somewhere safe to live.
 - **VM data** (`/data/vm_data/`) — router database and VM-level shared data. Only accessible if `access_vm_data = true`.
+
+The archive tier is operator-configured at the host level. When the operator hasn't set up an external backing (e.g. JuiceFS), the archive falls back to a local-disk subdirectory under `persistent_data_dir/app_archive/`. Apps see the same in-container path either way; only the backing changes.
 
 The host operator can optionally set `storage_min_free_mb` in the OpenHost config to require a minimum amount of free disk space. When free space drops below this threshold, the storage guard stops running apps until space is freed.
 
-All data dirs live under `/data/` in the container. All apps see the same path structure regardless of permissions — only the dirs they have access to are mounted. With `access_all_data`, the parent dirs are mounted instead (`/data/app_data/`, `/data/app_temp_data/`) so the app can see all apps' data.
+All data dirs live under `/data/` in the container. All apps see the same path structure regardless of permissions — only the dirs they have access to are mounted. With `access_all_data`, the parent dirs are mounted instead (`/data/app_data/`, `/data/app_temp_data/`, `/data/app_archive/`) so the app can see all apps' data.
 
 ## Environment Variable Injection
 
@@ -80,6 +84,7 @@ The host provisions requested data services and injects connection info as envir
 - `OPENHOST_SQLITE_<name>` — filesystem path to the named sqlite database (only if `sqlite` entries requested)
 - `OPENHOST_APP_DATA_DIR` — `/data/app_data/{app_name}` (only if app_data access granted)
 - `OPENHOST_APP_TEMP_DIR` — `/data/app_temp_data/{app_name}` (only if app_temp_data access granted)
+- `OPENHOST_APP_ARCHIVE_DIR` — `/data/app_archive/{app_name}` (only if app_archive access granted)
 - `OPENHOST_AUTH_PUBLIC_KEY` — PEM-encoded JWT public key for token verification (only if signing keys are available)
 - `OPENHOST_ROUTER_URL` — URL of the router's HTTP server, reachable from inside the container.
 


### PR DESCRIPTION
Adds a third per-app storage tier alongside app_data and app_temp_data: app_archive, opt-in via [data] app_archive=true in the manifest, bind-mounted into containers at /data/app_archive/<app>/. The host-side backing is operator-selected: defaults to a local-disk subdirectory under persistent_data_dir (so existing zones get the tier with no operator action), and can be repointed at a JuiceFS-on-S3 mount via an ansible role gated behind juicefs_enabled.

Apps see the same in-container path either way; only the host-side storage changes.

Phase 1+2 (the in-process plumbing): manifest field, validator, provision_data + run_container + deprovision_data signature changes, rename_app extension. Phase 3 (ansible): JuiceFS install/format/mount role with systemd ordering, daily metadata-dump timer for restic-based backup, operator docs.

Verified end-to-end on a real EC2 VM that an opt-in app sees /data/app_archive/<name>/ as expected and that backwards-compat is intact for apps without the opt-in. The JuiceFS-on-S3 path was NOT end-to-end tested against a live bucket — the role and its tests cover the static config rendering, sentinel-guarded format idempotency, systemd unit ordering (Requires=, not just After=), and credential handling (env file, never argv), but a fresh JuiceFS-backed VM with a real S3 round-trip still wants exercising before any production rollout. Happy to drive that test if you want; it needs a small vm-manager extension to plumb the juicefs_* ansible vars through /api/create.

Manifest validator rejects app_archive=true without app_data (or sqlite, or access_all_data), since the archive tier may be on a network FS and SQLite/advisory-lock-using apps need somewhere safe for working state.

344 unit tests pass, including new coverage for: provision/deprovision happy + missing-archive-dir + access_all_data variants, ansible template rendering (config.toml, openhost.service, juicefs-mount, juicefs-meta-dump), rename_app three-tier rename + rollback + rollback-itself-fails. Six rounds of vet across codex and claude harnesses, all findings addressed.

Companion fix already merged: openhost-vm-manager#16 threads the branch parameter through to ansible as openhost_commit. Without that, /api/create branch=X silently fell back to main on the deployed VM.