### PR TITLE
fix e2e cleanup to filter by instance name

### DIFF
--- a/.github/workflows/e2e-cleanup.yml
+++ b/.github/workflows/e2e-cleanup.yml
@@ -60,11 +60,11 @@ jobs:
       - name: Delete orphaned EC2 instances
         run: |
           CUTOFF=$(date -u -d "${MAX_AGE_HOURS} hours ago" +%Y-%m-%dT%H:%M:%SZ)
-          echo "Deleting openhost-e2e instances launched before $CUTOFF"
+          echo "Deleting openhost-e2e-* instances launched before $CUTOFF"
 
           INSTANCE_IDS=$(aws ec2 describe-instances \
             --filters \
-              "Name=tag:openhost-e2e,Values=true" \
+              "Name=tag:Name,Values=openhost-e2e-*" \
               "Name=instance-state-name,Values=running,stopped" \
             --query "Reservations[].Instances[?LaunchTime<'${CUTOFF}'].InstanceId" \
             --output text)

--- a/.github/workflows/e2e-cleanup.yml
+++ b/.github/workflows/e2e-cleanup.yml
@@ -78,3 +78,65 @@ jobs:
             echo "Terminating $id..."
             aws ec2 terminate-instances --instance-ids "$id" || echo "  Failed to terminate $id"
           done
+
+  cleanup-dns:
+    runs-on: ubuntu-latest
+    needs: [cleanup-gcp, cleanup-ec2]
+    if: always()
+    env:
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      AWS_DEFAULT_REGION: us-east-1
+    steps:
+      - name: Delete orphaned Route53 DNS records
+        env:
+          HOSTED_ZONE_ID: ${{ secrets.ROUTE53_HOSTED_ZONE_ID }}
+          BASE_DOMAIN: ${{ secrets.ROUTE53_BASE_DOMAIN }}
+        run: |
+          if [ -z "$HOSTED_ZONE_ID" ] || [ -z "$BASE_DOMAIN" ]; then
+            echo "Route53 secrets not configured, skipping DNS cleanup"
+            exit 0
+          fi
+
+          echo "Scanning for orphaned openhost-e2e-* DNS records in $BASE_DOMAIN"
+
+          RECORDS=$(aws route53 list-resource-record-sets \
+            --hosted-zone-id "$HOSTED_ZONE_ID" \
+            --query "ResourceRecordSets[?contains(Name, 'openhost-e2e-')].[Name,Type]" \
+            --output text)
+
+          if [ -z "$RECORDS" ]; then
+            echo "No orphaned DNS records found"
+            exit 0
+          fi
+
+          echo "$RECORDS" | while read -r name type; do
+            # Only clean up NS and A records we created
+            if [ "$type" != "NS" ] && [ "$type" != "A" ]; then
+              continue
+            fi
+
+            RRSET=$(aws route53 list-resource-record-sets \
+              --hosted-zone-id "$HOSTED_ZONE_ID" \
+              --start-record-name "$name" \
+              --start-record-type "$type" \
+              --max-items 1 \
+              --query "ResourceRecordSets[0]" \
+              --output json)
+
+            RRSET_NAME=$(echo "$RRSET" | jq -r '.Name')
+            RRSET_TYPE=$(echo "$RRSET" | jq -r '.Type')
+
+            # Verify it still matches (pagination guard)
+            if [ "$RRSET_NAME" != "$name" ] || [ "$RRSET_TYPE" != "$type" ]; then
+              continue
+            fi
+
+            echo "Deleting $type record: $name"
+            CHANGE_BATCH=$(echo "$RRSET" | jq -c '{Changes: [{Action: "DELETE", ResourceRecordSet: .}]}')
+            aws route53 change-resource-record-sets \
+              --hosted-zone-id "$HOSTED_ZONE_ID" \
+              --change-batch "$CHANGE_BATCH" 2>/dev/null \
+              && echo "  Deleted $name ($type)" \
+              || echo "  Failed to delete $name ($type)"
+          done


### PR DESCRIPTION
The EC2 cleanup job was filtering by the openhost-e2e tag which could match non-e2e instances if they happen to have that tag. Changed to filter by Name tag matching openhost-e2e-* to be consistent with how the GCP cleanup already works (name regex ^openhost-e2e-).