### PR TITLE
compute_space: wrap hypercorn in ProxyFixMiddleware when Caddy is in front

### DIFF
--- a/compute_space/src/compute_space/tests/test_integration.py
+++ b/compute_space/src/compute_space/tests/test_integration.py
@@ -1092,7 +1092,25 @@ class TestContainerE2E:
         assert "X-Forwarded-Host" in headers
 
     def test_proxy_strips_spoofed_forwarded_headers(self, admin_session, config):
-        """Client-supplied X-Forwarded-* headers are overwritten, not forwarded."""
+        """Client-supplied X-Forwarded-* headers are overwritten, not forwarded.
+
+        With ``start_caddy=False`` (the test default) the router runs
+        without ``ProxyFixMiddleware``, so any inbound
+        ``X-Forwarded-*`` headers are NOT trusted: ``quart_request``
+        observes the actual loopback connection scheme/host/client,
+        and ``proxy.py`` re-stamps the upstream-app request with
+        those values, dropping the spoofed ones.  This is the
+        threat model that protects an operator who exposes
+        compute_space directly without a trusted proxy in front.
+
+        The complementary case (``start_caddy=True``, where
+        ``ProxyFixMiddleware`` IS wrapped and inbound headers ARE
+        trusted because Caddy normalises them upstream of us) is
+        exercised at the unit level in ``test_proxy_fix.py`` —
+        full end-to-end coverage with a real Caddy in front would
+        require a more complex test harness and isn't currently in
+        the suite.
+        """
         base_url = f"http://{config.host}:{config.port}"
         r = admin_session.get(
             f"{base_url}/test-app/echo-headers",

--- a/compute_space/src/compute_space/tests/test_proxy_fix.py
+++ b/compute_space/src/compute_space/tests/test_proxy_fix.py
@@ -1,0 +1,135 @@
+"""Unit tests for the ProxyFixMiddleware wiring in ``web/start.py``.
+
+The integration-level test
+``TestContainerE2E.test_proxy_strips_spoofed_forwarded_headers`` covers
+the un-wrapped path (``start_caddy=False``).  These tests cover the
+wrapped path (``start_caddy=True``) without having to spin up a real
+Caddy in the test environment: we drive the middleware directly with a
+synthetic ASGI scope and assert that scheme / client / host get
+rewritten as expected, and that ``proxy.py`` would then forward the
+rewritten values onto the upstream app.
+
+These tests cover the *behaviour* of ``ProxyFixMiddleware`` configured
+with the ``mode`` / ``trusted_hops`` arguments ``main()`` uses today
+(asserted via ``_make_middleware``, the local mirror of those
+arguments).  They do NOT directly assert that ``main()`` actually
+wraps the app — a regression that silently drops the wrap from
+``start.py`` would still let these unit tests pass.  That higher-
+level invariant is left to operator inspection of ``start.py`` and
+to the (currently un-implemented) end-to-end path through real
+Caddy + hypercorn.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+from hypercorn.middleware import ProxyFixMiddleware
+
+
+async def _noop_app(_scope: Any, _receive: Any, _send: Any) -> None:
+    """Inert ASGI app — gets replaced by ``_drive_middleware`` before use."""
+    return None
+
+
+def _make_middleware() -> ProxyFixMiddleware:
+    """Build the middleware exactly the way ``main()`` does in production."""
+    return ProxyFixMiddleware(_noop_app, mode="legacy", trusted_hops=1)
+
+
+def _build_scope(headers: list[tuple[bytes, bytes]]) -> dict[str, Any]:
+    """Synthesise the relevant subset of an HTTP ASGI scope.
+
+    Mirrors the keys that ``ProxyFixMiddleware`` reads/writes
+    (``type``, ``scheme``, ``client``, ``headers``).  Anything the
+    middleware doesn't touch is omitted to keep the test focused.
+    """
+    return {
+        "type": "http",
+        "scheme": "http",
+        "client": ("127.0.0.1", 50001),
+        "headers": headers,
+    }
+
+
+def _drive_middleware(middleware: ProxyFixMiddleware, scope: dict[str, Any]) -> dict[str, Any]:
+    """Run the middleware against a synthetic scope, return the app-visible scope."""
+    seen_scope: dict[str, Any] = {}
+
+    async def fake_app(s: Any, receive: Any, send: Any) -> None:
+        seen_scope.update(s)
+
+    async def receive() -> Any:
+        return {"type": "http.disconnect"}
+
+    async def send(_msg: Any) -> None:
+        return None
+
+    # ProxyFixMiddleware's typed ASGI scope is narrower than what
+    # we synthesise here, but the middleware only reads keys it
+    # expects so the looseness is fine for tests.  Cast via Any to
+    # paper over the strict type without sprinkling ignores.
+    middleware.app = fake_app
+    asyncio.run(middleware(scope, receive, send))  # type: ignore[arg-type]
+    return seen_scope
+
+
+def test_proxyfix_promotes_inbound_x_forwarded_proto_to_scope_scheme() -> None:
+    """``X-Forwarded-Proto: https`` inbound becomes ``scope['scheme']='https'``.
+
+    This is the exact regression that broke peertube uploads:
+    without the wrap, ``scope['scheme']`` stayed ``http`` (the loopback
+    Caddy->hypercorn hop), so ``quart_request.scheme == 'http'`` and
+    ``proxy.py`` forwarded ``X-Forwarded-Proto: http`` to peertube,
+    which served the SPA an ``http://`` resumable-upload Location URL
+    that the browser blocked as Mixed Content.
+    """
+    middleware = _make_middleware()
+    scope = _build_scope(
+        [
+            (b"x-forwarded-proto", b"https"),
+            (b"x-forwarded-for", b"203.0.113.7"),
+            (b"x-forwarded-host", b"public.example.com"),
+            (b"host", b"127.0.0.1:8080"),
+        ]
+    )
+    out = _drive_middleware(middleware, scope)
+    assert out["scheme"] == "https"
+    assert out["client"][0] == "203.0.113.7"
+    # Host header is rewritten to the trusted forwarded value.
+    host_values = [v for k, v in out["headers"] if k.lower() == b"host"]
+    assert host_values == [b"public.example.com"]
+
+
+def test_proxyfix_only_trusts_last_hop_with_trusted_hops_1() -> None:
+    """``trusted_hops=1`` reads the last value in a comma-separated chain.
+
+    PeerTube's mid-tier Caddy and our public Caddy both stamp
+    X-Forwarded-Proto, so the header arrives as ``http, https`` (or
+    just ``https``) at compute_space — but compute_space sits at the
+    OUTER edge of the chain in production, so it should trust the
+    immediately-upstream value.  ``trusted_hops=1`` selects the
+    last comma-separated token, which is the value the
+    last (i.e. closest) trusted proxy added.
+    """
+    middleware = _make_middleware()
+    scope = _build_scope(
+        [
+            (b"x-forwarded-proto", b"http,https"),
+            (b"host", b"127.0.0.1:8080"),
+        ]
+    )
+    out = _drive_middleware(middleware, scope)
+    # Last token wins when trusted_hops=1.
+    assert out["scheme"] == "https"
+
+
+def test_proxyfix_leaves_scheme_untouched_when_no_xfp_header() -> None:
+    """If no inbound XFP, the scope's existing scheme is preserved."""
+    middleware = _make_middleware()
+    scope = _build_scope([(b"host", b"127.0.0.1:8080")])
+    out = _drive_middleware(middleware, scope)
+    assert out["scheme"] == "http"
+    # client also stays at the bare-connection value.
+    assert out["client"] == ("127.0.0.1", 50001)

--- a/compute_space/src/compute_space/web/start.py
+++ b/compute_space/src/compute_space/web/start.py
@@ -8,6 +8,7 @@ from typing import Any
 
 import hypercorn.asyncio
 import hypercorn.config
+from hypercorn.middleware import ProxyFixMiddleware
 
 from compute_space.config import load_config
 from compute_space.core.caddy import start_caddy
@@ -81,7 +82,64 @@ def main() -> None:
             raise RuntimeError("TLS is enabled but start_caddy is False. Caddy is required for TLS termination.")
 
     # Main web server
-    app = create_app(config)
+    quart_app = create_app(config)
+
+    # Wrap the ASGI app in hypercorn's ProxyFixMiddleware ONLY when
+    # we expect a trusted upstream proxy (``start_caddy=True``,
+    # i.e. our public Caddy reverse_proxy is in front of us).
+    # Without the wrap, ``quart_request.scheme`` is always ``http``
+    # — the scheme of the loopback Caddy->hypercorn hop — even when
+    # the original public request was HTTPS.  Downstream
+    # (``proxy.py``) sets ``X-Forwarded-Proto = quart_request.scheme``
+    # on the upstream request to each app, so the un-wrapped path
+    # silently rewrites the public ``https`` to ``http`` for every
+    # proxied request, which breaks any app that constructs absolute
+    # URLs from ``X-Forwarded-Proto`` (peertube's @uploadx/core
+    # resumable upload library is the canonical example: it builds
+    # a ``http://...`` resumable-upload Location header on a HTTPS
+    # page, and the browser blocks it as Mixed Content).
+    #
+    # Trust model and ``trusted_hops=1``: the middleware copies the
+    # SINGLE most-recent ``X-Forwarded-*`` value in each header
+    # onto the ASGI scope (``scope['scheme']``, ``scope['client']``,
+    # ``host`` header), i.e. whatever the immediately-upstream
+    # proxy added.  This trust is unconditional — the middleware
+    # has no IP-allowlist mechanism and trusts the connection peer
+    # implicitly.  We therefore wrap ONLY when Caddy is in front of
+    # us, because Caddy's ``reverse_proxy`` default behaviour is to
+    # OVERWRITE any client-supplied ``X-Forwarded-*`` headers with
+    # values derived from the actual TCP connection — so a hostile
+    # client cannot smuggle forged values past Caddy.  When
+    # ``start_caddy=False`` (development, tests, or operators who
+    # have an alternative trusted proxy), we leave the app
+    # un-wrapped and ``quart_request.scheme`` remains the connection
+    # scheme; operators putting their own proxy in front are
+    # expected to either run with TLS termination at hypercorn or
+    # set ``start_caddy=True`` to re-enable the wrap.
+    #
+    # KNOWN CAVEAT: hypercorn binds to ``config.host`` which defaults
+    # to ``0.0.0.0``, so even with ``start_caddy=True`` an attacker
+    # with direct network access to the bind port can bypass Caddy
+    # and supply arbitrary ``X-Forwarded-*`` values that ProxyFix
+    # will then trust.  In the OpenHost reference deployment, the
+    # OS-level firewall and the (lack of) NAT publishing for port
+    # 8080 keep the hypercorn socket reachable only from the same
+    # host as Caddy.  Tightening this — by binding hypercorn to
+    # ``127.0.0.1`` whenever ``start_caddy=True``, or switching to a
+    # UNIX socket — is a hardening followup worth doing but out of
+    # scope for the immediate fix.
+    #
+    # ``mode="legacy"`` reads the conventional ``X-Forwarded-For``
+    # / ``X-Forwarded-Proto`` / ``X-Forwarded-Host`` triplet rather
+    # than the newer RFC 7239 ``Forwarded`` header.  Caddy stamps
+    # the legacy headers by default, and most of the apps we
+    # proxy to are configured to read the legacy headers, so the
+    # legacy mode keeps the wire format consistent end-to-end.
+    asgi_app: Any
+    if config.start_caddy:
+        asgi_app = ProxyFixMiddleware(quart_app, mode="legacy", trusted_hops=1)
+    else:
+        asgi_app = quart_app
 
     hypercorn_config = hypercorn.config.Config()
     hypercorn_config.bind = [f"{config.host}:{config.port}"]
@@ -89,7 +147,7 @@ def main() -> None:
     hypercorn_config.shutdown_timeout = 5
 
     logger.info("running hypercorn serve")
-    restart_requested = asyncio.run(_serve(app, hypercorn_config))
+    restart_requested = asyncio.run(_serve(asgi_app, hypercorn_config))
     logger.info(f"hypercorn serve returned, restart_requested={restart_requested}")
 
     _terminate_children(children)


### PR DESCRIPTION
Without the wrap, quart_request.scheme is always 'http' (the loopback Caddy to hypercorn hop scheme), so proxy.py forwards X-Forwarded-Proto: http to every proxied app even when the public request was HTTPS. This breaks any app that builds absolute URLs from X-Forwarded-Proto, most visibly peertube's resumable upload library which serves http:// upload URLs on HTTPS pages and gets blocked by Mixed Content.

Wrap is conditional on start_caddy=True because ProxyFixMiddleware has no IP-allowlist and trusts the connection peer implicitly. Caddy in front normalises spoofable headers, so the wrap is safe; without Caddy, the un-wrapped path preserves the existing spoof-rejection guarantee.

Unit tests in test_proxy_fix.py cover the wrapped behaviour. The existing TestContainerE2E.test_proxy_strips_spoofed_forwarded_headers integration test continues to cover the un-wrapped path (which is what the test fixture configures).

Known limitation called out in start.py: hypercorn binds 0.0.0.0 by default, so direct network access to port 8080 still bypasses Caddy. Loopback bind is a hardening followup.