### PR TITLE
Buffer small proxy responses to avoid chunked encoding flakiness

### DIFF
--- a/compute_space/src/compute_space/web/helpers/proxy.py
+++ b/compute_space/src/compute_space/web/helpers/proxy.py
@@ -109,6 +109,8 @@ _HTTP_REQUEST_EXCLUDED_HEADERS = frozenset(
     }
 )
 
+_BUFFER_THRESHOLD = 512_000  # 500 KB — buffer small upstream responses to avoid chunked encoding
+
 _HTTP_RESPONSE_EXCLUDED_HEADERS = frozenset(
     {
         # per-hop headers (these get read as we receive the incoming request, and automatically set on the outgoing)
@@ -187,7 +189,16 @@ async def proxy_http_request(
             if k.lower() not in _HTTP_RESPONSE_EXCLUDED_HEADERS
         ]
 
-        if upstream_response.status_code in buffer_status_codes:
+        # Buffer small / special-status responses instead of streaming.
+        # Streaming forces chunked transfer-encoding and uses an anyio task
+        # group with a disconnect listener that can cancel the stream before
+        # the terminus chunk is sent, causing intermittent
+        # ChunkedEncodingError on the client side.
+        upstream_content_length = upstream_response.headers.get("content-length")
+        should_buffer = upstream_response.status_code in buffer_status_codes or (
+            upstream_content_length is not None and int(upstream_content_length) <= _BUFFER_THRESHOLD
+        )
+        if should_buffer:
             body = await upstream_response.aread()
             await upstream_response.aclose()
             await client.aclose()

--- a/compute_space/src/compute_space/web/helpers/proxy.py
+++ b/compute_space/src/compute_space/web/helpers/proxy.py
@@ -7,7 +7,6 @@ This also takes care of stripping openhost/auth relevant headers and cookies fro
 
 import asyncio
 from collections.abc import AsyncIterator
-from collections.abc import Container
 from collections.abc import Iterable
 from collections.abc import Set
 from typing import Any
@@ -129,19 +128,16 @@ async def proxy_http_request(
     override_path: str | None = None,
     extra_headers: Iterable[tuple[str, str]] = (),
     timeout: float = 30,
-    buffer_status_codes: Container[int] = frozenset({403}),
 ) -> ASGIResponse:
-    """Forward an HTTP request to a local port and return the response as an
-    ASGIResponse (streaming by default).
+    """Forward an HTTP request to a local port and return the response.
 
     The request body is streamed straight from the client into httpx via
-    ``request.stream()``; the response is streamed back via
-    ``ASGIStreamingResponse`` so neither direction has to fit in memory.
+    ``request.stream()``.
 
-    When the upstream status is in ``buffer_status_codes`` (default: just 403)
-    the body is buffered into bytes instead and a plain ``ASGIResponse`` is
-    returned.  This is the hook services_v2 uses to inspect 403 responses and
-    inject ``grant_url`` before relaying them.
+    Responses with a known ``Content-Length`` up to ``_BUFFER_THRESHOLD`` are
+    buffered into a plain ``ASGIResponse`` (which sets ``Content-Length`` and
+    avoids chunked encoding).  Larger or unknown-length responses are streamed
+    back via ``ASGIStreamingResponse`` so they don't have to fit in memory.
     """
     target_url = _format_proxy_request_url(request.scope, target_port, override_path)
     new_request_headers = _build_forwarded_request_headers(
@@ -189,15 +185,12 @@ async def proxy_http_request(
             if k.lower() not in _HTTP_RESPONSE_EXCLUDED_HEADERS
         ]
 
-        # Buffer small / special-status responses instead of streaming.
-        # Streaming forces chunked transfer-encoding and uses an anyio task
-        # group with a disconnect listener that can cancel the stream before
-        # the terminus chunk is sent, causing intermittent
-        # ChunkedEncodingError on the client side.
+        # Buffer small responses instead of streaming.  Streaming forces
+        # chunked transfer-encoding and uses an anyio task group with a
+        # disconnect listener that can cancel the stream before the terminus
+        # chunk is sent, causing intermittent ChunkedEncodingError.
         upstream_content_length = upstream_response.headers.get("content-length")
-        should_buffer = upstream_response.status_code in buffer_status_codes or (
-            upstream_content_length is not None and int(upstream_content_length) <= _BUFFER_THRESHOLD
-        )
+        should_buffer = upstream_content_length is not None and int(upstream_content_length) <= _BUFFER_THRESHOLD
         if should_buffer:
             body = await upstream_response.aread()
             await upstream_response.aclose()

--- a/compute_space/src/compute_space/web/routes/services_v2.py
+++ b/compute_space/src/compute_space/web/routes/services_v2.py
@@ -7,10 +7,10 @@ Routes:
     WS      /api/services/v2/call/{shortname}/{rest:path} — proxied WS call
     GET     /api/services/v2/oauth_callback              — OAuth callback fan-out
 
-The HTTP call route streams the response back to the client by default; on
-``403`` the body is buffered (see ``proxy_request``'s ``buffer_status_codes``)
-so we can inject ``grant_url`` into the ``permission_required`` payload before
-relaying it.
+The HTTP call route proxies the response back to the client.  Small responses
+(including 403s) are automatically buffered by ``proxy_http_request``, so we
+can inspect and inject ``grant_url`` into ``permission_required`` payloads
+before relaying them.
 
 CORS:
 - we need to handle CORS so that cross-origin service requests are allowed for client-side requests from the user's browser.
@@ -251,9 +251,6 @@ async def service_call(
 ) -> ASGIResponse:
     """Proxy a request to the provider declared under <shortname> in the
     consumer's manifest.
-
-    The response is streamed end-to-end except for 403s, which
-    ``proxy_http_request`` buffers so we can inject ``grant_url``.
     """
     consumer_app_id = verify_app_auth(request)
 


### PR DESCRIPTION
## Summary

- When the upstream response has a known `Content-Length` ≤ 500KB, buffer the body and return a plain `ASGIResponse` instead of streaming via `ASGIStreamingResponse`
- This sets `Content-Length` properly (avoiding chunked transfer encoding) and sidesteps a race in Litestar's `ASGIStreamingResponse.send_body()` task group where a disconnect cancel can interrupt the stream before the terminus chunk is sent
- Large/unknown-length responses (file downloads, true streams) still use the streaming path

## Context

`test_proxy_get`, `test_proxy_strips_zone_auth_cookies`, and `test_proxy_strips_spoofed_openhost_headers` intermittently fail with `ChunkedEncodingError: Response ended prematurely`. The proxy strips `Content-Length` from upstream responses and uses `ASGIStreamingResponse`, forcing Hypercorn into chunked encoding. The streaming response's `send_body()` runs `_stream` and `_listen_for_disconnect` concurrently — if the disconnect listener fires before the terminus event is sent, the chunked response is truncated.

## Test plan

- [x] `pixi run -e dev pytest -x compute_space/src/compute_space/tests/` — 501 passed
- [x] `pixi run -e dev mypy compute_space/src/compute_space/web/helpers/proxy.py` — clean
- [ ] CI: watch for `ChunkedEncodingError` in test-containers job

🤖 Generated with [Claude Code](https://claude.com/claude-code)