### PR TITLE
Fix open redirect in login GET handler

### DIFF
--- a/compute_space/src/compute_space/web/routes/pages/login.py
+++ b/compute_space/src/compute_space/web/routes/pages/login.py
@@ -37,10 +37,10 @@ def _validated_next(next_url: str, zone_domain: str) -> str | None:
 
 
 @get("/login")
-async def login_get(request: Request[Any, Any, Any], db: sqlite3.Connection) -> Response[Any]:
+async def login_get(request: Request[Any, Any, Any], db: sqlite3.Connection, config: Config) -> Response[Any]:
     next_param = request.query_params.get("next", "")
     if authenticate(request, db=db) is not None:
-        return Redirect(path=next_param or "/")
+        return Redirect(path=_validated_next(next_param, config.zone_domain) or "/")
     return Template(template_name="login.html", context={"next": next_param})
 
 


### PR DESCRIPTION
## Summary

- The `login_get` handler redirected already-authenticated users to the raw `?next=` query parameter without any validation, enabling open redirects to arbitrary external URLs (e.g. `https://evil.com`).
- The `_validated_next()` helper already existed and was correctly applied in `login_post`, but was missing from `login_get`.
- This fix adds `config: Config` to the `login_get` signature and wraps the redirect target with `_validated_next()`, so only same-zone absolute URLs or path-relative URLs are accepted. Anything else falls back to `/`.

## Test plan

- [x] All 499 compute_space tests pass (`pixi run -e dev pytest -x compute_space/src/compute_space/tests/`)
- [x] Pre-commit hooks (ruff, mypy, secrets detection) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)