### PR TITLE
fix(web): redirect to setup.setup endpoint after blueprint split

### DIFF
--- a/compute_space/src/compute_space/tests/test_pre_setup_redirect.py
+++ b/compute_space/src/compute_space/tests/test_pre_setup_redirect.py
@@ -1,0 +1,48 @@
+"""Smoke test: before owner setup, any request must redirect to /setup.
+
+This catches the failure mode where a route handler calls ``url_for`` for
+an endpoint that doesn't exist (e.g. ``auth.setup`` after the setup view
+moved to its own blueprint) — Werkzeug raises ``BuildError`` and the
+server returns 500 for *every* request before setup, locking the operator
+out of their own instance.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from compute_space.web.app import create_app
+
+from .conftest import _make_test_config
+
+
+@pytest.mark.asyncio
+async def test_root_redirects_to_setup_on_fresh_db(tmp_path: Path) -> None:
+    cfg = _make_test_config(tmp_path, port=20500)
+    app = create_app(cfg)
+
+    client = app.test_client()
+    resp = await client.get("/")
+
+    assert resp.status_code == 302, f"expected redirect to /setup, got {resp.status_code}"
+    location = resp.headers.get("Location", "")
+    assert location.endswith("/setup"), f"expected redirect to /setup, got {location!r}"
+
+
+@pytest.mark.asyncio
+async def test_login_page_redirects_to_setup_on_fresh_db(tmp_path: Path) -> None:
+    """The /login view itself also redirects to /setup when no owner exists.
+
+    Regression for the same class of bug — /login built ``url_for('auth.setup')``
+    which 500s once setup moved to its own blueprint.
+    """
+    cfg = _make_test_config(tmp_path, port=20501)
+    app = create_app(cfg)
+
+    client = app.test_client()
+    resp = await client.get("/login")
+
+    assert resp.status_code == 302, f"expected redirect, got {resp.status_code}"
+    assert resp.headers.get("Location", "").endswith("/setup")

--- a/compute_space/src/compute_space/web/app.py
+++ b/compute_space/src/compute_space/web/app.py
@@ -129,7 +129,7 @@ def create_app(config: Config | None = None) -> Quart:
             app._owner_verified = True  # type: ignore[attr-defined]
             return None
         claim = request.args.get("claim", "")
-        return redirect(url_for("auth.setup", claim=claim) if claim else url_for("auth.setup"))
+        return redirect(url_for("setup.setup", claim=claim) if claim else url_for("setup.setup"))
 
     # ─── Context processor ───
 

--- a/compute_space/src/compute_space/web/auth/middleware.py
+++ b/compute_space/src/compute_space/web/auth/middleware.py
@@ -207,7 +207,7 @@ def login_required(
         if owner is None:
             # Preserve claim token in redirect so /setup can validate it
             claim = request.args.get("claim", "")
-            response = redirect(url_for("auth.setup", claim=claim) if claim else url_for("auth.setup"))
+            response = redirect(url_for("setup.setup", claim=claim) if claim else url_for("setup.setup"))
         else:
             response = redirect(url_for("auth.login"))
 

--- a/compute_space/src/compute_space/web/routes/pages/login.py
+++ b/compute_space/src/compute_space/web/routes/pages/login.py
@@ -39,7 +39,7 @@ async def login() -> ResponseReturnValue:
     db = get_db()
     owner = db.execute("SELECT * FROM owner").fetchone()
     if owner is None:
-        return redirect(url_for("auth.setup"))
+        return redirect(url_for("setup.setup"))
 
     if request.method == "GET":
         if has_stale_cookies:


### PR DESCRIPTION
## Summary

- PR #84 moved the `/setup` view out of `auth_bp` into its own `setup_bp` (endpoint renamed `auth.setup` → `setup.setup`), but three `url_for("auth.setup")` callers in `web/app.py`, `web/auth/middleware.py`, and `web/routes/pages/login.py` were missed.
- On any fresh instance (no owner yet) the pre-setup `before_request` hook hits the broken `url_for`, Werkzeug raises `BuildError`, and the server 500s on *every* request — the operator can't even reach the claim page. Reproduced against a fresh deploy of `main`.
- Adds a smoke test that creates the app with an empty DB and asserts `GET /` and `GET /login` both redirect to `/setup`, so any future endpoint rename surfaces in CI instead of bricking deploys.

## Test plan

- [ ] CI green
- [ ] Manual: deploy this branch to a fresh instance and confirm `/` and `/login` redirect to `/setup` (instead of 500)