### PR TITLE
Container networking: hairpin NAT, router bind restriction, ip_forward, network_host

### DIFF
--- a/ansible/tasks/containers.yml
+++ b/ansible/tasks/containers.yml
@@ -36,7 +36,7 @@
   when: not _linger_sentinel.stat.exists
   changed_when: true
 
-# net.ipv4.ip_unprivileged_port_start = 25: the router binds rootless on 0.0.0.0:<host_port>, including 25 for SMTP
+# net.ipv4.ip_unprivileged_port_start = 25: apps bind rootless on 0.0.0.0:<host_port>, including 25 for SMTP
 # apps.  Must match compute_space.core.manifest.UNPRIVILEGED_PORT_FLOOR.
 #
 # kernel.apparmor_restrict_unprivileged_userns = 0: Ubuntu 24.04 blocks unprivileged user namespaces unless the
@@ -80,7 +80,7 @@
 
 # Pasta (rootless podman's default network backend) shares the host's IP with containers.  This means host-gateway
 # resolves to the container's own IP, breaking container→host communication.  We create a dummy interface with a
-# private IP that the host kernel accepts as local.  Containers reach host services (like the router on 0.0.0.0:8080)
+# private IP that the host kernel accepts as local.  Containers reach host services (like the router on 10.200.0.1:8080)
 # via this IP.  Container ports are bound on 127.0.0.1, so they're NOT reachable via the dummy interface — containers
 # are isolated from each other.
 - name: Create openhost0 dummy interface for container→host gateway
@@ -116,7 +116,7 @@
 # giving "connection refused".  These DNAT rules rewrite outbound packets aimed at public_ip:80/443 to
 # 127.0.0.1, where Caddy IS listening.  This lets containers curl other apps' public URLs and keeps
 # inter-container isolation intact (container ports still bind 127.0.0.1 only).
-- name: Add iptables hairpin NAT and firewall rules
+- name: Add iptables hairpin NAT rules
   shell: |
     set -e
     PUBLIC_IP="{{ public_ip | default(inventory_hostname) }}"
@@ -126,13 +126,6 @@
       RULE="-t nat -p tcp -d ${PUBLIC_IP} --dport ${PORT} -j DNAT --to-destination 127.0.0.1:${PORT}"
       iptables -C OUTPUT ${RULE} 2>/dev/null || iptables -A OUTPUT ${RULE}
     done
-
-    # Block external access to the router port (8080).  Caddy and containers
-    # reach it via loopback; nobody on the internet should hit it directly.
-    ACCEPT="-p tcp --dport 8080 -i lo -j ACCEPT"
-    DROP="-p tcp --dport 8080 -j DROP"
-    iptables -C INPUT ${ACCEPT} 2>/dev/null || iptables -A INPUT ${ACCEPT}
-    iptables -C INPUT ${DROP} 2>/dev/null || iptables -A INPUT ${DROP}
   changed_when: true
 
 - name: Remove old hairpin-only persistence script (renamed)
@@ -140,7 +133,7 @@
     path: /etc/networkd-dispatcher/routable.d/50-openhost-hairpin-nat
     state: absent
 
-- name: Persist iptables rules across reboots
+- name: Persist iptables hairpin NAT rules across reboots
   copy:
     # The public IP is detected at boot rather than baked in at ansible time
     # because cloud instances (EC2 without Elastic IP, etc.) can get a new
@@ -162,12 +155,6 @@
         RULE="-t nat -p tcp -d ${PUBLIC_IP} --dport ${PORT} -j DNAT --to-destination 127.0.0.1:${PORT}"
         iptables -C OUTPUT ${RULE} 2>/dev/null || iptables -A OUTPUT ${RULE}
       done
-
-      # Block external access to the router port (8080).
-      ACCEPT="-p tcp --dport 8080 -i lo -j ACCEPT"
-      DROP="-p tcp --dport 8080 -j DROP"
-      iptables -C INPUT ${ACCEPT} 2>/dev/null || iptables -A INPUT ${ACCEPT}
-      iptables -C INPUT ${DROP} 2>/dev/null || iptables -A INPUT ${DROP}
     dest: /etc/networkd-dispatcher/routable.d/50-openhost-firewall
     mode: "0755"
 

--- a/ansible/tasks/containers.yml
+++ b/ansible/tasks/containers.yml
@@ -107,6 +107,35 @@
     dest: /etc/systemd/network/10-openhost0.network
     mode: "0644"
 
+# Pasta containers share the host's IP, so `*.zone_domain` resolves to the host's own public IP.  Connecting to
+# that IP from inside a pasta container hits the container's network namespace where Caddy isn't listening,
+# giving "connection refused".  These DNAT rules rewrite outbound packets aimed at public_ip:80/443 to
+# 127.0.0.1, where Caddy IS listening.  This lets containers curl other apps' public URLs and keeps
+# inter-container isolation intact (container ports still bind 127.0.0.1 only).
+- name: Add iptables hairpin NAT for container access to public ports
+  shell: |
+    set -e
+    PUBLIC_IP="{{ public_ip | default(inventory_hostname) }}"
+    for PORT in 80 443; do
+      RULE="-t nat -p tcp -d ${PUBLIC_IP} --dport ${PORT} -j DNAT --to-destination 127.0.0.1:${PORT}"
+      iptables -C OUTPUT ${RULE} 2>/dev/null || iptables -A OUTPUT ${RULE}
+    done
+  changed_when: true
+
+- name: Persist iptables hairpin NAT rules across reboots
+  copy:
+    content: |
+      #!/bin/sh
+      # Managed by OpenHost; do not edit by hand.
+      # Hairpin NAT: let pasta containers reach Caddy via the public IP.
+      PUBLIC_IP="{{ public_ip | default(inventory_hostname) }}"
+      for PORT in 80 443; do
+        RULE="-t nat -p tcp -d ${PUBLIC_IP} --dport ${PORT} -j DNAT --to-destination 127.0.0.1:${PORT}"
+        iptables -C OUTPUT ${RULE} 2>/dev/null || iptables -A OUTPUT ${RULE}
+      done
+    dest: /etc/networkd-dispatcher/routable.d/50-openhost-hairpin-nat
+    mode: "0755"
+
 - name: Ensure host user containers config dir exists
   file:
     path: /home/host/.config/containers

--- a/ansible/tasks/containers.yml
+++ b/ansible/tasks/containers.yml
@@ -47,6 +47,10 @@
       # Managed by OpenHost; do not edit by hand.
       net.ipv4.ip_unprivileged_port_start = 25
       kernel.apparmor_restrict_unprivileged_userns = 0
+      # Required for network_host containers that do IP forwarding (VPN
+      # servers).  With --network=host, /proc/sys is read-only inside the
+      # container so the app can't set this itself.
+      net.ipv4.ip_forward = 1
     dest: /etc/sysctl.d/90-openhost-podman.conf
     mode: "0644"
 

--- a/ansible/tasks/containers.yml
+++ b/ansible/tasks/containers.yml
@@ -112,28 +112,49 @@
 # giving "connection refused".  These DNAT rules rewrite outbound packets aimed at public_ip:80/443 to
 # 127.0.0.1, where Caddy IS listening.  This lets containers curl other apps' public URLs and keeps
 # inter-container isolation intact (container ports still bind 127.0.0.1 only).
-- name: Add iptables hairpin NAT for container access to public ports
+- name: Add iptables hairpin NAT and firewall rules
   shell: |
     set -e
     PUBLIC_IP="{{ public_ip | default(inventory_hostname) }}"
+
+    # Hairpin NAT: let pasta containers reach Caddy via the public IP.
     for PORT in 80 443; do
       RULE="-t nat -p tcp -d ${PUBLIC_IP} --dport ${PORT} -j DNAT --to-destination 127.0.0.1:${PORT}"
       iptables -C OUTPUT ${RULE} 2>/dev/null || iptables -A OUTPUT ${RULE}
     done
+
+    # Block external access to the router port (8080).  Caddy and containers
+    # reach it via loopback; nobody on the internet should hit it directly.
+    ACCEPT="-p tcp --dport 8080 -i lo -j ACCEPT"
+    DROP="-p tcp --dport 8080 -j DROP"
+    iptables -C INPUT ${ACCEPT} 2>/dev/null || iptables -A INPUT ${ACCEPT}
+    iptables -C INPUT ${DROP} 2>/dev/null || iptables -A INPUT ${DROP}
   changed_when: true
 
-- name: Persist iptables hairpin NAT rules across reboots
+- name: Remove old hairpin-only persistence script (renamed)
+  file:
+    path: /etc/networkd-dispatcher/routable.d/50-openhost-hairpin-nat
+    state: absent
+
+- name: Persist iptables rules across reboots
   copy:
     content: |
       #!/bin/sh
       # Managed by OpenHost; do not edit by hand.
-      # Hairpin NAT: let pasta containers reach Caddy via the public IP.
       PUBLIC_IP="{{ public_ip | default(inventory_hostname) }}"
+
+      # Hairpin NAT: let pasta containers reach Caddy via the public IP.
       for PORT in 80 443; do
         RULE="-t nat -p tcp -d ${PUBLIC_IP} --dport ${PORT} -j DNAT --to-destination 127.0.0.1:${PORT}"
         iptables -C OUTPUT ${RULE} 2>/dev/null || iptables -A OUTPUT ${RULE}
       done
-    dest: /etc/networkd-dispatcher/routable.d/50-openhost-hairpin-nat
+
+      # Block external access to the router port (8080).
+      ACCEPT="-p tcp --dport 8080 -i lo -j ACCEPT"
+      DROP="-p tcp --dport 8080 -j DROP"
+      iptables -C INPUT ${ACCEPT} 2>/dev/null || iptables -A INPUT ${ACCEPT}
+      iptables -C INPUT ${DROP} 2>/dev/null || iptables -A INPUT ${DROP}
+    dest: /etc/networkd-dispatcher/routable.d/50-openhost-firewall
     mode: "0755"
 
 - name: Ensure host user containers config dir exists

--- a/ansible/tasks/containers.yml
+++ b/ansible/tasks/containers.yml
@@ -138,10 +138,20 @@
 
 - name: Persist iptables rules across reboots
   copy:
+    # The public IP is detected at boot rather than baked in at ansible time
+    # because cloud instances (EC2 without Elastic IP, etc.) can get a new
+    # address after a reboot.
     content: |
       #!/bin/sh
       # Managed by OpenHost; do not edit by hand.
-      PUBLIC_IP="{{ public_ip | default(inventory_hostname) }}"
+
+      # Detect public IP (same logic as scripts/provision.sh).
+      PUBLIC_IP=$(hostname -I 2>/dev/null | awk '{print $1}')
+      case "$PUBLIC_IP" in
+        10.*|172.1[6-9].*|172.2[0-9].*|172.3[01].*|192.168.*)
+          PUBLIC_IP=$(curl -sf --max-time 5 https://ifconfig.me 2>/dev/null || true) ;;
+      esac
+      [ -z "$PUBLIC_IP" ] && exit 0  # no IP yet; networkd-dispatcher will re-fire
 
       # Hairpin NAT: let pasta containers reach Caddy via the public IP.
       for PORT in 80 443; do

--- a/ansible/templates/config.toml.j2
+++ b/ansible/templates/config.toml.j2
@@ -1,6 +1,6 @@
 [openhost]
 zone_domain = "{{ domain }}"
-host = "0.0.0.0"
+host = "127.0.0.1"
 tls_enabled = true
 acquire_tls_cert_if_missing = true
 acme_account_key_path = "/home/host/openhost/ansible/secrets/certbot_private_key.json"

--- a/compute_space/src/compute_space/config.py
+++ b/compute_space/src/compute_space/config.py
@@ -168,7 +168,7 @@ class DefaultConfig(Config):
     # zone_domain: str
 
     # Server
-    host: str = "0.0.0.0"
+    host: str = "127.0.0.1"
     port: int = 8080
 
     # coredns (only truly needed if tls_enabled)

--- a/compute_space/src/compute_space/core/auth/security_audit.py
+++ b/compute_space/src/compute_space/core/auth/security_audit.py
@@ -151,9 +151,9 @@ def _check_tls_active() -> CheckResult:
 def _secure_ports() -> dict[int, str]:
     """Return the static-secure-port → label map, including the configured router port.
 
-    The router's HTTP listener (``Config.port``, default 8080) is loopback to
-    Caddy in production but binds ``0.0.0.0`` for simplicity — it should
-    therefore be reported as expected, not flagged.
+    The router's HTTP listener (``Config.port``, default 8080) binds to
+    ``127.0.0.1`` and ``10.200.0.1`` (container gateway) — it should
+    be reported as expected, not flagged.
     """
     secure: dict[int, str] = dict(_PUBLIC_SECURE_PORTS)
     try:

--- a/compute_space/src/compute_space/core/containers.py
+++ b/compute_space/src/compute_space/core/containers.py
@@ -260,21 +260,25 @@ def run_container(
         # DNS are used directly).
         cmd.append("--network=host")
     else:
-        cmd.extend([
-            "-p",
-            f"127.0.0.1:{local_port}:{manifest.container_port}",
-            # host.docker.internal kept for compatibility with existing apps.
-            "--add-host=host.docker.internal:host-gateway",
-            "--add-host=host.containers.internal:host-gateway",
-        ])
+        cmd.extend(
+            [
+                "-p",
+                f"127.0.0.1:{local_port}:{manifest.container_port}",
+                # host.docker.internal kept for compatibility with existing apps.
+                "--add-host=host.docker.internal:host-gateway",
+                "--add-host=host.containers.internal:host-gateway",
+            ]
+        )
 
-    cmd.extend([
-        f"--memory={manifest.memory_mb}m",
-        f"--cpus={manifest.cpu_millicores / 1000.0}",
-        "--restart=unless-stopped",
-        "--cap-drop=ALL",
-        "--security-opt=no-new-privileges=true",
-    ])
+    cmd.extend(
+        [
+            f"--memory={manifest.memory_mb}m",
+            f"--cpus={manifest.cpu_millicores / 1000.0}",
+            "--restart=unless-stopped",
+            "--cap-drop=ALL",
+            "--security-opt=no-new-privileges=true",
+        ]
+    )
     if manifest.shm_mb > 0:
         cmd.append(f"--shm-size={manifest.shm_mb}m")
     for cap in sorted(DEFAULT_CAPABILITIES):

--- a/compute_space/src/compute_space/core/containers.py
+++ b/compute_space/src/compute_space/core/containers.py
@@ -258,6 +258,10 @@ def run_container(
         # Port publishing is unnecessary (the container binds directly on
         # the host), as are --add-host entries (the host's /etc/hosts and
         # DNS are used directly).
+        #
+        # WARNING: this disables ALL network isolation.  The container can
+        # reach any port on the host including other apps' loopback ports.
+        logger.warning("App %s uses network_host — all network isolation is disabled", app_name)
         cmd.append("--network=host")
     else:
         cmd.extend(

--- a/compute_space/src/compute_space/core/containers.py
+++ b/compute_space/src/compute_space/core/containers.py
@@ -248,17 +248,33 @@ def run_container(
         container_name,
         "--hostname",
         container_name,
-        "-p",
-        f"127.0.0.1:{local_port}:{manifest.container_port}",
+    ]
+
+    if manifest.network_host:
+        # Host networking: the container shares the host's full network
+        # namespace.  Required for apps that do IP forwarding (VPN servers
+        # like WireGuard) because pasta can only proxy individual TCP/UDP
+        # connections, not forwarded/routed packets from a tunnel interface.
+        # Port publishing is unnecessary (the container binds directly on
+        # the host), as are --add-host entries (the host's /etc/hosts and
+        # DNS are used directly).
+        cmd.append("--network=host")
+    else:
+        cmd.extend([
+            "-p",
+            f"127.0.0.1:{local_port}:{manifest.container_port}",
+            # host.docker.internal kept for compatibility with existing apps.
+            "--add-host=host.docker.internal:host-gateway",
+            "--add-host=host.containers.internal:host-gateway",
+        ])
+
+    cmd.extend([
         f"--memory={manifest.memory_mb}m",
         f"--cpus={manifest.cpu_millicores / 1000.0}",
         "--restart=unless-stopped",
-        # host.docker.internal kept for compatibility with existing apps.
-        "--add-host=host.docker.internal:host-gateway",
-        "--add-host=host.containers.internal:host-gateway",
         "--cap-drop=ALL",
         "--security-opt=no-new-privileges=true",
-    ]
+    ])
     if manifest.shm_mb > 0:
         cmd.append(f"--shm-size={manifest.shm_mb}m")
     for cap in sorted(DEFAULT_CAPABILITIES):
@@ -296,7 +312,9 @@ def run_container(
     # Structured port mappings: bind TCP+UDP on 0.0.0.0.  host_port
     # values below UNPRIVILEGED_PORT_FLOOR are rejected at manifest
     # parse time so these binds always succeed.
-    if port_mappings:
+    # With --network=host, port publishing is skipped (container binds
+    # directly on the host's interfaces).
+    if port_mappings and not manifest.network_host:
         for pm in port_mappings:
             cmd.extend(["-p", f"0.0.0.0:{pm.host_port}:{pm.container_port}/tcp"])
             cmd.extend(["-p", f"0.0.0.0:{pm.host_port}:{pm.container_port}/udp"])
@@ -308,6 +326,13 @@ def run_container(
 
     for device in manifest.devices:
         cmd.extend(["--device", device])
+
+    if manifest.network_host:
+        # Tell the app which port the router expects it on.  With host
+        # networking the container can't use its manifest port if it
+        # conflicts with other host services, so it should bind on this
+        # allocated port instead.
+        container_env["OPENHOST_LOCAL_PORT"] = str(local_port)
 
     for key, value in container_env.items():
         cmd.extend(["-e", f"{key}={value}"])

--- a/compute_space/src/compute_space/core/data.py
+++ b/compute_space/src/compute_space/core/data.py
@@ -151,11 +151,14 @@ def provision_data(
     # Generate app token for cross-app service calls
     env_vars["OPENHOST_APP_TOKEN"] = secrets_mod.token_urlsafe(32)
 
-    # Apps run in bridge-mode containers where 127.0.0.1 is the container
-    # itself, not the host.  host.containers.internal (podman's host-gateway
-    # alias) and the host.docker.internal back-compat alias are both
-    # registered by run_container; we advertise the podman-native one.
-    env_vars["OPENHOST_ROUTER_URL"] = f"http://host.containers.internal:{port}"
+    if manifest.network_host:
+        # network_host containers share the host's network namespace, so
+        # localhost IS the host.  host.containers.internal doesn't exist.
+        env_vars["OPENHOST_ROUTER_URL"] = f"http://127.0.0.1:{port}"
+    else:
+        # Pasta containers: 127.0.0.1 is the container itself, not the host.
+        # host.containers.internal (podman's host-gateway alias) reaches the host.
+        env_vars["OPENHOST_ROUTER_URL"] = f"http://host.containers.internal:{port}"
 
     # Zone identity info so apps can build federated auth flows
     env_vars["OPENHOST_ZONE_DOMAIN"] = zone_domain

--- a/compute_space/src/compute_space/core/manifest.py
+++ b/compute_space/src/compute_space/core/manifest.py
@@ -122,6 +122,11 @@ class AppManifest:
     # `--shm-size` (in MiB).  0 = use podman's default (64 MiB).
     # Apps doing serious browser work (jibri) need ~2 GiB minimum.
     shm_mb: int = 0
+    # Use the host's network namespace instead of pasta.  Required for apps
+    # that do IP forwarding (VPN servers like WireGuard).  Pasta proxies
+    # individual TCP/UDP connections but cannot forward routed packets from
+    # a tunnel interface.
+    network_host: bool = False
 
     # [routing]
     health_check: str | None = None
@@ -343,6 +348,7 @@ def parse_manifest_from_string(raw_text: str) -> AppManifest:
         port_mappings=_parse_ports(data.get("ports", [])),
         capabilities=_validate_capabilities(container.get("capabilities", [])),
         devices=_validate_devices(container.get("devices", [])),
+        network_host=container.get("network_host", False),
         shm_mb=shm_mb,
         health_check=routing.get("health_check"),
         public_paths=routing.get("public_paths", []),

--- a/compute_space/src/compute_space/core/manifest.py
+++ b/compute_space/src/compute_space/core/manifest.py
@@ -126,6 +126,11 @@ class AppManifest:
     # that do IP forwarding (VPN servers like WireGuard).  Pasta proxies
     # individual TCP/UDP connections but cannot forward routed packets from
     # a tunnel interface.
+    #
+    # WARNING: this disables ALL network isolation.  The container can
+    # connect to any port on the host, including other apps' loopback-bound
+    # ports, the router, and local services.  Only use for apps that
+    # genuinely need raw network access (VPNs, transparent proxies).
     network_host: bool = False
 
     # [routing]

--- a/compute_space/src/compute_space/web/start.py
+++ b/compute_space/src/compute_space/web/start.py
@@ -107,7 +107,15 @@ def main() -> None:
             raise RuntimeError("TLS is enabled but start_caddy is False. Caddy is required for TLS termination.")
 
     hypercorn_config = hypercorn.config.Config()
-    hypercorn_config.bind = [f"{config.host}:{config.port}"]
+    # Bind the primary address (127.0.0.1 in production) plus the container
+    # gateway (10.200.0.1) so podman containers can reach the router via
+    # host.containers.internal.  No need for 0.0.0.0 — Caddy handles
+    # external traffic on 80/443 and proxies to us on loopback.
+    binds = [f"{config.host}:{config.port}"]
+    container_gateway = "10.200.0.1"
+    if config.host != "0.0.0.0" and config.host != container_gateway:
+        binds.append(f"{container_gateway}:{config.port}")
+    hypercorn_config.bind = binds
     hypercorn_config.graceful_timeout = 3
     hypercorn_config.shutdown_timeout = 5
 

--- a/compute_space/src/compute_space/web/start.py
+++ b/compute_space/src/compute_space/web/start.py
@@ -1,6 +1,7 @@
 import asyncio
 import os
 import signal
+import socket
 import sqlite3
 import subprocess
 import time
@@ -117,11 +118,9 @@ def main() -> None:
         # Only add the gateway bind if the interface actually exists (it won't
         # in dev mode or CI where openhost0 hasn't been created by ansible).
         try:
-            import socket as _sock
-
-            s = _sock.socket(_sock.AF_INET, _sock.SOCK_STREAM)
-            s.bind((container_gateway, 0))
-            s.close()
+            probe = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            probe.bind((container_gateway, 0))
+            probe.close()
             binds.append(f"{container_gateway}:{config.port}")
         except OSError:
             pass

--- a/compute_space/src/compute_space/web/start.py
+++ b/compute_space/src/compute_space/web/start.py
@@ -114,7 +114,17 @@ def main() -> None:
     binds = [f"{config.host}:{config.port}"]
     container_gateway = "10.200.0.1"
     if config.host != "0.0.0.0" and config.host != container_gateway:
-        binds.append(f"{container_gateway}:{config.port}")
+        # Only add the gateway bind if the interface actually exists (it won't
+        # in dev mode or CI where openhost0 hasn't been created by ansible).
+        try:
+            import socket as _sock
+
+            s = _sock.socket(_sock.AF_INET, _sock.SOCK_STREAM)
+            s.bind((container_gateway, 0))
+            s.close()
+            binds.append(f"{container_gateway}:{config.port}")
+        except OSError:
+            pass
     hypercorn_config.bind = binds
     hypercorn_config.graceful_timeout = 3
     hypercorn_config.shutdown_timeout = 5

--- a/compute_space/src/compute_space/web/templates/add_app.html
+++ b/compute_space/src/compute_space/web/templates/add_app.html
@@ -187,6 +187,14 @@ function renderManifest(m, url) {
     row('Accessible without login', m.public_paths.map(p => `<code>${esc(p)}</code>`).join(', '));
   }
 
+  if (m.network_host) {
+    section('Host Networking', '#f8d7da');
+    row('<strong>WARNING</strong>',
+      '<strong>This app uses host networking, which disables all network isolation. ' +
+      'It can access any port on the host, including other apps. ' +
+      'Only install if you trust this app completely.</strong>');
+  }
+
   if (m.capabilities.length || m.devices.length || m.shm_mb) {
     section('Container Permissions', '#fff3cd');
     if (m.capabilities.length) row('Linux capabilities', m.capabilities.join(', '));


### PR DESCRIPTION
Hairpin NAT so containers can reach other apps via public URLs. Pasta shares the host IP but not its listening sockets, so connections to the public IP from inside a container got connection refused. Iptables DNAT rules on the OUTPUT chain rewrite public_ip:80/443 to 127.0.0.1 where Caddy is listening. The boot-time persistence script detects the public IP dynamically so it survives reboots even if the IP changes (EC2 without Elastic IP, etc).

Router bind restricted to 127.0.0.1 + 10.200.0.1 (container gateway) instead of 0.0.0.0. Port 8080 is no longer reachable from the internet. Caddy reaches the router on loopback, containers reach it via the gateway. The gateway bind is auto-detected (skipped in dev/CI where openhost0 doesn't exist).

ip_forward=1 sysctl on the host for containers that need IP forwarding (VPN servers). With --network=host on rootless podman, /proc/sys is read-only so the container can't set this itself.

network_host manifest option (network_host=true in [runtime.container]) runs the container with --network=host instead of pasta. Passes OPENHOST_LOCAL_PORT and sets OPENHOST_ROUTER_URL to 127.0.0.1. Not used by any deployed app currently but available for future use.