### PR TITLE
Recurse submodules when cloning app repos

### DIFF
--- a/compute_space/src/compute_space/core/apps.py
+++ b/compute_space/src/compute_space/core/apps.py
@@ -139,7 +139,7 @@ async def clone_and_read_manifest(
     tmp_parent = tempfile.mkdtemp(prefix="openhost-clone-")
     clone_dir = os.path.join(tmp_parent, "repo")
     try:
-        clone_cmd = ["git", "clone"]
+        clone_cmd = ["git", "clone", "--recurse-submodules", "--shallow-submodules"]
         if ref:
             clone_cmd.extend(["--branch", ref])
         clone_cmd.extend([clone_url, clone_dir])


### PR DESCRIPTION
## Summary
- Regression from 28e681f5 (Deploy via git clone instead of rsync, 2026-04-28): the previous rsync path copied locally-populated submodules, but the new `git clone` invocation in `compute_space/src/compute_space/core/apps.py` omits `--recurse-submodules`.
- Apps like [sculptor-in-openhost](https://github.com/imbue-openhost/sculptor-in-openhost), which depend on a submodule (`sculptor`) being present at deploy time, fail to redeploy.
- Adds `--recurse-submodules --shallow-submodules` to the clone command.

## Test plan
- [ ] Redeploy sculptor-in-openhost and confirm the `sculptor` submodule is populated in the app's clone dir.
- [ ] Existing `compute_space` tests still pass (`pixi run -e dev pytest -x compute_space/tests/`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)