### PR TITLE
Fix /health endpoint leaking security audit data

### DIFF
--- a/compute_space/src/compute_space/core/auth/security_audit.py
+++ b/compute_space/src/compute_space/core/auth/security_audit.py
@@ -3,7 +3,7 @@
 Checks actual security posture regardless of config settings: TLS active,
 SSH password auth disabled, no unexpected ports.
 
-Results are exposed via /health and /api/security-audit endpoints.
+Results are exposed via the authenticated /api/security-audit endpoint.
 """
 
 import shutil

--- a/compute_space/src/compute_space/tests/test_integration.py
+++ b/compute_space/src/compute_space/tests/test_integration.py
@@ -83,8 +83,8 @@ def test_sqlite_provisioning():
         assert not os.path.exists(env_vars["OPENHOST_SQLITE_cache"])
 
 
-def test_pre_setup_security_audit(tmp_path):
-    """Security audit via /health returns valid results before owner setup."""
+def test_pre_setup_health(tmp_path):
+    """Health endpoint returns status ok and no security data before owner setup."""
     ROUTER_PORT = 18084
     base_url = f"http://127.0.0.1:{ROUTER_PORT}"
 
@@ -99,20 +99,7 @@ def test_pre_setup_security_audit(tmp_path):
 
         data = r.json()
         assert data["status"] == "ok"
-        assert "security" in data
-
-        security = data["security"]
-        assert isinstance(security["secure"], bool)
-        assert "checks" in security
-
-        expected_checks = {"ssh_password_disabled", "tls_active", "no_unexpected_ports"}
-        assert set(security["checks"].keys()) == expected_checks
-
-        for name, check in security["checks"].items():
-            assert "ok" in check, f"check {name} missing 'ok'"
-            assert "detail" in check, f"check {name} missing 'detail'"
-            assert isinstance(check["ok"], bool)
-            assert isinstance(check["detail"], str)
+        assert "security" not in data
     finally:
         if router is not None:
             _stop_router_process(router)
@@ -196,7 +183,7 @@ class TestRouterCore:
         assert r.status_code == 200
         data = r.json()
         assert data["status"] == "ok"
-        assert "security" in data
+        assert "security" not in data
 
     def test_post_setup_security_audit(self, admin_session, config):
         """Post-setup audit returns valid structure from /api/security-audit."""

--- a/compute_space/src/compute_space/web/routes/api/system.py
+++ b/compute_space/src/compute_space/web/routes/api/system.py
@@ -73,7 +73,6 @@ class OkResponse:
 @attr.s(auto_attribs=True, frozen=True)
 class HealthOk:
     status: str  # "ok"
-    security: AuditResult
 
 
 @attr.s(auto_attribs=True, frozen=True)
@@ -191,10 +190,10 @@ def compute_space_logs() -> Response[str]:
 
 
 @get("/health", sync_to_thread=False)
-def health(db: sqlite3.Connection) -> Response[HealthRestarting] | HealthOk:
+def health() -> Response[HealthRestarting] | HealthOk:
     if is_shutdown_pending():
         return Response(content=HealthRestarting(status="restarting"), status_code=503)
-    return HealthOk(status="ok", security=run_audit(db=db))
+    return HealthOk(status="ok")
 
 
 @get("/api/security-audit", guards=[require_owner_auth], sync_to_thread=False)

--- a/compute_space/src/compute_space/web/setup_app.py
+++ b/compute_space/src/compute_space/web/setup_app.py
@@ -28,7 +28,6 @@ from compute_space.config import provide_config
 from compute_space.core.auth.auth import DEFAULT_OWNER_USERNAME
 from compute_space.core.auth.auth import create_session
 from compute_space.core.auth.auth import validate_owner_username
-from compute_space.core.auth.security_audit import run_audit
 from compute_space.core.default_apps import deploy_default_apps
 from compute_space.core.logging import logger
 from compute_space.core.updates import is_shutdown_pending
@@ -146,14 +145,13 @@ async def _trigger_restart_after_response() -> None:
 
 
 @get("/health", sync_to_thread=False)
-def health() -> Response[dict[str, Any]]:
-    """Liveness + security audit, mirrors the full app's /health so external
-    probes (and the e2e test suite's pre-setup audit) get the same shape
-    before and after owner provisioning."""
+def health() -> Response[dict[str, str]]:
+    """Liveness probe.  Returns ``{"status": "ok"}`` (or 503 when restarting).
+    Security audit data is only available via the authenticated
+    ``/api/security-audit`` endpoint."""
     if is_shutdown_pending():
         return Response(content={"status": "restarting"}, status_code=503)
-    audit = run_audit(db=get_db())
-    return Response(content={"status": "ok", "security": audit})
+    return Response(content={"status": "ok"})
 
 
 def create_setup_app(config: Config) -> Litestar:

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -89,7 +89,7 @@ class TestSelfHost:
         assert r.status_code == 200
         data = r.json()
         assert data["status"] == "ok"
-        assert "security" in data
+        assert "security" not in data
 
     # -- 2. Setup (create owner) -------------------------------------------
 


### PR DESCRIPTION
## Summary
- The unauthenticated `/health` endpoint was returning the full security audit result (listening ports, SSH status, TLS status), giving attackers free reconnaissance data.
- Removed the `security` field from the `/health` response in both the main app (`system.py`) and setup app (`setup_app.py`). The endpoint now returns only `{"status": "ok"}`.
- Security audit data remains available at the authenticated `/api/security-audit` endpoint (guarded by `require_owner_auth`).
- Updated the `HealthOk` dataclass, removed the now-unused `run_audit` import from `setup_app.py`, and updated tests to assert security data is absent from `/health`.

## Test plan
- [x] `pixi run -e dev pytest -x compute_space/src/compute_space/tests/` -- 499 passed, 32 skipped
- [ ] Verify `/health` returns only `{"status": "ok"}` on a running instance
- [ ] Verify `/api/security-audit` still returns full audit data when authenticated

🤖 Generated with [Claude Code](https://claude.com/claude-code)