### PR TITLE
Allow removal/rename of archive-using apps when S3 was never configured

### DIFF
--- a/compute_space/src/compute_space/tests/test_remove_app_route.py
+++ b/compute_space/src/compute_space/tests/test_remove_app_route.py
@@ -36,15 +36,15 @@ async def _call_remove(cfg, app_id: str, *, keep_data: bool = False):
         return status, payload
 
 
-def _seed_app(db_path: str, name: str, status: str = "running") -> str:
+def _seed_app(db_path: str, name: str, status: str = "running", manifest_raw: str | None = None) -> str:
     """Insert a row and return its newly minted app_id."""
     app_id = new_app_id()
     db = sqlite3.connect(db_path)
     try:
         db.execute(
-            "INSERT INTO apps (app_id, name, version, repo_path, local_port, status) "
-            "VALUES (?, ?, '1.0', '/r', 19500, ?)",
-            (app_id, name, status),
+            "INSERT INTO apps (app_id, name, version, repo_path, local_port, status, manifest_raw) "
+            "VALUES (?, ?, '1.0', '/r', 19500, ?, ?)",
+            (app_id, name, status, manifest_raw),
         )
         db.commit()
     finally:
@@ -189,3 +189,63 @@ async def test_rename_app_refuses_when_removing(tmp_path: Path) -> None:
     status, payload = await _call_route(cfg, "rename_app", app_id, form_data={"name": "newname"})
     assert status == 409
     assert "removed" in payload["error"].lower()
+
+
+# ---- Archive guard: disabled backend should not block removal ----
+
+_ARCHIVE_MANIFEST = """\
+[app]
+name = "testapp"
+version = "0.1.0"
+[data]
+access_all_data = true
+"""
+
+_ARCHIVE_ONLY_MANIFEST = """\
+[app]
+name = "testapp"
+version = "0.1.0"
+[data]
+app_archive = true
+"""
+
+
+@pytest.mark.asyncio
+async def test_remove_archive_app_allowed_when_backend_disabled(tmp_path: Path) -> None:
+    """When S3 was never configured (backend='disabled'), removing an app
+    that declares access_all_data=true should succeed — there's no S3
+    data to orphan."""
+    cfg = _make_test_config(tmp_path)
+    init_db(_FakeApp(cfg.db_path))
+    app_id = _seed_app(cfg.db_path, "fbrowser", manifest_raw=_ARCHIVE_MANIFEST)
+
+    with patch("compute_space.web.routes.api.apps.threading.Thread") as Thread:
+        status, payload = await _call_remove(cfg, app_id, keep_data=False)
+
+    assert status == 202, f"Expected 202 but got {status}: {payload}"
+    assert payload == {"ok": True}
+    Thread.return_value.start.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_remove_archive_app_blocked_when_backend_s3_unhealthy(tmp_path: Path) -> None:
+    """When S3 was configured but the mount is unhealthy, removing an
+    archive-using app should still be blocked (503) to prevent orphaning
+    S3 bytes."""
+    cfg = _make_test_config(tmp_path)
+    init_db(_FakeApp(cfg.db_path))
+    app_id = _seed_app(cfg.db_path, "myarchive", manifest_raw=_ARCHIVE_ONLY_MANIFEST)
+
+    db = sqlite3.connect(cfg.db_path)
+    try:
+        db.execute("UPDATE archive_backend SET backend = 's3' WHERE id = 1")
+        db.commit()
+    finally:
+        db.close()
+
+    with patch("compute_space.web.routes.api.apps.threading.Thread") as Thread:
+        status, payload = await _call_remove(cfg, app_id, keep_data=False)
+
+    assert status == 503, f"Expected 503 but got {status}: {payload}"
+    assert "not healthy" in payload["error"].lower()
+    Thread.assert_not_called()

--- a/compute_space/src/compute_space/tests/test_rename_app.py
+++ b/compute_space/src/compute_space/tests/test_rename_app.py
@@ -164,6 +164,10 @@ async def test_rename_refuses_archive_using_app_when_archive_unhealthy(tmp_path:
                VALUES (?, ?, '1.0', ?, ?, 'running', ?)""",
             (app_id, "old-name", "/tmp/repo/old-name", 19500, "[data]\napp_archive = true\n"),
         )
+        # Set backend to "s3" so the guard fires when the mount is
+        # unhealthy.  With backend="disabled" (the default) the guard
+        # is intentionally skipped since there's no S3 data to orphan.
+        db.execute("UPDATE archive_backend SET backend = 's3' WHERE id = 1")
         db.commit()
     finally:
         db.close()

--- a/compute_space/src/compute_space/web/routes/api/apps.py
+++ b/compute_space/src/compute_space/web/routes/api/apps.py
@@ -442,16 +442,18 @@ async def remove_app(app_id: str) -> ResponseReturnValue:
     # disappears. Must run before the atomic-claim UPDATE.
     if not keep_data and not archive_backend.is_archive_dir_healthy(config, db):
         if archive_backend.manifest_uses_archive(app_row["manifest_raw"] or ""):
-            return jsonify(
-                {
-                    "error": "Archive backend is not healthy; refusing to "
-                    "remove an archive-using app's data because the "
-                    "S3-side bytes wouldn't actually be deleted.  "
-                    "Either restore the archive mount and retry, or "
-                    "use keep_data=1 to remove the app while leaving "
-                    "its data in place."
-                }
-            ), 503
+            backend_state = archive_backend.read_state(db)
+            if backend_state.backend != "disabled":
+                return jsonify(
+                    {
+                        "error": "Archive backend is not healthy; refusing to "
+                        "remove an archive-using app's data because the "
+                        "S3-side bytes wouldn't actually be deleted.  "
+                        "Either restore the archive mount and retry, or "
+                        "use keep_data=1 to remove the app while leaving "
+                        "its data in place."
+                    }
+                ), 503
 
     # Atomic claim: ``WHERE status != 'removing'`` makes concurrent
     # POSTs safe — only the first one gets rowcount=1 and spawns a
@@ -560,13 +562,15 @@ async def rename_app(app_id: str) -> ResponseReturnValue:
     # tier are unaffected and can rename freely on any backend state.
     if archive_backend.manifest_uses_archive(app_row["manifest_raw"] or ""):
         if not archive_backend.is_archive_dir_healthy(config, db):
-            return jsonify(
-                {
-                    "error": "Archive backend is not healthy; refusing to rename "
-                    "an archive-using app until the JuiceFS mount is live "
-                    "again (see the dashboard's Archive backend panel)."
-                }
-            ), 503
+            backend_state = archive_backend.read_state(db)
+            if backend_state.backend != "disabled":
+                return jsonify(
+                    {
+                        "error": "Archive backend is not healthy; refusing to rename "
+                        "an archive-using app until the JuiceFS mount is live "
+                        "again (see the dashboard's Archive backend panel)."
+                    }
+                ), 503
 
     if new_name == old_name:
         return jsonify({"ok": True, "name": new_name})


### PR DESCRIPTION
## Summary

- Built-in apps like file-browser declare access_all_data=true and get installed via deploy_default_apps which skips the S3 availability check
- On zones without S3 storage configured, trying to remove these apps returns a 503 because the archive health guard blocks it
- When the backend is still "disabled" (never configured), there are no S3-side bytes to orphan, so the guard is unnecessary
- This change skips the archive health guard during both removal and rename when backend == "disabled"