### PR TITLE
Add [permissions].deploy_apps as a new manifest-level router permission

### DIFF
--- a/compute_space/src/compute_space/core/apps.py
+++ b/compute_space/src/compute_space/core/apps.py
@@ -233,6 +233,7 @@ def insert_and_deploy(
     app_name: str | None = None,
     repo_url: str | None = None,
     port_overrides: dict[str, int] | None = None,
+    deploy_apps_granted: bool = False,
 ) -> str:
     """Insert app into DB and start background deploy.
 
@@ -242,6 +243,13 @@ def insert_and_deploy(
     grant_permissions_v2: if True, grant all [[permissions_v2]] entries
         from the manifest at install time.
     port_overrides: optional dict of label -> host_port from CLI/API.
+    deploy_apps_granted: if True, the owner has approved this app's
+        ``[permissions].deploy_apps`` request at install time.  Stored
+        on the app row so a follow-up PR can mint and validate a
+        deploy-scoped router token without re-prompting.  Caller is
+        responsible for ensuring the manifest actually requested the
+        permission before passing True; this function persists what
+        it's told and trusts the caller.
     """
     if app_name is None:
         app_name = manifest.name
@@ -273,8 +281,8 @@ def insert_and_deploy(
         """INSERT INTO apps
            (name, manifest_name, version, description, runtime_type, repo_path, repo_url,
             health_check, local_port, container_port, memory_mb, cpu_millicores,
-            gpu, public_paths, manifest_raw, status)
-           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            gpu, public_paths, manifest_raw, status, deploy_apps_permission)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
         (
             app_name,
             manifest.name,
@@ -292,6 +300,7 @@ def insert_and_deploy(
             json.dumps(manifest.public_paths),
             manifest.raw_toml,
             "building",
+            int(bool(deploy_apps_granted and manifest.deploy_apps_permission)),
         ),
     )
 

--- a/compute_space/src/compute_space/core/manifest.py
+++ b/compute_space/src/compute_space/core/manifest.py
@@ -141,6 +141,22 @@ class AppManifest:
     # [[permissions_v2]]
     permissions_v2: list[PermissionV2Request] = attr.Factory(list)
 
+    # [permissions]
+    #
+    # Per-app grants of router-managed capabilities, distinct from the
+    # service-level [services] / [[permissions_v2]] grants which mediate
+    # cross-app access.  Each field is a manifest *request*; grants are
+    # only applied when the owner explicitly approves at install time.
+    #
+    # ``deploy_apps``: when granted, the app is permitted to drive
+    # OpenHost's app-management surface (clone / install / reload /
+    # remove / status / list).  Used by the catalog app and any future
+    # automation consumer (CI deployers, agent-host integrations) that
+    # would otherwise need a hand-rolled owner-equivalent api_token.
+    # The corresponding token issuance + API gating land in a follow-up
+    # PR; this field is the manifest contract apps agree to before then.
+    deploy_apps_permission: bool = False
+
     # [app] metadata
     hidden: bool = False
 
@@ -273,6 +289,11 @@ def parse_manifest_from_string(raw_text: str) -> AppManifest:
     if runtime_type not in ("serverless", "serverfull"):
         raise ValueError(f"Invalid runtime type: {runtime_type}")
 
+    permissions_section = data.get("permissions", {})
+    deploy_apps_permission = permissions_section.get("deploy_apps", False)
+    if not isinstance(deploy_apps_permission, bool):
+        raise ValueError("[permissions].deploy_apps must be a boolean")
+
     container = runtime.get("container", {})
     if not container.get("image"):
         raise ValueError("[runtime.container].image is required")
@@ -326,6 +347,7 @@ def parse_manifest_from_string(raw_text: str) -> AppManifest:
         requires_services=_parse_requires_services(services),
         provides_services_v2=_parse_services_v2(data),
         permissions_v2=_parse_permissions_v2(data),
+        deploy_apps_permission=deploy_apps_permission,
         raw_toml=raw_text,
     )
 

--- a/compute_space/src/compute_space/db/schema.sql
+++ b/compute_space/src/compute_space/db/schema.sql
@@ -18,6 +18,12 @@ CREATE TABLE IF NOT EXISTS apps (
     gpu INTEGER NOT NULL DEFAULT 0,
     public_paths TEXT NOT NULL DEFAULT '[]',
     manifest_raw TEXT,
+    -- Owner-approved router-level grants.  Boolean columns rather than
+    -- a separate table because the cardinality is small and fixed at
+    -- one row per app.  Adding a permission is two changes (a new
+    -- column here plus a migration), and old apps end up with a 0
+    -- default which means "not granted".
+    deploy_apps_permission INTEGER NOT NULL DEFAULT 0,
     created_at TEXT NOT NULL DEFAULT (datetime('now')),
     updated_at TEXT NOT NULL DEFAULT (datetime('now'))
 );

--- a/compute_space/src/compute_space/db/versioned/migrations/v0006_apps_router_permissions.py
+++ b/compute_space/src/compute_space/db/versioned/migrations/v0006_apps_router_permissions.py
@@ -1,0 +1,10 @@
+"""v6: add per-app router-permission columns.  Body in v0006_apps_router_permissions.sql."""
+
+from __future__ import annotations
+
+from compute_space.db.versioned.base import SqlFileMigration
+
+
+class Migration0006AppsRouterPermissions(SqlFileMigration):
+    version = 6
+    sql_file = "v0006_apps_router_permissions.sql"

--- a/compute_space/src/compute_space/db/versioned/migrations/v0006_apps_router_permissions.sql
+++ b/compute_space/src/compute_space/db/versioned/migrations/v0006_apps_router_permissions.sql
@@ -1,0 +1,19 @@
+-- v6: add per-app router-permission columns.
+--
+-- Apps may request privileged grants on the router itself via a new
+-- [permissions] section in openhost.toml (separate from the per-service
+-- [services] / [[permissions_v2]] grants which mediate cross-app
+-- access).  The owner approves each grant explicitly at install time;
+-- approval state lives directly on the apps row so it's part of the
+-- same transaction as the install.
+--
+-- Boolean columns rather than a child table because the cardinality is
+-- small (one approval bit per permission per app) and fixed at install
+-- time.  Adding a permission is two changes: a new column here + a
+-- migration; old apps end up with a 0 default which means "not granted".
+--
+-- The runtime token issuance + API gating that *enforce* these grants
+-- ship in a follow-up PR; this migration just lays the persistence so
+-- the manifest contract can be merged independently.
+
+ALTER TABLE apps ADD COLUMN deploy_apps_permission INTEGER NOT NULL DEFAULT 0;

--- a/compute_space/src/compute_space/db/versioned/registry.py
+++ b/compute_space/src/compute_space/db/versioned/registry.py
@@ -12,6 +12,7 @@ from compute_space.db.versioned.migrations.v0002_noop import Migration0002Noop
 from compute_space.db.versioned.migrations.v0003_drop_password_needs_set import Migration0003DropPasswordNeedsSet
 from compute_space.db.versioned.migrations.v0004_apps_removing_status import Migration0004AppsRemovingStatus
 from compute_space.db.versioned.migrations.v0005_archive_backend import Migration0005ArchiveBackend
+from compute_space.db.versioned.migrations.v0006_apps_router_permissions import Migration0006AppsRouterPermissions
 
 # Numbered migrations in apply order. Versions MUST start at 2 and be
 # contiguous. v0 (legacy) and v1 (baseline produced by the existing
@@ -21,4 +22,5 @@ REGISTRY: list[Migration] = [
     Migration0003DropPasswordNeedsSet(),
     Migration0004AppsRemovingStatus(),
     Migration0005ArchiveBackend(),
+    Migration0006AppsRouterPermissions(),
 ]

--- a/compute_space/src/compute_space/tests/snapshots/empty/v0006.sql
+++ b/compute_space/src/compute_space/tests/snapshots/empty/v0006.sql
@@ -50,7 +50,7 @@ CREATE TABLE "apps" (
     manifest_raw TEXT,
     created_at TEXT NOT NULL DEFAULT (datetime('now')),
     updated_at TEXT NOT NULL DEFAULT (datetime('now'))
-);
+, deploy_apps_permission INTEGER NOT NULL DEFAULT 0);
 CREATE TABLE archive_backend (
     id INTEGER PRIMARY KEY CHECK (id = 1),
     backend TEXT NOT NULL DEFAULT 'disabled' CHECK(backend IN ('disabled', 's3')),
@@ -96,7 +96,7 @@ CREATE TABLE schema_version (
     id INTEGER PRIMARY KEY CHECK (id = 1),
     version INTEGER NOT NULL
 );
-INSERT INTO "schema_version" VALUES(1,5);
+INSERT INTO "schema_version" VALUES(1,6);
 CREATE TABLE service_defaults (
             service_url TEXT PRIMARY KEY,
             app_name TEXT NOT NULL,

--- a/compute_space/src/compute_space/tests/snapshots/owner_null_password/v0006.sql
+++ b/compute_space/src/compute_space/tests/snapshots/owner_null_password/v0006.sql
@@ -6,8 +6,6 @@ CREATE TABLE api_tokens (
     expires_at TEXT NOT NULL,
     created_at TEXT NOT NULL DEFAULT (datetime('now'))
 );
-INSERT INTO "api_tokens" VALUES(1,'ci-deploy','api-hash-ci','2099-01-01T00:00:00','2024-01-01T00:00:00');
-INSERT INTO "api_tokens" VALUES(2,'monitoring','api-hash-mon','2099-12-31T00:00:00','2024-03-01T00:00:00');
 CREATE TABLE app_databases (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     app_name TEXT NOT NULL,
@@ -16,8 +14,6 @@ CREATE TABLE app_databases (
     FOREIGN KEY (app_name) REFERENCES apps(name) ON DELETE CASCADE,
     UNIQUE(app_name, db_name)
 );
-INSERT INTO "app_databases" VALUES(1,'orders','orders_db','/data/orders/orders.db');
-INSERT INTO "app_databases" VALUES(2,'billing','billing_db','/data/billing/billing.db');
 CREATE TABLE app_port_mappings (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     app_name TEXT NOT NULL,
@@ -27,16 +23,11 @@ CREATE TABLE app_port_mappings (
     FOREIGN KEY (app_name) REFERENCES apps(name) ON DELETE CASCADE,
     UNIQUE(app_name, label)
 );
-INSERT INTO "app_port_mappings" VALUES(1,'orders','grpc',8000,19500);
-INSERT INTO "app_port_mappings" VALUES(2,'orders','health',8080,19501);
-INSERT INTO "app_port_mappings" VALUES(3,'billing','http',8000,19502);
 CREATE TABLE app_tokens (
     app_name TEXT PRIMARY KEY,
     token_hash TEXT NOT NULL UNIQUE,
     FOREIGN KEY (app_name) REFERENCES apps(name) ON DELETE CASCADE
 );
-INSERT INTO "app_tokens" VALUES('orders','app-hash-orders');
-INSERT INTO "app_tokens" VALUES('billing','app-hash-billing');
 CREATE TABLE "apps" (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     name TEXT NOT NULL UNIQUE,
@@ -59,9 +50,7 @@ CREATE TABLE "apps" (
     manifest_raw TEXT,
     created_at TEXT NOT NULL DEFAULT (datetime('now')),
     updated_at TEXT NOT NULL DEFAULT (datetime('now'))
-);
-INSERT INTO "apps" VALUES(1,'orders','orders','1.0.0','Order service','serverfull','/repo/orders',NULL,NULL,19100,NULL,NULL,'stopped',NULL,256,500,0,'[]',NULL,'2024-01-01T00:00:00','2024-01-01T00:00:00');
-INSERT INTO "apps" VALUES(2,'billing','billing','2.1.0','Billing service','serverfull','/repo/billing','https://git.example/billing',NULL,19101,NULL,NULL,'running',NULL,512,1000,0,'["/invoices"]',NULL,'2024-02-15T10:00:00','2024-02-15T10:00:00');
+, deploy_apps_permission INTEGER NOT NULL DEFAULT 0);
 CREATE TABLE archive_backend (
     id INTEGER PRIMARY KEY CHECK (id = 1),
     backend TEXT NOT NULL DEFAULT 'disabled' CHECK(backend IN ('disabled', 's3')),
@@ -82,15 +71,12 @@ CREATE TABLE "owner" (
     password_hash TEXT NOT NULL,
     created_at TEXT NOT NULL DEFAULT (datetime('now'))
 );
-INSERT INTO "owner" VALUES(1,'admin','argon2-stub-owner-hash','2024-01-01T00:00:00');
 CREATE TABLE permissions (
     consumer_app TEXT NOT NULL,
     permission_key TEXT NOT NULL,
     PRIMARY KEY (consumer_app, permission_key),
     FOREIGN KEY (consumer_app) REFERENCES apps(name) ON DELETE CASCADE
 );
-INSERT INTO "permissions" VALUES('orders','net.egress');
-INSERT INTO "permissions" VALUES('billing','net.egress');
 CREATE TABLE permissions_v2 (
             consumer_app TEXT NOT NULL,
             service_url TEXT NOT NULL,
@@ -106,13 +92,11 @@ CREATE TABLE refresh_tokens (
     expires_at TEXT NOT NULL,
     revoked INTEGER NOT NULL DEFAULT 0
 );
-INSERT INTO "refresh_tokens" VALUES(1,'refresh-hash-alpha','2099-01-01T00:00:00',0);
-INSERT INTO "refresh_tokens" VALUES(2,'refresh-hash-beta','2099-06-01T00:00:00',1);
 CREATE TABLE schema_version (
     id INTEGER PRIMARY KEY CHECK (id = 1),
     version INTEGER NOT NULL
 );
-INSERT INTO "schema_version" VALUES(1,5);
+INSERT INTO "schema_version" VALUES(1,6);
 CREATE TABLE service_defaults (
             service_url TEXT PRIMARY KEY,
             app_name TEXT NOT NULL,
@@ -124,8 +108,6 @@ CREATE TABLE service_providers (
     PRIMARY KEY (service_name, app_name),
     FOREIGN KEY (app_name) REFERENCES apps(name) ON DELETE CASCADE
 );
-INSERT INTO "service_providers" VALUES('payments','orders');
-INSERT INTO "service_providers" VALUES('invoices','billing');
 CREATE TABLE service_providers_v2 (
             service_url TEXT NOT NULL,
             app_name TEXT NOT NULL,

--- a/compute_space/src/compute_space/tests/snapshots/service_with_ports/v0006.sql
+++ b/compute_space/src/compute_space/tests/snapshots/service_with_ports/v0006.sql
@@ -6,6 +6,8 @@ CREATE TABLE api_tokens (
     expires_at TEXT NOT NULL,
     created_at TEXT NOT NULL DEFAULT (datetime('now'))
 );
+INSERT INTO "api_tokens" VALUES(1,'ci-deploy','api-hash-ci','2099-01-01T00:00:00','2024-01-01T00:00:00');
+INSERT INTO "api_tokens" VALUES(2,'monitoring','api-hash-mon','2099-12-31T00:00:00','2024-03-01T00:00:00');
 CREATE TABLE app_databases (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     app_name TEXT NOT NULL,
@@ -14,6 +16,8 @@ CREATE TABLE app_databases (
     FOREIGN KEY (app_name) REFERENCES apps(name) ON DELETE CASCADE,
     UNIQUE(app_name, db_name)
 );
+INSERT INTO "app_databases" VALUES(1,'orders','orders_db','/data/orders/orders.db');
+INSERT INTO "app_databases" VALUES(2,'billing','billing_db','/data/billing/billing.db');
 CREATE TABLE app_port_mappings (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     app_name TEXT NOT NULL,
@@ -23,11 +27,16 @@ CREATE TABLE app_port_mappings (
     FOREIGN KEY (app_name) REFERENCES apps(name) ON DELETE CASCADE,
     UNIQUE(app_name, label)
 );
+INSERT INTO "app_port_mappings" VALUES(1,'orders','grpc',8000,19500);
+INSERT INTO "app_port_mappings" VALUES(2,'orders','health',8080,19501);
+INSERT INTO "app_port_mappings" VALUES(3,'billing','http',8000,19502);
 CREATE TABLE app_tokens (
     app_name TEXT PRIMARY KEY,
     token_hash TEXT NOT NULL UNIQUE,
     FOREIGN KEY (app_name) REFERENCES apps(name) ON DELETE CASCADE
 );
+INSERT INTO "app_tokens" VALUES('orders','app-hash-orders');
+INSERT INTO "app_tokens" VALUES('billing','app-hash-billing');
 CREATE TABLE "apps" (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     name TEXT NOT NULL UNIQUE,
@@ -50,7 +59,9 @@ CREATE TABLE "apps" (
     manifest_raw TEXT,
     created_at TEXT NOT NULL DEFAULT (datetime('now')),
     updated_at TEXT NOT NULL DEFAULT (datetime('now'))
-);
+, deploy_apps_permission INTEGER NOT NULL DEFAULT 0);
+INSERT INTO "apps" VALUES(1,'orders','orders','1.0.0','Order service','serverfull','/repo/orders',NULL,NULL,19100,NULL,NULL,'stopped',NULL,256,500,0,'[]',NULL,'2024-01-01T00:00:00','2024-01-01T00:00:00',0);
+INSERT INTO "apps" VALUES(2,'billing','billing','2.1.0','Billing service','serverfull','/repo/billing','https://git.example/billing',NULL,19101,NULL,NULL,'running',NULL,512,1000,0,'["/invoices"]',NULL,'2024-02-15T10:00:00','2024-02-15T10:00:00',0);
 CREATE TABLE archive_backend (
     id INTEGER PRIMARY KEY CHECK (id = 1),
     backend TEXT NOT NULL DEFAULT 'disabled' CHECK(backend IN ('disabled', 's3')),
@@ -71,12 +82,15 @@ CREATE TABLE "owner" (
     password_hash TEXT NOT NULL,
     created_at TEXT NOT NULL DEFAULT (datetime('now'))
 );
+INSERT INTO "owner" VALUES(1,'admin','argon2-stub-owner-hash','2024-01-01T00:00:00');
 CREATE TABLE permissions (
     consumer_app TEXT NOT NULL,
     permission_key TEXT NOT NULL,
     PRIMARY KEY (consumer_app, permission_key),
     FOREIGN KEY (consumer_app) REFERENCES apps(name) ON DELETE CASCADE
 );
+INSERT INTO "permissions" VALUES('orders','net.egress');
+INSERT INTO "permissions" VALUES('billing','net.egress');
 CREATE TABLE permissions_v2 (
             consumer_app TEXT NOT NULL,
             service_url TEXT NOT NULL,
@@ -92,11 +106,13 @@ CREATE TABLE refresh_tokens (
     expires_at TEXT NOT NULL,
     revoked INTEGER NOT NULL DEFAULT 0
 );
+INSERT INTO "refresh_tokens" VALUES(1,'refresh-hash-alpha','2099-01-01T00:00:00',0);
+INSERT INTO "refresh_tokens" VALUES(2,'refresh-hash-beta','2099-06-01T00:00:00',1);
 CREATE TABLE schema_version (
     id INTEGER PRIMARY KEY CHECK (id = 1),
     version INTEGER NOT NULL
 );
-INSERT INTO "schema_version" VALUES(1,5);
+INSERT INTO "schema_version" VALUES(1,6);
 CREATE TABLE service_defaults (
             service_url TEXT PRIMARY KEY,
             app_name TEXT NOT NULL,
@@ -108,6 +124,8 @@ CREATE TABLE service_providers (
     PRIMARY KEY (service_name, app_name),
     FOREIGN KEY (app_name) REFERENCES apps(name) ON DELETE CASCADE
 );
+INSERT INTO "service_providers" VALUES('payments','orders');
+INSERT INTO "service_providers" VALUES('invoices','billing');
 CREATE TABLE service_providers_v2 (
             service_url TEXT NOT NULL,
             app_name TEXT NOT NULL,

--- a/compute_space/src/compute_space/tests/test_manifest.py
+++ b/compute_space/src/compute_space/tests/test_manifest.py
@@ -589,6 +589,53 @@ class TestAppArchive:
         assert manifest.access_all_data is True
 
 
+class TestRouterPermissions:
+    """Verify the ``[permissions]`` manifest section.
+
+    Apps may request privileged grants on the router itself (deploy
+    other apps, etc.).  The manifest only carries the *request*; whether
+    a grant is actually applied is the install-time consent flow's job.
+    These tests pin the parsing contract.
+    """
+
+    def test_deploy_apps_default_is_false(self):
+        manifest = parse_manifest_from_string(MINIMAL)
+        assert manifest.deploy_apps_permission is False
+
+    def test_deploy_apps_explicit_true(self):
+        toml = MINIMAL + "\n[permissions]\ndeploy_apps = true\n"
+        manifest = parse_manifest_from_string(toml)
+        assert manifest.deploy_apps_permission is True
+
+    def test_deploy_apps_explicit_false(self):
+        toml = MINIMAL + "\n[permissions]\ndeploy_apps = false\n"
+        manifest = parse_manifest_from_string(toml)
+        assert manifest.deploy_apps_permission is False
+
+    def test_deploy_apps_non_bool_rejected(self):
+        # Catches the common typo ``deploy_apps = "true"`` (TOML strings
+        # would otherwise parse without complaint and end up being
+        # treated as truthy in Python — fail closed instead).
+        toml = MINIMAL + '\n[permissions]\ndeploy_apps = "true"\n'
+        with pytest.raises(ValueError, match=r"\[permissions\]\.deploy_apps must be a boolean"):
+            parse_manifest_from_string(toml)
+
+    def test_permissions_section_absent_no_grants(self):
+        # No [permissions] table at all should be equivalent to all
+        # router permissions defaulting to False.
+        manifest = parse_manifest_from_string(MINIMAL)
+        assert manifest.deploy_apps_permission is False
+
+    def test_unrelated_keys_in_permissions_section_are_ignored(self):
+        # Forward-compat: unknown keys should not crash; the manifest is
+        # the source of truth for *requests*, the server's
+        # KNOWN_ROUTER_PERMISSIONS set is the source of truth for what's
+        # actually grantable.
+        toml = MINIMAL + "\n[permissions]\ndeploy_apps = true\nfuture_thing = true\n"
+        manifest = parse_manifest_from_string(toml)
+        assert manifest.deploy_apps_permission is True
+
+
 class TestShmMb:
     """[runtime.container].shm_mb."""
 

--- a/compute_space/src/compute_space/web/routes/api/apps.py
+++ b/compute_space/src/compute_space/web/routes/api/apps.py
@@ -39,6 +39,12 @@ from compute_space.core.services import get_oauth_token
 from compute_space.db import get_db
 from compute_space.web.middleware import login_required
 
+# Router-level permissions an app may request via ``[permissions]`` in
+# its ``openhost.toml`` and the owner may grant at install time.
+# Adding entries here is the manifest contract; the runtime token
+# issuance + API gating that *enforce* them lands in a follow-up PR.
+KNOWN_ROUTER_PERMISSIONS: frozenset[str] = frozenset({"deploy_apps"})
+
 
 def _is_removing(app_row: sqlite3.Row | None) -> bool:
     """True if the row is being torn down by remove_app_background.
@@ -185,6 +191,32 @@ async def api_add_app() -> ResponseReturnValue:
     else:
         grant_permissions = {k.strip() for k in grant_permissions_raw.split(",") if k.strip()}
 
+    # Privileged router permissions are per-perm form fields shaped
+    # ``grant_router_permission.<name>=1``.  We accumulate the set of
+    # granted names and validate against ``KNOWN_ROUTER_PERMISSIONS`` so a
+    # client typo or a future-version client doesn't accidentally grant
+    # something we don't know how to enforce.
+    granted_router_permissions: set[str] = set()
+    for key in form:
+        if not key.startswith("grant_router_permission."):
+            continue
+        perm_name = key.removeprefix("grant_router_permission.")
+        if perm_name not in KNOWN_ROUTER_PERMISSIONS:
+            return jsonify({"error": f"Unknown router permission: {perm_name!r}"}), 400
+        if (form.get(key) or "").strip().lower() not in ("1", "true", "yes"):
+            continue
+        granted_router_permissions.add(perm_name)
+
+    # Refuse grants the manifest doesn't request — the consent UI never
+    # offers them, but a hand-rolled API client could try.  Fail closed.
+    if "deploy_apps" in granted_router_permissions and not manifest.deploy_apps_permission:
+        shutil.rmtree(final_dir, ignore_errors=True)
+        return jsonify(
+            {"error": "deploy_apps router permission was granted but the manifest does not request it"}
+        ), 400
+
+    deploy_apps_granted = "deploy_apps" in granted_router_permissions
+
     # Parse port overrides from individual form fields: port_override.<label>=<host_port>
     port_overrides: dict[str, int] | None = None
     for key in form:
@@ -207,6 +239,7 @@ async def api_add_app() -> ResponseReturnValue:
             app_name=app_name,
             repo_url=repo_url,
             port_overrides=port_overrides,
+            deploy_apps_granted=deploy_apps_granted,
         )
     except (RuntimeError, ValueError) as e:
         # ValueError covers uid_map pool exhaustion (see compute_uid_map_base)

--- a/compute_space/src/compute_space/web/templates/add_app.html
+++ b/compute_space/src/compute_space/web/templates/add_app.html
@@ -67,6 +67,22 @@
     </table>
   </div>
 
+  <div id="router-permissions" style="display:none; margin-top:1em;">
+    <h3>Privileged Router Permissions</h3>
+    <p style="background:#f8d7da; border:1px solid #dc3545; padding:0.6em 0.8em; border-radius:4px;">
+      This app requests <b>privileged access</b> to the OpenHost router itself.
+      Granting any of the permissions below lets the app drive parts of OpenHost
+      that are normally only available to you.  Only grant these to apps you fully trust.
+      You can leave them unchecked here and grant them later if you change your mind.
+    </p>
+    <table>
+      <thead>
+        <tr><th>Permission</th><th>Effect</th><th>Action</th></tr>
+      </thead>
+      <tbody id="router-perm-body"></tbody>
+    </table>
+  </div>
+
   <div id="service-permissions" style="display:none; margin-top:1em;">
     <h3>Service Permissions</h3>
     <p>This app requests access to the following service keys. Uncheck any you don't want to grant now (you can grant them later from the app detail page).</p>
@@ -208,6 +224,29 @@ function renderManifest(m, url) {
 
   // Render port mappings section
   renderPortMappings(m.port_mappings || []);
+
+  // Render privileged router permissions (deploy_apps, etc.).  These are
+  // distinct from the per-service [services] grants below: they let the
+  // app drive the router's own admin surface, so we render them in a
+  // separately-styled "danger" section and start them UNCHECKED so the
+  // owner has to explicitly opt in (vs. service grants which default to
+  // checked because the manifest already justifies each one with a
+  // ``reason`` string).
+  const routerPermsEl = document.getElementById('router-permissions');
+  const routerPermRows = [];
+  if (m.deploy_apps_permission) {
+    routerPermRows.push(`<tr>
+      <td><code>deploy_apps</code></td>
+      <td>Drive OpenHost's app-management API: list / install / reload / remove apps on this zone.  Equivalent in scope to an owner API token, but scoped to one app.</td>
+      <td><label><input type="checkbox" class="router-perm-grant" data-perm="deploy_apps"> Grant</label></td>
+    </tr>`);
+  }
+  if (routerPermRows.length) {
+    routerPermsEl.style.display = '';
+    document.getElementById('router-perm-body').innerHTML = routerPermRows.join('');
+  } else {
+    routerPermsEl.style.display = 'none';
+  }
 
   // Render service permissions (secrets, etc.) with grant checkboxes
   const permsEl = document.getElementById('service-permissions');
@@ -366,6 +405,13 @@ async function deployApp() {
     if (cb.checked) approved.push(cb.dataset.service + '/' + cb.dataset.key);
   });
   form.append('grant_permissions', approved.join(','));
+
+  // Privileged router permissions — each as its own form field so the
+  // server doesn't have to parse a comma-separated string and can fail
+  // closed on unknown values.
+  document.querySelectorAll('.router-perm-grant:checked').forEach(cb => {
+    form.append(`grant_router_permission.${cb.dataset.perm}`, '1');
+  });
 
   // Collect port overrides as individual form fields
   document.querySelectorAll('.port-host-input').forEach(input => {

--- a/docs/manifest_spec.md
+++ b/docs/manifest_spec.md
@@ -62,6 +62,14 @@ Rootless podman can bind ports >= 25 only; `host_port` values below 25 are rejec
 | `access_vm_data` | boolean | no | false | Whether the app can access the VM's shared data directory |
 | `access_all_data` | boolean | no | false | Full access to permanent data, temp data, archive, and vm data |
 
+### `[permissions]` — optional
+
+Per-app grants of router-managed capabilities, distinct from the per-service `[services]` / `[[permissions_v2]]` grants that mediate cross-app access.  Each field is a manifest *request*; grants are applied only when the owner explicitly approves them at install time on the dashboard's "Privileged Router Permissions" panel (defaults unchecked, opt-in).
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `deploy_apps` | boolean | no | false | Request permission to drive OpenHost's app-management API: list / install / reload / remove apps on this zone.  Roughly equivalent in scope to an owner API token, but scoped to one app.  Used by the catalog app and any future automation consumer (CI deployers, agent-host integrations) that would otherwise need a hand-rolled owner-equivalent token. |
+
 ## Data Directory Structure
 
 Apps have three storage areas, each with different durability + size + latency tradeoffs. **By default, apps have no filesystem access.** Each must be explicitly requested:


### PR DESCRIPTION
Apps may now request privileged grants on the router itself via a new [permissions] section in openhost.toml, distinct from the per-service [services] / [[permissions_v2]] grants that mediate cross-app access. The first such permission is deploy_apps — a request to drive OpenHost's app-management API (list / install / reload / remove apps). Roughly equivalent in scope to an owner API token, but scoped to one app.

Scope of this PR is narrow: manifest contract + install-time consent plumbing only. The runtime token issuance + API gating that enforce deploy_apps ship in a follow-up PR; this commit is the contract that apps (catalog being the canonical consumer) can start declaring against without changing the router's auth surface.

Why scope this way: it lets apps that want this permission start asking for it, gives operators visibility into what's been requested + granted, and unblocks the catalog's vendoring (PR #65) without coupling either change to the token-flow rollout.

What's added:

* AppManifest.deploy_apps_permission populated from [permissions].deploy_apps in the openhost.toml parser
* /api/add_app accepts grant_router_permission.<name>=1 form fields, validated against a KNOWN_ROUTER_PERMISSIONS allowlist (fail closed on unknown names), and refuses grants the manifest doesn't request
* add_app.html surfaces a separately-styled 'Privileged Router Permissions' section rendering each request as an UNCHECKED opt-in checkbox (vs. service grants which default to checked because each one carries a manifest-level reason)
* New apps.deploy_apps_permission INTEGER column on the apps table — schema.sql + v0006 migration + refreshed snapshot tier
* docs/manifest_spec.md updated with the new section

Tests: 6 new manifest-parsing tests covering default-false, explicit grant, explicit refusal, non-bool typo rejection, missing-section equivalence, forward-compat for unknown keys. Snapshot suite refreshed to v0006. 431 tests pass; vet + ruff + mypy clean.

Branched off main, totally separate from the catalog-as-builtin PR (#65).