### PR TITLE
Add single-command server provisioning script

### DIFF
--- a/ansible/local_setup.yml
+++ b/ansible/local_setup.yml
@@ -1,0 +1,53 @@
+---
+# Local setup playbook — runs ON the target server (not remotely via SSH).
+#
+# Used by scripts/provision.sh to bootstrap a fresh server.
+# Reuses the same task files as setup.yml to avoid duplication.
+#
+# Usage (normally called by provision.sh, not directly):
+#   ansible-playbook ansible/local_setup.yml -e domain=<domain> -e public_ip=<ip> --connection=local -i localhost,
+#
+# Privilege model: provision.sh runs as root. In setup.yml, the "Setup
+# OpenHost" play runs as user=host (SSH'd in as host) with become=yes
+# for tasks that need root. Here we invert that: the play runs as root
+# and we use become/become_user=host for the pixi and service tasks
+# that should run as host. The pixi.yml tasks that use become: yes
+# (for setcap etc) then correctly escalate back to root.
+
+- name: Install system dependencies
+  hosts: localhost
+  connection: local
+  become: yes
+  gather_facts: yes
+  vars:
+    ansible_python_interpreter: /usr/bin/python3
+  tasks:
+    - import_tasks: tasks/apt_packages.yml
+    - import_tasks: tasks/containers.yml
+
+- name: Dev environment
+  hosts: localhost
+  connection: local
+  become: yes
+  gather_facts: yes
+  vars:
+    ansible_python_interpreter: /usr/bin/python3
+  tasks:
+    - import_tasks: tasks/dev_machine.yml
+
+# pixi.yml needs to run as host for pixi install, but escalate to root
+# for setcap. In local mode (running as root), we set become_user=host
+# at the play level. Tasks with become: yes override this back to root.
+- name: Setup OpenHost (pixi + service)
+  hosts: localhost
+  connection: local
+  become: yes
+  become_user: host
+  vars:
+    ansible_python_interpreter: /usr/bin/python3
+    # Allow become: yes in pixi.yml to escalate from host back to root
+    ansible_become_method: sudo
+  tasks:
+    - import_tasks: tasks/pixi.yml
+    - import_tasks: tasks/setup_openhost_service.yml
+    - import_tasks: tasks/restart_openhost_service.yml

--- a/ansible/tasks/pixi.yml
+++ b/ansible/tasks/pixi.yml
@@ -33,20 +33,24 @@
 
 - name: Set cap_net_bind_service on caddy
   become: yes
+  become_user: root
   shell: setcap 'cap_net_bind_service=+ep' {{ caddy_path.stdout }}
 
 - name: Set cap_net_bind_service on coredns
   become: yes
+  become_user: root
   shell: setcap 'cap_net_bind_service=+ep' {{ coredns_path.stdout }}
 
 - name: Create resolved.conf.d directory
   become: yes
+  become_user: root
   file:
     path: /etc/systemd/resolved.conf.d
     state: directory
 
 - name: Disable systemd-resolved stub listener (frees port 53 for coredns)
   become: yes
+  become_user: root
   copy:
     content: "[Resolve]\nDNSStubListener=no\n"
     dest: /etc/systemd/resolved.conf.d/no-stub.conf
@@ -54,6 +58,7 @@
 
 - name: Restart systemd-resolved
   become: yes
+  become_user: root
   systemd:
     name: systemd-resolved
     state: restarted

--- a/ansible/tasks/restart_openhost_service.yml
+++ b/ansible/tasks/restart_openhost_service.yml
@@ -1,6 +1,8 @@
 ---
 - name: Restart openhost service
   become: yes
+  become_user: root
   systemd:
     name: openhost
     state: restarted
+  when: not (skip_service_start | default(false) | bool)

--- a/ansible/tasks/setup_openhost_service.yml
+++ b/ansible/tasks/setup_openhost_service.yml
@@ -28,6 +28,7 @@
 
 - name: Install openhost systemd service
   become: yes
+  become_user: root
   template:
     src: templates/openhost.service.j2
     dest: /etc/systemd/system/openhost.service
@@ -37,12 +38,14 @@
 
 - name: Reload systemd
   become: yes
+  become_user: root
   systemd:
     daemon_reload: yes
   when: service_file.changed
 
 - name: Enable openhost service
   become: yes
+  become_user: root
   systemd:
     name: openhost
     enabled: yes

--- a/scripts/generate_acme_key.py
+++ b/scripts/generate_acme_key.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""Generate and register an ACME account key in certbot JWK format.
+
+Usage: python3 generate_acme_key.py <output-path> [--email <email>]
+
+Generates an RSA-2048 key, registers it with Let's Encrypt, and saves
+the JWK to the output path. The key can then be used by OpenHost for
+TLS certificate acquisition via DNS-01 challenges.
+"""
+
+import argparse
+import base64
+import json
+import sys
+
+from acme import client as acme_client
+from acme import messages
+from cryptography.hazmat.primitives.asymmetric import rsa
+from josepy import JWKRSA
+
+# Google Trust Services — the default ACME provider used by OpenHost
+GTS_PRODUCTION = "https://dv.acme-v02.api.pki.goog/directory"
+# Let's Encrypt as fallback
+LETS_ENCRYPT_DIRECTORY = "https://acme-v02.api.letsencrypt.org/directory"
+
+
+def _b64(n: int, length: int) -> str:
+    return base64.urlsafe_b64encode(n.to_bytes(length, byteorder="big")).rstrip(b"=").decode()
+
+
+def _generate_jwk() -> tuple[dict, JWKRSA]:
+    """Generate an RSA-2048 key and return (jwk_dict, JWKRSA)."""
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    nums = key.private_numbers()
+    pub = nums.public_numbers
+
+    jwk_dict = {
+        "kty": "RSA",
+        "n": _b64(pub.n, 256),
+        "e": _b64(pub.e, 3),
+        "d": _b64(nums.d, 256),
+        "p": _b64(nums.p, 128),
+        "q": _b64(nums.q, 128),
+        "dp": _b64(nums.dmp1, 128),
+        "dq": _b64(nums.dmq1, 128),
+        "qi": _b64(nums.iqmp, 128),
+    }
+
+    jwk_rsa = JWKRSA.from_json(jwk_dict)
+    return jwk_dict, jwk_rsa
+
+
+def _register_account(jwk_rsa: JWKRSA, email: str | None = None) -> str:
+    """Register the key with ACME providers. Returns the account URI.
+
+    Registers with both Google Trust Services (OpenHost's default) and
+    Let's Encrypt for maximum compatibility.
+    """
+    for name, directory_url in [("Google Trust Services", GTS_PRODUCTION), ("Let's Encrypt", LETS_ENCRYPT_DIRECTORY)]:
+        try:
+            net = acme_client.ClientNetwork(
+                jwk_rsa,
+                user_agent="openhost-provision/0.1",
+                timeout=30,
+            )
+            directory = messages.Directory.from_json(net.get(directory_url).json())
+            client = acme_client.ClientV2(directory, net)
+
+            reg_kwargs: dict = {"terms_of_service_agreed": True}
+            if email:
+                reg_kwargs["contact"] = (f"mailto:{email}",)
+
+            reg = messages.NewRegistration(**reg_kwargs)
+            try:
+                account = client.new_account(reg)
+                print(f"  Registered with {name}: {account.uri}")
+            except Exception:
+                # ConflictError means already registered -- that's fine
+                print(f"  Already registered with {name}")
+        except Exception as e:
+            print(f"  Warning: {name} registration failed: {e}")
+
+    return "registered"
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Generate and register an ACME account key")
+    parser.add_argument("output", help="Output path for the JWK JSON file")
+    parser.add_argument("--email", default="", help="Contact email for Let's Encrypt account")
+    args = parser.parse_args()
+
+    print("Generating RSA-2048 key...")
+    jwk_dict, jwk_rsa = _generate_jwk()
+
+    print(f"Registering with Let's Encrypt ({LETS_ENCRYPT_DIRECTORY})...")
+    try:
+        account_uri = _register_account(jwk_rsa, args.email or None)
+        print(f"Registered account: {account_uri}")
+    except Exception as e:
+        print(f"Warning: account registration failed: {e}", file=sys.stderr)
+        print("The key will be saved but may need manual registration.", file=sys.stderr)
+
+    with open(args.output, "w") as f:
+        json.dump(jwk_dict, f, indent=2)
+
+    print(f"Saved ACME account key to {args.output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/provision.sh
+++ b/scripts/provision.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+# provision.sh — Bootstrap a fresh Ubuntu 24.04 server into a running OpenHost instance.
+#
+# Usage (run as root on the target server):
+#   curl -fsSL https://raw.githubusercontent.com/imbue-openhost/openhost/main/scripts/provision.sh | bash -s -- --domain myhost.example.com
+#
+# Prerequisites:
+#   - Fresh Ubuntu 24.04 server with root access
+#   - DNS A record: <domain> -> server IP
+#   - DNS NS + A records for subdomain delegation (see docs)
+#
+# What it does:
+#   1. Creates the 'host' user with SSH keys from root
+#   2. Installs ansible-core and git
+#   3. Clones the openhost repository
+#   4. Runs ansible/local_setup.yml (reuses the same tasks as remote setup.yml)
+#   5. Generates an ACME account key for TLS certificates
+#
+# The ansible playbook handles: apt packages, podman, pixi, config, systemd service.
+
+set -euo pipefail
+
+DOMAIN=""
+BRANCH="main"
+REPO_URL="https://github.com/imbue-openhost/openhost.git"
+OPENHOST_DIR="/home/host/openhost"
+
+usage() {
+    echo "Usage: $0 --domain <domain> [--branch <branch>] [--repo <repo-url>]"
+    echo ""
+    echo "  --domain   Required. Domain name (e.g., myhost.example.com)"
+    echo "  --branch   Git branch to deploy (default: main)"
+    echo "  --repo     Git repo URL (default: imbue-openhost/openhost)"
+}
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --domain)   DOMAIN="$2"; shift 2 ;;
+        --branch)   BRANCH="$2"; shift 2 ;;
+        --repo)     REPO_URL="$2"; shift 2 ;;
+        -h|--help)  usage; exit 0 ;;
+        *)          echo "Unknown option: $1"; usage; exit 1 ;;
+    esac
+done
+
+if [ -z "$DOMAIN" ]; then
+    echo "Error: --domain is required"
+    usage
+    exit 1
+fi
+
+if [ "$(id -u)" -ne 0 ]; then
+    echo "Error: this script must be run as root"
+    exit 1
+fi
+
+echo "=== OpenHost Provisioning ==="
+echo "  Domain: $DOMAIN"
+echo "  Branch: $BRANCH"
+echo ""
+
+# ---- Create host user ----
+if ! id -u host >/dev/null 2>&1; then
+    echo "--- Creating host user ---"
+    useradd -m -s /bin/bash -G sudo host
+    echo "host ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/host
+    chmod 0440 /etc/sudoers.d/host
+
+    # Copy SSH authorized_keys so the user can SSH in after provisioning
+    if [ -f /root/.ssh/authorized_keys ]; then
+        mkdir -p /home/host/.ssh
+        cp /root/.ssh/authorized_keys /home/host/.ssh/authorized_keys
+        chown -R host:host /home/host/.ssh
+        chmod 700 /home/host/.ssh
+        chmod 600 /home/host/.ssh/authorized_keys
+    fi
+fi
+
+# ---- Install prerequisites ----
+echo "--- Installing ansible and git ---"
+apt-get update -qq
+apt-get install -y -qq ansible-core git > /dev/null 2>&1
+
+# ---- Clone the repo ----
+echo "--- Cloning OpenHost ($BRANCH) ---"
+if [ -d "$OPENHOST_DIR/.git" ]; then
+    cd "$OPENHOST_DIR"
+    su host -c "git fetch origin"
+    su host -c "git checkout $BRANCH"
+    su host -c "git reset --hard origin/$BRANCH"
+else
+    su host -c "git clone --branch $BRANCH $REPO_URL $OPENHOST_DIR"
+fi
+chown -R host:host "$OPENHOST_DIR"
+
+# ---- Detect public IP ----
+PUBLIC_IP=""
+PUBLIC_IP=$(hostname -I 2>/dev/null | awk '{print $1}' || true)
+if [ -z "$PUBLIC_IP" ] || echo "$PUBLIC_IP" | grep -qE '^(10\.|172\.(1[6-9]|2[0-9]|3[01])\.|192\.168\.)'; then
+    PUBLIC_IP=$(curl -sf --max-time 5 https://ifconfig.me 2>/dev/null || true)
+fi
+echo "  Public IP: ${PUBLIC_IP:-unknown}"
+
+# ---- Run ansible (but skip the service start — we need ACME key first) ----
+echo "--- Running setup playbook ---"
+cd "$OPENHOST_DIR"
+ansible-playbook ansible/local_setup.yml \
+    -e "domain=$DOMAIN" \
+    -e "public_ip=${PUBLIC_IP:-127.0.0.1}" \
+    -e "acme_directory_url=https://acme-v02.api.letsencrypt.org/directory" \
+    -e "skip_service_start=true" \
+    --connection=local \
+    -i "localhost,"
+
+# ---- Generate ACME account key if missing ----
+ACME_KEY_PATH="$OPENHOST_DIR/ansible/secrets/certbot_private_key.json"
+if [ ! -f "$ACME_KEY_PATH" ]; then
+    echo "--- Generating ACME account key ---"
+    mkdir -p "$(dirname "$ACME_KEY_PATH")"
+    su host -c "cd $OPENHOST_DIR && /home/host/.pixi/bin/pixi run python3 scripts/generate_acme_key.py $ACME_KEY_PATH"
+    chmod 600 "$ACME_KEY_PATH"
+    chown host:host "$ACME_KEY_PATH"
+fi
+
+# ---- Start the service ----
+echo "--- Starting OpenHost ---"
+systemctl start openhost
+
+echo ""
+echo "=== OpenHost provisioning complete ==="
+echo ""
+echo "  Dashboard: https://$DOMAIN"
+echo "  SSH:       ssh host@$DOMAIN"
+echo ""
+echo "  Check status:  systemctl status openhost"
+echo "  View logs:     journalctl -u openhost -f"


### PR DESCRIPTION
Adds scripts/provision.sh for bootstrapping a fresh Ubuntu 24.04 server into a running OpenHost instance with one command:

    curl -fsSL .../provision.sh | bash -s -- --domain host.example.com

What it does:
1. Creates host user with SSH keys
2. Installs ansible-core + git
3. Clones the openhost repo
4. Runs ansible/local_setup.yml (reuses existing task files)
5. Generates and registers ACME account key
6. Starts the OpenHost service

Design choices:
- local_setup.yml imports the same tasks as setup.yml (apt_packages, containers, pixi, etc.) so changes to ansible tasks apply to both flows automatically
- The become_user: root additions to pixi.yml, setup_openhost_service.yml, and restart_openhost_service.yml are no-ops in the existing remote flow
- generate_acme_key.py registers with both GTS and Lets Encrypt for compatibility

Tested end-to-end on andrew-3 (Hetzner CPX31): full wipe to running instance with TLS in a single command.

Depends on #85 (test fix) and #86 (ACME support), both included in this branch so CI passes independently.