### PR TITLE
Fix flaky TestResolvePortMappings tests (port-collision on CI runners)

### DIFF
--- a/compute_space/src/compute_space/tests/test_ports.py
+++ b/compute_space/src/compute_space/tests/test_ports.py
@@ -1,6 +1,8 @@
 """Unit tests for port allocation and availability checking."""
 
 import sqlite3
+from collections.abc import Iterator
+from unittest import mock
 
 import pytest
 
@@ -83,7 +85,30 @@ class TestCheckPortAvailable:
         assert available is False
 
 
+@pytest.fixture
+def _always_bindable() -> Iterator[None]:
+    """Pretend every port is OS-bindable so resolve_port_mappings tests
+    don't depend on what's actually bound on the CI runner.
+
+    Without this mock, resolve_port_mappings tests that hardcode
+    high ports (e.g., 59200) can fail intermittently on shared
+    CI runners where some unrelated process — kernel-allocated
+    ephemeral source ports, runner-installed services, etc. —
+    happens to occupy the chosen number.  The tests want to
+    exercise resolve_port_mappings' DB-bookkeeping logic, not
+    its OS-side bindability check, so mocking _port_is_bindable
+    out is the right scope of fix.
+    """
+    with mock.patch("compute_space.core.ports._port_is_bindable", return_value=True):
+        yield
+
+
 class TestResolvePortMappings:
+    @pytest.fixture(autouse=True)
+    def _bindable(self, _always_bindable: None) -> None:
+        """Apply the bindable-port mock to every test in this class."""
+        return None
+
     def test_fixed_ports_pass_through(self, db):
         mappings = [PortMapping(label="web", container_port=80, host_port=59200)]
         resolved = resolve_port_mappings(mappings, db, 59200, 59300)


### PR DESCRIPTION
TestResolvePortMappings tests in compute_space/src/compute_space/tests/test_ports.py use hardcoded high ports (e.g. 59200) in their fixed-port assertions, then call resolve_port_mappings() which in turn calls check_port_available() which performs a real socket bind to verify OS-side availability. On shared CI runners (and locally when an unrelated process happens to occupy the chosen number), this leads to spurious failures with errors like 'Port 59200 ... is already in use by host-level service'.

This was observed in PR #71 where the test-containers job failed three port tests:
- test_fixed_ports_pass_through
- test_duplicate_port_in_batch_raises
- test_mixed_fixed_and_auto

All three failures had the same root cause and the tests passed locally and on prior main-branch CI runs — pure runner-state flake.

Fix: add an autouse class-scoped fixture to TestResolvePortMappings that mocks _port_is_bindable to True. The tests are exercising the DB-bookkeeping and batch-validation logic of resolve_port_mappings, not the OS bindability check, so mocking that single function out at the right scope removes the runner-state dependency without weakening any of the assertions. The other test class (TestCheckPortAvailable) keeps the real behaviour because its tests are about port-state semantics.

Verified locally by manually binding port 59200 in a background process and running the tests — all 5 TestResolvePortMappings tests still pass with the mock, where without the mock they would all fail with 'already in use'.

Vet checked: clean across 3 parallel LLM runs.