### PR TITLE
Fix test_expired_token_refresh: strip OPENHOST_* env vars from test subprocesses

### DIFF
--- a/compute_space/src/compute_space/tests/conftest.py
+++ b/compute_space/src/compute_space/tests/conftest.py
@@ -82,6 +82,11 @@ def _make_test_config(tmp_path: Path, **overrides: Any) -> Config:
 def _make_test_env(config_path: str) -> dict[str, str]:
     """Build an env dict for launching a router subprocess."""
     env = os.environ.copy()
+    # Strip OPENHOST_* vars from the host environment so they don't
+    # override test config (e.g. OPENHOST_ZONE_DOMAIN from a container).
+    for key in list(env):
+        if key.startswith("OPENHOST_"):
+            del env[key]
     env["OPENHOST_CONFIG"] = config_path
     env["SECRET_KEY"] = "test-secret-key"
     return env

--- a/compute_space/src/compute_space/tests/utils.py
+++ b/compute_space/src/compute_space/tests/utils.py
@@ -159,6 +159,11 @@ def managed_router(config: Config, startup_timeout: int = 30) -> Generator[subpr
     config_path = os.path.join(config.temporary_data_dir, "config.toml")
     config.to_toml(config_path)
     env = os.environ.copy()
+    # Strip OPENHOST_* vars from the host environment so they don't
+    # override test config (e.g. OPENHOST_ZONE_DOMAIN from a container).
+    for key in list(env):
+        if key.startswith("OPENHOST_"):
+            del env[key]
     env["OPENHOST_CONFIG"] = config_path
     env["SECRET_KEY"] = "test-secret-key"
 


### PR DESCRIPTION
OPENHOST_ZONE_DOMAIN and other OPENHOST_* vars from the host environment leaked into router test subprocesses, overriding the test config's zone_domain. This caused the expired JWT's issuer/audience (testzone.local) to mismatch the server's actual zone_domain, making decode_access_token_allow_expired return None and the token refresh fail with a 302.

Strips all OPENHOST_* vars in managed_router() and _make_test_env() before launching test subprocesses. Only OPENHOST_CONFIG (pointing to the test TOML) is set.

Reproduces when running tests inside an OpenHost container (e.g. agent-host) where OPENHOST_ZONE_DOMAIN is set.