### PR TITLE
Drop Quart dependencies from compute_space/core/

### DIFF
--- a/compute_space/src/compute_space/core/auth/__init__.py
+++ b/compute_space/src/compute_space/core/auth/__init__.py
@@ -15,23 +15,45 @@ from typing import Any
 import jwt
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
-from quart import Request
-from quart import Response
-from quart.wrappers import Websocket
 
 from compute_space.config import get_config
+from compute_space.core.auth.cookies import ACCESS_TOKEN_EXPIRY
+from compute_space.core.auth.cookies import COOKIE_ACCESS
+from compute_space.core.auth.cookies import COOKIE_REFRESH
+from compute_space.core.auth.cookies import REFRESH_GRACE_PERIOD
+from compute_space.core.auth.cookies import REFRESH_TOKEN_EXPIRY
+from compute_space.core.auth.cookies import _cookie_domain
+from compute_space.core.auth.cookies import build_auth_cookies
+from compute_space.core.auth.cookies import clear_auth_cookies_spec
+from compute_space.core.auth.inputs import AuthInputs
 from compute_space.core.logging import logger
 from compute_space.core.util import write_restricted
 from compute_space.db import get_db
 
+# Re-exported for backward compatibility — external callers do
+# ``from compute_space.core.auth import COOKIE_ACCESS`` etc.
+__all__ = [
+    "ACCESS_TOKEN_EXPIRY",
+    "AuthInputs",
+    "COOKIE_ACCESS",
+    "COOKIE_REFRESH",
+    "REFRESH_GRACE_PERIOD",
+    "REFRESH_TOKEN_EXPIRY",
+    "_cookie_domain",
+    "build_auth_cookies",
+    "clear_auth_cookies_spec",
+    "create_access_token",
+    "create_refresh_token",
+    "decode_access_token",
+    "decode_access_token_allow_expired",
+    "get_current_user",
+    "get_public_key_pem",
+    "load_keys",
+    "resolve_app_from_token",
+]
+
 _private_key: str | None = None
 _public_key: str | None = None
-
-ACCESS_TOKEN_EXPIRY = 3600  # 60 minutes
-REFRESH_TOKEN_EXPIRY = 2592000  # 30 days
-
-COOKIE_ACCESS = "zone_auth"
-COOKIE_REFRESH = "zone_refresh"
 
 
 def _generate_keypair(keys_dir: str) -> tuple[str, str]:
@@ -123,9 +145,6 @@ def decode_access_token(token: str) -> dict[str, Any] | None:
         return None
 
 
-REFRESH_GRACE_PERIOD = timedelta(hours=2)
-
-
 def decode_access_token_allow_expired(token: str) -> dict[str, Any] | None:
     """Decode a JWT allowing up to REFRESH_GRACE_PERIOD past expiry -- used during token refresh."""
     try:
@@ -142,80 +161,6 @@ def decode_access_token_allow_expired(token: str) -> dict[str, Any] | None:
         )
     except jwt.InvalidTokenError:
         return None
-
-
-def _cookie_domain(request_host: str | None = None) -> str | None:
-    """Return the cookie domain, or None to use the default (request host).
-
-    When zone_domain is set (e.g. "user.dev-host.imbue.com") and the request
-    is coming from that domain (or a subdomain of it), the cookie domain is
-    set explicitly so cookies are shared with app subdomains like
-    "dau-tracker.user.dev-host.imbue.com".
-
-    When the request comes from a different host (e.g. 127.0.0.1 or localhost),
-    returns None so the cookie is scoped to the request host — otherwise the
-    browser would reject the Set-Cookie (domain mismatch).
-    """
-    zone = get_config().zone_domain
-    if not zone:
-        return None
-    zone_no_port = zone.split(":")[0]
-    if request_host:
-        host_no_port = request_host.split(":")[0]
-        if host_no_port != zone_no_port and not host_no_port.endswith("." + zone_no_port):
-            return None
-    return zone_no_port
-
-
-def set_auth_cookies(
-    response: Response,
-    access_token: str,
-    refresh_token: str | None = None,
-    request: Request | None = None,
-) -> Response:
-    """Set zone_auth (and optionally zone_refresh) cookies."""
-    request_host = request.host if request else None
-    domain = _cookie_domain(request_host)
-    response.set_cookie(
-        COOKIE_ACCESS,
-        access_token,
-        path="/",
-        domain=domain,
-        httponly=True,
-        secure=get_config().tls_enabled,
-        samesite="Lax",
-        max_age=ACCESS_TOKEN_EXPIRY + int(REFRESH_GRACE_PERIOD.total_seconds()),
-    )
-    if refresh_token:
-        response.set_cookie(
-            COOKIE_REFRESH,
-            refresh_token,
-            path="/",
-            domain=domain,
-            httponly=True,
-            secure=get_config().tls_enabled,
-            samesite="Lax",
-            max_age=REFRESH_TOKEN_EXPIRY,
-        )
-    return response
-
-
-def clear_auth_cookies(response: Response, request: Request | None = None) -> Response:
-    """Delete auth cookies.
-
-    Clears cookies both with the computed domain and without, to handle stale
-    cookies that were set with a different Domain attribute (e.g. after switching
-    TLS mode or changing zone_domain).
-    """
-    request_host = request.host if request else None
-    domain = _cookie_domain(request_host)
-    response.delete_cookie(COOKIE_ACCESS, path="/", domain=domain)
-    response.delete_cookie(COOKIE_REFRESH, path="/", domain=domain)
-    # Also clear without explicit domain, in case cookies were set differently
-    if domain is not None:
-        response.delete_cookie(COOKIE_ACCESS, path="/")
-        response.delete_cookie(COOKIE_REFRESH, path="/")
-    return response
 
 
 def _validate_api_token(token: str) -> dict[str, str] | None:
@@ -248,10 +193,9 @@ def resolve_app_from_token(token: str) -> str | None:
     return row["app_id"] if row else None
 
 
-def get_current_user_from_request(request: Request | Websocket) -> dict[str, Any] | None:
-    """Extract and verify identity from request cookies or Authorization header.
+def get_current_user(inputs: AuthInputs) -> dict[str, Any] | None:
+    """Extract and verify identity from cookies or Authorization header.
 
-    Accepts either an HTTP Request or a Websocket — both expose .headers and .cookies.
     Checks JWT cookie first, then falls back to Authorization: Bearer token.
     Returns claims dict or None.
 
@@ -260,8 +204,7 @@ def get_current_user_from_request(request: Request | Websocket) -> dict[str, Any
     # Warn on duplicate auth cookies — this happens when cookies were set with
     # different Domain attributes (e.g. after a config change). The browser
     # sends both, but only the first is read, which may be stale/invalid.
-    cookie_header = request.headers.get("Cookie", "")
-    dupes = cookie_header.count(f"{COOKIE_ACCESS}=")
+    dupes = inputs.cookie_header.count(f"{COOKIE_ACCESS}=")
     if dupes > 1:
         logger.warning(
             "Duplicate %s cookies detected (%d instances) for %s %s. "
@@ -269,19 +212,18 @@ def get_current_user_from_request(request: Request | Websocket) -> dict[str, Any
             "The user should clear cookies to fix this.",
             COOKIE_ACCESS,
             dupes,
-            getattr(request, "method", "WS"),
-            request.path,
+            inputs.method,
+            inputs.path,
         )
 
-    token = request.cookies.get(COOKIE_ACCESS)
+    token = inputs.cookies.get(COOKIE_ACCESS)
     if token:
         claims = decode_access_token(token)
         if claims:
             return claims
 
     # Fall back to Authorization: Bearer (API tokens)
-    auth_header = request.headers.get("Authorization", "")
-    if auth_header.startswith("Bearer "):
-        return _validate_api_token(auth_header.removeprefix("Bearer "))
+    if inputs.auth_header.startswith("Bearer "):
+        return _validate_api_token(inputs.auth_header.removeprefix("Bearer "))
 
     return None

--- a/compute_space/src/compute_space/core/auth/cookies.py
+++ b/compute_space/src/compute_space/core/auth/cookies.py
@@ -1,0 +1,116 @@
+"""Framework-neutral cookie helpers for auth.
+
+The web layer translates ``CookieSpec`` values into framework-specific Response cookies.
+"""
+
+from datetime import timedelta
+from typing import Literal
+
+import attr
+
+from compute_space.config import get_config
+
+SameSite = Literal["lax", "strict", "none"]
+
+ACCESS_TOKEN_EXPIRY = 3600  # 60 minutes
+REFRESH_TOKEN_EXPIRY = 2592000  # 30 days
+REFRESH_GRACE_PERIOD = timedelta(hours=2)
+
+COOKIE_ACCESS = "zone_auth"
+COOKIE_REFRESH = "zone_refresh"
+
+
+@attr.s(auto_attribs=True, frozen=True)
+class CookieSpec:
+    """A framework-neutral description of a cookie to set or clear.
+
+    For deletions, ``value`` is the empty string and ``max_age`` is ``0``; the web layer may
+    still translate this to a framework-specific delete call if it prefers.
+    """
+
+    name: str
+    value: str
+    path: str = "/"
+    domain: str | None = None
+    max_age: int | None = None
+    secure: bool = False
+    http_only: bool = True
+    same_site: SameSite = "lax"
+    delete: bool = False
+
+
+def _cookie_domain(request_host: str | None = None) -> str | None:
+    """Return the cookie domain, or None to use the default (request host).
+
+    When zone_domain is set (e.g. "user.dev-host.imbue.com") and the request
+    is coming from that domain (or a subdomain of it), the cookie domain is
+    set explicitly so cookies are shared with app subdomains like
+    "dau-tracker.user.dev-host.imbue.com".
+
+    When the request comes from a different host (e.g. 127.0.0.1 or localhost),
+    returns None so the cookie is scoped to the request host — otherwise the
+    browser would reject the Set-Cookie (domain mismatch).
+    """
+    zone = get_config().zone_domain
+    if not zone:
+        return None
+    zone_no_port = zone.split(":")[0]
+    if request_host:
+        host_no_port = request_host.split(":")[0]
+        if host_no_port != zone_no_port and not host_no_port.endswith("." + zone_no_port):
+            return None
+    return zone_no_port
+
+
+def build_auth_cookies(
+    access_token: str,
+    refresh_token: str | None = None,
+    request_host: str | None = None,
+) -> list[CookieSpec]:
+    """Return cookie specs to set zone_auth (and optionally zone_refresh)."""
+    domain = _cookie_domain(request_host)
+    secure = get_config().tls_enabled
+    cookies = [
+        CookieSpec(
+            name=COOKIE_ACCESS,
+            value=access_token,
+            path="/",
+            domain=domain,
+            max_age=ACCESS_TOKEN_EXPIRY + int(REFRESH_GRACE_PERIOD.total_seconds()),
+            secure=secure,
+            http_only=True,
+            same_site="lax",
+        )
+    ]
+    if refresh_token:
+        cookies.append(
+            CookieSpec(
+                name=COOKIE_REFRESH,
+                value=refresh_token,
+                path="/",
+                domain=domain,
+                max_age=REFRESH_TOKEN_EXPIRY,
+                secure=secure,
+                http_only=True,
+                same_site="lax",
+            )
+        )
+    return cookies
+
+
+def clear_auth_cookies_spec(request_host: str | None = None) -> list[CookieSpec]:
+    """Return cookie specs to delete the auth cookies.
+
+    Clears cookies both with the computed domain and without, to handle stale
+    cookies that were set with a different Domain attribute (e.g. after switching
+    TLS mode or changing zone_domain).
+    """
+    domain = _cookie_domain(request_host)
+    specs = [
+        CookieSpec(name=COOKIE_ACCESS, value="", path="/", domain=domain, delete=True),
+        CookieSpec(name=COOKIE_REFRESH, value="", path="/", domain=domain, delete=True),
+    ]
+    if domain is not None:
+        specs.append(CookieSpec(name=COOKIE_ACCESS, value="", path="/", domain=None, delete=True))
+        specs.append(CookieSpec(name=COOKIE_REFRESH, value="", path="/", domain=None, delete=True))
+    return specs

--- a/compute_space/src/compute_space/core/auth/inputs.py
+++ b/compute_space/src/compute_space/core/auth/inputs.py
@@ -1,0 +1,23 @@
+"""Framework-neutral inputs for authentication checks.
+
+The web layer constructs an ``AuthInputs`` from its framework-specific request/websocket
+object and passes it to ``get_current_user``.
+"""
+
+import attr
+
+
+@attr.s(auto_attribs=True, frozen=True)
+class AuthInputs:
+    """Inputs needed to identify the current user from a request or websocket.
+
+    ``method`` is the HTTP verb ("GET", "POST", ...) for HTTP requests, or "WS" for
+    websockets. ``cookie_header`` is the raw ``Cookie:`` header value (used for duplicate
+    detection); ``cookies`` is the parsed map.
+    """
+
+    cookies: dict[str, str]
+    cookie_header: str
+    auth_header: str
+    method: str
+    path: str

--- a/compute_space/src/compute_space/core/auth/service_access_rules.py
+++ b/compute_space/src/compute_space/core/auth/service_access_rules.py
@@ -6,8 +6,15 @@ or raising ServiceAccessDenied to deny the request.
 """
 
 from typing import Any
+from typing import Protocol
 
-from quart import Request
+
+class ServiceRequest(Protocol):
+    """Framework-neutral view of an HTTP request used by service access rules."""
+
+    method: str
+
+    async def get_json(self) -> Any: ...
 
 
 class ServiceAccessDenied(Exception):
@@ -15,7 +22,7 @@ class ServiceAccessDenied(Exception):
         self.message = message
 
 
-async def check_service_access_rules(service_name: str, service_endpoint: str, req: Request) -> list[str]:
+async def check_service_access_rules(service_name: str, service_endpoint: str, req: ServiceRequest) -> list[str]:
     """Determine what permissions are required for a service proxy request.
 
     Returns:
@@ -30,7 +37,7 @@ async def check_service_access_rules(service_name: str, service_endpoint: str, r
     raise ServiceAccessDenied(f"No access rules defined for service '{service_name}'")
 
 
-async def _get_json_body(req: Request) -> dict[Any, Any]:
+async def _get_json_body(req: ServiceRequest) -> dict[Any, Any]:
     """Parse JSON body or raise ServiceAccessDenied on failure."""
     try:
         data = await req.get_json()
@@ -41,7 +48,7 @@ async def _get_json_body(req: Request) -> dict[Any, Any]:
     return data
 
 
-async def _secrets_access_rules(service_endpoint: str, req: Request) -> list[str]:
+async def _secrets_access_rules(service_endpoint: str, req: ServiceRequest) -> list[str]:
     """Access rules for the secrets service. Whitelist of allowed endpoints.
 
     Returns a list of required permissions.

--- a/compute_space/src/compute_space/core/startup.py
+++ b/compute_space/src/compute_space/core/startup.py
@@ -2,8 +2,6 @@ import os
 import sqlite3
 import threading
 
-from quart import Quart
-
 from compute_space.config import Config
 from compute_space.core import archive_backend
 from compute_space.core.apps import start_app_process
@@ -14,7 +12,6 @@ from compute_space.core.containers import is_container_running
 from compute_space.core.default_apps import deploy_default_apps
 from compute_space.core.logging import logger
 from compute_space.core.storage import start_storage_guard
-from compute_space.db import init_db
 
 
 def _mark_running_apps_container_runtime_missing(config: Config) -> int:
@@ -139,10 +136,8 @@ def _retry_pending_default_apps(config: Config) -> None:
         db.close()
 
 
-def init_app(app: Quart) -> None:
-    """Initialize DB and app state. Call after data directories are ready."""
-    config = app.openhost_config  # type: ignore[attr-defined]
-    init_db(app)
+def init_app(config: Config) -> None:
+    """Initialize app state from config. Call after data directories and DB are ready."""
     db = sqlite3.connect(config.db_path)
     try:
         archive_backend.attach_on_startup(config, db)

--- a/compute_space/src/compute_space/core/terminal.py
+++ b/compute_space/src/compute_space/core/terminal.py
@@ -9,11 +9,19 @@ import signal
 import struct
 import subprocess
 import termios
-
-from quart.wrappers import Websocket
+from typing import Protocol
 
 from compute_space.core.logging import logger
 from compute_space.core.updates import wait_for_shutdown
+
+
+class TerminalWebsocket(Protocol):
+    """Framework-neutral websocket interface used by the terminal bridge."""
+
+    async def send(self, data: bytes) -> None: ...
+
+    async def receive(self) -> bytes | str: ...
+
 
 # Track active sessions for cleanup on shutdown.
 _active_sessions: dict[int, tuple[subprocess.Popen[bytes], int]] = {}
@@ -24,7 +32,7 @@ def _set_winsize(fd: int, rows: int, cols: int) -> None:
     fcntl.ioctl(fd, termios.TIOCSWINSZ, struct.pack("HHHH", rows, cols, 0, 0))
 
 
-async def handle_terminal_ws(ws: Websocket) -> None:
+async def handle_terminal_ws(ws: TerminalWebsocket) -> None:
     """Handle a WebSocket connection by bridging it to a PTY running bash.
 
     Wire protocol:

--- a/compute_space/src/compute_space/web/app.py
+++ b/compute_space/src/compute_space/web/app.py
@@ -18,6 +18,7 @@ from compute_space.core.startup import init_app
 from compute_space.core.terminal import cleanup_all as cleanup_terminal
 from compute_space.db import close_db
 from compute_space.db import get_db
+from compute_space.db import init_db
 
 # ─── App Factory ───
 
@@ -81,7 +82,8 @@ def create_app(config: Config | None = None) -> Quart:
     app.register_blueprint(proxy_bp)  # registers before_app_request / before_app_websocket subdomain hooks
 
     # Initialize DB and app state
-    init_app(app)
+    init_db(app)
+    init_app(config)
 
     # ─── Before-request hooks ───
 

--- a/compute_space/src/compute_space/web/auth/cookies.py
+++ b/compute_space/src/compute_space/web/auth/cookies.py
@@ -1,0 +1,45 @@
+"""Quart adapters that translate framework-neutral cookie specs into Response cookies."""
+
+from quart import Request
+from quart import Response
+
+from compute_space.core.auth.cookies import CookieSpec
+from compute_space.core.auth.cookies import build_auth_cookies
+from compute_space.core.auth.cookies import clear_auth_cookies_spec
+
+
+def _apply_cookie(response: Response, spec: CookieSpec) -> None:
+    if spec.delete:
+        response.delete_cookie(spec.name, path=spec.path, domain=spec.domain)
+        return
+    response.set_cookie(
+        spec.name,
+        spec.value,
+        path=spec.path,
+        domain=spec.domain,
+        max_age=spec.max_age,
+        httponly=spec.http_only,
+        secure=spec.secure,
+        samesite=spec.same_site.capitalize(),
+    )
+
+
+def set_auth_cookies(
+    response: Response,
+    access_token: str,
+    refresh_token: str | None = None,
+    request: Request | None = None,
+) -> Response:
+    """Set zone_auth (and optionally zone_refresh) cookies on a Quart response."""
+    request_host = request.host if request else None
+    for spec in build_auth_cookies(access_token, refresh_token, request_host=request_host):
+        _apply_cookie(response, spec)
+    return response
+
+
+def clear_auth_cookies(response: Response, request: Request | None = None) -> Response:
+    """Delete the auth cookies on a Quart response."""
+    request_host = request.host if request else None
+    for spec in clear_auth_cookies_spec(request_host=request_host):
+        _apply_cookie(response, spec)
+    return response

--- a/compute_space/src/compute_space/web/auth/inputs.py
+++ b/compute_space/src/compute_space/web/auth/inputs.py
@@ -1,0 +1,17 @@
+"""Quart adapters that build framework-neutral ``AuthInputs`` from a Quart request/websocket."""
+
+from quart.wrappers import Request
+from quart.wrappers import Websocket
+
+from compute_space.core.auth.inputs import AuthInputs
+
+
+def auth_inputs_from_request(req_or_ws: Request | Websocket) -> AuthInputs:
+    """Build an ``AuthInputs`` from a Quart Request or Websocket."""
+    return AuthInputs(
+        cookies=dict(req_or_ws.cookies),
+        cookie_header=req_or_ws.headers.get("Cookie", ""),
+        auth_header=req_or_ws.headers.get("Authorization", ""),
+        method=getattr(req_or_ws, "method", "WS"),
+        path=req_or_ws.path,
+    )

--- a/compute_space/src/compute_space/web/auth/middleware.py
+++ b/compute_space/src/compute_space/web/auth/middleware.py
@@ -21,6 +21,8 @@ from compute_space.config import get_config
 from compute_space.core import auth
 from compute_space.core.auth import resolve_app_from_token
 from compute_space.db import get_db
+from compute_space.web.auth.cookies import clear_auth_cookies
+from compute_space.web.auth.inputs import auth_inputs_from_request
 
 
 def _wants_json() -> bool:
@@ -80,10 +82,9 @@ def _try_refresh() -> dict[str, Any] | None:
 def _app_from_origin(req_or_ws: Request | Websocket) -> str | None:
     """Resolve app_id from Origin/Referer subdomain + valid JWT cookie.
 
-    Accepts either a quart Request or Websocket — both expose .headers and are accepted
-    by auth.get_current_user_from_request.
+    Accepts either a quart Request or Websocket — both expose .headers.
     """
-    if not auth.get_current_user_from_request(req_or_ws):
+    if not auth.get_current_user(auth_inputs_from_request(req_or_ws)):
         return None
 
     origin = req_or_ws.headers.get("Origin", "") or req_or_ws.headers.get("Referer", "")
@@ -142,7 +143,7 @@ def login_required(
 ) -> Callable[..., Awaitable[ResponseReturnValue]]:
     @wraps(f)
     async def decorated(*args: Any, **kwargs: Any) -> ResponseReturnValue:
-        claims = auth.get_current_user_from_request(request)
+        claims = auth.get_current_user(auth_inputs_from_request(request))
         if claims is not None:
             return await _ensure_async(f, *args, **kwargs)  # type: ignore[no-any-return]
 
@@ -166,7 +167,7 @@ def login_required(
             response = redirect(url_for("auth.login"))
 
         if has_stale_cookies:
-            auth.clear_auth_cookies(response, request=request)  # type: ignore[arg-type]
+            clear_auth_cookies(response, request=request)  # type: ignore[arg-type]
         return response
 
     return decorated

--- a/compute_space/src/compute_space/web/auth/pages.py
+++ b/compute_space/src/compute_space/web/auth/pages.py
@@ -21,6 +21,9 @@ from compute_space.core import auth
 from compute_space.core.default_apps import deploy_default_apps
 from compute_space.core.logging import logger
 from compute_space.db import get_db
+from compute_space.web.auth.cookies import clear_auth_cookies
+from compute_space.web.auth.cookies import set_auth_cookies
+from compute_space.web.auth.inputs import auth_inputs_from_request
 from compute_space.web.auth.middleware import _try_refresh  # noqa: F401 — re-exported
 from compute_space.web.auth.middleware import login_required  # noqa: F401 — re-exported
 
@@ -61,7 +64,7 @@ async def attach_refreshed_token(response: Response) -> Response:
     new_token = getattr(g, "new_access_token", None)
     if new_token:
         refresh_tok = getattr(g, "refresh_token", None)
-        auth.set_auth_cookies(response, new_token, refresh_tok, request=request)
+        set_auth_cookies(response, new_token, refresh_tok, request=request)
     return response
 
 
@@ -141,13 +144,13 @@ async def setup() -> ResponseReturnValue:
         logger.error("default_apps deploy raised unexpectedly: %s", exc)
 
     response = redirect(url_for("apps.dashboard"))
-    auth.set_auth_cookies(response, access_token, refresh_token, request=request)  # type: ignore[arg-type]
+    set_auth_cookies(response, access_token, refresh_token, request=request)  # type: ignore[arg-type]
     return response
 
 
 @auth_bp.route("/login", methods=["GET", "POST"])
 async def login() -> ResponseReturnValue:
-    if auth.get_current_user_from_request(request):
+    if auth.get_current_user(auth_inputs_from_request(request)):
         return redirect(url_for("apps.dashboard"))
 
     # If stale auth cookies are present (invalid JWT, e.g. after key rotation on
@@ -163,7 +166,7 @@ async def login() -> ResponseReturnValue:
     if request.method == "GET":
         if has_stale_cookies:
             response = redirect(url_for("auth.login"))
-            auth.clear_auth_cookies(response, request=request)  # type: ignore[arg-type]
+            clear_auth_cookies(response, request=request)  # type: ignore[arg-type]
             return response
         return await render_template("login.html")
 
@@ -186,7 +189,7 @@ async def login() -> ResponseReturnValue:
     db.commit()
 
     response = redirect(url_for("apps.dashboard"))
-    auth.set_auth_cookies(response, access_token, refresh_token, request=request)  # type: ignore[arg-type]
+    set_auth_cookies(response, access_token, refresh_token, request=request)  # type: ignore[arg-type]
     return response
 
 
@@ -203,5 +206,5 @@ def logout() -> ResponseReturnValue:
         db.commit()
 
     response = redirect(url_for("auth.login"))
-    auth.clear_auth_cookies(response, request=request)  # type: ignore[arg-type]
+    clear_auth_cookies(response, request=request)  # type: ignore[arg-type]
     return response

--- a/compute_space/src/compute_space/web/routes/pages/system.py
+++ b/compute_space/src/compute_space/web/routes/pages/system.py
@@ -4,6 +4,7 @@ from quart import websocket
 
 from compute_space.core import auth
 from compute_space.core.terminal import handle_terminal_ws
+from compute_space.web.auth.inputs import auth_inputs_from_request
 from compute_space.web.auth.middleware import login_required
 
 pages_system_bp = Blueprint("pages_system", __name__)
@@ -33,7 +34,7 @@ async def terminal_page() -> str:
 @pages_system_bp.websocket("/terminal/ws")
 async def terminal_ws() -> None:
     """WebSocket endpoint for the terminal PTY bridge."""
-    claims: dict[str, str] | None = auth.get_current_user_from_request(websocket)
+    claims: dict[str, str] | None = auth.get_current_user(auth_inputs_from_request(websocket))
     if claims is None:
         return
-    await handle_terminal_ws(websocket)
+    await handle_terminal_ws(websocket)  # type: ignore[arg-type]

--- a/compute_space/src/compute_space/web/routes/proxy.py
+++ b/compute_space/src/compute_space/web/routes/proxy.py
@@ -12,6 +12,8 @@ from compute_space.core import auth
 from compute_space.core.apps import find_app_by_name
 from compute_space.core.apps import is_public_path
 from compute_space.core.apps import parse_app_from_host
+from compute_space.web.auth.cookies import set_auth_cookies
+from compute_space.web.auth.inputs import auth_inputs_from_request
 from compute_space.web.auth.middleware import _try_refresh
 from compute_space.web.proxy import proxy_request
 from compute_space.web.proxy import ws_proxy
@@ -49,7 +51,7 @@ async def _app_subdomain_routing() -> ResponseReturnValue | None:
         return Response(f"App '{app_subdomain}' not found", status=404)
 
     new_access_token = None
-    claims = auth.get_current_user_from_request(request)
+    claims = auth.get_current_user(auth_inputs_from_request(request))
     if claims is None:
         claims = _try_refresh()
         if claims:
@@ -71,7 +73,7 @@ async def _app_subdomain_routing() -> ResponseReturnValue | None:
     )
 
     if new_access_token:
-        auth.set_auth_cookies(
+        set_auth_cookies(
             response,
             new_access_token,
             request.cookies.get(auth.COOKIE_REFRESH),
@@ -91,7 +93,7 @@ async def _app_subdomain_routing_ws() -> str | None:
         return None
     app_row = find_app_by_name(app_subdomain)
     if app_row and app_row["status"] in ("running", "starting"):
-        claims = auth.get_current_user_from_request(websocket)
+        claims = auth.get_current_user(auth_inputs_from_request(websocket))
         if claims is not None or is_public_path(app_row, websocket.path):
             await ws_proxy(app_row["local_port"], websocket, identity_headers=_identity_headers(claims))
     return ""  # non-None to skip dispatch


### PR DESCRIPTION
## Summary
- Establish layering rule that `compute_space/core/` must remain framework-agnostic, in prep for the future Litestar migration. Quart remains the active framework for `web/` — only the `core/` boundary is tightened here.
- Cookie helpers split: `core/auth/cookies.py` exposes a framework-neutral `CookieSpec` plus `build_auth_cookies` / `clear_auth_cookies_spec`; `web/auth/cookies.py` wraps these with Quart `set_auth_cookies` / `clear_auth_cookies` for Response objects.
- Auth identity decoupled: `core.auth.get_current_user(AuthInputs)` replaces `get_current_user_from_request(request)`; `web/auth/inputs.py` adapts Quart `Request` / `Websocket` into `AuthInputs`. `core/auth/service_access_rules.py` now takes a `ServiceRequest` Protocol; `core/terminal.handle_terminal_ws` takes a `TerminalWebsocket` Protocol. `core/startup.init_app` takes `Config` directly; `web/app.py` calls `init_db(app)` then `init_app(config)`.

## Test plan
- [x] `pixi run -e dev pytest -x` — 531 passed, 30 skipped
- [x] `pixi run -e dev mypy compute_space/src/` — no issues
- [x] `pixi run -e dev ruff check compute_space/src/` — clean
- [x] `grep -rn "from quart\|import quart" compute_space/src/compute_space/core/` returns nothing
- [ ] Manual smoke: log in, navigate, log out — exercises set/clear cookie path through new web/auth/cookies.py

## Follow-ups
- `compute_space/db/connection.py` still imports `quart.g`, `quart.current_app`, and accepts `Quart` in `init_db(app)`. That module is out of scope for this PR but needs the same treatment in a follow-up before `core/` can call into a fully framework-neutral `db/` layer.