### PR TITLE
Drop Quart dependencies from db/connection.py

### DIFF
--- a/compute_space/src/compute_space/core/startup.py
+++ b/compute_space/src/compute_space/core/startup.py
@@ -142,7 +142,7 @@ def _retry_pending_default_apps(config: Config) -> None:
 def init_app(app: Quart) -> None:
     """Initialize DB and app state. Call after data directories are ready."""
     config = app.openhost_config  # type: ignore[attr-defined]
-    init_db(app)
+    init_db(config.db_path)
     db = sqlite3.connect(config.db_path)
     try:
         archive_backend.attach_on_startup(config, db)

--- a/compute_space/src/compute_space/db/connection.py
+++ b/compute_space/src/compute_space/db/connection.py
@@ -1,13 +1,13 @@
 import contextlib
+import contextvars
 import sqlite3
 import uuid
 from collections.abc import Iterator
 
-from quart import Quart
-from quart import current_app
-from quart import g
-
 from compute_space.db.versioned import apply_migrations
+
+_db_path: str | None = None
+_db_var: contextvars.ContextVar[sqlite3.Connection | None] = contextvars.ContextVar("db", default=None)
 
 
 @contextlib.contextmanager
@@ -30,19 +30,27 @@ def make_atomic_with_savepoint(db: sqlite3.Connection) -> Iterator[None]:
 
 
 def get_db() -> sqlite3.Connection:
-    if "db" not in g:
-        g.db = sqlite3.connect(current_app.config["DB_PATH"], check_same_thread=False)
-        g.db.row_factory = sqlite3.Row
-        g.db.execute("PRAGMA journal_mode=WAL")
-        g.db.execute("PRAGMA foreign_keys=ON")
-    return g.db  # type: ignore[no-any-return]
+    db = _db_var.get()
+    if db is None:
+        if _db_path is None:
+            raise RuntimeError("init_db() must be called before get_db()")
+        db = sqlite3.connect(_db_path, check_same_thread=False)
+        db.row_factory = sqlite3.Row
+        db.execute("PRAGMA journal_mode=WAL")
+        db.execute("PRAGMA foreign_keys=ON")
+        _db_var.set(db)
+    return db
 
 
 def close_db(exception: BaseException | None = None) -> None:
-    db = g.pop("db", None)
+    db = _db_var.get()
     if db is not None:
         db.close()
+        _db_var.set(None)
 
 
-def init_db(app: Quart) -> None:
-    apply_migrations(app.config["DB_PATH"])
+def init_db(db_path: str) -> None:
+    """Set the SQLite path used by ``get_db`` and apply pending migrations."""
+    global _db_path
+    _db_path = db_path
+    apply_migrations(db_path)

--- a/compute_space/src/compute_space/tests/conftest.py
+++ b/compute_space/src/compute_space/tests/conftest.py
@@ -49,19 +49,6 @@ def _resolve_test_zone_to_localhost() -> Iterator[None]:
         socket.getaddrinfo = real_getaddrinfo
 
 
-class _FakeApp:
-    """Minimal Quart-like stand-in exposing just ``.config['DB_PATH']``.
-
-    Used by tests that call ``compute_space.db.connection.init_db``
-    (which reads ``app.config['DB_PATH']``) without setting up a real
-    Quart app.  Lives in conftest so every test module that needs one
-    can import a single shared implementation.
-    """
-
-    def __init__(self, db_path: str) -> None:
-        self.config = {"DB_PATH": db_path}
-
-
 def _make_test_config(tmp_path: Path, **overrides: Any) -> Config:
     """Create a DefaultConfig with temp dirs under tmp_path. Returns the Config object."""
     cfg = DefaultConfig(

--- a/compute_space/src/compute_space/tests/test_api_archive_backend.py
+++ b/compute_space/src/compute_space/tests/test_api_archive_backend.py
@@ -17,7 +17,6 @@ from compute_space.core.app_id import new_app_id
 from compute_space.core.manifest import AppManifest
 from compute_space.db.connection import init_db
 
-from .conftest import _FakeApp
 from .conftest import _make_test_config
 
 
@@ -50,7 +49,7 @@ def cfg(tmp_path: Path):
 
 @pytest.fixture
 def app(cfg):
-    init_db(_FakeApp(cfg.db_path))
+    init_db(cfg.db_path)
     yield _make_app(cfg)
 
 

--- a/compute_space/src/compute_space/tests/test_app_status.py
+++ b/compute_space/src/compute_space/tests/test_app_status.py
@@ -20,7 +20,6 @@ from compute_space.core.app_id import new_app_id
 from compute_space.core.containers import BUILD_CACHE_CORRUPT_MARKER
 from compute_space.db.connection import init_db
 
-from .conftest import _FakeApp
 from .conftest import _make_test_config
 
 
@@ -28,7 +27,7 @@ async def _app_status_response(tmp_path: Path, *, error_message: str, port: int)
     """Drive /api/app_status/<name> end-to-end against a real Quart app
     with a real on-disk sqlite schema.  Returns (status_code, payload)."""
     cfg = _make_test_config(tmp_path, port=port)
-    init_db(_FakeApp(cfg.db_path))
+    init_db(cfg.db_path)
 
     # Insert one app row with the error_message of interest.
     app_id = new_app_id()

--- a/compute_space/src/compute_space/tests/test_archive_backend.py
+++ b/compute_space/src/compute_space/tests/test_archive_backend.py
@@ -19,7 +19,6 @@ from compute_space.core.archive_backend import juicefs_mount_dir
 from compute_space.core.archive_backend import read_state
 from compute_space.db.connection import init_db
 
-from .conftest import _FakeApp
 from .conftest import _make_test_config
 
 
@@ -31,7 +30,7 @@ def cfg(tmp_path: Path):
 @pytest.fixture
 def db(cfg):
     """Initialised sqlite DB so the archive_backend table exists, seeded disabled."""
-    init_db(_FakeApp(cfg.db_path))
+    init_db(cfg.db_path)
     conn = sqlite3.connect(cfg.db_path)
     yield conn
     conn.close()

--- a/compute_space/src/compute_space/tests/test_installer_route.py
+++ b/compute_space/src/compute_space/tests/test_installer_route.py
@@ -26,7 +26,6 @@ from compute_space.core.installer import InstallResult
 from compute_space.db.connection import init_db
 from compute_space.web.routes.services_v2 import services_v2_bp
 
-from .conftest import _FakeApp
 from .conftest import _make_test_config
 
 CALLER_APP = "openhost-catalog"
@@ -114,7 +113,7 @@ def cfg(tmp_path: Path):
 
 @pytest.fixture
 def app(cfg):
-    init_db(_FakeApp(cfg.db_path))
+    init_db(cfg.db_path)
     _seed_caller(cfg.db_path)
     yield _make_app(cfg)
 
@@ -190,7 +189,7 @@ async def test_proposed_grant_uses_manifest_declared_prefix(cfg):
     """When the consumer's manifest declares a broad prefix, a denial for an
     URL that matches that prefix must propose the broad grant — not a fresh
     per-URL grant — so a single approval covers every install."""
-    init_db(_FakeApp(cfg.db_path))
+    init_db(cfg.db_path)
     _seed_caller(
         cfg.db_path,
         app_name=NARROW_CALLER_APP,
@@ -218,7 +217,7 @@ async def test_proposed_grant_falls_back_when_manifest_prefix_doesnt_match(cfg):
     """If the consumer's manifest only declares a narrow prefix that does NOT
     cover the requested URL, fall back to a per-URL grant rather than
     suggesting a grant that wouldn't help."""
-    init_db(_FakeApp(cfg.db_path))
+    init_db(cfg.db_path)
     _seed_caller(
         cfg.db_path,
         app_name=NARROW_CALLER_APP,

--- a/compute_space/src/compute_space/tests/test_podman_availability.py
+++ b/compute_space/src/compute_space/tests/test_podman_availability.py
@@ -29,7 +29,6 @@ from compute_space.core.containers import container_runtime_available
 from compute_space.core.containers import is_container_running
 from compute_space.db.connection import init_db as real_init_db
 
-from .conftest import _FakeApp
 from .conftest import _make_test_config
 
 # ---------------------------------------------------------------------------
@@ -165,7 +164,7 @@ def _insert_app(db_path: str, name: str, status: str, container_id: str | None, 
 
 def _init_schema(db_path: str) -> None:
     """Create the minimal apps schema we need for these tests."""
-    real_init_db(_FakeApp(db_path))
+    real_init_db(db_path)
 
 
 def test_check_app_status_marks_running_apps_error_when_podman_missing(

--- a/compute_space/src/compute_space/tests/test_remove_app_background.py
+++ b/compute_space/src/compute_space/tests/test_remove_app_background.py
@@ -10,7 +10,6 @@ from compute_space.core.app_id import new_app_id
 from compute_space.core.apps import remove_app_background
 from compute_space.db.connection import init_db
 
-from .conftest import _FakeApp
 from .conftest import _make_test_config
 
 
@@ -70,7 +69,7 @@ def test_remove_cascades_to_all_child_tables(tmp_path: Path) -> None:
     orphan rows accumulate in app_tokens / permissions / etc.
     """
     cfg = _make_test_config(tmp_path)
-    init_db(_FakeApp(cfg.db_path))
+    init_db(cfg.db_path)
     app_id = _seed_app_with_children(cfg.db_path, "myapp")
 
     with (
@@ -100,7 +99,7 @@ def test_remove_cascades_to_all_child_tables(tmp_path: Path) -> None:
 def test_remove_keep_data_calls_temp_only(tmp_path: Path) -> None:
     """``keep_data=True`` must hit the temp-only deprovision path."""
     cfg = _make_test_config(tmp_path)
-    init_db(_FakeApp(cfg.db_path))
+    init_db(cfg.db_path)
     app_id = _seed_app_with_children(cfg.db_path, "myapp")
 
     with (
@@ -118,7 +117,7 @@ def test_remove_keep_data_calls_temp_only(tmp_path: Path) -> None:
 def test_remove_full_calls_full_deprovision(tmp_path: Path) -> None:
     """``keep_data=False`` must hit the full deprovision."""
     cfg = _make_test_config(tmp_path)
-    init_db(_FakeApp(cfg.db_path))
+    init_db(cfg.db_path)
     app_id = _seed_app_with_children(cfg.db_path, "myapp")
 
     with (
@@ -143,7 +142,7 @@ def test_remove_proceeds_when_deprovision_raises(tmp_path: Path) -> None:
     would otherwise be stuck in 'removing' forever and the user could
     never re-deploy."""
     cfg = _make_test_config(tmp_path)
-    init_db(_FakeApp(cfg.db_path))
+    init_db(cfg.db_path)
     app_id = _seed_app_with_children(cfg.db_path, "myapp")
 
     with (
@@ -160,7 +159,7 @@ def test_remove_proceeds_when_deprovision_raises(tmp_path: Path) -> None:
 def test_remove_returns_quietly_when_app_already_gone(tmp_path: Path) -> None:
     """Calling the worker for a non-existent app must be a clean no-op."""
     cfg = _make_test_config(tmp_path)
-    init_db(_FakeApp(cfg.db_path))
+    init_db(cfg.db_path)
 
     with (
         patch("compute_space.core.apps.stop_app_process") as stop,
@@ -181,7 +180,7 @@ def test_remove_records_error_when_db_delete_path_explodes(tmp_path: Path) -> No
     the operator isn't left staring at a permanent 'removing' indicator.
     """
     cfg = _make_test_config(tmp_path)
-    init_db(_FakeApp(cfg.db_path))
+    init_db(cfg.db_path)
     app_id = _seed_app_with_children(cfg.db_path, "myapp")
 
     real_connect = sqlite3.connect

--- a/compute_space/src/compute_space/tests/test_remove_app_route.py
+++ b/compute_space/src/compute_space/tests/test_remove_app_route.py
@@ -14,7 +14,6 @@ import compute_space.web.routes.api.apps as apps_routes
 from compute_space.core.app_id import new_app_id
 from compute_space.db.connection import init_db
 
-from .conftest import _FakeApp
 from .conftest import _make_test_config
 
 
@@ -57,7 +56,7 @@ async def test_remove_returns_202_and_marks_removing(tmp_path: Path) -> None:
     """Happy path: row flips to 'removing' synchronously, worker is
     spawned, response is 202."""
     cfg = _make_test_config(tmp_path)
-    init_db(_FakeApp(cfg.db_path))
+    init_db(cfg.db_path)
     app_id = _seed_app(cfg.db_path, "myapp")
 
     with patch("compute_space.web.routes.api.apps.threading.Thread") as Thread:
@@ -79,7 +78,7 @@ async def test_remove_returns_202_and_marks_removing(tmp_path: Path) -> None:
 @pytest.mark.asyncio
 async def test_remove_404_when_app_missing(tmp_path: Path) -> None:
     cfg = _make_test_config(tmp_path)
-    init_db(_FakeApp(cfg.db_path))
+    init_db(cfg.db_path)
 
     with patch("compute_space.web.routes.api.apps.threading.Thread") as Thread:
         # Mint a valid-shaped id that won't exist in the DB.
@@ -98,7 +97,7 @@ async def test_remove_rolls_back_if_thread_spawn_fails(tmp_path: Path) -> None:
     retry hits the already_removing short-circuit.
     """
     cfg = _make_test_config(tmp_path)
-    init_db(_FakeApp(cfg.db_path))
+    init_db(cfg.db_path)
     app_id = _seed_app(cfg.db_path, "myapp")
 
     failing_thread = MagicMock()
@@ -121,7 +120,7 @@ async def test_remove_rolls_back_if_thread_spawn_fails(tmp_path: Path) -> None:
 async def test_concurrent_removes_only_spawn_one_worker(tmp_path: Path) -> None:
     """Two POSTs racing on the same app: only one wins the atomic claim."""
     cfg = _make_test_config(tmp_path)
-    init_db(_FakeApp(cfg.db_path))
+    init_db(cfg.db_path)
     app_id = _seed_app(cfg.db_path, "myapp")
 
     with patch("compute_space.web.routes.api.apps.threading.Thread") as Thread:
@@ -161,7 +160,7 @@ async def _call_route(cfg, view_name: str, app_id: str, *, form_data=None, metho
 @pytest.mark.asyncio
 async def test_stop_app_refuses_when_removing(tmp_path: Path) -> None:
     cfg = _make_test_config(tmp_path)
-    init_db(_FakeApp(cfg.db_path))
+    init_db(cfg.db_path)
     app_id = _seed_app(cfg.db_path, "myapp", status="removing")
 
     status, payload = await _call_route(cfg, "stop_app", app_id)
@@ -172,7 +171,7 @@ async def test_stop_app_refuses_when_removing(tmp_path: Path) -> None:
 @pytest.mark.asyncio
 async def test_reload_app_refuses_when_removing(tmp_path: Path) -> None:
     cfg = _make_test_config(tmp_path)
-    init_db(_FakeApp(cfg.db_path))
+    init_db(cfg.db_path)
     app_id = _seed_app(cfg.db_path, "myapp", status="removing")
 
     status, payload = await _call_route(cfg, "reload_app", app_id)
@@ -183,7 +182,7 @@ async def test_reload_app_refuses_when_removing(tmp_path: Path) -> None:
 @pytest.mark.asyncio
 async def test_rename_app_refuses_when_removing(tmp_path: Path) -> None:
     cfg = _make_test_config(tmp_path)
-    init_db(_FakeApp(cfg.db_path))
+    init_db(cfg.db_path)
     app_id = _seed_app(cfg.db_path, "myapp", status="removing")
 
     status, payload = await _call_route(cfg, "rename_app", app_id, form_data={"name": "newname"})

--- a/compute_space/src/compute_space/tests/test_rename_app.py
+++ b/compute_space/src/compute_space/tests/test_rename_app.py
@@ -14,7 +14,6 @@ import compute_space.web.routes.api.apps as apps_routes
 from compute_space.core.app_id import new_app_id
 from compute_space.db.connection import init_db
 
-from .conftest import _FakeApp
 from .conftest import _make_test_config
 
 
@@ -87,7 +86,7 @@ def _make_per_app_dirs(cfg, app_name: str, tiers: list[str]) -> dict[str, Path]:
 async def test_rename_renames_all_three_tiers(tmp_path: Path) -> None:
     """A rename must move app_data, app_temp_data, AND app_archive subdirectories; forgetting the archive tier would orphan its contents under the old name."""
     cfg = _make_test_config(tmp_path, port=20200)
-    init_db(_FakeApp(cfg.db_path))
+    init_db(cfg.db_path)
     app_id = _seed_app_row(cfg.db_path, "old-name")
     _make_per_app_dirs(cfg, "old-name", ["app_data", "app_temp_data", "app_archive"])
 
@@ -104,7 +103,7 @@ async def test_rename_renames_all_three_tiers(tmp_path: Path) -> None:
 async def test_rename_skips_missing_tier_without_error(tmp_path: Path) -> None:
     """An app that never opted into app_archive has no subdir under the archive tier; rename_app must skip it cleanly rather than fail on a missing source."""
     cfg = _make_test_config(tmp_path, port=20201)
-    init_db(_FakeApp(cfg.db_path))
+    init_db(cfg.db_path)
     app_id = _seed_app_row(cfg.db_path, "old-name")
     _make_per_app_dirs(cfg, "old-name", ["app_data", "app_temp_data"])
 
@@ -117,7 +116,7 @@ async def test_rename_skips_missing_tier_without_error(tmp_path: Path) -> None:
 async def test_rename_rollback_on_archive_failure(tmp_path: Path) -> None:
     """If the archive-tier rename fails partway through (e.g. JuiceFS mount transiently unhealthy), the previously-renamed app_data and app_temp_data dirs must be rolled back so on-disk state matches the unchanged DB rows."""
     cfg = _make_test_config(tmp_path, port=20202)
-    init_db(_FakeApp(cfg.db_path))
+    init_db(cfg.db_path)
     app_id = _seed_app_row(cfg.db_path, "old-name", status="running")
     _make_per_app_dirs(cfg, "old-name", ["app_data", "app_temp_data", "app_archive"])
 
@@ -153,7 +152,7 @@ async def test_rename_refuses_archive_using_app_when_archive_unhealthy(tmp_path:
     the old name.  Apps that don't use archive aren't affected (see the
     test below for that)."""
     cfg = _make_test_config(tmp_path, port=20299)
-    init_db(_FakeApp(cfg.db_path))
+    init_db(cfg.db_path)
 
     # Seed an app whose manifest opts into app_archive.
     app_id = new_app_id()
@@ -203,7 +202,7 @@ async def test_rename_rollback_continues_when_a_rollback_rename_itself_fails(
 ) -> None:
     """If a rollback rename also fails, the endpoint must still return 500 surfacing the original forward-rename failure (not the rollback failure), continue rolling back the other renamed tiers, and restore the DB status field."""
     cfg = _make_test_config(tmp_path, port=20203)
-    init_db(_FakeApp(cfg.db_path))
+    init_db(cfg.db_path)
     app_id = _seed_app_row(cfg.db_path, "old-name", status="running")
     _make_per_app_dirs(cfg, "old-name", ["app_data", "app_temp_data", "app_archive"])
 
@@ -248,7 +247,7 @@ async def test_rename_non_archive_app_works_with_disabled_backend(tmp_path: Path
     archive backend is the default 'disabled'.  Pre-fix, the gate
     blocked all renames whenever the backend was unhealthy."""
     cfg = _make_test_config(tmp_path, port=20305)
-    init_db(_FakeApp(cfg.db_path))
+    init_db(cfg.db_path)
 
     app_id = new_app_id()
     db = sqlite3.connect(cfg.db_path)

--- a/compute_space/src/compute_space/tests/test_token_hashing.py
+++ b/compute_space/src/compute_space/tests/test_token_hashing.py
@@ -7,14 +7,9 @@ from compute_space.core.app_id import new_app_id
 from compute_space.db.connection import init_db
 
 
-class _FakeApp:
-    def __init__(self, db_path: str):
-        self.config = {"DB_PATH": db_path}
-
-
 def _init_test_db(tmp_path) -> str:
     db_path = str(tmp_path / "test.db")
-    init_db(_FakeApp(db_path))
+    init_db(db_path)
     return db_path
 
 


### PR DESCRIPTION
## Summary
- Replace `quart.g` per-request connection cache with a module-level `contextvars.ContextVar` in `compute_space/db/connection.py` — Quart routes still get task-scoped isolation since each request runs in its own asyncio task, and the existing `app.teardown_appcontext(close_db)` registration in `web/app.py` keeps working unchanged.
- `init_db` now takes a `db_path: str` instead of a Quart app, dropping the last `quart.Quart` / `quart.current_app` imports from `db/`. Caller in `core/startup.py` and ~10 test files updated; the `_FakeApp` shim in `tests/conftest.py` is gone.
- Sibling to #78 (which did the same for `core/`). Independent — no dependency between the two PRs; only possible overlap is `web/app.py`, which this PR does not touch. Together they prepare for a future Litestar migration by enforcing the rule that foundational modules don't import a specific web framework.

## Test plan
- [x] `pixi run -e dev pytest -x` — 531 passed, 30 skipped
- [x] `ruff` and `mypy` clean (pre-commit)
- [x] `grep "from quart\|import quart" compute_space/src/compute_space/db/` returns nothing
- [ ] Smoke-test a Quart route end-to-end on dev2 (request hits `get_db()`, response 200, connection closed via `teardown_appcontext`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)