### PR TITLE
Make archive_backend API JSON-only; align dashboard reload body

### DIFF
--- a/compute_space/src/compute_space/tests/test_api_archive_backend.py
+++ b/compute_space/src/compute_space/tests/test_api_archive_backend.py
@@ -139,7 +139,7 @@ def test_get_meta_dumps_null_on_s3_list_failure(
 def test_configure_requires_creds(client: TestClient[Litestar], cookies: dict[str, str]) -> None:
     resp = client.post(
         "/api/storage/archive_backend/configure",
-        data={"s3_bucket": "b"},
+        json={"s3_bucket": "b"},
         cookies=cookies,
     )
     assert resp.status_code == 400
@@ -164,7 +164,7 @@ def test_configure_rejects_invalid_s3_prefix(client: TestClient[Litestar], cooki
     ):
         resp = client.post(
             "/api/storage/archive_backend/configure",
-            data={
+            json={
                 "s3_bucket": "b",
                 "s3_access_key_id": "a",
                 "s3_secret_access_key": "s",
@@ -191,7 +191,7 @@ def test_configure_rejects_when_already_configured(
         db.close()
     resp = client.post(
         "/api/storage/archive_backend/configure",
-        data={"s3_bucket": "b2", "s3_access_key_id": "a", "s3_secret_access_key": "s"},
+        json={"s3_bucket": "b2", "s3_access_key_id": "a", "s3_secret_access_key": "s"},
         cookies=cookies,
     )
     assert resp.status_code == 409
@@ -218,7 +218,7 @@ def test_configure_happy_path(client: TestClient[Litestar], cookies: dict[str, s
 
         resp = client.post(
             "/api/storage/archive_backend/configure",
-            data={
+            json={
                 "s3_bucket": "mybucket",
                 "s3_access_key_id": "AKIA",
                 "s3_secret_access_key": "secret",
@@ -239,7 +239,7 @@ def test_configure_happy_path(client: TestClient[Litestar], cookies: dict[str, s
 def test_test_connection_requires_fields(client: TestClient[Litestar], cookies: dict[str, str]) -> None:
     resp = client.post(
         "/api/storage/archive_backend/test_connection",
-        data={"s3_bucket": "b"},
+        json={"s3_bucket": "b"},
         cookies=cookies,
     )
     assert resp.status_code == 400
@@ -248,7 +248,7 @@ def test_test_connection_requires_fields(client: TestClient[Litestar], cookies: 
 def test_test_connection_rejects_invalid_s3_prefix(client: TestClient[Litestar], cookies: dict[str, str]) -> None:
     resp = client.post(
         "/api/storage/archive_backend/test_connection",
-        data={
+        json={
             "s3_bucket": "b",
             "s3_access_key_id": "a",
             "s3_secret_access_key": "s",
@@ -263,7 +263,7 @@ def test_test_connection_surfaces_errors(client: TestClient[Litestar], cookies: 
     with mock.patch.object(archive_backend, "test_s3_credentials", return_value="bucket not found"):
         resp = client.post(
             "/api/storage/archive_backend/test_connection",
-            data={"s3_bucket": "b", "s3_access_key_id": "a", "s3_secret_access_key": "s"},
+            json={"s3_bucket": "b", "s3_access_key_id": "a", "s3_secret_access_key": "s"},
             cookies=cookies,
         )
     assert resp.status_code == 400
@@ -274,7 +274,7 @@ def test_test_connection_succeeds(client: TestClient[Litestar], cookies: dict[st
     with mock.patch.object(archive_backend, "test_s3_credentials", return_value=None):
         resp = client.post(
             "/api/storage/archive_backend/test_connection",
-            data={"s3_bucket": "b", "s3_access_key_id": "a", "s3_secret_access_key": "s"},
+            json={"s3_bucket": "b", "s3_access_key_id": "a", "s3_secret_access_key": "s"},
             cookies=cookies,
         )
     assert resp.status_code == 200

--- a/compute_space/src/compute_space/web/routes/api/archive_backend.py
+++ b/compute_space/src/compute_space/web/routes/api/archive_backend.py
@@ -13,7 +13,6 @@ from litestar import Response
 from litestar import Router
 from litestar import get
 from litestar import post
-from litestar.enums import RequestEncodingType
 from litestar.params import Body
 
 from compute_space.config import Config
@@ -103,7 +102,7 @@ def _normalise_s3_prefix(raw: str | None) -> str | None:
 
 
 @attr.s(auto_attribs=True, frozen=True)
-class TestConnectionForm:
+class TestConnectionRequest:
     s3_bucket: str
     s3_access_key_id: str
     s3_secret_access_key: str
@@ -113,7 +112,7 @@ class TestConnectionForm:
 
 
 @attr.s(auto_attribs=True, frozen=True)
-class ConfigureArchiveForm:
+class ConfigureArchiveRequest:
     s3_bucket: str
     s3_access_key_id: str
     s3_secret_access_key: str
@@ -153,7 +152,7 @@ async def get_archive_backend(db: sqlite3.Connection, config: Config) -> Backend
 
 @post("/api/storage/archive_backend/test_connection", status_code=200, guards=[require_owner_auth])
 async def test_connection(
-    data: Annotated[TestConnectionForm, Body(media_type=RequestEncodingType.URL_ENCODED)],
+    data: Annotated[TestConnectionRequest, Body(media_type=MediaType.JSON)],
 ) -> Response[TestConnectionOk] | Response[TestConnectionError]:
     """Pre-flight S3 reachability/credentials check; doesn't touch the DB or live mount."""
     try:
@@ -175,7 +174,7 @@ async def test_connection(
 
 @post("/api/storage/archive_backend/configure", status_code=200, guards=[require_owner_auth])
 async def configure_archive_backend(
-    data: Annotated[ConfigureArchiveForm, Body(media_type=RequestEncodingType.URL_ENCODED)],
+    data: Annotated[ConfigureArchiveRequest, Body(media_type=MediaType.JSON)],
     db: sqlite3.Connection,
     config: Config,
 ) -> Response[BackendStateResponse] | Response[ErrorResponse]:

--- a/compute_space/src/compute_space/web/static/js/dashboard.js
+++ b/compute_space/src/compute_space/web/static/js/dashboard.js
@@ -15,9 +15,12 @@ function refreshApps() {
     .catch(function() {});
 }
 
-function appAction(appId, action, formData) {
+function appAction(appId, action, body) {
   var opts = {method: 'POST', credentials: 'same-origin'};
-  if (formData) { opts.body = formData; }
+  if (body) {
+    opts.headers = {'Content-Type': 'application/json'};
+    opts.body = JSON.stringify(body);
+  }
   return fetch(action + '/' + appId, opts)
     .then(function(r) {
       return r.json().then(function(d) { return {ok: r.ok, data: d}; },
@@ -36,9 +39,7 @@ function appAction(appId, action, formData) {
 }
 
 function reloadAndUpdate(appId) {
-  var fd = new FormData();
-  fd.append('update', '1');
-  appAction(appId, 'reload_app', fd);
+  appAction(appId, 'reload_app', {update: true});
 }
 
 function updateApps(apps) {


### PR DESCRIPTION
## Summary

- Convert the two `/api/storage/archive_backend/*` POST routes (and their tests) from `URL_ENCODED` form bodies to `application/json`. They were the only `/api/` routes still on form encoding, and `system.js` was already sending JSON, so every configure/test_connection call was failing with a Litestar 400 that listed every field as missing (`Object missing required field "s3_bucket"`, etc.).
- Fix a latent bug in `dashboard.js`: `reloadAndUpdate` was sending a `multipart/form-data` body to `/reload_app/{id}`, but the handler's `data: ReloadAppRequest = ReloadAppRequest()` defaults to JSON. The parse failed silently, the default kicked in, and `update=true` was being dropped. Now sends `{"update": true}` as JSON.

`/identity/approve` stays URL-encoded — it's a server-rendered browser HTML form, not an API route.

## Test plan

- [x] `pixi run -e dev pytest -x compute_space/src/compute_space/tests/test_api_archive_backend.py` — 20 passed
- [x] `pixi run -e dev pytest -x compute_space/src/compute_space/tests/test_remove_app_route.py` — 7 passed
- [ ] After deploy: open the system page → "Configure S3 archive storage" → fill in bogus creds → "Test connection" should now show a real `S3 reachability test failed: …` error instead of an empty `Failed:` (the empty string was the Litestar validation body, which has no `error` key)
- [ ] After deploy: click "Reload & update" on an app and verify the log shows `reloading app (update=True)` (it was previously falling back to `update=False`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)