### PR TITLE
security(proxy): strip zone_auth cookie and inbound X-OpenHost-* headers

### DIFF
--- a/compute_space/src/compute_space/tests/test_integration.py
+++ b/compute_space/src/compute_space/tests/test_integration.py
@@ -1134,6 +1134,30 @@ class TestContainerE2E:
         assert headers.get("X-Forwarded-Proto") != "evil"
         assert headers.get("X-Forwarded-Host") != "evil.example.com"
 
+    def test_proxy_strips_zone_auth_cookies(self, admin_session, config):
+        """The owner's zone_auth / zone_refresh cookies must not reach the backend app."""
+        r = admin_session.get(f"{_app_url(config, 'test-app')}/echo-headers")
+        assert r.status_code == 200
+        cookie_header = r.json()["headers"].get("Cookie", "")
+        assert "zone_auth=" not in cookie_header
+        assert "zone_refresh=" not in cookie_header
+
+    def test_proxy_strips_spoofed_openhost_headers(self, admin_session, config):
+        """Client-supplied X-OpenHost-* headers must be stripped — only the router may set them."""
+        r = admin_session.get(
+            f"{_app_url(config, 'test-app')}/echo-headers",
+            headers={
+                "X-OpenHost-Is-Owner": "true",
+                "X-OpenHost-Identity": "spoofed",
+            },
+        )
+        assert r.status_code == 200
+        headers = r.json()["headers"]
+        # The router strips inbound X-OpenHost-* and re-injects its own.
+        # X-OpenHost-Is-Owner may be re-set by the router, but the spoofed
+        # X-OpenHost-Identity value must not be passed through.
+        assert headers.get("X-OpenHost-Identity") != "spoofed"
+
     def test_proxy_404(self, admin_session, config):
         """Unknown paths within the app return the app's 404."""
         r = admin_session.get(f"{_app_url(config, 'test-app')}/no-such-path")

--- a/compute_space/src/compute_space/web/proxy.py
+++ b/compute_space/src/compute_space/web/proxy.py
@@ -1,4 +1,5 @@
 import asyncio
+from collections.abc import Iterable
 from typing import Any
 
 import httpx
@@ -12,6 +13,39 @@ from compute_space.core.logging import logger
 from compute_space.core.updates import wait_for_shutdown
 from compute_space.web.auth.cookies import COOKIE_ACCESS
 from compute_space.web.auth.cookies import COOKIE_REFRESH
+
+# Zone auth cookies must never reach a backend app — apps share the zone
+# domain, so forwarding these would let any app replay the owner's session
+# against compute_space admin APIs or other apps.
+_STRIPPED_COOKIES = frozenset({COOKIE_ACCESS, COOKIE_REFRESH})
+
+# The router is the sole authority for X-OpenHost-* identity headers.
+# Any inbound value would let a client spoof identity to the backend app.
+_OPENHOST_HEADER_PREFIX = "x-openhost-"
+
+
+def _sanitize_forwarded_headers(headers: Iterable[tuple[str, str]]) -> dict[str, str]:
+    """Filter inbound headers before forwarding to a backend app.
+
+    Drops X-OpenHost-* headers (the router is their sole authority) and strips
+    zone auth cookies from the Cookie header (apps must not see or replay the
+    owner's session). Protocol-level filtering (Host, Connection, etc.) is
+    left to each caller.
+    """
+    cookie_prefixes = tuple(f"{name}=" for name in _STRIPPED_COOKIES)
+    sanitized: dict[str, str] = {}
+    for key, value in headers:
+        lower = key.lower()
+        if lower.startswith(_OPENHOST_HEADER_PREFIX):
+            continue
+        if lower == "cookie":
+            value = "; ".join(
+                part.strip() for part in value.split(";") if not part.strip().startswith(cookie_prefixes)
+            )
+            if not value:
+                continue
+        sanitized[key] = value
+    return sanitized
 
 
 async def proxy_request(
@@ -53,16 +87,10 @@ async def proxy_request(
         "x-forwarded-for",
         "x-forwarded-proto",
         "x-forwarded-host",
-        "cookie",
     }
-    # Strip any inbound X-OpenHost-* headers — the router is the sole authority
-    # for these, and forwarding a client-supplied value would let any caller
-    # spoof identity to the backend app.
-    headers = {
-        key: value
-        for key, value in quart_request.headers
-        if key.lower() not in excluded_headers and not key.lower().startswith("x-openhost-")
-    }
+    headers = _sanitize_forwarded_headers(
+        (k, v) for k, v in quart_request.headers if k.lower() not in excluded_headers
+    )
     headers["X-Forwarded-For"] = quart_request.remote_addr or ""
     headers["X-Forwarded-Proto"] = quart_request.scheme
     headers["X-Forwarded-Host"] = quart_request.host
@@ -76,9 +104,6 @@ async def proxy_request(
 
     try:
         body = await quart_request.get_data()
-        # Strip the zone auth cookies before forwarding — the backend app must
-        # not see (and therefore cannot replay) the owner's session credentials.
-        cookies = {k: v for k, v in quart_request.cookies.items() if k not in (COOKIE_ACCESS, COOKIE_REFRESH)}
         # Use granular timeouts: the default 30s is for connect/pool,
         # but read/write get a longer window to handle large uploads
         # (e.g. migration data transfers can be hundreds of MB).
@@ -97,7 +122,6 @@ async def proxy_request(
                 url=target_url,
                 headers=headers,
                 content=body,
-                cookies=cookies,
                 follow_redirects=False,
                 timeout=request_timeout,
             )
@@ -155,37 +179,29 @@ async def ws_proxy(
         target_url += f"?{query_string}"
 
     # Forward relevant headers to the backend
-    extra_headers = {}
-    subprotocols = []
+    excluded_headers = {
+        "host",
+        "connection",
+        "upgrade",
+        "sec-websocket-key",
+        "sec-websocket-version",
+        "sec-websocket-extensions",
+        "sec-websocket-protocol",
+        "x-forwarded-for",
+        "x-forwarded-proto",
+        "x-forwarded-host",
+    }
+    subprotocols: list[str] = []
+    forwardable: list[tuple[str, str]] = []
     for key, value in client_ws.headers:
         lower = key.lower()
         if lower == "sec-websocket-protocol":
             subprotocols = [s.strip() for s in value.split(",")]
-        elif lower == "cookie":
-            # Strip the zone auth cookies before forwarding — the backend must
-            # not see (and therefore cannot replay) the owner's session.
-            filtered = "; ".join(
-                part.strip()
-                for part in value.split(";")
-                if not part.strip().startswith((f"{COOKIE_ACCESS}=", f"{COOKIE_REFRESH}="))
-            )
-            if filtered:
-                extra_headers[key] = filtered
-        elif lower.startswith("x-openhost-"):
-            # The router is the sole authority for X-OpenHost-* headers — drop any inbound value.
             continue
-        elif lower not in {
-            "host",
-            "connection",
-            "upgrade",
-            "sec-websocket-key",
-            "sec-websocket-version",
-            "sec-websocket-extensions",
-            "x-forwarded-for",
-            "x-forwarded-proto",
-            "x-forwarded-host",
-        }:
-            extra_headers[key] = value
+        if lower in excluded_headers:
+            continue
+        forwardable.append((key, value))
+    extra_headers = _sanitize_forwarded_headers(forwardable)
     extra_headers["X-Forwarded-For"] = client_ws.remote_addr or ""
     extra_headers["X-Forwarded-Proto"] = client_ws.scheme
     extra_headers["X-Forwarded-Host"] = client_ws.host

--- a/compute_space/src/compute_space/web/proxy.py
+++ b/compute_space/src/compute_space/web/proxy.py
@@ -10,6 +10,7 @@ from werkzeug.datastructures import Headers
 
 from compute_space.core.logging import logger
 from compute_space.core.updates import wait_for_shutdown
+from compute_space.web.auth.cookies import COOKIE_ACCESS
 from compute_space.web.auth.cookies import COOKIE_REFRESH
 
 
@@ -54,7 +55,14 @@ async def proxy_request(
         "x-forwarded-host",
         "cookie",
     }
-    headers = {key: value for key, value in quart_request.headers if key.lower() not in excluded_headers}
+    # Strip any inbound X-OpenHost-* headers — the router is the sole authority
+    # for these, and forwarding a client-supplied value would let any caller
+    # spoof identity to the backend app.
+    headers = {
+        key: value
+        for key, value in quart_request.headers
+        if key.lower() not in excluded_headers and not key.lower().startswith("x-openhost-")
+    }
     headers["X-Forwarded-For"] = quart_request.remote_addr or ""
     headers["X-Forwarded-Proto"] = quart_request.scheme
     headers["X-Forwarded-Host"] = quart_request.host
@@ -68,7 +76,9 @@ async def proxy_request(
 
     try:
         body = await quart_request.get_data()
-        cookies = {k: v for k, v in quart_request.cookies.items() if k not in (COOKIE_REFRESH,)}
+        # Strip the zone auth cookies before forwarding — the backend app must
+        # not see (and therefore cannot replay) the owner's session credentials.
+        cookies = {k: v for k, v in quart_request.cookies.items() if k not in (COOKIE_ACCESS, COOKIE_REFRESH)}
         # Use granular timeouts: the default 30s is for connect/pool,
         # but read/write get a longer window to handle large uploads
         # (e.g. migration data transfers can be hundreds of MB).
@@ -152,12 +162,18 @@ async def ws_proxy(
         if lower == "sec-websocket-protocol":
             subprotocols = [s.strip() for s in value.split(",")]
         elif lower == "cookie":
-            # Strip auth cookies, forward the rest
+            # Strip the zone auth cookies before forwarding — the backend must
+            # not see (and therefore cannot replay) the owner's session.
             filtered = "; ".join(
-                part.strip() for part in value.split(";") if not part.strip().startswith((f"{COOKIE_REFRESH}=",))
+                part.strip()
+                for part in value.split(";")
+                if not part.strip().startswith((f"{COOKIE_ACCESS}=", f"{COOKIE_REFRESH}="))
             )
             if filtered:
                 extra_headers[key] = filtered
+        elif lower.startswith("x-openhost-"):
+            # The router is the sole authority for X-OpenHost-* headers — drop any inbound value.
+            continue
         elif lower not in {
             "host",
             "connection",


### PR DESCRIPTION
The proxy was forwarding the owner's zone_auth JWT cookie to every app backend. Apps run on subdomains of zone_domain and the cookie is set with Domain=zone_domain, so any app the owner visits could read the JWT from its incoming request and replay it against compute_space admin APIs or any other app — a privilege-escalation vector for a platform that hosts untrusted apps.

Separately, X-OpenHost-* headers were not stripped from inbound requests. Clients (including public-path callers) could spoof X-OpenHost-Is-Owner: true directly to apps. Now the router is the sole authority for these headers.