### PR TITLE
Preserve empty-body semantics in proxy forwarding

### DIFF
--- a/compute_space/src/compute_space/web/helpers/proxy.py
+++ b/compute_space/src/compute_space/web/helpers/proxy.py
@@ -164,7 +164,15 @@ async def proxy_http_request(
                 break
         elif msg["type"] == "http.disconnect":
             break
-    request_body = b"".join(body_parts) if body_parts else b""
+    request_body = b"".join(body_parts)
+
+    # Pass content=None for truly bodyless requests (e.g. GET with no
+    # Content-Length / Transfer-Encoding) so httpx omits body framing
+    # entirely.  For requests that explicitly declared a body -- even an
+    # empty one (Content-Length: 0) -- forward the bytes so the backend
+    # sees the same semantics the client intended.
+    has_declared_body = "content-length" in request.headers or "transfer-encoding" in request.headers
+    content = request_body if has_declared_body else None
 
     client = httpx.AsyncClient(timeout=timeout)
     try:
@@ -172,7 +180,7 @@ async def proxy_http_request(
             method=str(request.method),
             url=target_url,
             headers=new_request_headers,
-            content=request_body if request_body else None,
+            content=content,
         )
         try:
             upstream_response = await client.send(new_request, stream=True)


### PR DESCRIPTION
Followup to #119. The truthiness check (request_body if request_body else None) treated a POST with Content-Length: 0 the same as a bodyless GET since b"" is falsy. This checks the original request headers to distinguish bodyless requests from requests with an explicitly empty body.