### PR TITLE
Migrate api/system to Litestar + add fallback wrapper

### DIFF
--- a/compute_space/src/compute_space/tests/test_build_cache.py
+++ b/compute_space/src/compute_space/tests/test_build_cache.py
@@ -4,13 +4,43 @@ The endpoint runs ``podman image prune --all --force`` via
 ``drop_docker_build_cache`` in compute_space.core.containers.
 """
 
+from __future__ import annotations
+
 import subprocess
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Any
 
 import pytest
-from quart import Quart
+from litestar import Litestar
+from litestar.testing import TestClient
 
 from compute_space.core.containers import drop_docker_build_cache
+from compute_space.db.connection import init_db
 from compute_space.web.routes.api import system as system_routes
+from compute_space.web.routes.api.system import system_routes as system_router
+
+from ._litestar_helpers import auth_cookie
+from ._litestar_helpers import make_test_app
+from .conftest import _make_test_config
+
+
+@pytest.fixture
+def cfg(tmp_path: Path) -> Any:
+    cfg = _make_test_config(tmp_path, port=20800)
+    init_db(cfg.db_path)
+    return cfg
+
+
+@pytest.fixture
+def client(cfg: Any) -> Iterator[TestClient[Litestar]]:
+    with TestClient(app=make_test_app(system_router)) as c:
+        yield c
+
+
+@pytest.fixture
+def cookies(cfg: Any) -> dict[str, str]:
+    return auth_cookie(cfg)
 
 
 def test_drop_docker_build_cache_runs_podman_image_prune(
@@ -58,39 +88,26 @@ def test_drop_docker_build_cache_raises_on_error(
         drop_docker_build_cache()
 
 
-@pytest.mark.asyncio
-async def test_drop_docker_cache_endpoint_success(
-    monkeypatch: pytest.MonkeyPatch,
+def test_drop_docker_cache_endpoint_success(
+    monkeypatch: pytest.MonkeyPatch, client: TestClient[Litestar], cookies: dict[str, str]
 ) -> None:
-    app = Quart(__name__)
     monkeypatch.setattr(
         system_routes,
         "drop_docker_build_cache",
         lambda: "Total reclaimed space: 12.3MB",
     )
-
-    async with app.app_context():
-        response = system_routes.drop_docker_cache.__wrapped__()  # type: ignore[attr-defined]
-        assert response.status_code == 200
-        payload = await response.get_json()
-
-    assert payload == {"ok": True, "output": "Total reclaimed space: 12.3MB"}
+    resp = client.post("/api/drop-docker-cache", cookies=cookies)
+    assert resp.status_code == 200
+    assert resp.json() == {"ok": True, "output": "Total reclaimed space: 12.3MB"}
 
 
-@pytest.mark.asyncio
-async def test_drop_docker_cache_endpoint_failure(
-    monkeypatch: pytest.MonkeyPatch,
+def test_drop_docker_cache_endpoint_failure(
+    monkeypatch: pytest.MonkeyPatch, client: TestClient[Litestar], cookies: dict[str, str]
 ) -> None:
-    app = Quart(__name__)
-
     def _raise_error() -> str:
         raise RuntimeError("podman engine error")
 
     monkeypatch.setattr(system_routes, "drop_docker_build_cache", _raise_error)
-
-    async with app.app_context():
-        response, status_code = system_routes.drop_docker_cache.__wrapped__()  # type: ignore[attr-defined]
-        assert status_code == 500
-        payload = await response.get_json()
-
-    assert payload == {"ok": False, "error": "podman engine error"}
+    resp = client.post("/api/drop-docker-cache", cookies=cookies)
+    assert resp.status_code == 500
+    assert resp.json() == {"error": "podman engine error"}

--- a/compute_space/src/compute_space/tests/test_integration.py
+++ b/compute_space/src/compute_space/tests/test_integration.py
@@ -407,7 +407,7 @@ class TestRouterCore:
         base = _zone_url(config)
 
         # Create a token
-        r = admin_session.post(f"{base}/api/tokens", data={"name": "test-token", "expiry_hours": "1"})
+        r = admin_session.post(f"{base}/api/tokens", json={"name": "test-token", "expiry_hours": "1"})
         assert r.status_code == 200
         data = r.json()
         assert "token" in data
@@ -431,7 +431,7 @@ class TestRouterCore:
         # Delete the token
         token_id = next(t["id"] for t in tokens if t["name"] == "test-token")
         r = admin_session.delete(f"{base}/api/tokens/{token_id}")
-        assert r.status_code == 200
+        assert r.status_code == 204
 
         # Token should no longer work
         r = requests.get(
@@ -444,7 +444,7 @@ class TestRouterCore:
     def test_api_token_no_expiry(self, admin_session, config):
         """Tokens created with expiry_hours=never should work."""
         base = _zone_url(config)
-        r = admin_session.post(f"{base}/api/tokens", data={"name": "no-expiry", "expiry_hours": "never"})
+        r = admin_session.post(f"{base}/api/tokens", json={"name": "no-expiry", "expiry_hours": "never"})
         data = r.json()
         assert data["expires_at"] is None
 

--- a/compute_space/src/compute_space/web/app.py
+++ b/compute_space/src/compute_space/web/app.py
@@ -45,6 +45,7 @@ from compute_space.web.routes.api.identity import identity_routes
 from compute_space.web.routes.api.permissions_v2 import api_permissions_v2_routes
 from compute_space.web.routes.api.services_v2 import api_services_v2_routes
 from compute_space.web.routes.api.settings import api_settings_routes
+from compute_space.web.routes.api.system import system_routes
 from compute_space.web.routes.pages.apps import pages_apps_routes
 from compute_space.web.routes.pages.login import pages_login_routes
 from compute_space.web.routes.pages.permissions_v2 import pages_permissions_v2_routes
@@ -224,7 +225,6 @@ def _build_quart_fallback(config: Config, static_dir: Path) -> Quart:
     # constructs a Quart Blueprint at import time and we don't want those to
     # exist if a caller (e.g. the setup-only app) builds Litestar alone.
     from compute_space.web.routes.api.apps import api_apps_bp  # noqa: PLC0415
-    from compute_space.web.routes.api.system import system_bp  # noqa: PLC0415
     from compute_space.web.routes.docs import docs_bp  # noqa: PLC0415
 
     web_dir = Path(__file__).parent
@@ -269,7 +269,6 @@ def _build_quart_fallback(config: Config, static_dir: Path) -> Quart:
     quart_app.register_blueprint(pages_settings_stub_bp)
     quart_app.register_blueprint(apps_stub_bp)
     quart_app.register_blueprint(api_apps_bp)
-    quart_app.register_blueprint(system_bp)
     quart_app.register_blueprint(docs_bp)
 
     # Quart-side templating helpers, matching the Litestar Jinja globals so the
@@ -339,6 +338,7 @@ def create_app(config: Config) -> ASGIApp:
             api_permissions_v2_routes,
             api_services_v2_routes,
             api_settings_routes,
+            system_routes,
             identity_routes,
             pages_apps_routes,
             pages_login_routes,

--- a/compute_space/src/compute_space/web/helpers/proxy.py
+++ b/compute_space/src/compute_space/web/helpers/proxy.py
@@ -109,6 +109,8 @@ _HTTP_REQUEST_EXCLUDED_HEADERS = frozenset(
     }
 )
 
+_BUFFER_THRESHOLD = 512_000  # 500 KB — buffer small upstream responses to avoid chunked encoding
+
 _HTTP_RESPONSE_EXCLUDED_HEADERS = frozenset(
     {
         # per-hop headers (these get read as we receive the incoming request, and automatically set on the outgoing)
@@ -187,7 +189,16 @@ async def proxy_http_request(
             if k.lower() not in _HTTP_RESPONSE_EXCLUDED_HEADERS
         ]
 
-        if upstream_response.status_code in buffer_status_codes:
+        # Buffer small / special-status responses instead of streaming.
+        # Streaming forces chunked transfer-encoding and uses an anyio task
+        # group with a disconnect listener that can cancel the stream before
+        # the terminus chunk is sent, causing intermittent
+        # ChunkedEncodingError on the client side.
+        upstream_content_length = upstream_response.headers.get("content-length")
+        should_buffer = upstream_response.status_code in buffer_status_codes or (
+            upstream_content_length is not None and int(upstream_content_length) <= _BUFFER_THRESHOLD
+        )
+        if should_buffer:
             body = await upstream_response.aread()
             await upstream_response.aclose()
             await client.aclose()

--- a/compute_space/src/compute_space/web/helpers/proxy.py
+++ b/compute_space/src/compute_space/web/helpers/proxy.py
@@ -109,8 +109,6 @@ _HTTP_REQUEST_EXCLUDED_HEADERS = frozenset(
     }
 )
 
-_BUFFER_THRESHOLD = 512_000  # 500 KB — buffer small upstream responses to avoid chunked encoding
-
 _HTTP_RESPONSE_EXCLUDED_HEADERS = frozenset(
     {
         # per-hop headers (these get read as we receive the incoming request, and automatically set on the outgoing)
@@ -189,16 +187,7 @@ async def proxy_http_request(
             if k.lower() not in _HTTP_RESPONSE_EXCLUDED_HEADERS
         ]
 
-        # Buffer small / special-status responses instead of streaming.
-        # Streaming forces chunked transfer-encoding and uses an anyio task
-        # group with a disconnect listener that can cancel the stream before
-        # the terminus chunk is sent, causing intermittent
-        # ChunkedEncodingError on the client side.
-        upstream_content_length = upstream_response.headers.get("content-length")
-        should_buffer = upstream_response.status_code in buffer_status_codes or (
-            upstream_content_length is not None and int(upstream_content_length) <= _BUFFER_THRESHOLD
-        )
-        if should_buffer:
+        if upstream_response.status_code in buffer_status_codes:
             body = await upstream_response.aread()
             await upstream_response.aclose()
             await client.aclose()

--- a/compute_space/src/compute_space/web/routes/api/system.py
+++ b/compute_space/src/compute_space/web/routes/api/system.py
@@ -49,8 +49,8 @@ class CreateTokenRequest:
     sentinel ``"never"`` (= no expiry) and a numeric value share one field
     without forcing the JS client to send different keys."""
 
-    name: str = ""
-    expiry_hours: str = ""
+    name: str
+    expiry_hours: str | None = None
 
 
 @attr.s(auto_attribs=True, frozen=True)
@@ -135,9 +135,9 @@ async def api_tokens_create(
     data: CreateTokenRequest, db: sqlite3.Connection
 ) -> Response[CreatedToken] | Response[ErrorResponse]:
     name = data.name.strip() or "Untitled"
-    expiry_hours_raw = data.expiry_hours.strip()
+    expiry_hours_raw = data.expiry_hours.strip() if data.expiry_hours else ""
     expires_at: datetime | None
-    if expiry_hours_raw == "" or expiry_hours_raw.lower() == "never":
+    if not expiry_hours_raw or expiry_hours_raw.lower() == "never":
         expires_at = None
     else:
         try:

--- a/compute_space/src/compute_space/web/routes/api/system.py
+++ b/compute_space/src/compute_space/web/routes/api/system.py
@@ -1,17 +1,22 @@
 import hashlib
 import secrets
+import sqlite3
 import subprocess
 from datetime import UTC
 from datetime import datetime
 from datetime import timedelta
 
-from quart import Blueprint
-from quart import Response
-from quart import jsonify
-from quart import request
-from quart.typing import ResponseReturnValue
+import attr
+from litestar import MediaType
+from litestar import Response
+from litestar import Router
+from litestar import delete
+from litestar import get
+from litestar import post
 
-from compute_space.config import get_config
+from compute_space.config import Config
+from compute_space.core.auth.security_audit import AuditResult
+from compute_space.core.auth.security_audit import ListeningPort
 from compute_space.core.auth.security_audit import is_sshd_active
 from compute_space.core.auth.security_audit import list_listening_ports
 from compute_space.core.auth.security_audit import run_audit
@@ -21,210 +26,243 @@ from compute_space.core.storage import is_guard_paused
 from compute_space.core.storage import set_guard_paused
 from compute_space.core.storage import storage_status
 from compute_space.core.updates import is_shutdown_pending
-from compute_space.db import get_db
-from compute_space.web.auth.quart_compat import login_required
+from compute_space.web.auth.auth import require_owner_auth
 
-system_bp: Blueprint = Blueprint("system", __name__)
-
-DEFAULT_TOKEN_EXPIRY_HOURS: int = 8
+DEFAULT_TOKEN_EXPIRY_HOURS: float = 8.0
 
 
-# ─── API Tokens ───
+# ─── attrs models ──────────────────────────────────────────────────────────
 
 
-@system_bp.route("/api/tokens", methods=["GET"])
-@login_required
-async def api_tokens_list() -> Response:
-    db = get_db()
+@attr.s(auto_attribs=True, frozen=True)
+class ApiToken:
+    id: int
+    name: str
+    expires_at: str | None
+    created_at: str
+    expired: bool
+
+
+@attr.s(auto_attribs=True, frozen=True)
+class CreateTokenRequest:
+    """Body for ``POST /api/tokens``.  ``expiry_hours`` is a string so the
+    sentinel ``"never"`` (= no expiry) and a numeric value share one field
+    without forcing the JS client to send different keys."""
+
+    name: str = ""
+    expiry_hours: str = ""
+
+
+@attr.s(auto_attribs=True, frozen=True)
+class CreatedToken:
+    token: str
+    name: str
+    expires_at: str | None
+
+
+@attr.s(auto_attribs=True, frozen=True)
+class ErrorResponse:
+    error: str
+
+
+@attr.s(auto_attribs=True, frozen=True)
+class OkResponse:
+    ok: bool
+
+
+@attr.s(auto_attribs=True, frozen=True)
+class HealthOk:
+    status: str  # "ok"
+    security: AuditResult
+
+
+@attr.s(auto_attribs=True, frozen=True)
+class HealthRestarting:
+    status: str  # "restarting"
+
+
+@attr.s(auto_attribs=True, frozen=True)
+class ListeningPortsResponse:
+    ports: list[ListeningPort]
+
+
+@attr.s(auto_attribs=True, frozen=True)
+class ToggleStorageGuardRequest:
+    paused: bool
+
+
+@attr.s(auto_attribs=True, frozen=True)
+class StorageGuardResponse:
+    guard_paused: bool
+
+
+@attr.s(auto_attribs=True, frozen=True)
+class SshStatusResponse:
+    ssh_enabled: bool
+
+
+@attr.s(auto_attribs=True, frozen=True)
+class DropCacheOk:
+    ok: bool  # always True
+    output: str
+
+
+# ─── API Tokens ────────────────────────────────────────────────────────────
+
+
+@get("/api/tokens", guards=[require_owner_auth])
+async def api_tokens_list(db: sqlite3.Connection) -> list[ApiToken]:
     rows = db.execute("SELECT id, name, expires_at, created_at FROM api_tokens ORDER BY created_at DESC").fetchall()
     now = datetime.now(UTC)
-    tokens = []
+    tokens: list[ApiToken] = []
     for r in rows:
         has_expiry = bool(r["expires_at"])
         expired = has_expiry and datetime.fromisoformat(r["expires_at"]) < now
         tokens.append(
-            {
-                "id": r["id"],
-                "name": r["name"],
-                "expires_at": r["expires_at"] or None,
-                "created_at": r["created_at"],
-                "expired": expired,
-            }
+            ApiToken(
+                id=r["id"],
+                name=r["name"],
+                expires_at=r["expires_at"] or None,
+                created_at=r["created_at"],
+                expired=expired,
+            )
         )
-    return jsonify(tokens)
+    return tokens
 
 
-@system_bp.route("/api/tokens", methods=["POST"])
-@login_required
-async def api_tokens_create() -> Response | tuple[Response, int]:
-    form = await request.form
-    name = (form.get("name") or "").strip() or "Untitled"
-    expiry_hours_raw = form.get("expiry_hours", "").strip()
+@post("/api/tokens", status_code=200, guards=[require_owner_auth])
+async def api_tokens_create(
+    data: CreateTokenRequest, db: sqlite3.Connection
+) -> Response[CreatedToken] | Response[ErrorResponse]:
+    name = data.name.strip() or "Untitled"
+    expiry_hours_raw = data.expiry_hours.strip()
+    expires_at: datetime | None
     if expiry_hours_raw == "" or expiry_hours_raw.lower() == "never":
         expires_at = None
     else:
         try:
             expiry_hours = float(expiry_hours_raw)
-        except (ValueError, TypeError):
+        except ValueError:
             expiry_hours = DEFAULT_TOKEN_EXPIRY_HOURS
         if expiry_hours <= 0:
-            return jsonify({"error": "Expiry must be positive"}), 400
+            return Response(content=ErrorResponse(error="Expiry must be positive"), status_code=400)
         expires_at = datetime.now(UTC) + timedelta(hours=expiry_hours)
 
     raw_token = secrets.token_urlsafe(32)
     token_hash = hashlib.sha256(raw_token.encode()).hexdigest()
 
-    db = get_db()
     db.execute(
         "INSERT INTO api_tokens (name, token_hash, expires_at) VALUES (?, ?, ?)",
         (name, token_hash, expires_at.isoformat() if expires_at else ""),
     )
     db.commit()
 
-    return jsonify(
-        {
-            "token": raw_token,
-            "name": name,
-            "expires_at": expires_at.isoformat() if expires_at else None,
-        }
+    return Response(
+        content=CreatedToken(
+            token=raw_token,
+            name=name,
+            expires_at=expires_at.isoformat() if expires_at else None,
+        ),
+        status_code=200,
+        media_type=MediaType.JSON,
     )
 
 
-@system_bp.route("/api/tokens/<int:token_id>", methods=["DELETE"])
-@login_required
-async def api_tokens_delete(token_id: int) -> Response:
-    db = get_db()
+@delete("/api/tokens/{token_id:int}", guards=[require_owner_auth])
+async def api_tokens_delete(token_id: int, db: sqlite3.Connection) -> None:
     db.execute("DELETE FROM api_tokens WHERE id = ?", (token_id,))
     db.commit()
-    return jsonify({"ok": True})
 
 
-# ─── Compute Space Logs ───
+# ─── Compute Space Logs ────────────────────────────────────────────────────
 
 
-@system_bp.route("/api/compute_space_logs")
-@login_required
-def compute_space_logs() -> Response:
+@get("/api/compute_space_logs", guards=[require_owner_auth], media_type=MediaType.TEXT, sync_to_thread=False)
+def compute_space_logs() -> Response[str]:
     """Return the compute space log file contents."""
     log_path = get_log_path()
     if log_path is None:
-        return Response("Log file not configured", status=503, content_type="text/plain")
+        return Response(content="Log file not configured", status_code=503, media_type=MediaType.TEXT)
     with open(log_path) as f:
-        return Response(f.read(), content_type="text/plain")
+        return Response(content=f.read(), status_code=200, media_type=MediaType.TEXT)
 
 
-# ─── Health & Security ───
+# ─── Health & Security ─────────────────────────────────────────────────────
 
 
-@system_bp.route("/health")
-def health() -> ResponseReturnValue:
+@get("/health", sync_to_thread=False)
+def health(db: sqlite3.Connection) -> Response[HealthRestarting] | HealthOk:
     if is_shutdown_pending():
-        return jsonify({"status": "restarting"}), 503
-    audit = run_audit(db=get_db())
-    return jsonify({"status": "ok", "security": audit})
+        return Response(content=HealthRestarting(status="restarting"), status_code=503)
+    return HealthOk(status="ok", security=run_audit(db=db))
 
 
-@system_bp.route("/api/security-audit")
-@login_required
-def security_audit() -> Response:
-    return jsonify(run_audit(db=get_db()))
+@get("/api/security-audit", guards=[require_owner_auth], sync_to_thread=False)
+def security_audit(db: sqlite3.Connection) -> AuditResult:
+    return run_audit(db=db)
 
 
-@system_bp.route("/api/listening-ports")
-@login_required
-def listening_ports() -> Response:
+@get("/api/listening-ports", guards=[require_owner_auth], sync_to_thread=False)
+def listening_ports(db: sqlite3.Connection) -> ListeningPortsResponse:
     """Return every TCP port the VM is listening on, with classification."""
-    return jsonify({"ports": list_listening_ports(db=get_db())})
+    return ListeningPortsResponse(ports=list_listening_ports(db=db))
 
 
-@system_bp.route("/api/storage-status")
-@login_required
-def api_storage_status() -> Response:
-    return jsonify(storage_status(get_config()))
+@get("/api/storage-status", guards=[require_owner_auth], sync_to_thread=False)
+def api_storage_status(config: Config) -> dict[str, object]:
+    return storage_status(config)
 
 
-@system_bp.route("/api/storage-guard", methods=["POST"])
-@login_required
-async def toggle_storage_guard() -> Response:
+@post("/api/storage-guard", status_code=200, guards=[require_owner_auth], sync_to_thread=False)
+def toggle_storage_guard(data: ToggleStorageGuardRequest) -> StorageGuardResponse:
     """Pause or resume the storage guard."""
-    form = await request.form
-    paused = (form.get("paused") or "").strip().lower() in ("1", "true", "yes")
-    set_guard_paused(paused)
-    return jsonify({"guard_paused": is_guard_paused()})
+    set_guard_paused(data.paused)
+    return StorageGuardResponse(guard_paused=is_guard_paused())
 
 
-# ─── SSH Toggle ───
+# ─── SSH Toggle ────────────────────────────────────────────────────────────
 
 
-@system_bp.route("/api/ssh-status")
-@login_required
-def ssh_status() -> Response:
-    return jsonify({"ssh_enabled": is_sshd_active()})
+@get("/api/ssh-status", guards=[require_owner_auth], sync_to_thread=False)
+def ssh_status() -> SshStatusResponse:
+    return SshStatusResponse(ssh_enabled=is_sshd_active())
 
 
-@system_bp.route("/toggle-ssh", methods=["POST"])
-@login_required
-async def toggle_ssh() -> Response:
+@post("/toggle-ssh", status_code=200, guards=[require_owner_auth], sync_to_thread=False)
+def toggle_ssh() -> SshStatusResponse:
     if is_sshd_active():
         subprocess.run(
-            [
-                "sudo",
-                "-n",
-                "systemctl",
-                "stop",
-                "ssh.service",
-                "sshd.service",
-                "ssh.socket",
-            ],
+            ["sudo", "-n", "systemctl", "stop", "ssh.service", "sshd.service", "ssh.socket"],
             timeout=10,
         )
         subprocess.run(
-            [
-                "sudo",
-                "-n",
-                "systemctl",
-                "mask",
-                "ssh.service",
-                "sshd.service",
-                "ssh.socket",
-            ],
+            ["sudo", "-n", "systemctl", "mask", "ssh.service", "sshd.service", "ssh.socket"],
             timeout=10,
         )
-        return jsonify({"ssh_enabled": False})
-    else:
-        subprocess.run(
-            [
-                "sudo",
-                "-n",
-                "systemctl",
-                "unmask",
-                "ssh.service",
-                "sshd.service",
-                "ssh.socket",
-            ],
-            timeout=10,
-        )
-        subprocess.run(["sudo", "-n", "systemctl", "start", "ssh.service"], timeout=10)
-        return jsonify({"ssh_enabled": is_sshd_active()})
+        return SshStatusResponse(ssh_enabled=False)
+    subprocess.run(
+        ["sudo", "-n", "systemctl", "unmask", "ssh.service", "sshd.service", "ssh.socket"],
+        timeout=10,
+    )
+    subprocess.run(["sudo", "-n", "systemctl", "start", "ssh.service"], timeout=10)
+    return SshStatusResponse(ssh_enabled=is_sshd_active())
 
 
-# ─── Router restart ───
+# ─── Router restart ────────────────────────────────────────────────────────
 
 
-@system_bp.route("/api/drop-docker-cache", methods=["POST"])
-@login_required
-def drop_docker_cache() -> Response | tuple[Response, int]:
+@post("/api/drop-docker-cache", status_code=200, guards=[require_owner_auth], sync_to_thread=False)
+def drop_docker_cache() -> Response[DropCacheOk] | Response[ErrorResponse]:
     """Drop the container build cache to free disk space."""
     try:
         output = drop_docker_build_cache()
     except RuntimeError as e:
-        return jsonify({"ok": False, "error": str(e)}), 500
-    return jsonify({"ok": True, "output": output})
+        return Response(content=ErrorResponse(error=str(e)), status_code=500)
+    return Response(content=DropCacheOk(ok=True, output=output), status_code=200, media_type=MediaType.JSON)
 
 
-@system_bp.route("/restart_router", methods=["POST"])
-@login_required
-def restart_router() -> Response:
+@post("/restart_router", status_code=200, guards=[require_owner_auth], sync_to_thread=False)
+def restart_router() -> OkResponse:
     """Restart the router systemd service to pick up code changes."""
     subprocess.Popen(
         [
@@ -236,4 +274,24 @@ def restart_router() -> Response:
         ],
         start_new_session=True,
     )
-    return jsonify({"ok": True})
+    return OkResponse(ok=True)
+
+
+system_routes = Router(
+    path="/",
+    route_handlers=[
+        api_tokens_list,
+        api_tokens_create,
+        api_tokens_delete,
+        compute_space_logs,
+        health,
+        security_audit,
+        listening_ports,
+        api_storage_status,
+        toggle_storage_guard,
+        ssh_status,
+        toggle_ssh,
+        drop_docker_cache,
+        restart_router,
+    ],
+)

--- a/compute_space/src/compute_space/web/static/js/dashboard.js
+++ b/compute_space/src/compute_space/web/static/js/dashboard.js
@@ -87,14 +87,18 @@ function loadTokens() {
 }
 
 function createToken() {
-  var fd = new FormData();
-  fd.append('name', document.getElementById('token-name').value);
+  var body = {name: document.getElementById('token-name').value};
   if (document.getElementById('token-no-expiry').checked) {
-    fd.append('expiry_hours', 'never');
+    body.expiry_hours = 'never';
   } else {
-    fd.append('expiry_hours', document.getElementById('token-expiry').value);
+    body.expiry_hours = document.getElementById('token-expiry').value;
   }
-  fetch(config.tokensCreateUrl, {method: 'POST', credentials: 'same-origin', body: fd})
+  fetch(config.tokensCreateUrl, {
+    method: 'POST',
+    credentials: 'same-origin',
+    headers: {'Content-Type': 'application/json'},
+    body: JSON.stringify(body),
+  })
     .then(function(r) { return r.json(); })
     .then(function(data) {
       if (data.error) { alert(data.error); return; }

--- a/compute_space/src/compute_space/web/static/js/system.js
+++ b/compute_space/src/compute_space/web/static/js/system.js
@@ -66,10 +66,12 @@ function updateListeningPorts() {
 // ─── Storage Status ───
 
 function toggleStorageGuard(pause) {
-  var fd = new FormData();
-  fd.append('paused', pause ? '1' : '0');
-  fetch(config.toggleStorageGuardUrl, {method: 'POST', credentials: 'same-origin', body: fd})
-    .then(function() { updateStorageStatus(); });
+  fetch(config.toggleStorageGuardUrl, {
+    method: 'POST',
+    credentials: 'same-origin',
+    headers: {'Content-Type': 'application/json'},
+    body: JSON.stringify({paused: !!pause}),
+  }).then(function() { updateStorageStatus(); });
 }
 
 function updateStorageStatus() {

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -317,7 +317,7 @@ class TestSelfHost:
         """Create an API token and use it to access a protected endpoint."""
         r = session.post(
             f"{router_url}/api/tokens",
-            data={"name": "e2e-test-token", "expiry_hours": "1"},
+            json={"name": "e2e-test-token", "expiry_hours": "1"},
             timeout=10,
         )
         assert r.status_code == 200
@@ -363,7 +363,7 @@ class TestSelfHost:
 
         # Delete it
         r = session.delete(f"{router_url}/api/tokens/{token_id}", timeout=10)
-        assert r.status_code == 200
+        assert r.status_code == 204
 
         # Token should no longer work
         token = getattr(TestSelfHost, "_api_token", None)


### PR DESCRIPTION
## Summary

Stacked on #108. Third in the series. Moves the 12 ``/api/...`` system routes (tokens CRUD, compute_space_logs, health, security audit, listening ports, storage status / guard toggle, SSH status / toggle, drop docker cache, restart router) to native Litestar handlers with attrs-typed request and response bodies. POST endpoints take typed JSON bodies (no more ``form.get(key)`` lookups); dashboard JS for ``api_tokens_create`` and ``toggle_storage_guard`` switches from ``FormData`` to ``JSON.stringify`` accordingly.

## Notable: outer fallback wrapper replaces the @asgi mount

Litestar 2.x routes path-parameterised handlers (``/api/tokens/{token_id:int}``, ``/app_detail/{app_id}``, ``/api/services/v2/call/...``) at lower precedence than a mount at ``/``, so ``@asgi(path="/", is_mount=True)`` was silently shadowing every Litestar route that had a path param — including PR #107's ``/app_detail/{app_id}`` and this PR's ``DELETE /api/tokens/{id}``. Specific routes never ran; every such request 404'd out of the Quart fallback instead.

Replaced the mount with a middleware-style wrapper that invokes Litestar first and only delegates to Quart on a routing 404. Specific routes win, the Quart sub-app still catches everything else, and the request body is left untouched on the 404 path so Quart can re-read it.

## Other fixups in this PR

- pre-existing typo fixed: ``init_db(_FakeApp(cfg.db_path))`` → ``init_db(cfg.db_path)`` in test_remove_app_route.py (an undefined ``_FakeApp`` snuck in via #103).
- integration test ``test_api_token_create_and_use`` now asserts 204 on DELETE (Litestar's default for ``@delete``) and sends ``json=`` instead of ``data=`` for the create-token POST.
- ``test_build_cache.py`` rewritten to drive the route via Litestar TestClient.

## Test plan

- [x] `pixi run -e dev pytest compute_space/src/compute_space/tests/` — 501 passing, 32 skipped, 0 failures
- [x] `pixi run -e dev mypy compute_space/src/compute_space/` — clean
- [x] `pixi run -e dev ruff check compute_space/src/compute_space/` — clean
- [ ] Manual: tokens UI on the dashboard (create + delete), storage guard pause/resume on /system, SSH toggle, drop docker cache

🤖 Generated with [Claude Code](https://claude.com/claude-code)