### PR TITLE
Add Sculptor workspace setup instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,17 @@ Notes:
 pre-commit install
 ```
 
+### sculptor workspace setup script
+
+add
+```
+cp -r [YOUR_LOCAL_OPENHOST_CHECKOUT]/.idea .
+pre-commit install
+```
+
+in settings->repositories->openhost->Workspace setup command. adapt to any IDE config or other git-ignored files you'd like copied over; this one is for pycharm + pre-commit.
+
+
 ## testing
 
 ```bash


### PR DESCRIPTION
## Summary
- Adds a new section to the README documenting how to configure Sculptor's workspace setup command
- Shows how to automatically copy IDE config (e.g. PyCharm `.idea/` directory) and install pre-commit hooks when creating a new workspace
- Points users to Settings → Repositories → openhost → Workspace setup command

## Test plan
- [ ] Verify the new section renders correctly on GitHub
- [ ] Confirm the instructions are accurate for the current Sculptor settings UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)