### PR TITLE
Inline literal URLs in templates; drop url_for shim

### DIFF
--- a/compute_space/src/compute_space/web/app.py
+++ b/compute_space/src/compute_space/web/app.py
@@ -66,52 +66,6 @@ def _make_static_url(static_dir: Path) -> Any:
     return static_url
 
 
-# Templates use ``url_for(endpoint, **kwargs)`` with the legacy Quart blueprint
-# endpoint names that pre-date the Litestar migration.  Litestar's own
-# ``url_for`` only knows about Litestar routes, so we map the legacy endpoint
-# names to their paths directly here.  Values may use ``str.format``-style
-# placeholders for routes with path params; the ``url_for`` shim runs them
-# through ``str.format(**kwargs)``.
-#
-# Add a new entry whenever a template gains a ``url_for(...)`` call to an
-# endpoint that isn't already listed.
-_TEMPLATE_ENDPOINT_PATHS: dict[str, str] = {
-    # layout.html (rendered for every page)
-    "apps.dashboard": "/dashboard",
-    "apps.add_app": "/add_app",
-    "pages_system.system_page": "/system/",
-    "pages_system.logs_page": "/logs/",
-    "pages_system.terminal_page": "/terminal/",
-    "pages_settings.settings_page": "/settings",
-    # dashboard.html
-    "apps.app_detail": "/app_detail/{app_id}",
-    "api_apps.api_apps": "/api/apps",
-    "system.api_tokens_list": "/api/tokens",
-    "system.api_tokens_create": "/api/tokens",
-    # app_detail.html
-    "api_apps.stop_app": "/stop_app/{app_id}",
-    "api_apps.reload_app": "/reload_app/{app_id}",
-    "api_apps.remove_app": "/remove_app/{app_id}",
-    "api_apps.rename_app": "/rename_app/{app_id}",
-    "api_apps.app_logs": "/app_logs/{app_id}",
-    "api_apps.app_status": "/api/app_status/{app_id}",
-    "system.drop_docker_cache": "/api/drop-docker-cache",
-    # system.html
-    "system.security_audit": "/api/security-audit",
-    "system.listening_ports": "/api/listening-ports",
-    "system.api_storage_status": "/api/storage-status",
-    "system.restart_router": "/restart_router",
-    "system.ssh_status": "/api/ssh-status",
-    "system.toggle_ssh": "/toggle-ssh",
-    "system.toggle_storage_guard": "/api/storage-guard",
-    "api_archive_backend.get_archive_backend": "/api/storage/archive_backend",
-    "api_archive_backend.test_connection": "/api/storage/archive_backend/test_connection",
-    "api_archive_backend.configure_archive_backend": "/api/storage/archive_backend/configure",
-    # logs.html
-    "system.compute_space_logs": "/api/compute_space_logs",
-}
-
-
 def _template_globals(config: Config, static_dir: Path) -> dict[str, Any]:
     zone_domain = config.zone_domain
     zone_name = zone_domain.split(".")[0] if zone_domain else None
@@ -120,19 +74,11 @@ def _template_globals(config: Config, static_dir: Path) -> dict[str, Any]:
         proto = "https" if config.tls_enabled else "http"
         return f"{proto}://{app_name}.{zone_domain}/"
 
-    def url_for(endpoint: str, **kwargs: Any) -> str:
-        try:
-            path = _TEMPLATE_ENDPOINT_PATHS[endpoint]
-        except KeyError as e:
-            raise KeyError(f"No template path mapping for endpoint {endpoint!r}") from e
-        return path.format(**kwargs) if kwargs else path
-
     return {
         "zone_name": zone_name,
         "zone_domain": zone_domain,
         "app_url": app_url,
         "static_url": _make_static_url(static_dir),
-        "url_for": url_for,
     }
 
 

--- a/compute_space/src/compute_space/web/templates/app_detail.html
+++ b/compute_space/src/compute_space/web/templates/app_detail.html
@@ -70,24 +70,24 @@
 
 <br>
 <div id="app-action-buttons" style="display: flex; gap: 0.5rem; align-items: center; flex-wrap: wrap;">
-  <button class="btn" onclick="appAction('{{ url_for('api_apps.stop_app', app_id=app.app_id) }}', null, {label: 'Stopping'})">Stop App</button>
-  <button class="btn" onclick="appAction('{{ url_for('api_apps.reload_app', app_id=app.app_id) }}', null, {label: 'Reloading'})">Reload App</button>
-  <button class="btn" onclick="appAction('{{ url_for('api_apps.reload_app', app_id=app.app_id) }}', {update: true}, {label: 'Updating &amp; reloading'})">Update &amp; Reload</button>
-  <button class="btn" onclick="if(confirm('Remove {{ app.name }} but keep its databases and files? You can re-deploy later to the same app name to reuse the data.')) appAction('{{ url_for('api_apps.remove_app', app_id=app.app_id) }}', {keep_data: true}, {isRemove: true, label: 'Removing (keeping data)'})">Remove App (Keep Data)</button>
-  <button class="btn btn-danger" onclick="if(confirm('Remove {{ app.name }}? This deletes all app data permanently.')) appAction('{{ url_for('api_apps.remove_app', app_id=app.app_id) }}', {}, {isRemove: true, label: 'Removing'})">Remove App &amp; Data</button>
+  <button class="btn" onclick="appAction('/stop_app/{{ app.app_id }}', null, {label: 'Stopping'})">Stop App</button>
+  <button class="btn" onclick="appAction('/reload_app/{{ app.app_id }}', null, {label: 'Reloading'})">Reload App</button>
+  <button class="btn" onclick="appAction('/reload_app/{{ app.app_id }}', {update: true}, {label: 'Updating &amp; reloading'})">Update &amp; Reload</button>
+  <button class="btn" onclick="if(confirm('Remove {{ app.name }} but keep its databases and files? You can re-deploy later to the same app name to reuse the data.')) appAction('/remove_app/{{ app.app_id }}', {keep_data: true}, {isRemove: true, label: 'Removing (keeping data)'})">Remove App (Keep Data)</button>
+  <button class="btn btn-danger" onclick="if(confirm('Remove {{ app.name }}? This deletes all app data permanently.')) appAction('/remove_app/{{ app.app_id }}', {}, {isRemove: true, label: 'Removing'})">Remove App &amp; Data</button>
   <span id="app-action-msg" style="margin-left:0.5em;"></span>
 </div>
 
 <script id="page-config" type="application/json">
 {
-  "renameAppUrl": "{{ url_for('api_apps.rename_app', app_id=app.app_id) }}",
-  "appDetailUrl": "{{ url_for('apps.app_detail', app_id=app.app_id) }}",
-  "appLogsUrl": "{{ url_for('api_apps.app_logs', app_id=app.app_id) }}",
-  "appStatusUrl": "{{ url_for('api_apps.app_status', app_id=app.app_id) }}",
+  "renameAppUrl": "/rename_app/{{ app.app_id }}",
+  "appDetailUrl": "/app_detail/{{ app.app_id }}",
+  "appLogsUrl": "/app_logs/{{ app.app_id }}",
+  "appStatusUrl": "/api/app_status/{{ app.app_id }}",
   "appStatus": {{ app.status | tojson }},
   "nextUrl": {{ next_url | default("", true) | tojson }},
-  "reloadAppUrl": "{{ url_for('api_apps.reload_app', app_id=app.app_id) }}",
-  "dropBuildCacheUrl": "{{ url_for('system.drop_docker_cache') }}"
+  "reloadAppUrl": "/reload_app/{{ app.app_id }}",
+  "dropBuildCacheUrl": "/api/drop-docker-cache"
 }
 </script>
 <script src="{{ static_url('js/app-detail.js') }}"></script>

--- a/compute_space/src/compute_space/web/templates/dashboard.html
+++ b/compute_space/src/compute_space/web/templates/dashboard.html
@@ -22,7 +22,7 @@
        the polling loop; server-side guards (409 on stop/reload/rename
        of a removing row) make stray clicks safe no-ops. #}
     <td class="app-actions">
-      <a href="{{ url_for('apps.app_detail', app_id=app.app_id) }}">Details</a>
+      <a href="/app_detail/{{ app.app_id }}">Details</a>
       <button class="btn" onclick="appAction('{{ app.app_id }}', 'reload_app')">Reload</button>
       <button class="btn" onclick="reloadAndUpdate('{{ app.app_id }}')">Reload &amp; Update</button>
       <button class="btn btn-danger" onclick="if(confirm('Remove {{ app.name }} and delete all data permanently?')) appAction('{{ app.app_id }}', 'remove_app')">Remove</button>
@@ -31,7 +31,7 @@
   {% endfor %}
 </table>
 {% else %}
-<p>No apps deployed yet. <a href="{{ url_for('apps.add_app') }}">Deploy one now.</a></p>
+<p>No apps deployed yet. <a href="/add_app">Deploy one now.</a></p>
 {% endif %}
 
 <h2 style="margin-top: 2em;">API Tokens</h2>
@@ -60,9 +60,9 @@
 
 <script id="page-config" type="application/json">
 {
-  "apiAppsUrl": {% if apps %}"{{ url_for('api_apps.api_apps') }}"{% else %}null{% endif %},
-  "tokensListUrl": "{{ url_for('system.api_tokens_list') }}",
-  "tokensCreateUrl": "{{ url_for('system.api_tokens_create') }}"
+  "apiAppsUrl": {% if apps %}"/api/apps"{% else %}null{% endif %},
+  "tokensListUrl": "/api/tokens",
+  "tokensCreateUrl": "/api/tokens"
 }
 </script>
 <script src="{{ static_url('js/dashboard.js') }}"></script>

--- a/compute_space/src/compute_space/web/templates/layout.html
+++ b/compute_space/src/compute_space/web/templates/layout.html
@@ -36,12 +36,12 @@
 <body>
   <h1>{% if zone_name %}{{ zone_name }}'s Private Compute Space{% else %}OpenHost{% endif %}</h1>
   <nav>
-    <a href="{{ url_for('apps.dashboard') }}">Dashboard</a>
-    <a href="{{ url_for('apps.add_app') }}">Deploy App</a>
-    <a href="{{ url_for('pages_system.system_page') }}">System</a>
-    <a href="{{ url_for('pages_system.logs_page') }}">Logs</a>
-    <a href="{{ url_for('pages_system.terminal_page') }}">Terminal</a>
-    <a href="{{ url_for('pages_settings.settings_page') }}">Settings</a>
+    <a href="/dashboard">Dashboard</a>
+    <a href="/add_app">Deploy App</a>
+    <a href="/system/">System</a>
+    <a href="/logs/">Logs</a>
+    <a href="/terminal/">Terminal</a>
+    <a href="/settings">Settings</a>
     <a href="/docs/" target="_blank" rel="noopener">Docs</a>
     <span class="spacer"></span>
   </nav>

--- a/compute_space/src/compute_space/web/templates/logs.html
+++ b/compute_space/src/compute_space/web/templates/logs.html
@@ -19,7 +19,7 @@
   }
 
   function fetchLogs() {
-    fetch('{{ url_for("system.compute_space_logs") }}', {credentials: 'same-origin'})
+    fetch('/api/compute_space_logs', {credentials: 'same-origin'})
       .then(function(r) { return r.text(); })
       .then(function(text) {
         var sel = window.getSelection();

--- a/compute_space/src/compute_space/web/templates/system.html
+++ b/compute_space/src/compute_space/web/templates/system.html
@@ -58,17 +58,17 @@
 
 <script id="page-config" type="application/json">
 {
-  "securityAuditUrl": "{{ url_for('system.security_audit') }}",
-  "listeningPortsUrl": "{{ url_for('system.listening_ports') }}",
-  "storageStatusUrl": "{{ url_for('system.api_storage_status') }}",
-  "restartRouterUrl": "{{ url_for('system.restart_router') }}",
-  "dropBuildCacheUrl": "{{ url_for('system.drop_docker_cache') }}",
-  "sshStatusUrl": "{{ url_for('system.ssh_status') }}",
-  "toggleSshUrl": "{{ url_for('system.toggle_ssh') }}",
-  "toggleStorageGuardUrl": "{{ url_for('system.toggle_storage_guard') }}",
-  "archiveBackendUrl": "{{ url_for('api_archive_backend.get_archive_backend') }}",
-  "archiveBackendTestUrl": "{{ url_for('api_archive_backend.test_connection') }}",
-  "archiveBackendConfigureUrl": "{{ url_for('api_archive_backend.configure_archive_backend') }}"
+  "securityAuditUrl": "/api/security-audit",
+  "listeningPortsUrl": "/api/listening-ports",
+  "storageStatusUrl": "/api/storage-status",
+  "restartRouterUrl": "/restart_router",
+  "dropBuildCacheUrl": "/api/drop-docker-cache",
+  "sshStatusUrl": "/api/ssh-status",
+  "toggleSshUrl": "/toggle-ssh",
+  "toggleStorageGuardUrl": "/api/storage-guard",
+  "archiveBackendUrl": "/api/storage/archive_backend",
+  "archiveBackendTestUrl": "/api/storage/archive_backend/test_connection",
+  "archiveBackendConfigureUrl": "/api/storage/archive_backend/configure"
 }
 </script>
 <script src="{{ static_url('js/system.js') }}"></script>


### PR DESCRIPTION
## Summary

Templates were calling ``url_for('apps.dashboard')``, ``url_for('api_apps.app_status', app_id=...)``, etc. — Quart blueprint endpoint names that had no actual referent after the Litestar migration; ``web/app.py`` carried a 27-entry mapping dict + a custom ``url_for`` shim in ``_template_globals`` to resolve them.

The indirection wasn't buying us anything: the URLs are stable, the dict had to be updated by hand whenever a new template ``url_for(...)`` showed up, and the layer of misdirection made it harder to grep "where is this URL used".

This PR:
- Replaces every ``url_for(...)`` call in the 5 templates with its literal path (e.g. ``/dashboard``, ``/app_detail/{{ app.app_id }}``).
- Drops ``_TEMPLATE_ENDPOINT_PATHS`` and the ``url_for`` shim function from ``web/app.py``.

Net: −54 lines in app.py, ~30 url_for call sites cleaned up in templates.

## Test plan

- [x] `pixi run -e dev mypy compute_space/src/compute_space/` — clean
- [x] `pixi run -e dev ruff check compute_space/src/compute_space/` — clean
- [ ] Manual smoke-test: hit /dashboard, /settings, /system/, /logs/, /app_detail/<id>, /add_app in a browser — links and action buttons should still resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)