### PR TITLE
default_apps: allow remote git URL entries

### DIFF
--- a/compute_space/src/compute_space/config.py
+++ b/compute_space/src/compute_space/config.py
@@ -43,8 +43,13 @@ class Config:
     port_range_start: int
     port_range_end: int
 
-    # Builtin app directory names to deploy at /setup completion (set
-    # to [] to opt out).  Keyed on dirname under apps_dir.
+    # Apps to deploy at /setup completion (set to [] to opt out).
+    # Each entry is either:
+    #   - a bare dirname under apps_dir (vendored builtin, e.g. "secrets_v2"), or
+    #   - a remote git URL the router will clone on first boot
+    #     (e.g. "https://github.com/imbue-openhost/openhost-catalog").
+    # Remote URLs are dispatched through the same clone path as
+    # /api/add_app and do not need to be present on disk ahead of time.
     default_apps: list[str]
 
     def evolve(self, **kwargs: Any) -> Self:

--- a/compute_space/src/compute_space/core/default_apps.py
+++ b/compute_space/src/compute_space/core/default_apps.py
@@ -35,6 +35,15 @@ from compute_space.core.manifest import parse_manifest
 
 MAX_RETRY_ATTEMPTS = 3
 
+# Hard upper bound on a single remote clone attempt before
+# ``_run_clone_in_thread`` gives up and returns a failure.  ``clone_and_read_manifest``
+# already imposes a 120s timeout on the ``git clone`` subprocess; this is a
+# defence-in-depth ceiling on the whole worker (DNS, manifest parse,
+# token-strip subcommand, etc.) so a stuck clone cannot freeze the ``/setup``
+# request indefinitely.  Failures here are retried by ``deploy_default_apps``
+# up to ``MAX_RETRY_ATTEMPTS``.
+REMOTE_CLONE_TIMEOUT_SECONDS = 180
+
 
 @attr.s(auto_attribs=True, frozen=True)
 class DefaultAppOutcome:
@@ -95,17 +104,33 @@ def _install_vendored(dir_name: str, config: Config, db: sqlite3.Connection) -> 
     return _finalize_install(manifest, clone_dir, tmp_parent, config, db, repo_url=f"file://{app_dir}")
 
 
-def _run_clone_in_thread(repo_url: str) -> tuple[AppManifest | None, str | None, str | None]:
+def _run_clone_in_thread(
+    repo_url: str, timeout_seconds: float | None = None
+) -> tuple[AppManifest | None, str | None, str | None]:
     """Run ``clone_and_read_manifest`` from a sync context.
 
     Cannot use ``asyncio.run`` directly because this module is called
     from an already-running event loop (the ``/setup`` Quart handler).
     A fresh thread with its own event loop sidesteps that.
+
+    Bounded by ``timeout_seconds`` (defaults to
+    ``REMOTE_CLONE_TIMEOUT_SECONDS``, resolved at call time so tests can
+    monkeypatch the module constant) so a hung clone (DNS stall,
+    unresponsive git remote past its own subprocess timeout, etc.) cannot
+    block the caller indefinitely.  On timeout the worker thread is left
+    running as a daemon — it will exit when the underlying ``git clone``
+    subprocess eventually returns — and the caller sees a ``RuntimeError``.
     """
+    if timeout_seconds is None:
+        timeout_seconds = REMOTE_CLONE_TIMEOUT_SECONDS
     result: dict[str, Any] = {}
 
     def _worker() -> None:
-        loop = asyncio.new_event_loop()
+        try:
+            loop = asyncio.new_event_loop()
+        except Exception as exc:  # noqa: BLE001 — surfaced via result["error"]
+            result["error"] = exc
+            return
         try:
             result["value"] = loop.run_until_complete(clone_and_read_manifest(repo_url))
         except Exception as exc:  # noqa: BLE001 — surfaced via result["error"]
@@ -115,7 +140,9 @@ def _run_clone_in_thread(repo_url: str) -> tuple[AppManifest | None, str | None,
 
     t = threading.Thread(target=_worker, daemon=True)
     t.start()
-    t.join()
+    t.join(timeout=timeout_seconds)
+    if t.is_alive():
+        raise RuntimeError(f"clone exceeded {timeout_seconds}s timeout")
     if "error" in result:
         raise result["error"]
     return result["value"]  # type: ignore[no-any-return]

--- a/compute_space/src/compute_space/core/default_apps.py
+++ b/compute_space/src/compute_space/core/default_apps.py
@@ -1,21 +1,36 @@
-"""Auto-deploy ``config.default_apps`` builtin apps at /setup completion."""
+"""Auto-deploy ``config.default_apps`` apps at /setup completion.
+
+Each entry in ``config.default_apps`` is either:
+
+- A bare dirname under ``config.apps_dir`` (vendored builtin, e.g.
+  ``"secrets_v2"``) — copied from disk, same as the original
+  default-apps behavior.
+- A remote git URL (e.g.
+  ``"https://github.com/imbue-openhost/openhost-catalog"``) — cloned
+  on demand via the same path used by ``/api/add_app``.  The repo
+  does not need to be present on disk ahead of time.
+"""
 
 from __future__ import annotations
 
+import asyncio
 import json
 import os
 import shutil
 import sqlite3
 import tempfile
+import threading
 from typing import Any
 
 import attr
 
 from compute_space.config import Config
+from compute_space.core.apps import clone_and_read_manifest
 from compute_space.core.apps import insert_and_deploy
 from compute_space.core.apps import move_clone_to_app_temp_dir
 from compute_space.core.apps import validate_manifest
 from compute_space.core.logging import logger
+from compute_space.core.manifest import AppManifest
 from compute_space.core.manifest import parse_manifest
 
 MAX_RETRY_ATTEMPTS = 3
@@ -27,6 +42,14 @@ class DefaultAppOutcome:
     status: str  # "ok" | "skipped" | "failed"
     attempts: int
     error: str | None = None
+
+
+def _is_remote_url(spec: str) -> bool:
+    """A default_apps entry is a remote URL (vs a bare dirname) if it
+    contains a scheme separator.  ``file://`` is treated as remote-style
+    (handled by the clone path) so operators can use it interchangeably.
+    """
+    return "://" in spec
 
 
 def _load_sentinel(path: str) -> dict[str, dict[str, Any]]:
@@ -54,8 +77,8 @@ def _write_sentinel(path: str, state: dict[str, dict[str, Any]]) -> None:
         logger.warning("Could not write default_apps sentinel %s: %s", path, exc)
 
 
-def _install_one(dir_name: str, config: Config, db: sqlite3.Connection) -> tuple[str, str | None]:
-    """Returns (status, error).  status in {"ok", "skipped", "failed"}."""
+def _install_vendored(dir_name: str, config: Config, db: sqlite3.Connection) -> tuple[str, str | None]:
+    """Install a vendored builtin app by its dirname under ``config.apps_dir``."""
     app_dir = os.path.join(config.apps_dir, dir_name)
     if not os.path.isdir(app_dir) or not os.path.isfile(os.path.join(app_dir, "openhost.toml")):
         return "failed", f"builtin app dir or openhost.toml missing: {app_dir}"
@@ -69,6 +92,69 @@ def _install_one(dir_name: str, config: Config, db: sqlite3.Connection) -> tuple
         shutil.rmtree(tmp_parent, ignore_errors=True)
         return "failed", f"clone/parse: {exc}"
 
+    return _finalize_install(manifest, clone_dir, tmp_parent, config, db, repo_url=f"file://{app_dir}")
+
+
+def _run_clone_in_thread(repo_url: str) -> tuple[AppManifest | None, str | None, str | None]:
+    """Run ``clone_and_read_manifest`` from a sync context.
+
+    Cannot use ``asyncio.run`` directly because this module is called
+    from an already-running event loop (the ``/setup`` Quart handler).
+    A fresh thread with its own event loop sidesteps that.
+    """
+    result: dict[str, Any] = {}
+
+    def _worker() -> None:
+        loop = asyncio.new_event_loop()
+        try:
+            result["value"] = loop.run_until_complete(clone_and_read_manifest(repo_url))
+        except Exception as exc:  # noqa: BLE001 — surfaced via result["error"]
+            result["error"] = exc
+        finally:
+            loop.close()
+
+    t = threading.Thread(target=_worker, daemon=True)
+    t.start()
+    t.join()
+    if "error" in result:
+        raise result["error"]
+    return result["value"]  # type: ignore[no-any-return]
+
+
+def _install_remote(repo_url: str, config: Config, db: sqlite3.Connection) -> tuple[str, str | None]:
+    """Install an app from a remote git URL by cloning it on demand.
+
+    Uses the unauthenticated clone path on purpose: this code runs at
+    /setup completion (and on every boot to retry pending installs), so
+    the Secrets app may not be installed yet and there is no browser
+    session to start a GitHub OAuth flow against.  Default apps are
+    expected to be public repos.  Operators who need private-repo
+    builtins should install them via the dashboard's /add_app flow
+    after first boot.
+    """
+    try:
+        manifest, clone_dir, error = _run_clone_in_thread(repo_url)
+    except Exception as exc:
+        return "failed", f"clone: {exc}"
+
+    if error or manifest is None or clone_dir is None:
+        return "failed", f"clone: {error or 'unknown error'}"
+
+    tmp_parent = os.path.dirname(clone_dir)
+    return _finalize_install(manifest, clone_dir, tmp_parent, config, db, repo_url=repo_url)
+
+
+def _finalize_install(
+    manifest: AppManifest,
+    clone_dir: str,
+    tmp_parent: str,
+    config: Config,
+    db: sqlite3.Connection,
+    *,
+    repo_url: str,
+) -> tuple[str, str | None]:
+    """Common tail after either a copytree or a remote clone has produced
+    a parsed manifest in ``clone_dir``."""
     if db.execute("SELECT 1 FROM apps WHERE name = ?", (manifest.name,)).fetchone():
         shutil.rmtree(tmp_parent, ignore_errors=True)
         return "skipped", None
@@ -87,11 +173,18 @@ def _install_one(dir_name: str, config: Config, db: sqlite3.Connection) -> tuple
             db,
             grant_permissions=set(),
             grant_permissions_v2=True,
-            repo_url=f"file://{app_dir}",
+            repo_url=repo_url,
         )
     except Exception as exc:
         return "failed", f"insert_and_deploy: {exc}"
     return "ok", None
+
+
+def _install_one(spec: str, config: Config, db: sqlite3.Connection) -> tuple[str, str | None]:
+    """Returns (status, error).  status in {"ok", "skipped", "failed"}."""
+    if _is_remote_url(spec):
+        return _install_remote(spec, config, db)
+    return _install_vendored(spec, config, db)
 
 
 def deploy_default_apps(config: Config, db: sqlite3.Connection) -> list[DefaultAppOutcome]:
@@ -103,8 +196,8 @@ def deploy_default_apps(config: Config, db: sqlite3.Connection) -> list[DefaultA
     sentinel = _load_sentinel(config.default_apps_sentinel_path)
     outcomes: list[DefaultAppOutcome] = []
 
-    for dir_name in config.default_apps:
-        prior = sentinel.get(dir_name) or {}
+    for spec in config.default_apps:
+        prior = sentinel.get(spec) or {}
         prior_status = prior.get("status")
         try:
             prior_attempts = int(prior.get("attempts", 0))
@@ -112,20 +205,20 @@ def deploy_default_apps(config: Config, db: sqlite3.Connection) -> list[DefaultA
             prior_attempts = 0
 
         if prior_status in ("ok", "skipped"):
-            outcomes.append(DefaultAppOutcome(dir_name, prior_status, prior_attempts))
+            outcomes.append(DefaultAppOutcome(spec, prior_status, prior_attempts))
             continue
         if prior_status == "failed" and prior_attempts >= MAX_RETRY_ATTEMPTS:
-            outcomes.append(DefaultAppOutcome(dir_name, "failed", prior_attempts, prior.get("error")))
+            outcomes.append(DefaultAppOutcome(spec, "failed", prior_attempts, prior.get("error")))
             continue
 
         try:
-            status, error = _install_one(dir_name, config, db)
+            status, error = _install_one(spec, config, db)
         except Exception as exc:
             status, error = "failed", f"unexpected: {exc}"
 
         attempts = prior_attempts + 1 if status == "failed" else 1
-        outcomes.append(DefaultAppOutcome(dir_name, status, attempts, error))
-        sentinel[dir_name] = {"status": status, "attempts": attempts, "error": error}
+        outcomes.append(DefaultAppOutcome(spec, status, attempts, error))
+        sentinel[spec] = {"status": status, "attempts": attempts, "error": error}
 
     _write_sentinel(config.default_apps_sentinel_path, sentinel)
 

--- a/compute_space/src/compute_space/tests/test_default_apps.py
+++ b/compute_space/src/compute_space/tests/test_default_apps.py
@@ -311,3 +311,29 @@ def test_mixed_local_and_remote_entries(cfg_with_apps, monkeypatch):
         "secrets_v2": "ok",
         "https://github.com/example/from-remote": "ok",
     }
+
+
+def test_remote_clone_timeout_returns_failed(cfg_with_apps, monkeypatch):
+    """A hung clone must not block /setup indefinitely; the worker thread
+    times out and the entry is recorded as failed (and retried on next boot)."""
+    _patch_insert_and_deploy(monkeypatch)
+
+    async def hang_forever(repo_url, github_token=None):  # noqa: ANN001
+        await asyncio.sleep(60)  # Far longer than the patched timeout.
+        return None, None, None  # never reached
+
+    monkeypatch.setattr(da, "clone_and_read_manifest", hang_forever)
+    # Shrink the timeout so the test doesn't take 3 minutes.
+    monkeypatch.setattr(da, "REMOTE_CLONE_TIMEOUT_SECONDS", 0.2)
+
+    cfg = cfg_with_apps.evolve(default_apps=["https://github.com/foo/bar"])
+
+    db = sqlite3.connect(cfg.db_path)
+    try:
+        result = da.deploy_default_apps(cfg, db)
+    finally:
+        db.close()
+
+    assert len(result) == 1
+    assert result[0].status == "failed"
+    assert "timeout" in (result[0].error or "").lower()

--- a/compute_space/src/compute_space/tests/test_default_apps.py
+++ b/compute_space/src/compute_space/tests/test_default_apps.py
@@ -2,15 +2,19 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 import os
+import shutil
 import sqlite3
+import tempfile
 from pathlib import Path
 
 import pytest
 
 from compute_space.config import DefaultConfig
 from compute_space.core import default_apps as da
+from compute_space.core.manifest import parse_manifest
 from compute_space.db.migrations import _schema_path
 
 
@@ -161,3 +165,149 @@ def test_empty_default_apps_is_no_op(tmp_path: Path):
 
     assert result == []
     assert not os.path.isfile(cfg.default_apps_sentinel_path)
+
+
+# --- Remote URL support ---
+
+
+def test_is_remote_url_classification():
+    assert da._is_remote_url("https://github.com/foo/bar") is True
+    assert da._is_remote_url("http://example.com/repo") is True
+    assert da._is_remote_url("file:///tmp/foo") is True
+    assert da._is_remote_url("git+ssh://git@host/repo.git") is True
+    # Bare dirnames are NOT remote URLs.
+    assert da._is_remote_url("secrets_v2") is False
+    assert da._is_remote_url("file_browser") is False
+    assert da._is_remote_url("openhost-catalog") is False
+
+
+def test_remote_url_entry_dispatches_to_clone_path(cfg_with_apps, monkeypatch):
+    """A URL-form default_apps entry routes through clone_and_read_manifest,
+    not the local copytree path.  We patch the clone function to keep the
+    test hermetic."""
+    _patch_insert_and_deploy(monkeypatch)
+
+    # Make a fake "cloned" tree at a fresh tempdir so move_clone_to_app_temp_dir
+    # has something to operate on.
+    src_app_dir = Path(cfg_with_apps.apps_dir) / "secrets_v2"
+    fake_clone_parent = tempfile.mkdtemp(prefix="openhost-clone-")
+    fake_clone_dir = os.path.join(fake_clone_parent, "repo")
+    shutil.copytree(src_app_dir, fake_clone_dir)
+    fake_manifest = parse_manifest(fake_clone_dir)
+
+    calls: list[str] = []
+
+    async def fake_clone(repo_url, github_token=None):  # noqa: ANN001
+        calls.append(repo_url)
+        return fake_manifest, fake_clone_dir, None
+
+    monkeypatch.setattr(da, "clone_and_read_manifest", fake_clone)
+
+    # Replace the config's default_apps with a single remote URL entry.
+    cfg = cfg_with_apps.evolve(default_apps=["https://github.com/imbue-openhost/openhost-catalog"])
+
+    db = sqlite3.connect(cfg.db_path)
+    try:
+        result = da.deploy_default_apps(cfg, db)
+    finally:
+        db.close()
+
+    assert calls == ["https://github.com/imbue-openhost/openhost-catalog"]
+    assert len(result) == 1
+    assert result[0].status == "ok"
+    assert result[0].name == "https://github.com/imbue-openhost/openhost-catalog"
+
+    # The sentinel keys on the spec string (the URL), not the manifest name.
+    with open(cfg.default_apps_sentinel_path) as f:
+        sentinel = json.load(f)
+    assert "https://github.com/imbue-openhost/openhost-catalog" in sentinel
+
+
+def test_remote_url_clone_failure_is_retried(cfg_with_apps, monkeypatch):
+    """Clone failures get the same retry-budget treatment as local failures."""
+    _patch_insert_and_deploy(monkeypatch)
+
+    async def always_fail(repo_url, github_token=None):  # noqa: ANN001
+        return None, None, "fake network error"
+
+    monkeypatch.setattr(da, "clone_and_read_manifest", always_fail)
+
+    cfg = cfg_with_apps.evolve(default_apps=["https://github.com/foo/bar"])
+
+    for i in range(da.MAX_RETRY_ATTEMPTS):
+        db = sqlite3.connect(cfg.db_path)
+        try:
+            result = da.deploy_default_apps(cfg, db)
+        finally:
+            db.close()
+        assert len(result) == 1
+        assert result[0].status == "failed"
+        assert result[0].attempts == i + 1
+        assert "fake network error" in (result[0].error or "")
+
+
+def test_remote_install_works_from_running_event_loop(cfg_with_apps, monkeypatch):
+    """deploy_default_apps is called from /setup (an async Quart handler).
+    Plain asyncio.run() would raise; the in-module thread wrapper must
+    isolate the clone's event loop from the caller's."""
+    _patch_insert_and_deploy(monkeypatch)
+
+    src_app_dir = Path(cfg_with_apps.apps_dir) / "secrets_v2"
+    fake_clone_parent = tempfile.mkdtemp(prefix="openhost-clone-")
+    fake_clone_dir = os.path.join(fake_clone_parent, "repo")
+    shutil.copytree(src_app_dir, fake_clone_dir)
+    fake_manifest = parse_manifest(fake_clone_dir)
+
+    async def fake_clone(repo_url, github_token=None):  # noqa: ANN001
+        return fake_manifest, fake_clone_dir, None
+
+    monkeypatch.setattr(da, "clone_and_read_manifest", fake_clone)
+
+    cfg = cfg_with_apps.evolve(default_apps=["https://github.com/foo/bar"])
+
+    async def runner():
+        db = sqlite3.connect(cfg.db_path)
+        try:
+            return da.deploy_default_apps(cfg, db)
+        finally:
+            db.close()
+
+    result = asyncio.run(runner())
+    assert len(result) == 1
+    assert result[0].status == "ok", result[0].error
+
+
+def test_mixed_local_and_remote_entries(cfg_with_apps, monkeypatch):
+    """A single deploy can contain both vendored and remote entries."""
+    _patch_insert_and_deploy(monkeypatch)
+
+    src_app_dir = Path(cfg_with_apps.apps_dir) / "file_browser"
+    fake_clone_parent = tempfile.mkdtemp(prefix="openhost-clone-")
+    fake_clone_dir = os.path.join(fake_clone_parent, "repo")
+    shutil.copytree(src_app_dir, fake_clone_dir)
+    # Rename the manifest so it doesn't collide with the vendored file_browser
+    (Path(fake_clone_dir) / "openhost.toml").write_text(
+        '[app]\nname = "from-remote"\nversion = "0.1"\n[runtime.container]\nimage = "Dockerfile"\nport = 8080\n'
+    )
+    fake_manifest = parse_manifest(fake_clone_dir)
+
+    async def fake_clone(repo_url, github_token=None):  # noqa: ANN001
+        return fake_manifest, fake_clone_dir, None
+
+    monkeypatch.setattr(da, "clone_and_read_manifest", fake_clone)
+
+    cfg = cfg_with_apps.evolve(
+        default_apps=["secrets_v2", "https://github.com/example/from-remote"],
+    )
+
+    db = sqlite3.connect(cfg.db_path)
+    try:
+        result = da.deploy_default_apps(cfg, db)
+    finally:
+        db.close()
+
+    by_name = {o.name: o.status for o in result}
+    assert by_name == {
+        "secrets_v2": "ok",
+        "https://github.com/example/from-remote": "ok",
+    }


### PR DESCRIPTION
Until now config.default_apps was a list of bare dirnames under apps_dir — only vendored builtins could be auto-deployed at /setup. This change lets entries be either a dirname (existing behaviour, unchanged) or a remote git URL. Remote URLs are cloned on demand using the same path /api/add_app uses, so the repo does not need to be vendored or pre-cloned on disk.

URL detection is the presence of "://" in the entry. The sentinel key remains the spec string verbatim. Clone failures get the same MAX_RETRY_ATTEMPTS retry budget as local failures.

Uses an in-module thread wrapper around clone_and_read_manifest because deploy_default_apps is invoked from the /setup async Quart handler — plain asyncio.run() would refuse to start a new loop from inside the request's running loop.

Remote installs intentionally skip the GitHub OAuth fallback path (clone_with_github_fallback): the Secrets app may not be installed at first boot, and there is no browser session to start a device flow against. Default apps are expected to be public; private builtins can be installed via the normal dashboard /add_app flow afterwards.

Test plan

9 default_apps tests total (5 existing all still pass; 4 new). New tests cover URL classification, the clone-path dispatch, clone-failure retries, running-event-loop safety, and mixed local+remote entries.

PR ordering

1. andrew/installer-service-v2 (#68 — installer v2 service)
2. **This PR** — let default_apps accept remote URLs
3. andrew/migrate-to-installer-service (in openhost-catalog) — catalog uses the new service
4. andrew/auto-install-catalog — add catalog to default default_apps

This PR is independent of #68 and can land in either order.