### PR TITLE
Set stable container hostname via --hostname flag

### DIFF
--- a/compute_space/src/compute_space/core/containers.py
+++ b/compute_space/src/compute_space/core/containers.py
@@ -240,6 +240,8 @@ def run_container(
         "-d",
         "--name",
         container_name,
+        "--hostname",
+        container_name,
         "-p",
         f"127.0.0.1:{local_port}:{manifest.container_port}",
         f"--memory={manifest.memory_mb}m",


### PR DESCRIPTION
## Summary
- Adds `--hostname` flag to `podman run` command, setting it to the container name (`openhost-{app_name}`)
- Fixes apps that use `gethostname()` for identity (e.g. Stalwart's cluster node ID) getting a new identity on each container restart, causing stale queue locks

## Test plan
- [ ] Deploy stalwart-email-server, restart it, verify `hostname` inside container is `openhost-stalwart-email-server` (stable)
- [ ] Verify Stalwart's ClusterNode entries use the stable hostname

🤖 Generated with [Claude Code](https://claude.com/claude-code)