### PR TITLE
Set both OPENHOST_SQLITE_x and OPENHOST_SQLITE_X env vars

### DIFF
--- a/compute_space/src/compute_space/core/data.py
+++ b/compute_space/src/compute_space/core/data.py
@@ -109,6 +109,9 @@ def provision_data(
             # (e.g. "if not exists: create tables") triggers correctly.
             env_key = f"OPENHOST_SQLITE_{db_name}"
             env_vars[env_key] = db_path
+            upper_key = f"OPENHOST_SQLITE_{db_name.upper()}"
+            if upper_key != env_key:
+                env_vars[upper_key] = db_path
 
     if manifest.app_temp_data or manifest.access_all_data:
         os.makedirs(app_temp_dir, exist_ok=True)

--- a/compute_space/src/compute_space/tests/test_integration.py
+++ b/compute_space/src/compute_space/tests/test_integration.py
@@ -66,9 +66,13 @@ def test_sqlite_provisioning():
         assert os.path.isdir(sqlite_dir)
 
         assert "OPENHOST_SQLITE_main" in env_vars
+        assert "OPENHOST_SQLITE_MAIN" in env_vars
         assert "OPENHOST_SQLITE_cache" in env_vars
+        assert "OPENHOST_SQLITE_CACHE" in env_vars
         assert env_vars["OPENHOST_SQLITE_main"] == os.path.join(sqlite_dir, "main.db")
+        assert env_vars["OPENHOST_SQLITE_MAIN"] == os.path.join(sqlite_dir, "main.db")
         assert env_vars["OPENHOST_SQLITE_cache"] == os.path.join(sqlite_dir, "cache.db")
+        assert env_vars["OPENHOST_SQLITE_CACHE"] == os.path.join(sqlite_dir, "cache.db")
 
         # .db files should NOT exist yet — the app creates them
         assert not os.path.exists(env_vars["OPENHOST_SQLITE_main"])

--- a/docs/manifest_spec.md
+++ b/docs/manifest_spec.md
@@ -77,7 +77,7 @@ All data dirs live under `/data/` in the container. All apps see the same path s
 
 The host provisions requested data services and injects connection info as environment variables:
 
-- `OPENHOST_SQLITE_<name>` — filesystem path to the named sqlite database (only if `sqlite` entries requested)
+- `OPENHOST_SQLITE_<NAME>` — filesystem path to the named sqlite database (only if `sqlite` entries requested)
 - `OPENHOST_APP_DATA_DIR` — `/data/app_data/{app_name}` (only if app_data access granted)
 - `OPENHOST_APP_TEMP_DIR` — `/data/app_temp_data/{app_name}` (only if app_temp_data access granted)
 - `OPENHOST_AUTH_PUBLIC_KEY` — PEM-encoded JWT public key for token verification (only if signing keys are available)


### PR DESCRIPTION
## Summary
- `data.py` now sets both `OPENHOST_SQLITE_{name}` (original case) and `OPENHOST_SQLITE_{NAME}` (uppercase) so apps can use either convention
- Fixes mismatch where apps like `secrets_v2` and `oauth_provider` read `OPENHOST_SQLITE_MAIN` but only `OPENHOST_SQLITE_main` was set
- Updates `manifest_spec.md` to document the uppercase `<NAME>` convention (already used in `creating_an_app.md`)

## Test plan
- [x] `test_sqlite_provisioning` passes with new assertions for uppercase keys
- [ ] Verify existing apps still work after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)