### PR TITLE
Lift WS proxy max_size cap, enable compression, abort on shutdown

### DIFF
--- a/compute_space/src/compute_space/web/proxy.py
+++ b/compute_space/src/compute_space/web/proxy.py
@@ -10,6 +10,7 @@ from werkzeug.datastructures import Headers
 
 from compute_space.core.auth import COOKIE_REFRESH
 from compute_space.core.logging import logger
+from compute_space.core.updates import wait_for_shutdown
 
 
 async def proxy_request(
@@ -223,10 +224,15 @@ async def ws_proxy(
                 except Exception:
                     pass
 
-            # Run both directions concurrently; when either ends, cancel the other.
+            # Run both directions concurrently. Also race against the global
+            # shutdown event so that long-lived websocket sessions don't hold
+            # hypercorn's graceful_timeout open during a restart — without this
+            # the proxy will sit on each open connection until either side
+            # closes naturally, dragging out shutdown by minutes.
             tasks = [
                 asyncio.ensure_future(backend_to_client()),
                 asyncio.ensure_future(client_to_backend()),
+                asyncio.ensure_future(wait_for_shutdown()),
             ]
             try:
                 done, pending = await asyncio.wait(tasks, return_when=asyncio.FIRST_COMPLETED)

--- a/compute_space/src/compute_space/web/proxy.py
+++ b/compute_space/src/compute_space/web/proxy.py
@@ -181,9 +181,18 @@ async def ws_proxy(
     # `websockets` client to emit an empty `Sec-WebSocket-Protocol:` header, which strict backends
     # (including `websockets`' own server, as used by Selkies / the linuxserver webtop image) reject
     # with `InvalidHeaderFormat: expected token at 0 in`.
+    #
+    # `max_size=None` lifts the default 1 MiB incoming-message cap: the proxy shouldn't impose its
+    # own size policy — apps decide their own limits, and a 1 MiB ceiling here silently kills any
+    # backend that legitimately sends a larger frame (e.g. a CRDT's initial-state sync).
+    #
+    # Compression is left at the websockets default (permessage-deflate offered): the previous
+    # `compression=None` was overly cautious — RFC 7692 already mandates graceful fallback if the
+    # backend rejects the extension, and enabling it dramatically reduces transfer sizes for the
+    # text-heavy traffic this proxy commonly carries.
     ws_kwargs: dict[str, Any] = {
         "additional_headers": extra_headers,
-        "compression": None,  # avoid permessage-deflate mismatches with backend
+        "max_size": None,
         "open_timeout": 10,
         "close_timeout": 5,
     }


### PR DESCRIPTION
## Summary
- Set `max_size=None` on the proxy's `websockets.connect()` so the proxy stops imposing the websockets-lib default 1 MiB incoming-message cap on backends.
- Drop `compression=None`; let the websockets default offer permessage-deflate.
- Race `wait_for_shutdown()` against the two pump tasks so long-lived websocket sessions don't block hypercorn's graceful shutdown.

## Why
A backend app sent a CRDT initial-state sync ~1.5 MB to its frontend. The proxy's client-side websockets connection silently rejected the frame at the library default (1 MiB), tearing the connection down with a 1006 abnormal closure. The browser's y-websocket auto-reconnects, exchanges the same too-large frame, gets dropped again, and so on — from the app's logs the connection just keeps cycling.

The proxy isn't the right layer to enforce a frame-size policy — apps already configure their own ASGI server limits (this app uses hypercorn's `websocket_max_message_size = 64 MiB`). Passing `max_size=None` lets that backend choice stand.

For compression, the previous `compression=None` cited "permessage-deflate mismatches with backend" but RFC 7692 already mandates graceful fallback if the backend rejects the extension, and websockets implements that. Enabling it gives a real transfer-size win on text-heavy traffic (markdown, JSON, awareness deltas) without changing semantics.

The shutdown change is exposed by the first one: previously the size limit caused websocket connections to die in a tight reconnect loop, so they were short-lived and shutdown didn't have to wait on them. Now that connections actually stay open, we hit a separate latent bug — hypercorn's `graceful_timeout`/`shutdown_timeout` don't apply to in-flight websockets, so a restart with active sessions stalls for minutes. The proxy now listens to the existing `wait_for_shutdown()` helper and tears connections down promptly.

## Test plan
- [x] Deploy to a personal instance and confirm a CRDT-backed app (md-notes) syncs a >1 MB document without the connection looping.
- [x] Open a small-doc websocket session (e.g. <100 KB) and confirm it still works — both with and without compression negotiated.
- [x] Smoke-test a backend known to be picky about extensions (Selkies / linuxserver webtop, mentioned in the existing comment) to confirm RFC 7692 fallback kicks in cleanly.
- [x] Trigger an openhost restart while a long-lived websocket session is open and confirm shutdown completes within `graceful_timeout`+`shutdown_timeout` rather than stalling for minutes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)