### PR TITLE
Support fresh ACME keys: auto-register accounts and Let's Encrypt fallback

### DIFF
--- a/ansible/templates/config.toml.j2
+++ b/ansible/templates/config.toml.j2
@@ -4,6 +4,10 @@ host = "0.0.0.0"
 tls_enabled = true
 acquire_tls_cert_if_missing = true
 acme_account_key_path = "/home/host/openhost/ansible/secrets/certbot_private_key.json"
+acme_email = "{{ acme_email | default('openhost@' + domain) }}"
+{% if acme_directory_url is defined %}
+acme_directory_url = "{{ acme_directory_url }}"
+{% endif %}
 coredns_enabled = true
 public_ip = "{{ public_ip | default(inventory_hostname) }}"
 start_caddy = true

--- a/compute_space/src/compute_space/config.py
+++ b/compute_space/src/compute_space/config.py
@@ -23,6 +23,7 @@ class Config:
     acquire_tls_cert_if_missing: bool
     acme_email: str | None
     acme_account_key_path: str | None
+    acme_directory_url: str | None
 
     # coredns (only really needed if acquiring TLS certs via DNS-01, or if using NS dns records)
     coredns_enabled: bool
@@ -167,6 +168,7 @@ class DefaultConfig(Config):
     acquire_tls_cert_if_missing: bool = False
     acme_email: str | None = None
     acme_account_key_path: str | None = None
+    acme_directory_url: str | None = None
 
     start_caddy: bool = True
 

--- a/compute_space/src/compute_space/core/tls/acquire_cert.py
+++ b/compute_space/src/compute_space/core/tls/acquire_cert.py
@@ -24,6 +24,7 @@ async def acquire_tls_cert(
     coredns_zonefile_path: Path,
     directory_url: str | None = None,
     verify_ssl: bool = True,
+    acme_email: str | None = None,
 ) -> None:
 
     logger.info(f"Acquiring TLS certificate for {domain}...")
@@ -42,6 +43,7 @@ async def acquire_tls_cert(
         coredns_zonefile_path=coredns_zonefile_path,
         account_key=account_key,
         verify_ssl=verify_ssl,
+        acme_email=acme_email,
     )
 
     logger.info(f"TLS cert acquired for {domain}, writing to {cert_path} and {key_path}")

--- a/compute_space/src/compute_space/core/tls/util.py
+++ b/compute_space/src/compute_space/core/tls/util.py
@@ -48,6 +48,7 @@ def _acquire_cert_dns01(
     coredns_zonefile_path: Path,
     account_key: JWKRSA,
     verify_ssl: bool = True,
+    acme_email: str | None = None,
 ) -> tuple[bytes, bytes]:
     """Acquire cert via DNS-01 challenge by writing TXT records to the local zone file."""
     tls_key = _generate_tls_key()
@@ -67,9 +68,22 @@ def _acquire_cert_dns01(
         reg = messages.NewRegistration(only_return_existing=True)
         account = acme_client.query_registration(acme_client.new_account(reg))
     except errors.ConflictError as e:
-        # will always fail and hit this path.
-        # this is an odd pattern but i can't quickly figure out the right way to do it
+        # Account exists but only_return_existing returns a conflict.
         account = messages.RegistrationResource(uri=e.location)
+    except messages.Error as e:
+        # Account doesn't exist for this key -- register a new one.
+        if "accountDoesNotExist" in str(e):
+            logger.info("DNS-01: no existing account for this key, registering new one")
+            reg_kwargs: dict[str, object] = {"terms_of_service_agreed": True}
+            if acme_email:
+                reg_kwargs["contact"] = (f"mailto:{acme_email}",)
+            reg = messages.NewRegistration(**reg_kwargs)
+            try:
+                account = acme_client.new_account(reg)
+            except errors.ConflictError as ce:
+                account = messages.RegistrationResource(uri=ce.location)
+        else:
+            raise
     acme_client.net.account = account
     logger.info(f"DNS-01: found account {account.uri}")
 

--- a/compute_space/src/compute_space/web/start.py
+++ b/compute_space/src/compute_space/web/start.py
@@ -66,6 +66,8 @@ def main() -> None:
                     key_path=config.tls_key_path,
                     acme_account_key_path=Path(config.acme_account_key_path),
                     coredns_zonefile_path=config.coredns_zonefile_path,
+                    acme_email=config.acme_email,
+                    directory_url=config.acme_directory_url,
                 )
             )
 


### PR DESCRIPTION
Existing deployments use a pre-registered GTS ACME key. Fresh provisions (e.g. from the upcoming provision script) generate a new key with no associated account, causing cert acquisition to fail with accountDoesNotExist.

Changes:
- Auto-register new ACME accounts when the key has no existing account
- Add acme_email config field (required by GTS for new registrations)
- Add acme_directory_url config field so fresh provisions can use Let's Encrypt (GTS requires External Account Binding for new accounts, which needs a GTS API key)
- Thread both fields from config through start.py -> acquire_cert -> _acquire_cert_dns01
- Config template defaults acme_email to openhost@<domain>

Tested on andrew-3 with a freshly generated key -- TLS cert acquired successfully via Let's Encrypt.