### PR TITLE
installer: propose manifest-declared grant on 403 instead of per-URL

### DIFF
--- a/compute_space/src/compute_space/tests/test_installer_route.py
+++ b/compute_space/src/compute_space/tests/test_installer_route.py
@@ -138,6 +138,10 @@ async def test_install_without_grant_returns_permission_required(app, cfg):
     body = await resp.get_json()
     assert body["error"] == "permission_required"
     assert body["required_grant"]["grant"]["capability"] == "install"
+    # The proposed grant must come from the consumer's manifest-declared
+    # prefix ("*" in CALLER_MANIFEST), not the verbatim requested URL —
+    # otherwise the owner gets a fresh approval prompt per repo.
+    assert body["required_grant"]["grant"]["repo_url_prefix"] == "*"
 
 
 @pytest.mark.asyncio
@@ -152,6 +156,85 @@ async def test_install_with_non_matching_grant_denied(app, cfg):
     assert resp.status_code == 403
     body = await resp.get_json()
     assert body["error"] == "permission_required"
+
+
+# Caller whose manifest declares the GitHub-org prefix the catalog actually ships
+# with.  Used by test_proposed_grant_uses_manifest_declared_prefix to exercise
+# the org-scoped (rather than wildcard) path.
+NARROW_CALLER_APP = "narrow-catalog"
+NARROW_CALLER_TOKEN = "narrow-test-token"
+NARROW_CALLER_MANIFEST = """
+[app]
+name = "narrow-catalog"
+version = "0.2.0"
+
+[runtime.container]
+image = "Dockerfile"
+port = 8080
+
+[[services.v2.consumes]]
+service = "github.com/imbue-openhost/openhost/services/installer"
+shortname = "installer"
+version = ">=0.1.0"
+grants = [{capability = "install", repo_url_prefix = "https://github.com/imbue-openhost/"}]
+"""
+
+
+@pytest.mark.asyncio
+async def test_proposed_grant_uses_manifest_declared_prefix(cfg):
+    """When the consumer's manifest declares a broad prefix, a denial for an
+    URL that matches that prefix must propose the broad grant — not a fresh
+    per-URL grant — so a single approval covers every install."""
+    from compute_space.db.connection import init_db
+
+    init_db(_FakeApp(cfg.db_path))
+    _seed_caller(
+        cfg.db_path,
+        app_name=NARROW_CALLER_APP,
+        token=NARROW_CALLER_TOKEN,
+        manifest_raw=NARROW_CALLER_MANIFEST,
+    )
+
+    app = _make_app(cfg)
+    client = app.test_client()
+    resp = await client.post(
+        _url("install"),
+        headers={"Authorization": f"Bearer {NARROW_CALLER_TOKEN}", "Content-Type": "application/json"},
+        data=json.dumps({"repo_url": "https://github.com/imbue-openhost/openhost-gemini"}),
+    )
+    assert resp.status_code == 403
+    body = await resp.get_json()
+    assert body["required_grant"]["grant"] == {
+        "capability": "install",
+        "repo_url_prefix": "https://github.com/imbue-openhost/",
+    }
+
+
+@pytest.mark.asyncio
+async def test_proposed_grant_falls_back_when_manifest_prefix_doesnt_match(cfg):
+    """If the consumer's manifest only declares a narrow prefix that does NOT
+    cover the requested URL, fall back to a per-URL grant rather than
+    suggesting a grant that wouldn't help."""
+    from compute_space.db.connection import init_db
+
+    init_db(_FakeApp(cfg.db_path))
+    _seed_caller(
+        cfg.db_path,
+        app_name=NARROW_CALLER_APP,
+        token=NARROW_CALLER_TOKEN,
+        manifest_raw=NARROW_CALLER_MANIFEST,
+    )
+
+    app = _make_app(cfg)
+    client = app.test_client()
+    resp = await client.post(
+        _url("install"),
+        headers={"Authorization": f"Bearer {NARROW_CALLER_TOKEN}", "Content-Type": "application/json"},
+        data=json.dumps({"repo_url": "https://gitlab.com/something/else"}),
+    )
+    assert resp.status_code == 403
+    body = await resp.get_json()
+    assert body["required_grant"]["grant"]["repo_url_prefix"] == "https://gitlab.com/something/else"
 
 
 @pytest.mark.asyncio

--- a/compute_space/src/compute_space/tests/test_installer_route.py
+++ b/compute_space/src/compute_space/tests/test_installer_route.py
@@ -185,8 +185,6 @@ async def test_proposed_grant_uses_manifest_declared_prefix(cfg):
     """When the consumer's manifest declares a broad prefix, a denial for an
     URL that matches that prefix must propose the broad grant — not a fresh
     per-URL grant — so a single approval covers every install."""
-    from compute_space.db.connection import init_db
-
     init_db(_FakeApp(cfg.db_path))
     _seed_caller(
         cfg.db_path,
@@ -215,8 +213,6 @@ async def test_proposed_grant_falls_back_when_manifest_prefix_doesnt_match(cfg):
     """If the consumer's manifest only declares a narrow prefix that does NOT
     cover the requested URL, fall back to a per-URL grant rather than
     suggesting a grant that wouldn't help."""
-    from compute_space.db.connection import init_db
-
     init_db(_FakeApp(cfg.db_path))
     _seed_caller(
         cfg.db_path,

--- a/compute_space/src/compute_space/web/routes/services_v2.py
+++ b/compute_space/src/compute_space/web/routes/services_v2.py
@@ -19,10 +19,10 @@ from compute_space.config import get_config
 from compute_space.core.apps import find_app_by_name
 from compute_space.core.auth import resolve_app_from_token
 from compute_space.core.containers import get_docker_logs
-from compute_space.core.installer import INSTALLER_SERVICE_URL
-from compute_space.core.installer import INSTALLER_SERVICE_VERSION
 from compute_space.core.installer import GRANT_KEY_CAPABILITY
 from compute_space.core.installer import GRANT_KEY_REPO_URL_PREFIX
+from compute_space.core.installer import INSTALLER_SERVICE_URL
+from compute_space.core.installer import INSTALLER_SERVICE_VERSION
 from compute_space.core.installer import INSTALL_CAPABILITY
 from compute_space.core.installer import InstallError
 from compute_space.core.installer import check_install_allowed
@@ -367,9 +367,7 @@ def _json_ok(body: dict[str, Any]) -> Response:
     return Response(json.dumps(body), status=200, content_type="application/json")
 
 
-def _proposed_install_grant_from_manifest(
-    consumer_app: str, repo_url: str, db: sqlite3.Connection
-) -> dict[str, str]:
+def _proposed_install_grant_from_manifest(consumer_app: str, repo_url: str, db: sqlite3.Connection) -> dict[str, str]:
     """Pick the install grant payload to offer the owner on a 403.
 
     Prefers a grant the consumer **already declared** in its
@@ -412,9 +410,7 @@ def _proposed_install_grant_from_manifest(
     return fallback
 
 
-def _installer_permission_denied(
-    consumer_app: str, repo_url: str, reason: str, db: sqlite3.Connection
-) -> Response:
+def _installer_permission_denied(consumer_app: str, repo_url: str, reason: str, db: sqlite3.Connection) -> Response:
     """Return the v2 standard permission_required shape with a grant URL.
 
     The proposed grant comes from the consumer's manifest-declared

--- a/compute_space/src/compute_space/web/routes/services_v2.py
+++ b/compute_space/src/compute_space/web/routes/services_v2.py
@@ -21,9 +21,13 @@ from compute_space.core.auth import resolve_app_from_token
 from compute_space.core.containers import get_docker_logs
 from compute_space.core.installer import INSTALLER_SERVICE_URL
 from compute_space.core.installer import INSTALLER_SERVICE_VERSION
+from compute_space.core.installer import GRANT_KEY_CAPABILITY
+from compute_space.core.installer import GRANT_KEY_REPO_URL_PREFIX
+from compute_space.core.installer import INSTALL_CAPABILITY
 from compute_space.core.installer import InstallError
 from compute_space.core.installer import check_install_allowed
 from compute_space.core.installer import install_from_repo_url
+from compute_space.core.manifest import parse_manifest_from_string
 from compute_space.core.permissions_v2 import get_granted_permissions_v2
 from compute_space.core.services import ServiceNotAvailable
 from compute_space.core.services_v2 import ShortnameNotDeclared
@@ -307,7 +311,7 @@ async def _handle_installer_request(
 
         grants = [g.grant for g in get_granted_permissions_v2(consumer_app, INSTALLER_SERVICE_URL)]
         if (reason := check_install_allowed(repo_url, grants)) is not None:
-            return _installer_permission_denied(consumer_app, repo_url, reason)
+            return _installer_permission_denied(consumer_app, repo_url, reason, db)
 
         try:
             result = await install_from_repo_url(
@@ -363,13 +367,63 @@ def _json_ok(body: dict[str, Any]) -> Response:
     return Response(json.dumps(body), status=200, content_type="application/json")
 
 
-def _installer_permission_denied(consumer_app: str, repo_url: str, reason: str) -> Response:
+def _proposed_install_grant_from_manifest(
+    consumer_app: str, repo_url: str, db: sqlite3.Connection
+) -> dict[str, str]:
+    """Pick the install grant payload to offer the owner on a 403.
+
+    Prefers a grant the consumer **already declared** in its
+    ``[[services.v2.consumes]]`` block for the installer service whose
+    ``repo_url_prefix`` matches ``repo_url`` — so a manifest-declared
+    broad grant (e.g. ``"https://github.com/"``) gets approved once and
+    covers every subsequent install instead of producing one approval
+    prompt per repo.
+
+    Falls back to a per-URL grant only if the consumer's manifest
+    declares no installer grants at all, or none whose prefix covers the
+    requested URL.  This keeps behaviour sane for consumers that haven't
+    been updated to declare a broader prefix yet.
+    """
+    fallback = {GRANT_KEY_CAPABILITY: INSTALL_CAPABILITY, GRANT_KEY_REPO_URL_PREFIX: repo_url}
+    row = db.execute("SELECT manifest_raw FROM apps WHERE name = ?", (consumer_app,)).fetchone()
+    if not row or not row["manifest_raw"]:
+        return fallback
+    try:
+        manifest = parse_manifest_from_string(row["manifest_raw"])
+    except Exception:
+        return fallback
+
+    for consume in manifest.consumes_services_v2:
+        if consume.service != INSTALLER_SERVICE_URL:
+            continue
+        for g in consume.grants:
+            if not isinstance(g, dict):
+                continue
+            if g.get(GRANT_KEY_CAPABILITY) != INSTALL_CAPABILITY:
+                continue
+            prefix = g.get(GRANT_KEY_REPO_URL_PREFIX, "")
+            if not isinstance(prefix, str):
+                continue
+            if prefix in ("", "*") or repo_url.startswith(prefix):
+                return {
+                    GRANT_KEY_CAPABILITY: INSTALL_CAPABILITY,
+                    GRANT_KEY_REPO_URL_PREFIX: prefix,
+                }
+    return fallback
+
+
+def _installer_permission_denied(
+    consumer_app: str, repo_url: str, reason: str, db: sqlite3.Connection
+) -> Response:
     """Return the v2 standard permission_required shape with a grant URL.
 
-    Body matches the post-PR67 ``required_grant`` field name (``grant``
-    rather than ``grant_payload``).
+    The proposed grant comes from the consumer's manifest-declared
+    ``[[services.v2.consumes]]`` block when possible, so approving once
+    covers every repo the consumer's manifest already declared a prefix
+    for.  Falls back to a per-URL grant only if the manifest declares
+    no matching prefix.
     """
-    grant = {"capability": "install", "repo_url_prefix": repo_url}
+    grant = _proposed_install_grant_from_manifest(consumer_app, repo_url, db)
     try:
         approve_path = url_for(
             "pages_permissions_v2.approve_permissions_v2",


### PR DESCRIPTION
When the installer denies an install for missing permissions, propose the consumer's manifest-declared repo_url_prefix grant (e.g. the catalog's 'https://github.com/' prefix) rather than synthesizing a new per-URL grant. One approval covers every install instead of one per repo.

Falls back to the per-URL grant only when the manifest declares no matching prefix.

Two new tests; existing test strengthened to assert the wildcard prefix is echoed back instead of the verbatim URL.