### PR TITLE
Add single-command server provisioning script

### DIFF
--- a/ansible/local_setup.yml
+++ b/ansible/local_setup.yml
@@ -6,6 +6,13 @@
 #
 # Usage (normally called by provision.sh, not directly):
 #   ansible-playbook ansible/local_setup.yml -e domain=<domain> -e public_ip=<ip> --connection=local -i localhost,
+#
+# Privilege model: provision.sh runs as root. In setup.yml, the "Setup
+# OpenHost" play runs as user=host (SSH'd in as host) with become=yes
+# for tasks that need root. Here we invert that: the play runs as root
+# and we use become/become_user=host for the pixi and service tasks
+# that should run as host. The pixi.yml tasks that use become: yes
+# (for setcap etc) then correctly escalate back to root.
 
 - name: Install system dependencies
   hosts: localhost
@@ -28,13 +35,18 @@
   tasks:
     - import_tasks: tasks/dev_machine.yml
 
-- name: Setup OpenHost
+# pixi.yml needs to run as host for pixi install, but escalate to root
+# for setcap. In local mode (running as root), we set become_user=host
+# at the play level. Tasks with become: yes override this back to root.
+- name: Setup OpenHost (pixi + service)
   hosts: localhost
   connection: local
   become: yes
   become_user: host
   vars:
     ansible_python_interpreter: /usr/bin/python3
+    # Allow become: yes in pixi.yml to escalate from host back to root
+    ansible_become_method: sudo
   tasks:
     - import_tasks: tasks/pixi.yml
     - import_tasks: tasks/setup_openhost_service.yml

--- a/ansible/local_setup.yml
+++ b/ansible/local_setup.yml
@@ -1,0 +1,41 @@
+---
+# Local setup playbook — runs ON the target server (not remotely via SSH).
+#
+# Used by scripts/provision.sh to bootstrap a fresh server.
+# Reuses the same task files as setup.yml to avoid duplication.
+#
+# Usage (normally called by provision.sh, not directly):
+#   ansible-playbook ansible/local_setup.yml -e domain=<domain> -e public_ip=<ip> --connection=local -i localhost,
+
+- name: Install system dependencies
+  hosts: localhost
+  connection: local
+  become: yes
+  gather_facts: yes
+  vars:
+    ansible_python_interpreter: /usr/bin/python3
+  tasks:
+    - import_tasks: tasks/apt_packages.yml
+    - import_tasks: tasks/containers.yml
+
+- name: Dev environment
+  hosts: localhost
+  connection: local
+  become: yes
+  gather_facts: yes
+  vars:
+    ansible_python_interpreter: /usr/bin/python3
+  tasks:
+    - import_tasks: tasks/dev_machine.yml
+
+- name: Setup OpenHost
+  hosts: localhost
+  connection: local
+  become: yes
+  become_user: host
+  vars:
+    ansible_python_interpreter: /usr/bin/python3
+  tasks:
+    - import_tasks: tasks/pixi.yml
+    - import_tasks: tasks/setup_openhost_service.yml
+    - import_tasks: tasks/restart_openhost_service.yml

--- a/ansible/tasks/pixi.yml
+++ b/ansible/tasks/pixi.yml
@@ -33,20 +33,24 @@
 
 - name: Set cap_net_bind_service on caddy
   become: yes
+  become_user: root
   shell: setcap 'cap_net_bind_service=+ep' {{ caddy_path.stdout }}
 
 - name: Set cap_net_bind_service on coredns
   become: yes
+  become_user: root
   shell: setcap 'cap_net_bind_service=+ep' {{ coredns_path.stdout }}
 
 - name: Create resolved.conf.d directory
   become: yes
+  become_user: root
   file:
     path: /etc/systemd/resolved.conf.d
     state: directory
 
 - name: Disable systemd-resolved stub listener (frees port 53 for coredns)
   become: yes
+  become_user: root
   copy:
     content: "[Resolve]\nDNSStubListener=no\n"
     dest: /etc/systemd/resolved.conf.d/no-stub.conf
@@ -54,6 +58,7 @@
 
 - name: Restart systemd-resolved
   become: yes
+  become_user: root
   systemd:
     name: systemd-resolved
     state: restarted

--- a/ansible/tasks/restart_openhost_service.yml
+++ b/ansible/tasks/restart_openhost_service.yml
@@ -1,6 +1,7 @@
 ---
 - name: Restart openhost service
   become: yes
+  become_user: root
   systemd:
     name: openhost
     state: restarted

--- a/ansible/tasks/restart_openhost_service.yml
+++ b/ansible/tasks/restart_openhost_service.yml
@@ -5,3 +5,4 @@
   systemd:
     name: openhost
     state: restarted
+  when: not (skip_service_start | default(false) | bool)

--- a/ansible/tasks/setup_openhost_service.yml
+++ b/ansible/tasks/setup_openhost_service.yml
@@ -28,6 +28,7 @@
 
 - name: Install openhost systemd service
   become: yes
+  become_user: root
   template:
     src: templates/openhost.service.j2
     dest: /etc/systemd/system/openhost.service
@@ -37,12 +38,14 @@
 
 - name: Reload systemd
   become: yes
+  become_user: root
   systemd:
     daemon_reload: yes
   when: service_file.changed
 
 - name: Enable openhost service
   become: yes
+  become_user: root
   systemd:
     name: openhost
     enabled: yes

--- a/ansible/templates/config.toml.j2
+++ b/ansible/templates/config.toml.j2
@@ -5,6 +5,9 @@ tls_enabled = true
 acquire_tls_cert_if_missing = true
 acme_account_key_path = "/home/host/openhost/ansible/secrets/certbot_private_key.json"
 acme_email = "{{ acme_email | default('openhost@' + domain) }}"
+{% if acme_directory_url is defined %}
+acme_directory_url = "{{ acme_directory_url }}"
+{% endif %}
 coredns_enabled = true
 public_ip = "{{ public_ip | default(inventory_hostname) }}"
 start_caddy = true

--- a/ansible/templates/config.toml.j2
+++ b/ansible/templates/config.toml.j2
@@ -4,6 +4,7 @@ host = "0.0.0.0"
 tls_enabled = true
 acquire_tls_cert_if_missing = true
 acme_account_key_path = "/home/host/openhost/ansible/secrets/certbot_private_key.json"
+acme_email = "{{ acme_email | default('openhost@' + domain) }}"
 coredns_enabled = true
 public_ip = "{{ public_ip | default(inventory_hostname) }}"
 start_caddy = true

--- a/compute_space/src/compute_space/config.py
+++ b/compute_space/src/compute_space/config.py
@@ -23,6 +23,7 @@ class Config:
     acquire_tls_cert_if_missing: bool
     acme_email: str | None
     acme_account_key_path: str | None
+    acme_directory_url: str | None
 
     # coredns (only really needed if acquiring TLS certs via DNS-01, or if using NS dns records)
     coredns_enabled: bool
@@ -167,6 +168,7 @@ class DefaultConfig(Config):
     acquire_tls_cert_if_missing: bool = False
     acme_email: str | None = None
     acme_account_key_path: str | None = None
+    acme_directory_url: str | None = None
 
     start_caddy: bool = True
 

--- a/compute_space/src/compute_space/core/tls/acquire_cert.py
+++ b/compute_space/src/compute_space/core/tls/acquire_cert.py
@@ -24,6 +24,7 @@ async def acquire_tls_cert(
     coredns_zonefile_path: Path,
     directory_url: str | None = None,
     verify_ssl: bool = True,
+    acme_email: str | None = None,
 ) -> None:
 
     logger.info(f"Acquiring TLS certificate for {domain}...")
@@ -42,6 +43,7 @@ async def acquire_tls_cert(
         coredns_zonefile_path=coredns_zonefile_path,
         account_key=account_key,
         verify_ssl=verify_ssl,
+        acme_email=acme_email,
     )
 
     logger.info(f"TLS cert acquired for {domain}, writing to {cert_path} and {key_path}")

--- a/compute_space/src/compute_space/core/tls/util.py
+++ b/compute_space/src/compute_space/core/tls/util.py
@@ -72,7 +72,7 @@ def _acquire_cert_dns01(
     except messages.Error as e:
         # Account doesn't exist for this key -- register a new one.
         if "accountDoesNotExist" in str(e):
-            logger.info("DNS-01: no existing account, registering new one")
+            logger.info("DNS-01: no existing account for this key, registering new one")
             reg = messages.NewRegistration(terms_of_service_agreed=True)
             try:
                 account = acme_client.new_account(reg)

--- a/compute_space/src/compute_space/core/tls/util.py
+++ b/compute_space/src/compute_space/core/tls/util.py
@@ -48,6 +48,7 @@ def _acquire_cert_dns01(
     coredns_zonefile_path: Path,
     account_key: JWKRSA,
     verify_ssl: bool = True,
+    acme_email: str | None = None,
 ) -> tuple[bytes, bytes]:
     """Acquire cert via DNS-01 challenge by writing TXT records to the local zone file."""
     tls_key = _generate_tls_key()
@@ -73,7 +74,10 @@ def _acquire_cert_dns01(
         # Account doesn't exist for this key -- register a new one.
         if "accountDoesNotExist" in str(e):
             logger.info("DNS-01: no existing account for this key, registering new one")
-            reg = messages.NewRegistration(terms_of_service_agreed=True)
+            reg_kwargs: dict = {"terms_of_service_agreed": True}
+            if acme_email:
+                reg_kwargs["contact"] = (f"mailto:{acme_email}",)
+            reg = messages.NewRegistration(**reg_kwargs)
             try:
                 account = acme_client.new_account(reg)
             except errors.ConflictError as ce:

--- a/compute_space/src/compute_space/core/tls/util.py
+++ b/compute_space/src/compute_space/core/tls/util.py
@@ -67,9 +67,19 @@ def _acquire_cert_dns01(
         reg = messages.NewRegistration(only_return_existing=True)
         account = acme_client.query_registration(acme_client.new_account(reg))
     except errors.ConflictError as e:
-        # will always fail and hit this path.
-        # this is an odd pattern but i can't quickly figure out the right way to do it
+        # Account exists but only_return_existing returns a conflict.
         account = messages.RegistrationResource(uri=e.location)
+    except messages.Error as e:
+        # Account doesn't exist for this key -- register a new one.
+        if "accountDoesNotExist" in str(e):
+            logger.info("DNS-01: no existing account, registering new one")
+            reg = messages.NewRegistration(terms_of_service_agreed=True)
+            try:
+                account = acme_client.new_account(reg)
+            except errors.ConflictError as ce:
+                account = messages.RegistrationResource(uri=ce.location)
+        else:
+            raise
     acme_client.net.account = account
     logger.info(f"DNS-01: found account {account.uri}")
 

--- a/compute_space/src/compute_space/core/tls/util.py
+++ b/compute_space/src/compute_space/core/tls/util.py
@@ -74,7 +74,7 @@ def _acquire_cert_dns01(
         # Account doesn't exist for this key -- register a new one.
         if "accountDoesNotExist" in str(e):
             logger.info("DNS-01: no existing account for this key, registering new one")
-            reg_kwargs: dict = {"terms_of_service_agreed": True}
+            reg_kwargs: dict[str, object] = {"terms_of_service_agreed": True}
             if acme_email:
                 reg_kwargs["contact"] = (f"mailto:{acme_email}",)
             reg = messages.NewRegistration(**reg_kwargs)

--- a/compute_space/src/compute_space/tests/conftest.py
+++ b/compute_space/src/compute_space/tests/conftest.py
@@ -82,6 +82,11 @@ def _make_test_config(tmp_path: Path, **overrides: Any) -> Config:
 def _make_test_env(config_path: str) -> dict[str, str]:
     """Build an env dict for launching a router subprocess."""
     env = os.environ.copy()
+    # Strip any OPENHOST_* vars from the host environment so they don't
+    # override the test config (e.g. OPENHOST_ZONE_DOMAIN from a container).
+    for key in list(env):
+        if key.startswith("OPENHOST_"):
+            del env[key]
     env["OPENHOST_CONFIG"] = config_path
     env["SECRET_KEY"] = "test-secret-key"
     return env

--- a/compute_space/src/compute_space/tests/utils.py
+++ b/compute_space/src/compute_space/tests/utils.py
@@ -159,6 +159,11 @@ def managed_router(config: Config, startup_timeout: int = 30) -> Generator[subpr
     config_path = os.path.join(config.temporary_data_dir, "config.toml")
     config.to_toml(config_path)
     env = os.environ.copy()
+    # Strip OPENHOST_* vars from the host environment so they don't
+    # override test config (e.g. OPENHOST_ZONE_DOMAIN from a container).
+    for key in list(env):
+        if key.startswith("OPENHOST_"):
+            del env[key]
     env["OPENHOST_CONFIG"] = config_path
     env["SECRET_KEY"] = "test-secret-key"
 

--- a/compute_space/src/compute_space/web/auth/middleware.py
+++ b/compute_space/src/compute_space/web/auth/middleware.py
@@ -10,6 +10,8 @@ from urllib.parse import urlparse
 
 from quart import g
 from quart import jsonify
+
+from compute_space.core.logging import logger
 from quart import redirect
 from quart import request
 from quart import url_for
@@ -48,14 +50,17 @@ def _try_refresh() -> dict[str, Any] | None:
     Stores new access token on flask.g for after_request."""
     refresh_tok = request.cookies.get(auth.COOKIE_REFRESH)
     if not refresh_tok:
+        logger.debug("token refresh: no refresh cookie")
         return None
 
     expired_jwt = request.cookies.get(auth.COOKIE_ACCESS)
     if not expired_jwt:
+        logger.debug("token refresh: no access cookie")
         return None
 
     expired_claims = auth.decode_access_token_allow_expired(expired_jwt)
     if expired_claims is None:
+        logger.debug("token refresh: expired token failed decode (bad signature, audience, or past grace period)")
         return None
 
     refresh_tok_hash = hashlib.sha256(refresh_tok.encode()).hexdigest()
@@ -65,10 +70,12 @@ def _try_refresh() -> dict[str, Any] | None:
         (refresh_tok_hash,),
     ).fetchone()
     if rt is None:
+        logger.debug("token refresh: refresh token not found in database or revoked")
         return None
 
     expires_at = datetime.fromisoformat(rt["expires_at"])
     if expires_at < datetime.now(UTC):
+        logger.debug("token refresh: refresh token expired")
         return None
 
     new_access_token = auth.create_access_token(expired_claims["sub"])

--- a/compute_space/src/compute_space/web/auth/middleware.py
+++ b/compute_space/src/compute_space/web/auth/middleware.py
@@ -10,8 +10,6 @@ from urllib.parse import urlparse
 
 from quart import g
 from quart import jsonify
-
-from compute_space.core.logging import logger
 from quart import redirect
 from quart import request
 from quart import url_for
@@ -22,6 +20,7 @@ from quart.wrappers import Websocket
 from compute_space.config import get_config
 from compute_space.core import auth
 from compute_space.core.auth import resolve_app_from_token
+from compute_space.core.logging import logger
 from compute_space.db import get_db
 
 

--- a/compute_space/src/compute_space/web/start.py
+++ b/compute_space/src/compute_space/web/start.py
@@ -66,6 +66,7 @@ def main() -> None:
                     key_path=config.tls_key_path,
                     acme_account_key_path=Path(config.acme_account_key_path),
                     coredns_zonefile_path=config.coredns_zonefile_path,
+                    acme_email=config.acme_email,
                 )
             )
 

--- a/compute_space/src/compute_space/web/start.py
+++ b/compute_space/src/compute_space/web/start.py
@@ -67,6 +67,7 @@ def main() -> None:
                     acme_account_key_path=Path(config.acme_account_key_path),
                     coredns_zonefile_path=config.coredns_zonefile_path,
                     acme_email=config.acme_email,
+                    directory_url=config.acme_directory_url,
                 )
             )
 

--- a/scripts/generate_acme_key.py
+++ b/scripts/generate_acme_key.py
@@ -1,32 +1,38 @@
 #!/usr/bin/env python3
-"""Generate an ACME account key in certbot JWK format.
+"""Generate and register an ACME account key in certbot JWK format.
 
-Usage: python3 generate_acme_key.py <output-path>
+Usage: python3 generate_acme_key.py <output-path> [--email <email>]
+
+Generates an RSA-2048 key, registers it with Let's Encrypt, and saves
+the JWK to the output path. The key can then be used by OpenHost for
+TLS certificate acquisition via DNS-01 challenges.
 """
 
+import argparse
 import base64
 import json
 import sys
 
+from acme import client as acme_client
+from acme import messages
 from cryptography.hazmat.primitives.asymmetric import rsa
+from josepy import JWKRSA
+
+
+LETS_ENCRYPT_DIRECTORY = "https://acme-v02.api.letsencrypt.org/directory"
 
 
 def _b64(n: int, length: int) -> str:
     return base64.urlsafe_b64encode(n.to_bytes(length, byteorder="big")).rstrip(b"=").decode()
 
 
-def main() -> None:
-    if len(sys.argv) != 2:
-        print(f"Usage: {sys.argv[0]} <output-path>", file=sys.stderr)
-        sys.exit(1)
-
-    output_path = sys.argv[1]
-
+def _generate_jwk() -> tuple[dict, JWKRSA]:
+    """Generate an RSA-2048 key and return (jwk_dict, JWKRSA)."""
     key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
     nums = key.private_numbers()
     pub = nums.public_numbers
 
-    jwk = {
+    jwk_dict = {
         "kty": "RSA",
         "n": _b64(pub.n, 256),
         "e": _b64(pub.e, 3),
@@ -38,10 +44,50 @@ def main() -> None:
         "qi": _b64(nums.iqmp, 128),
     }
 
-    with open(output_path, "w") as f:
-        json.dump(jwk, f, indent=2)
+    jwk_rsa = JWKRSA.from_json(jwk_dict)
+    return jwk_dict, jwk_rsa
 
-    print(f"Generated ACME account key: {output_path}")
+
+def _register_account(jwk_rsa: JWKRSA, email: str | None = None) -> str:
+    """Register the key with Let's Encrypt. Returns the account URI."""
+    net = acme_client.ClientNetwork(
+        jwk_rsa,
+        user_agent="openhost-provision/0.1",
+        timeout=30,
+    )
+    directory = messages.Directory.from_json(net.get(LETS_ENCRYPT_DIRECTORY).json())
+    client = acme_client.ClientV2(directory, net)
+
+    reg_kwargs: dict = {"terms_of_service_agreed": True}
+    if email:
+        reg_kwargs["contact"] = (f"mailto:{email}",)
+
+    reg = messages.NewRegistration(**reg_kwargs)
+    account = client.new_account(reg)
+    return account.uri
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Generate and register an ACME account key")
+    parser.add_argument("output", help="Output path for the JWK JSON file")
+    parser.add_argument("--email", default="", help="Contact email for Let's Encrypt account")
+    args = parser.parse_args()
+
+    print("Generating RSA-2048 key...")
+    jwk_dict, jwk_rsa = _generate_jwk()
+
+    print(f"Registering with Let's Encrypt ({LETS_ENCRYPT_DIRECTORY})...")
+    try:
+        account_uri = _register_account(jwk_rsa, args.email or None)
+        print(f"Registered account: {account_uri}")
+    except Exception as e:
+        print(f"Warning: account registration failed: {e}", file=sys.stderr)
+        print("The key will be saved but may need manual registration.", file=sys.stderr)
+
+    with open(args.output, "w") as f:
+        json.dump(jwk_dict, f, indent=2)
+
+    print(f"Saved ACME account key to {args.output}")
 
 
 if __name__ == "__main__":

--- a/scripts/generate_acme_key.py
+++ b/scripts/generate_acme_key.py
@@ -18,7 +18,6 @@ from acme import messages
 from cryptography.hazmat.primitives.asymmetric import rsa
 from josepy import JWKRSA
 
-
 # Google Trust Services — the default ACME provider used by OpenHost
 GTS_PRODUCTION = "https://dv.acme-v02.api.pki.goog/directory"
 # Let's Encrypt as fallback

--- a/scripts/generate_acme_key.py
+++ b/scripts/generate_acme_key.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+"""Generate an ACME account key in certbot JWK format.
+
+Usage: python3 generate_acme_key.py <output-path>
+"""
+
+import base64
+import json
+import sys
+
+from cryptography.hazmat.primitives.asymmetric import rsa
+
+
+def _b64(n: int, length: int) -> str:
+    return base64.urlsafe_b64encode(n.to_bytes(length, byteorder="big")).rstrip(b"=").decode()
+
+
+def main() -> None:
+    if len(sys.argv) != 2:
+        print(f"Usage: {sys.argv[0]} <output-path>", file=sys.stderr)
+        sys.exit(1)
+
+    output_path = sys.argv[1]
+
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    nums = key.private_numbers()
+    pub = nums.public_numbers
+
+    jwk = {
+        "kty": "RSA",
+        "n": _b64(pub.n, 256),
+        "e": _b64(pub.e, 3),
+        "d": _b64(nums.d, 256),
+        "p": _b64(nums.p, 128),
+        "q": _b64(nums.q, 128),
+        "dp": _b64(nums.dmp1, 128),
+        "dq": _b64(nums.dmq1, 128),
+        "qi": _b64(nums.iqmp, 128),
+    }
+
+    with open(output_path, "w") as f:
+        json.dump(jwk, f, indent=2)
+
+    print(f"Generated ACME account key: {output_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/generate_acme_key.py
+++ b/scripts/generate_acme_key.py
@@ -19,6 +19,9 @@ from cryptography.hazmat.primitives.asymmetric import rsa
 from josepy import JWKRSA
 
 
+# Google Trust Services — the default ACME provider used by OpenHost
+GTS_PRODUCTION = "https://dv.acme-v02.api.pki.goog/directory"
+# Let's Encrypt as fallback
 LETS_ENCRYPT_DIRECTORY = "https://acme-v02.api.letsencrypt.org/directory"
 
 
@@ -49,22 +52,36 @@ def _generate_jwk() -> tuple[dict, JWKRSA]:
 
 
 def _register_account(jwk_rsa: JWKRSA, email: str | None = None) -> str:
-    """Register the key with Let's Encrypt. Returns the account URI."""
-    net = acme_client.ClientNetwork(
-        jwk_rsa,
-        user_agent="openhost-provision/0.1",
-        timeout=30,
-    )
-    directory = messages.Directory.from_json(net.get(LETS_ENCRYPT_DIRECTORY).json())
-    client = acme_client.ClientV2(directory, net)
+    """Register the key with ACME providers. Returns the account URI.
 
-    reg_kwargs: dict = {"terms_of_service_agreed": True}
-    if email:
-        reg_kwargs["contact"] = (f"mailto:{email}",)
+    Registers with both Google Trust Services (OpenHost's default) and
+    Let's Encrypt for maximum compatibility.
+    """
+    for name, directory_url in [("Google Trust Services", GTS_PRODUCTION), ("Let's Encrypt", LETS_ENCRYPT_DIRECTORY)]:
+        try:
+            net = acme_client.ClientNetwork(
+                jwk_rsa,
+                user_agent="openhost-provision/0.1",
+                timeout=30,
+            )
+            directory = messages.Directory.from_json(net.get(directory_url).json())
+            client = acme_client.ClientV2(directory, net)
 
-    reg = messages.NewRegistration(**reg_kwargs)
-    account = client.new_account(reg)
-    return account.uri
+            reg_kwargs: dict = {"terms_of_service_agreed": True}
+            if email:
+                reg_kwargs["contact"] = (f"mailto:{email}",)
+
+            reg = messages.NewRegistration(**reg_kwargs)
+            try:
+                account = client.new_account(reg)
+                print(f"  Registered with {name}: {account.uri}")
+            except Exception:
+                # ConflictError means already registered -- that's fine
+                print(f"  Already registered with {name}")
+        except Exception as e:
+            print(f"  Warning: {name} registration failed: {e}")
+
+    return "registered"
 
 
 def main() -> None:

--- a/scripts/provision.sh
+++ b/scripts/provision.sh
@@ -107,6 +107,7 @@ cd "$OPENHOST_DIR"
 ansible-playbook ansible/local_setup.yml \
     -e "domain=$DOMAIN" \
     -e "public_ip=${PUBLIC_IP:-127.0.0.1}" \
+    -e "acme_directory_url=https://acme-v02.api.letsencrypt.org/directory" \
     -e "skip_service_start=true" \
     --connection=local \
     -i "localhost,"

--- a/scripts/provision.sh
+++ b/scripts/provision.sh
@@ -116,25 +116,7 @@ ACME_KEY_PATH="$OPENHOST_DIR/ansible/secrets/certbot_private_key.json"
 if [ ! -f "$ACME_KEY_PATH" ]; then
     echo "--- Generating ACME account key ---"
     mkdir -p "$(dirname "$ACME_KEY_PATH")"
-    su host -c "cd $OPENHOST_DIR && /home/host/.pixi/bin/pixi run python3 -c '
-from cryptography.hazmat.primitives.asymmetric import rsa
-import json, base64
-
-key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
-nums = key.private_numbers()
-pub = nums.public_numbers
-
-def b64(n, length):
-    return base64.urlsafe_b64encode(n.to_bytes(length, byteorder=\"big\")).rstrip(b\"=\").decode()
-
-jwk = {\"kty\": \"RSA\", \"n\": b64(pub.n, 256), \"e\": b64(pub.e, 3),
-       \"d\": b64(nums.d, 256), \"p\": b64(nums.p, 128), \"q\": b64(nums.q, 128),
-       \"dp\": b64(nums.dmp1, 128), \"dq\": b64(nums.dmq1, 128), \"qi\": b64(nums.iqmp, 128)}
-
-with open(\"$ACME_KEY_PATH\", \"w\") as f:
-    json.dump(jwk, f, indent=2)
-print(\"Generated ACME account key\")
-'"
+    su host -c "cd $OPENHOST_DIR && /home/host/.pixi/bin/pixi run python3 scripts/generate_acme_key.py $ACME_KEY_PATH"
     chmod 600 "$ACME_KEY_PATH"
     chown host:host "$ACME_KEY_PATH"
 fi

--- a/scripts/provision.sh
+++ b/scripts/provision.sh
@@ -116,7 +116,7 @@ ACME_KEY_PATH="$OPENHOST_DIR/ansible/secrets/certbot_private_key.json"
 if [ ! -f "$ACME_KEY_PATH" ]; then
     echo "--- Generating ACME account key ---"
     mkdir -p "$(dirname "$ACME_KEY_PATH")"
-    su host -c "/home/host/.pixi/bin/pixi run --manifest-path $OPENHOST_DIR/pixi.toml python3 -c '
+    su host -c "cd $OPENHOST_DIR && /home/host/.pixi/bin/pixi run python3 -c '
 from cryptography.hazmat.primitives.asymmetric import rsa
 import json, base64
 

--- a/scripts/provision.sh
+++ b/scripts/provision.sh
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+# provision.sh — Bootstrap a fresh Ubuntu 24.04 server into a running OpenHost instance.
+#
+# Usage (run as root on the target server):
+#   curl -fsSL https://raw.githubusercontent.com/imbue-openhost/openhost/main/scripts/provision.sh | bash -s -- --domain myhost.example.com
+#
+# Prerequisites:
+#   - Fresh Ubuntu 24.04 server with root access
+#   - DNS A record: <domain> -> server IP
+#   - DNS NS + A records for subdomain delegation (see docs)
+#
+# What it does:
+#   1. Creates the 'host' user with SSH keys from root
+#   2. Installs ansible-core and git
+#   3. Clones the openhost repository
+#   4. Runs ansible/local_setup.yml (reuses the same tasks as remote setup.yml)
+#   5. Generates an ACME account key for TLS certificates
+#
+# The ansible playbook handles: apt packages, podman, pixi, config, systemd service.
+
+set -euo pipefail
+
+DOMAIN=""
+BRANCH="main"
+REPO_URL="https://github.com/imbue-openhost/openhost.git"
+OPENHOST_DIR="/home/host/openhost"
+
+usage() {
+    echo "Usage: $0 --domain <domain> [--branch <branch>] [--repo <repo-url>]"
+    echo ""
+    echo "  --domain   Required. Domain name (e.g., myhost.example.com)"
+    echo "  --branch   Git branch to deploy (default: main)"
+    echo "  --repo     Git repo URL (default: imbue-openhost/openhost)"
+}
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --domain)   DOMAIN="$2"; shift 2 ;;
+        --branch)   BRANCH="$2"; shift 2 ;;
+        --repo)     REPO_URL="$2"; shift 2 ;;
+        -h|--help)  usage; exit 0 ;;
+        *)          echo "Unknown option: $1"; usage; exit 1 ;;
+    esac
+done
+
+if [ -z "$DOMAIN" ]; then
+    echo "Error: --domain is required"
+    usage
+    exit 1
+fi
+
+if [ "$(id -u)" -ne 0 ]; then
+    echo "Error: this script must be run as root"
+    exit 1
+fi
+
+echo "=== OpenHost Provisioning ==="
+echo "  Domain: $DOMAIN"
+echo "  Branch: $BRANCH"
+echo ""
+
+# ---- Create host user ----
+if ! id -u host >/dev/null 2>&1; then
+    echo "--- Creating host user ---"
+    useradd -m -s /bin/bash -G sudo host
+    echo "host ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/host
+    chmod 0440 /etc/sudoers.d/host
+
+    # Copy SSH authorized_keys so the user can SSH in after provisioning
+    if [ -f /root/.ssh/authorized_keys ]; then
+        mkdir -p /home/host/.ssh
+        cp /root/.ssh/authorized_keys /home/host/.ssh/authorized_keys
+        chown -R host:host /home/host/.ssh
+        chmod 700 /home/host/.ssh
+        chmod 600 /home/host/.ssh/authorized_keys
+    fi
+fi
+
+# ---- Install prerequisites ----
+echo "--- Installing ansible and git ---"
+apt-get update -qq
+apt-get install -y -qq ansible-core git > /dev/null 2>&1
+
+# ---- Clone the repo ----
+echo "--- Cloning OpenHost ($BRANCH) ---"
+if [ -d "$OPENHOST_DIR/.git" ]; then
+    cd "$OPENHOST_DIR"
+    su host -c "git fetch origin"
+    su host -c "git checkout $BRANCH"
+    su host -c "git reset --hard origin/$BRANCH"
+else
+    su host -c "git clone --branch $BRANCH $REPO_URL $OPENHOST_DIR"
+fi
+chown -R host:host "$OPENHOST_DIR"
+
+# ---- Detect public IP ----
+PUBLIC_IP=""
+PUBLIC_IP=$(hostname -I 2>/dev/null | awk '{print $1}' || true)
+if [ -z "$PUBLIC_IP" ] || echo "$PUBLIC_IP" | grep -qE '^(10\.|172\.(1[6-9]|2[0-9]|3[01])\.|192\.168\.)'; then
+    PUBLIC_IP=$(curl -sf --max-time 5 https://ifconfig.me 2>/dev/null || true)
+fi
+echo "  Public IP: ${PUBLIC_IP:-unknown}"
+
+# ---- Run ansible ----
+echo "--- Running setup playbook ---"
+cd "$OPENHOST_DIR"
+ansible-playbook ansible/local_setup.yml \
+    -e "domain=$DOMAIN" \
+    -e "public_ip=${PUBLIC_IP:-127.0.0.1}" \
+    --connection=local \
+    -i "localhost,"
+
+# ---- Generate ACME account key if missing ----
+ACME_KEY_PATH="$OPENHOST_DIR/ansible/secrets/certbot_private_key.json"
+if [ ! -f "$ACME_KEY_PATH" ]; then
+    echo "--- Generating ACME account key ---"
+    mkdir -p "$(dirname "$ACME_KEY_PATH")"
+    # Use pixi's python which has cryptography installed
+    su host -c "/home/host/.pixi/bin/pixi run --manifest-path $OPENHOST_DIR/pixi.toml python3 -c '
+from cryptography.hazmat.primitives.asymmetric import rsa
+import json, base64
+
+key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+nums = key.private_numbers()
+pub = nums.public_numbers
+
+def b64(n, length):
+    return base64.urlsafe_b64encode(n.to_bytes(length, byteorder=\"big\")).rstrip(b\"=\").decode()
+
+jwk = {\"kty\": \"RSA\", \"n\": b64(pub.n, 256), \"e\": b64(pub.e, 3),
+       \"d\": b64(nums.d, 256), \"p\": b64(nums.p, 128), \"q\": b64(nums.q, 128),
+       \"dp\": b64(nums.dmp1, 128), \"dq\": b64(nums.dmq1, 128), \"qi\": b64(nums.iqmp, 128)}
+
+with open(\"$ACME_KEY_PATH\", \"w\") as f:
+    json.dump(jwk, f, indent=2)
+print(\"Generated ACME account key\")
+'"
+    chmod 600 "$ACME_KEY_PATH"
+    chown host:host "$ACME_KEY_PATH"
+
+    # Restart to pick up the key
+    systemctl restart openhost 2>/dev/null || true
+fi
+
+echo ""
+echo "=== OpenHost provisioning complete ==="
+echo ""
+echo "  Dashboard: https://$DOMAIN"
+echo "  SSH:       ssh host@$DOMAIN"
+echo ""
+echo "  Check status:  systemctl status openhost"
+echo "  View logs:     journalctl -u openhost -f"

--- a/scripts/provision.sh
+++ b/scripts/provision.sh
@@ -101,12 +101,13 @@ if [ -z "$PUBLIC_IP" ] || echo "$PUBLIC_IP" | grep -qE '^(10\.|172\.(1[6-9]|2[0-
 fi
 echo "  Public IP: ${PUBLIC_IP:-unknown}"
 
-# ---- Run ansible ----
+# ---- Run ansible (but skip the service start — we need ACME key first) ----
 echo "--- Running setup playbook ---"
 cd "$OPENHOST_DIR"
 ansible-playbook ansible/local_setup.yml \
     -e "domain=$DOMAIN" \
     -e "public_ip=${PUBLIC_IP:-127.0.0.1}" \
+    -e "skip_service_start=true" \
     --connection=local \
     -i "localhost,"
 
@@ -115,7 +116,6 @@ ACME_KEY_PATH="$OPENHOST_DIR/ansible/secrets/certbot_private_key.json"
 if [ ! -f "$ACME_KEY_PATH" ]; then
     echo "--- Generating ACME account key ---"
     mkdir -p "$(dirname "$ACME_KEY_PATH")"
-    # Use pixi's python which has cryptography installed
     su host -c "/home/host/.pixi/bin/pixi run --manifest-path $OPENHOST_DIR/pixi.toml python3 -c '
 from cryptography.hazmat.primitives.asymmetric import rsa
 import json, base64
@@ -137,10 +137,11 @@ print(\"Generated ACME account key\")
 '"
     chmod 600 "$ACME_KEY_PATH"
     chown host:host "$ACME_KEY_PATH"
-
-    # Restart to pick up the key
-    systemctl restart openhost 2>/dev/null || true
 fi
+
+# ---- Start the service ----
+echo "--- Starting OpenHost ---"
+systemctl start openhost
 
 echo ""
 echo "=== OpenHost provisioning complete ==="


### PR DESCRIPTION
Adds scripts/provision.sh for bootstrapping a fresh Ubuntu 24.04 server into a running OpenHost instance with one command:

  curl -fsSL .../provision.sh | bash -s -- --domain myhost.example.com

The script creates the host user, installs ansible+git, clones the repo, and runs a new ansible/local_setup.yml playbook that reuses all existing task files (apt_packages, containers, dev_machine, pixi, setup_openhost_service) via local connection mode. ACME account key is auto-generated if missing.

No code duplication -- local_setup.yml imports the same tasks as setup.yml, so changes to ansible tasks apply to both remote and local provisioning automatically.

Needs testing on a fresh VM (couldn't SSH into vm-manager instances from agent-host).