### PR TITLE
Add 'installer' v2 service for cross-app installation

### DIFF
--- a/compute_space/src/compute_space/core/apps.py
+++ b/compute_space/src/compute_space/core/apps.py
@@ -233,6 +233,7 @@ def insert_and_deploy(
     app_name: str | None = None,
     repo_url: str | None = None,
     port_overrides: dict[str, int] | None = None,
+    installed_by: str | None = None,
 ) -> str:
     """Insert app into DB and start background deploy.
 
@@ -242,6 +243,11 @@ def insert_and_deploy(
     grant_permissions_v2: if True, grant all [[services.v2.consumes]] entries
         from the manifest at install time.
     port_overrides: optional dict of label -> host_port from CLI/API.
+    installed_by: consumer app name when the install came in via the
+        installer v2 service.  Stored on the apps row in the same
+        INSERT (so there's no race with the background build thread)
+        and used by the installer's /status and /logs endpoints to
+        scope visibility to the installs each caller initiated.
     """
     if app_name is None:
         app_name = manifest.name
@@ -273,8 +279,8 @@ def insert_and_deploy(
         """INSERT INTO apps
            (name, manifest_name, version, description, runtime_type, repo_path, repo_url,
             health_check, local_port, container_port, memory_mb, cpu_millicores,
-            gpu, public_paths, manifest_raw, status)
-           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            gpu, public_paths, manifest_raw, status, installed_by)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
         (
             app_name,
             manifest.name,
@@ -292,6 +298,7 @@ def insert_and_deploy(
             json.dumps(manifest.public_paths),
             manifest.raw_toml,
             "building",
+            installed_by,
         ),
     )
 

--- a/compute_space/src/compute_space/core/installer.py
+++ b/compute_space/src/compute_space/core/installer.py
@@ -1,0 +1,144 @@
+"""Programmatic app install for the ``installer`` v2 service.
+
+The v2 service proxy in :mod:`compute_space.web.routes.services_v2`
+intercepts requests whose resolved service URL is
+``INSTALLER_SERVICE_URL`` and dispatches them here.  The functions in
+this module are also the seam used by the default-apps deploy hook to
+install builtin apps from remote URLs (see
+:mod:`compute_space.core.default_apps`).
+"""
+
+from __future__ import annotations
+
+import shutil
+import sqlite3
+
+import attr
+
+from compute_space.config import Config
+from compute_space.core.apps import clone_with_github_fallback
+from compute_space.core.apps import insert_and_deploy
+from compute_space.core.apps import move_clone_to_app_temp_dir
+from compute_space.core.apps import validate_manifest
+from compute_space.core.permissions_v2 import Grant
+
+# Service URL the v2 service proxy matches against to dispatch to this
+# module instead of resolving a normal provider app.
+INSTALLER_SERVICE_URL = "github.com/imbue-openhost/openhost/services/installer"
+
+# Service version this build of the installer exposes.  v2 callers send a
+# SemVer specifier (e.g. ``>=0.1.0``) in their manifest's
+# [[services.v2.consumes]].version; the proxy checks it against this
+# constant.
+INSTALLER_SERVICE_VERSION = "0.1.0"
+
+# Grant payload keys understood by ``check_install_allowed``.
+GRANT_KEY_CAPABILITY = "capability"
+GRANT_KEY_REPO_URL_PREFIX = "repo_url_prefix"
+INSTALL_CAPABILITY = "install"
+
+
+@attr.s(auto_attribs=True, frozen=True)
+class InstallResult:
+    """Successful install result returned by ``install_from_repo_url``."""
+
+    app_name: str
+    status: str  # always "building" — the actual build runs in a daemon thread
+
+
+class InstallError(Exception):
+    """Raised by ``install_from_repo_url`` on any expected failure mode."""
+
+    def __init__(self, message: str, status_code: int = 400):
+        super().__init__(message)
+        self.message = message
+        self.status_code = status_code
+
+
+def check_install_allowed(repo_url: str, grants: list[Grant]) -> str | None:
+    """Validate the caller's grants against the requested ``repo_url``.
+
+    Returns ``None`` if at least one grant permits installing the given
+    ``repo_url``; otherwise returns a human-readable reason describing
+    the missing grant.  The caller is responsible for turning that into
+    a 403 permission_required response.
+
+    The installer expects dict-shaped grants with
+    ``capability == "install"`` and a ``repo_url_prefix`` string.  Non-
+    dict grants (strings, lists) are skipped; they may be present if the
+    catalog also requests other capabilities later.
+    """
+    if not grants:
+        return "no installer grants present"
+    for g in grants:
+        if not isinstance(g, dict):
+            continue
+        if g.get(GRANT_KEY_CAPABILITY) != INSTALL_CAPABILITY:
+            continue
+        prefix = g.get(GRANT_KEY_REPO_URL_PREFIX, "")
+        if not isinstance(prefix, str):
+            continue
+        if prefix in ("", "*"):
+            return None
+        if repo_url.startswith(prefix):
+            return None
+    return "no installer grant matches the requested repo_url"
+
+
+async def install_from_repo_url(
+    repo_url: str,
+    config: Config,
+    db: sqlite3.Connection,
+    *,
+    app_name: str | None = None,
+    installed_by: str | None = None,
+) -> InstallResult:
+    """Clone ``repo_url``, validate, and kick off a background build.
+
+    Mirrors the ``/api/add_app`` flow but is callable from sync core
+    contexts (default-apps deploy hook) and from the v2 service proxy.
+
+    ``installed_by`` records the consumer app that requested the install
+    (or ``None`` for owner-initiated installs).  Threaded through
+    ``insert_and_deploy`` so it lands on the apps row in the same
+    INSERT — no separate UPDATE that could race with the background
+    build thread's status writes.
+
+    Raises ``InstallError`` on every expected failure.
+    """
+    if not repo_url:
+        raise InstallError("repo_url is required", status_code=400)
+
+    manifest, clone_dir, error, authorize_url = await clone_with_github_fallback(repo_url, return_to="/")
+    if authorize_url is not None:
+        # The owner needs to approve GitHub OAuth to clone a private repo.
+        # The installer service is server-to-server; we don't have a
+        # browser session to redirect.  Surface the URL in the error.
+        raise InstallError(f"GitHub authorization required: {authorize_url}", status_code=401)
+    if error or manifest is None or clone_dir is None:
+        raise InstallError(f"clone failed: {error or 'unknown error'}", status_code=400)
+
+    effective_name = app_name or manifest.name
+    validation_error = validate_manifest(manifest, db, app_name=effective_name)
+    if validation_error is not None:
+        shutil.rmtree(clone_dir, ignore_errors=True)
+        raise InstallError(validation_error, status_code=400)
+
+    final_dir = move_clone_to_app_temp_dir(clone_dir, effective_name, config)
+
+    try:
+        deployed_name = insert_and_deploy(
+            manifest,
+            final_dir,
+            config,
+            db,
+            grant_permissions=set(),
+            grant_permissions_v2=True,
+            app_name=effective_name,
+            repo_url=repo_url,
+            installed_by=installed_by,
+        )
+    except (RuntimeError, ValueError) as exc:
+        raise InstallError(f"deploy failed: {exc}", status_code=400) from exc
+
+    return InstallResult(app_name=deployed_name, status="building")

--- a/compute_space/src/compute_space/db/schema.sql
+++ b/compute_space/src/compute_space/db/schema.sql
@@ -18,6 +18,7 @@ CREATE TABLE IF NOT EXISTS apps (
     gpu INTEGER NOT NULL DEFAULT 0,
     public_paths TEXT NOT NULL DEFAULT '[]',
     manifest_raw TEXT,
+    installed_by TEXT,
     created_at TEXT NOT NULL DEFAULT (datetime('now')),
     updated_at TEXT NOT NULL DEFAULT (datetime('now'))
 );

--- a/compute_space/src/compute_space/db/versioned/migrations/v0006_apps_installed_by.py
+++ b/compute_space/src/compute_space/db/versioned/migrations/v0006_apps_installed_by.py
@@ -1,0 +1,10 @@
+"""v6: add ``apps.installed_by`` column.  Body in v0006_apps_installed_by.sql."""
+
+from __future__ import annotations
+
+from compute_space.db.versioned.base import SqlFileMigration
+
+
+class Migration0006AppsInstalledBy(SqlFileMigration):
+    version = 6
+    sql_file = "v0006_apps_installed_by.sql"

--- a/compute_space/src/compute_space/db/versioned/migrations/v0006_apps_installed_by.sql
+++ b/compute_space/src/compute_space/db/versioned/migrations/v0006_apps_installed_by.sql
@@ -1,0 +1,10 @@
+-- v6: add ``apps.installed_by`` for the installer v2 service.
+--
+-- When an app is installed via the ``installer`` v2 service rather
+-- than owner-initiated UI/CLI, the requesting consumer app's name is
+-- recorded here so the installer service can scope status/logs queries
+-- to the installs each caller initiated.  NULL for owner-initiated
+-- installs (the existing /api/add_app path); set to the consumer app
+-- name for installer-service-initiated installs.
+
+ALTER TABLE apps ADD COLUMN installed_by TEXT;

--- a/compute_space/src/compute_space/db/versioned/registry.py
+++ b/compute_space/src/compute_space/db/versioned/registry.py
@@ -12,6 +12,7 @@ from compute_space.db.versioned.migrations.v0002_noop import Migration0002Noop
 from compute_space.db.versioned.migrations.v0003_drop_password_needs_set import Migration0003DropPasswordNeedsSet
 from compute_space.db.versioned.migrations.v0004_apps_removing_status import Migration0004AppsRemovingStatus
 from compute_space.db.versioned.migrations.v0005_archive_backend import Migration0005ArchiveBackend
+from compute_space.db.versioned.migrations.v0006_apps_installed_by import Migration0006AppsInstalledBy
 
 # Numbered migrations in apply order. Versions MUST start at 2 and be
 # contiguous. v0 (legacy) and v1 (baseline produced by the existing
@@ -21,4 +22,5 @@ REGISTRY: list[Migration] = [
     Migration0003DropPasswordNeedsSet(),
     Migration0004AppsRemovingStatus(),
     Migration0005ArchiveBackend(),
+    Migration0006AppsInstalledBy(),
 ]

--- a/compute_space/src/compute_space/tests/snapshots/empty/v0006.sql
+++ b/compute_space/src/compute_space/tests/snapshots/empty/v0006.sql
@@ -50,7 +50,7 @@ CREATE TABLE "apps" (
     manifest_raw TEXT,
     created_at TEXT NOT NULL DEFAULT (datetime('now')),
     updated_at TEXT NOT NULL DEFAULT (datetime('now'))
-);
+, installed_by TEXT);
 CREATE TABLE archive_backend (
     id INTEGER PRIMARY KEY CHECK (id = 1),
     backend TEXT NOT NULL DEFAULT 'disabled' CHECK(backend IN ('disabled', 's3')),
@@ -96,7 +96,7 @@ CREATE TABLE schema_version (
     id INTEGER PRIMARY KEY CHECK (id = 1),
     version INTEGER NOT NULL
 );
-INSERT INTO "schema_version" VALUES(1,5);
+INSERT INTO "schema_version" VALUES(1,6);
 CREATE TABLE service_defaults (
             service_url TEXT PRIMARY KEY,
             app_name TEXT NOT NULL,

--- a/compute_space/src/compute_space/tests/snapshots/owner_null_password/v0006.sql
+++ b/compute_space/src/compute_space/tests/snapshots/owner_null_password/v0006.sql
@@ -6,8 +6,6 @@ CREATE TABLE api_tokens (
     expires_at TEXT NOT NULL,
     created_at TEXT NOT NULL DEFAULT (datetime('now'))
 );
-INSERT INTO "api_tokens" VALUES(1,'ci-deploy','api-hash-ci','2099-01-01T00:00:00','2024-01-01T00:00:00');
-INSERT INTO "api_tokens" VALUES(2,'monitoring','api-hash-mon','2099-12-31T00:00:00','2024-03-01T00:00:00');
 CREATE TABLE app_databases (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     app_name TEXT NOT NULL,
@@ -16,8 +14,6 @@ CREATE TABLE app_databases (
     FOREIGN KEY (app_name) REFERENCES apps(name) ON DELETE CASCADE,
     UNIQUE(app_name, db_name)
 );
-INSERT INTO "app_databases" VALUES(1,'orders','orders_db','/data/orders/orders.db');
-INSERT INTO "app_databases" VALUES(2,'billing','billing_db','/data/billing/billing.db');
 CREATE TABLE app_port_mappings (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     app_name TEXT NOT NULL,
@@ -27,16 +23,11 @@ CREATE TABLE app_port_mappings (
     FOREIGN KEY (app_name) REFERENCES apps(name) ON DELETE CASCADE,
     UNIQUE(app_name, label)
 );
-INSERT INTO "app_port_mappings" VALUES(1,'orders','grpc',8000,19500);
-INSERT INTO "app_port_mappings" VALUES(2,'orders','health',8080,19501);
-INSERT INTO "app_port_mappings" VALUES(3,'billing','http',8000,19502);
 CREATE TABLE app_tokens (
     app_name TEXT PRIMARY KEY,
     token_hash TEXT NOT NULL UNIQUE,
     FOREIGN KEY (app_name) REFERENCES apps(name) ON DELETE CASCADE
 );
-INSERT INTO "app_tokens" VALUES('orders','app-hash-orders');
-INSERT INTO "app_tokens" VALUES('billing','app-hash-billing');
 CREATE TABLE "apps" (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     name TEXT NOT NULL UNIQUE,
@@ -59,9 +50,7 @@ CREATE TABLE "apps" (
     manifest_raw TEXT,
     created_at TEXT NOT NULL DEFAULT (datetime('now')),
     updated_at TEXT NOT NULL DEFAULT (datetime('now'))
-);
-INSERT INTO "apps" VALUES(1,'orders','orders','1.0.0','Order service','serverfull','/repo/orders',NULL,NULL,19100,NULL,NULL,'stopped',NULL,256,500,0,'[]',NULL,'2024-01-01T00:00:00','2024-01-01T00:00:00');
-INSERT INTO "apps" VALUES(2,'billing','billing','2.1.0','Billing service','serverfull','/repo/billing','https://git.example/billing',NULL,19101,NULL,NULL,'running',NULL,512,1000,0,'["/invoices"]',NULL,'2024-02-15T10:00:00','2024-02-15T10:00:00');
+, installed_by TEXT);
 CREATE TABLE archive_backend (
     id INTEGER PRIMARY KEY CHECK (id = 1),
     backend TEXT NOT NULL DEFAULT 'disabled' CHECK(backend IN ('disabled', 's3')),
@@ -82,15 +71,12 @@ CREATE TABLE "owner" (
     password_hash TEXT NOT NULL,
     created_at TEXT NOT NULL DEFAULT (datetime('now'))
 );
-INSERT INTO "owner" VALUES(1,'admin','argon2-stub-owner-hash','2024-01-01T00:00:00');
 CREATE TABLE permissions (
     consumer_app TEXT NOT NULL,
     permission_key TEXT NOT NULL,
     PRIMARY KEY (consumer_app, permission_key),
     FOREIGN KEY (consumer_app) REFERENCES apps(name) ON DELETE CASCADE
 );
-INSERT INTO "permissions" VALUES('orders','net.egress');
-INSERT INTO "permissions" VALUES('billing','net.egress');
 CREATE TABLE permissions_v2 (
             consumer_app TEXT NOT NULL,
             service_url TEXT NOT NULL,
@@ -106,13 +92,11 @@ CREATE TABLE refresh_tokens (
     expires_at TEXT NOT NULL,
     revoked INTEGER NOT NULL DEFAULT 0
 );
-INSERT INTO "refresh_tokens" VALUES(1,'refresh-hash-alpha','2099-01-01T00:00:00',0);
-INSERT INTO "refresh_tokens" VALUES(2,'refresh-hash-beta','2099-06-01T00:00:00',1);
 CREATE TABLE schema_version (
     id INTEGER PRIMARY KEY CHECK (id = 1),
     version INTEGER NOT NULL
 );
-INSERT INTO "schema_version" VALUES(1,5);
+INSERT INTO "schema_version" VALUES(1,6);
 CREATE TABLE service_defaults (
             service_url TEXT PRIMARY KEY,
             app_name TEXT NOT NULL,
@@ -124,8 +108,6 @@ CREATE TABLE service_providers (
     PRIMARY KEY (service_name, app_name),
     FOREIGN KEY (app_name) REFERENCES apps(name) ON DELETE CASCADE
 );
-INSERT INTO "service_providers" VALUES('payments','orders');
-INSERT INTO "service_providers" VALUES('invoices','billing');
 CREATE TABLE service_providers_v2 (
             service_url TEXT NOT NULL,
             app_name TEXT NOT NULL,

--- a/compute_space/src/compute_space/tests/snapshots/service_with_ports/v0006.sql
+++ b/compute_space/src/compute_space/tests/snapshots/service_with_ports/v0006.sql
@@ -6,6 +6,8 @@ CREATE TABLE api_tokens (
     expires_at TEXT NOT NULL,
     created_at TEXT NOT NULL DEFAULT (datetime('now'))
 );
+INSERT INTO "api_tokens" VALUES(1,'ci-deploy','api-hash-ci','2099-01-01T00:00:00','2024-01-01T00:00:00');
+INSERT INTO "api_tokens" VALUES(2,'monitoring','api-hash-mon','2099-12-31T00:00:00','2024-03-01T00:00:00');
 CREATE TABLE app_databases (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     app_name TEXT NOT NULL,
@@ -14,6 +16,8 @@ CREATE TABLE app_databases (
     FOREIGN KEY (app_name) REFERENCES apps(name) ON DELETE CASCADE,
     UNIQUE(app_name, db_name)
 );
+INSERT INTO "app_databases" VALUES(1,'orders','orders_db','/data/orders/orders.db');
+INSERT INTO "app_databases" VALUES(2,'billing','billing_db','/data/billing/billing.db');
 CREATE TABLE app_port_mappings (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     app_name TEXT NOT NULL,
@@ -23,11 +27,16 @@ CREATE TABLE app_port_mappings (
     FOREIGN KEY (app_name) REFERENCES apps(name) ON DELETE CASCADE,
     UNIQUE(app_name, label)
 );
+INSERT INTO "app_port_mappings" VALUES(1,'orders','grpc',8000,19500);
+INSERT INTO "app_port_mappings" VALUES(2,'orders','health',8080,19501);
+INSERT INTO "app_port_mappings" VALUES(3,'billing','http',8000,19502);
 CREATE TABLE app_tokens (
     app_name TEXT PRIMARY KEY,
     token_hash TEXT NOT NULL UNIQUE,
     FOREIGN KEY (app_name) REFERENCES apps(name) ON DELETE CASCADE
 );
+INSERT INTO "app_tokens" VALUES('orders','app-hash-orders');
+INSERT INTO "app_tokens" VALUES('billing','app-hash-billing');
 CREATE TABLE "apps" (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     name TEXT NOT NULL UNIQUE,
@@ -50,7 +59,9 @@ CREATE TABLE "apps" (
     manifest_raw TEXT,
     created_at TEXT NOT NULL DEFAULT (datetime('now')),
     updated_at TEXT NOT NULL DEFAULT (datetime('now'))
-);
+, installed_by TEXT);
+INSERT INTO "apps" VALUES(1,'orders','orders','1.0.0','Order service','serverfull','/repo/orders',NULL,NULL,19100,NULL,NULL,'stopped',NULL,256,500,0,'[]',NULL,'2024-01-01T00:00:00','2024-01-01T00:00:00',NULL);
+INSERT INTO "apps" VALUES(2,'billing','billing','2.1.0','Billing service','serverfull','/repo/billing','https://git.example/billing',NULL,19101,NULL,NULL,'running',NULL,512,1000,0,'["/invoices"]',NULL,'2024-02-15T10:00:00','2024-02-15T10:00:00',NULL);
 CREATE TABLE archive_backend (
     id INTEGER PRIMARY KEY CHECK (id = 1),
     backend TEXT NOT NULL DEFAULT 'disabled' CHECK(backend IN ('disabled', 's3')),
@@ -71,12 +82,15 @@ CREATE TABLE "owner" (
     password_hash TEXT NOT NULL,
     created_at TEXT NOT NULL DEFAULT (datetime('now'))
 );
+INSERT INTO "owner" VALUES(1,'admin','argon2-stub-owner-hash','2024-01-01T00:00:00');
 CREATE TABLE permissions (
     consumer_app TEXT NOT NULL,
     permission_key TEXT NOT NULL,
     PRIMARY KEY (consumer_app, permission_key),
     FOREIGN KEY (consumer_app) REFERENCES apps(name) ON DELETE CASCADE
 );
+INSERT INTO "permissions" VALUES('orders','net.egress');
+INSERT INTO "permissions" VALUES('billing','net.egress');
 CREATE TABLE permissions_v2 (
             consumer_app TEXT NOT NULL,
             service_url TEXT NOT NULL,
@@ -92,11 +106,13 @@ CREATE TABLE refresh_tokens (
     expires_at TEXT NOT NULL,
     revoked INTEGER NOT NULL DEFAULT 0
 );
+INSERT INTO "refresh_tokens" VALUES(1,'refresh-hash-alpha','2099-01-01T00:00:00',0);
+INSERT INTO "refresh_tokens" VALUES(2,'refresh-hash-beta','2099-06-01T00:00:00',1);
 CREATE TABLE schema_version (
     id INTEGER PRIMARY KEY CHECK (id = 1),
     version INTEGER NOT NULL
 );
-INSERT INTO "schema_version" VALUES(1,5);
+INSERT INTO "schema_version" VALUES(1,6);
 CREATE TABLE service_defaults (
             service_url TEXT PRIMARY KEY,
             app_name TEXT NOT NULL,
@@ -108,6 +124,8 @@ CREATE TABLE service_providers (
     PRIMARY KEY (service_name, app_name),
     FOREIGN KEY (app_name) REFERENCES apps(name) ON DELETE CASCADE
 );
+INSERT INTO "service_providers" VALUES('payments','orders');
+INSERT INTO "service_providers" VALUES('invoices','billing');
 CREATE TABLE service_providers_v2 (
             service_url TEXT NOT NULL,
             app_name TEXT NOT NULL,

--- a/compute_space/src/compute_space/tests/test_installer.py
+++ b/compute_space/src/compute_space/tests/test_installer.py
@@ -1,0 +1,95 @@
+"""Unit tests for the ``installer`` v2 service core helpers.
+
+The end-to-end install + service-proxy flow is exercised in the e2e
+integration tests; here we focus on the small, deterministic units:
+``check_install_allowed`` grant matching and the constants the proxy
+relies on.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from compute_space.core.installer import GRANT_KEY_CAPABILITY
+from compute_space.core.installer import GRANT_KEY_REPO_URL_PREFIX
+from compute_space.core.installer import INSTALLER_SERVICE_URL
+from compute_space.core.installer import INSTALL_CAPABILITY
+from compute_space.core.installer import InstallError
+from compute_space.core.installer import check_install_allowed
+
+
+class TestCheckInstallAllowed:
+    def test_empty_grants_denied(self) -> None:
+        assert check_install_allowed("https://github.com/foo/bar", []) is not None
+
+    def test_matching_prefix_allowed(self) -> None:
+        grants = [
+            {
+                GRANT_KEY_CAPABILITY: INSTALL_CAPABILITY,
+                GRANT_KEY_REPO_URL_PREFIX: "https://github.com/imbue-openhost/",
+            },
+        ]
+        assert check_install_allowed("https://github.com/imbue-openhost/openhost-catalog", grants) is None
+
+    def test_non_matching_prefix_denied(self) -> None:
+        grants = [
+            {
+                GRANT_KEY_CAPABILITY: INSTALL_CAPABILITY,
+                GRANT_KEY_REPO_URL_PREFIX: "https://github.com/imbue-openhost/",
+            },
+        ]
+        assert check_install_allowed("https://github.com/evil/badapp", grants) is not None
+
+    def test_wildcard_prefix_allows_anything(self) -> None:
+        grants = [{GRANT_KEY_CAPABILITY: INSTALL_CAPABILITY, GRANT_KEY_REPO_URL_PREFIX: "*"}]
+        assert check_install_allowed("https://anywhere.invalid/repo", grants) is None
+
+    def test_empty_prefix_allows_anything(self) -> None:
+        grants = [{GRANT_KEY_CAPABILITY: INSTALL_CAPABILITY, GRANT_KEY_REPO_URL_PREFIX: ""}]
+        assert check_install_allowed("https://anywhere.invalid/repo", grants) is None
+
+    def test_wrong_capability_ignored(self) -> None:
+        grants = [
+            {GRANT_KEY_CAPABILITY: "read_logs", GRANT_KEY_REPO_URL_PREFIX: "*"},
+        ]
+        assert check_install_allowed("https://github.com/foo/bar", grants) is not None
+
+    def test_missing_capability_field_ignored(self) -> None:
+        grants = [{GRANT_KEY_REPO_URL_PREFIX: "*"}]
+        assert check_install_allowed("https://github.com/foo/bar", grants) is not None
+
+    def test_non_string_prefix_ignored(self) -> None:
+        grants = [{GRANT_KEY_CAPABILITY: INSTALL_CAPABILITY, GRANT_KEY_REPO_URL_PREFIX: 123}]
+        # Single bad grant: not matched; deny.
+        assert check_install_allowed("https://github.com/foo/bar", grants) is not None
+
+    def test_first_matching_grant_wins(self) -> None:
+        grants = [
+            {GRANT_KEY_CAPABILITY: "noop", GRANT_KEY_REPO_URL_PREFIX: "*"},
+            {
+                GRANT_KEY_CAPABILITY: INSTALL_CAPABILITY,
+                GRANT_KEY_REPO_URL_PREFIX: "https://github.com/imbue-openhost/",
+            },
+        ]
+        assert check_install_allowed("https://github.com/imbue-openhost/openhost-catalog", grants) is None
+        assert check_install_allowed("https://github.com/other/", grants) is not None
+
+    def test_service_url_constant_is_stable(self) -> None:
+        # The catalog manifest pins this string; if it ever needs to
+        # change we should bump the service version too.
+        assert INSTALLER_SERVICE_URL == "github.com/imbue-openhost/openhost/services/installer"
+
+
+class TestInstallError:
+    def test_default_status_code(self) -> None:
+        err = InstallError("oops")
+        assert err.message == "oops"
+        assert err.status_code == 400
+
+    def test_custom_status_code(self) -> None:
+        err = InstallError("nope", status_code=401)
+        assert err.status_code == 401
+
+    def test_is_exception(self) -> None:
+        with pytest.raises(InstallError):
+            raise InstallError("boom")

--- a/compute_space/src/compute_space/tests/test_installer_route.py
+++ b/compute_space/src/compute_space/tests/test_installer_route.py
@@ -1,0 +1,292 @@
+"""Integration tests for the installer dispatch inside the v2 service proxy.
+
+Tests the request-routing surface: shortname dispatch, version specifier
+handling, permission check, endpoint dispatch (install / status / logs),
+and the ``{installed_by != caller}`` visibility scoping.  The actual
+install side-effect (clone + build + run) is patched out — that's
+exercised in the end-to-end harness, not here.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import sqlite3
+from pathlib import Path
+from unittest import mock
+
+import pytest
+from quart import Quart
+
+from compute_space.core.installer import INSTALLER_SERVICE_URL
+from compute_space.core.installer import InstallError
+from compute_space.core.installer import InstallResult
+from compute_space.core.permissions_v2 import grant_permission_v2
+from compute_space.db.connection import init_db
+from compute_space.web.routes.services_v2 import services_v2_bp
+
+from .conftest import _FakeApp
+from .conftest import _make_test_config
+
+CALLER_APP = "openhost-catalog"
+CALLER_TOKEN = "test-installer-caller-token"
+
+# Manifest the caller declares.  Crucially includes a
+# [[services.v2.consumes]] entry pointing at the installer service so
+# /api/services/v2/call/installer/... resolves.
+CALLER_MANIFEST = """
+[app]
+name = "openhost-catalog"
+version = "0.2.0"
+
+[runtime.container]
+image = "Dockerfile"
+port = 8080
+
+[[services.v2.consumes]]
+service = "github.com/imbue-openhost/openhost/services/installer"
+shortname = "installer"
+version = ">=0.1.0"
+grants = [{capability = "install", repo_url_prefix = "*"}]
+"""
+
+
+def _make_app(cfg) -> Quart:  # noqa: ANN001
+    app = Quart(__name__)
+    app.config["DB_PATH"] = cfg.db_path
+    app.openhost_config = cfg  # type: ignore[attr-defined]
+    app.register_blueprint(services_v2_bp)
+    return app
+
+
+def _seed_caller(
+    db_path: str,
+    app_name: str = CALLER_APP,
+    token: str = CALLER_TOKEN,
+    manifest_raw: str = CALLER_MANIFEST,
+) -> None:
+    """Insert the caller's apps row (with manifest_raw) + app_tokens row
+    so app_auth_required can resolve the bearer to the caller name AND
+    lookup_shortname can find the installer shortname declaration."""
+    db = sqlite3.connect(db_path)
+    try:
+        db.row_factory = sqlite3.Row
+        db.execute(
+            """INSERT INTO apps
+                 (name, version, repo_path, local_port, status, installed_by, manifest_raw)
+               VALUES (?, ?, ?, ?, ?, NULL, ?)""",
+            (app_name, "0.0.0", f"/tmp/{app_name}", 19500, "running", manifest_raw),
+        )
+        token_hash = hashlib.sha256(token.encode()).hexdigest()
+        db.execute(
+            "INSERT INTO app_tokens (app_name, token_hash) VALUES (?, ?)",
+            (app_name, token_hash),
+        )
+        db.commit()
+    finally:
+        db.close()
+
+
+def _grant_installer(db_path: str, app_name: str, repo_url_prefix: str = "*") -> None:
+    """Add a permissions_v2 row letting ``app_name`` use the installer service."""
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    try:
+        with mock.patch("compute_space.core.permissions_v2.get_db", return_value=conn):
+            grant_permission_v2(
+                app_name,
+                INSTALLER_SERVICE_URL,
+                {"capability": "install", "repo_url_prefix": repo_url_prefix},
+            )
+    finally:
+        conn.close()
+
+
+@pytest.fixture
+def cfg(tmp_path: Path):
+    return _make_test_config(tmp_path, port=20500)
+
+
+@pytest.fixture
+def app(cfg):
+    init_db(_FakeApp(cfg.db_path))
+    _seed_caller(cfg.db_path)
+    yield _make_app(cfg)
+
+
+def _url(endpoint: str) -> str:
+    """Build the v2 shortname-call URL for the installer."""
+    return "/api/services/v2/call/installer/" + endpoint.lstrip("/")
+
+
+def _headers(token: str = CALLER_TOKEN) -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}", "Content-Type": "application/json"}
+
+
+# --- /install --------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_install_without_grant_returns_permission_required(app, cfg):
+    client = app.test_client()
+    resp = await client.post(
+        _url("install"),
+        headers=_headers(),
+        data=json.dumps({"repo_url": "https://github.com/imbue-openhost/openhost-catalog"}),
+    )
+    assert resp.status_code == 403
+    body = await resp.get_json()
+    assert body["error"] == "permission_required"
+    assert body["required_grant"]["grant"]["capability"] == "install"
+
+
+@pytest.mark.asyncio
+async def test_install_with_non_matching_grant_denied(app, cfg):
+    _grant_installer(cfg.db_path, CALLER_APP, repo_url_prefix="https://github.com/imbue-openhost/")
+    client = app.test_client()
+    resp = await client.post(
+        _url("install"),
+        headers=_headers(),
+        data=json.dumps({"repo_url": "https://github.com/evil/badapp"}),
+    )
+    assert resp.status_code == 403
+    body = await resp.get_json()
+    assert body["error"] == "permission_required"
+
+
+@pytest.mark.asyncio
+async def test_install_with_matching_grant_succeeds(app, cfg):
+    _grant_installer(cfg.db_path, CALLER_APP, repo_url_prefix="*")
+
+    async def fake_install(repo_url, config, db, *, app_name=None, installed_by=None):
+        return InstallResult(app_name="newapp", status="building")
+
+    client = app.test_client()
+    with mock.patch("compute_space.web.routes.services_v2.install_from_repo_url", side_effect=fake_install):
+        resp = await client.post(
+            _url("install"),
+            headers=_headers(),
+            data=json.dumps({"repo_url": "https://github.com/anyone/anything"}),
+        )
+    assert resp.status_code == 200, await resp.get_data(as_text=True)
+    body = await resp.get_json()
+    assert body == {"ok": True, "app_name": "newapp", "status": "building"}
+
+
+@pytest.mark.asyncio
+async def test_install_propagates_install_error_status_code(app, cfg):
+    _grant_installer(cfg.db_path, CALLER_APP, repo_url_prefix="*")
+
+    async def fake_install(*args, **kwargs):
+        raise InstallError("manifest invalid", status_code=400)
+
+    client = app.test_client()
+    with mock.patch("compute_space.web.routes.services_v2.install_from_repo_url", side_effect=fake_install):
+        resp = await client.post(
+            _url("install"),
+            headers=_headers(),
+            data=json.dumps({"repo_url": "https://github.com/foo/bar"}),
+        )
+    assert resp.status_code == 400
+    body = await resp.get_json()
+    assert body["error"] == "install_failed"
+    assert "manifest invalid" in body["message"]
+
+
+@pytest.mark.asyncio
+async def test_install_rejects_missing_repo_url(app, cfg):
+    _grant_installer(cfg.db_path, CALLER_APP, repo_url_prefix="*")
+    client = app.test_client()
+    resp = await client.post(
+        _url("install"),
+        headers=_headers(),
+        data=json.dumps({"app_name": "no-url-supplied"}),
+    )
+    assert resp.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_install_rejects_non_json_body(app, cfg):
+    _grant_installer(cfg.db_path, CALLER_APP, repo_url_prefix="*")
+    client = app.test_client()
+    resp = await client.post(_url("install"), headers=_headers(), data="not-json")
+    assert resp.status_code == 400
+
+
+# --- /status/<name> --------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_status_returns_404_for_unknown_app(app, cfg):
+    _grant_installer(cfg.db_path, CALLER_APP)
+    client = app.test_client()
+    resp = await client.get(_url("status/nope"), headers=_headers())
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_status_returns_403_for_app_not_installed_by_caller(app, cfg):
+    _grant_installer(cfg.db_path, CALLER_APP)
+    db = sqlite3.connect(cfg.db_path)
+    try:
+        db.execute(
+            """INSERT INTO apps (name, version, repo_path, local_port, status, installed_by)
+               VALUES (?, ?, ?, ?, ?, NULL)""",
+            ("dashboard-installed-app", "1.0.0", "/tmp/dash", 19501, "running"),
+        )
+        db.commit()
+    finally:
+        db.close()
+    client = app.test_client()
+    resp = await client.get(_url("status/dashboard-installed-app"), headers=_headers())
+    assert resp.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_status_returns_app_state_for_caller_installs(app, cfg):
+    _grant_installer(cfg.db_path, CALLER_APP)
+    db = sqlite3.connect(cfg.db_path)
+    try:
+        db.execute(
+            """INSERT INTO apps (name, version, repo_path, local_port, status, installed_by, error_message)
+               VALUES (?, ?, ?, ?, ?, ?, ?)""",
+            ("catalog-installed-app", "1.0.0", "/tmp/c", 19502, "running", CALLER_APP, None),
+        )
+        db.commit()
+    finally:
+        db.close()
+    client = app.test_client()
+    resp = await client.get(_url("status/catalog-installed-app"), headers=_headers())
+    assert resp.status_code == 200
+    body = await resp.get_json()
+    assert body == {"status": "running", "error": None}
+
+
+# --- Shortname not declared ------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_unknown_shortname_returns_404(app, cfg):
+    """Calls to /api/services/v2/call/<other>/... 404 because the caller's
+    manifest only declares the installer shortname."""
+    _grant_installer(cfg.db_path, CALLER_APP, repo_url_prefix="*")
+    client = app.test_client()
+    resp = await client.post(
+        "/api/services/v2/call/not-installed/anything",
+        headers=_headers(),
+        data=json.dumps({}),
+    )
+    assert resp.status_code == 404
+    body = await resp.get_json()
+    assert body["error"] == "shortname_not_declared"
+
+
+# --- Unknown installer sub-endpoint ----------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_unknown_installer_subpath_returns_404(app, cfg):
+    _grant_installer(cfg.db_path, CALLER_APP)
+    client = app.test_client()
+    resp = await client.post(_url("wat"), headers=_headers(), data=json.dumps({}))
+    assert resp.status_code == 404

--- a/compute_space/src/compute_space/web/routes/services_v2.py
+++ b/compute_space/src/compute_space/web/routes/services_v2.py
@@ -2,8 +2,13 @@
 provider-side permission validation."""
 
 import json
+import sqlite3
+from typing import Any
 
 import attr
+from packaging.specifiers import InvalidSpecifier
+from packaging.specifiers import SpecifierSet
+from packaging.version import Version
 from quart import Blueprint
 from quart import Response
 from quart import request
@@ -12,6 +17,12 @@ from quart import websocket
 
 from compute_space.config import get_config
 from compute_space.core.auth import resolve_app_from_token
+from compute_space.core.containers import get_docker_logs
+from compute_space.core.installer import INSTALLER_SERVICE_URL
+from compute_space.core.installer import INSTALLER_SERVICE_VERSION
+from compute_space.core.installer import InstallError
+from compute_space.core.installer import check_install_allowed
+from compute_space.core.installer import install_from_repo_url
 from compute_space.core.permissions_v2 import get_granted_permissions_v2
 from compute_space.core.services import ServiceNotAvailable
 from compute_space.core.services_v2 import ShortnameNotDeclared
@@ -179,6 +190,11 @@ async def service_call(shortname: str, rest: str, app_name: str) -> Response:
     except ShortnameNotDeclared as e:
         return _json_error("shortname_not_declared", e.message, 404)
 
+    # Installer is a router-internal pseudo-service: it has no provider
+    # app and its handlers run in-process to share the router's DB.
+    if service_url == INSTALLER_SERVICE_URL:
+        return await _handle_installer_request(consumer_app, version_spec, rest, db)
+
     try:
         _, provider_port, _, provider_endpoint = resolve_provider(service_url, version_spec, db)
     except ServiceNotAvailable as e:
@@ -241,3 +257,135 @@ async def service_call_ws(shortname: str, rest: str) -> None:
         },
         override_path=target_path,
     )
+
+
+# ─── Installer (router-internal v2 service) ───
+#
+# The installer has no provider app — its handlers run in-process so they
+# can share the router's DB and apps.* state.  Apps that consume it
+# declare:
+#
+#     [[services.v2.consumes]]
+#     service   = "github.com/imbue-openhost/openhost/services/installer"
+#     shortname = "installer"
+#     version   = ">=0.1.0"
+#     grants    = [{capability = "install", repo_url_prefix = "https://..."}]
+#
+# and call /api/services/v2/call/installer/{install,status/<name>,logs/<name>}.
+
+
+async def _handle_installer_request(
+    consumer_app: str, version_spec: str, rest: str, db: sqlite3.Connection
+) -> Response:
+    """Dispatch ``installer`` v2 service requests in-process.
+
+    Routes:
+        POST /install                — body: {repo_url, app_name?}
+        GET  /status/<app_name>      — only for apps this consumer installed
+        GET  /logs/<app_name>        — only for apps this consumer installed
+    """
+    try:
+        spec = SpecifierSet(version_spec)
+    except InvalidSpecifier:
+        return _json_error("bad_request", f"Invalid version specifier: {version_spec}", 400)
+    if Version(INSTALLER_SERVICE_VERSION) not in spec:
+        return _json_error(
+            "service_not_available",
+            f"installer version {INSTALLER_SERVICE_VERSION} does not match {version_spec}",
+            503,
+        )
+
+    parts = rest.strip("/").split("/")
+
+    # POST /install
+    if request.method == "POST" and parts == ["install"]:
+        body = await _read_json_body()
+        if not isinstance(body, dict):
+            return _json_error("bad_request", "request body must be JSON object", 400)
+        repo_url = (body.get("repo_url") or "").strip()
+        if not repo_url:
+            return _json_error("bad_request", "repo_url is required", 400)
+        app_name = (body.get("app_name") or "").strip() or None
+
+        grants = [g.grant for g in get_granted_permissions_v2(consumer_app, INSTALLER_SERVICE_URL)]
+        if (reason := check_install_allowed(repo_url, grants)) is not None:
+            return _installer_permission_denied(consumer_app, repo_url, reason)
+
+        try:
+            result = await install_from_repo_url(
+                repo_url, get_config(), db, app_name=app_name, installed_by=consumer_app
+            )
+        except InstallError as exc:
+            return _json_error("install_failed", exc.message, exc.status_code)
+        return _json_ok({"ok": True, "app_name": result.app_name, "status": result.status})
+
+    # GET /status/<app_name> and GET /logs/<app_name>
+    if request.method == "GET" and len(parts) == 2 and parts[0] in ("status", "logs"):
+        sub, app_name = parts
+        row, denied = _lookup_consumer_install(consumer_app, app_name, db)
+        if denied is not None:
+            return denied
+        assert row is not None
+        if sub == "status":
+            return _json_ok({"status": row["status"], "error": row["error_message"]})
+        logs = get_docker_logs(app_name, get_config().temporary_data_dir, row["container_id"])
+        return Response(logs, status=200, content_type="text/plain; charset=utf-8")
+
+    return _json_error("bad_request", f"Unknown installer endpoint: {request.method} /{rest}", 404)
+
+
+async def _read_json_body() -> Any:
+    try:
+        return await request.get_json()
+    except Exception:
+        return None
+
+
+def _lookup_consumer_install(
+    consumer_app: str, app_name: str, db: sqlite3.Connection
+) -> tuple[sqlite3.Row | None, Response | None]:
+    """Fetch the apps row only if ``consumer_app`` installed it.
+
+    Returns ``(row, None)`` on success or ``(None, error_response)`` on
+    not_found / forbidden.  The row carries every column callers need so
+    /status and /logs can share the lookup.
+    """
+    row = db.execute(
+        "SELECT status, error_message, container_id, installed_by FROM apps WHERE name = ?",
+        (app_name,),
+    ).fetchone()
+    if not row:
+        return None, _json_error("not_found", f"app {app_name!r} not found", 404)
+    if row["installed_by"] != consumer_app:
+        return None, _json_error("forbidden", f"{consumer_app} did not install {app_name!r}", 403)
+    return row, None
+
+
+def _json_ok(body: dict[str, Any]) -> Response:
+    return Response(json.dumps(body), status=200, content_type="application/json")
+
+
+def _installer_permission_denied(consumer_app: str, repo_url: str, reason: str) -> Response:
+    """Return the v2 standard permission_required shape with a grant URL.
+
+    Body matches the post-PR67 ``required_grant`` field name (``grant``
+    rather than ``grant_payload``).
+    """
+    grant = {"capability": "install", "repo_url_prefix": repo_url}
+    try:
+        approve_path = url_for(
+            "pages_permissions_v2.approve_permissions_v2",
+            app=consumer_app,
+            service=INSTALLER_SERVICE_URL,
+            grant=json.dumps(grant, sort_keys=True),
+        )
+        grant_url = f"https://{get_config().zone_domain}{approve_path}"
+    except Exception:
+        # In tests where the permissions blueprint isn't registered.
+        grant_url = ""
+    body = {
+        "error": "permission_required",
+        "message": reason,
+        "required_grant": {"grant": grant, "scope": "global", "grant_url": grant_url},
+    }
+    return Response(json.dumps(body), status=403, content_type="application/json")


### PR DESCRIPTION
Introduces a router-internal v2 service so a calling app (notably the catalog) can install other apps without holding an owner-level API token. Replaces the legacy APP_REPO_ROUTER_TOKEN pattern, which gave the caller full owner privileges, with a scoped permissions_v2 grant.

Service URL: github.com/imbue-openhost/openhost/services/installer
Endpoints: POST /install, GET /status/<name>, GET /logs/<name>

The proxy dispatches in-process; there is no provider app to install first. Auth uses the existing app_auth_required bearer check (each app's OPENHOST_APP_TOKEN). Grants are prefix-matched against the requested repo_url; empty or "*" prefix allows anything; missing grants return the standard {error: permission_required, required_grant: ...} 403 so the existing owner-approval UI handles it.

New apps.installed_by column (v6 migration) scopes /status and /logs to the caller's own installs. Written as part of the same INSERT in insert_and_deploy to avoid races with the background build thread.

Test plan

25 new tests in test_installer.py (grant matching) and test_installer_route.py (full route dispatch via Quart test_client, with installs mocked). Existing test suite still passes; snapshot files regenerated for v6.

PR ordering

1. This PR (installer v2 service)
2. andrew/default-apps-remote-urls (lets default_apps accept remote URLs)
3. andrew/migrate-to-installer-service (in openhost-catalog) - catalog uses the new service
4. andrew/auto-install-catalog (add catalog to default default_apps)