### PR TITLE
Fix CORS preflight handler: logic inversion + silent shadowing

### DIFF
--- a/compute_space/src/compute_space/tests/test_cors_preflight.py
+++ b/compute_space/src/compute_space/tests/test_cors_preflight.py
@@ -1,0 +1,88 @@
+"""Tests for the CORS preflight (OPTIONS) handler on the v2 service-call path."""
+
+from __future__ import annotations
+
+import sqlite3
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Any
+
+import pytest
+from litestar import Litestar
+from litestar.di import Provide
+from litestar.testing import TestClient
+
+from compute_space.config import provide_config
+from compute_space.core.app_id import new_app_id
+from compute_space.db import provide_db
+from compute_space.db.connection import init_db
+from compute_space.web.routes.services_v2 import services_v2_routes
+
+from .conftest import _make_test_config
+
+APP_NAME = "test-cors-app"
+CALL_URL = f"/api/services/v2/call/{APP_NAME}/some-endpoint"
+# get_app_from_hostname expects a Host-header style value (hostname[:port]),
+# not a full URL — so Origin values here use that format.
+APP_ORIGIN = f"{APP_NAME}.testzone.local"
+
+
+def _make_app() -> Litestar:
+    return Litestar(
+        route_handlers=[services_v2_routes],
+        dependencies={
+            "config": Provide(provide_config, sync_to_thread=False),
+            "db": Provide(provide_db),
+        },
+        openapi_config=None,
+    )
+
+
+def _seed_app(db_path: str) -> None:
+    db = sqlite3.connect(db_path)
+    try:
+        db.execute(
+            """INSERT INTO apps
+                 (app_id, name, version, repo_path, local_port, status, installed_by)
+               VALUES (?, ?, ?, ?, ?, ?, NULL)""",
+            (new_app_id(), APP_NAME, "1.0.0", f"/tmp/{APP_NAME}", 19600, "running"),
+        )
+        db.commit()
+    finally:
+        db.close()
+
+
+@pytest.fixture
+def cfg(tmp_path: Path) -> Any:
+    return _make_test_config(tmp_path, port=20600)
+
+
+@pytest.fixture
+def client(cfg: Any) -> Iterator[TestClient[Litestar]]:
+    init_db(cfg.db_path)
+    _seed_app(cfg.db_path)
+    with TestClient(app=_make_app()) as c:
+        yield c
+
+
+def test_options_known_app_origin_returns_cors_headers(client: TestClient[Litestar]) -> None:
+    """OPTIONS with an Origin matching a known app should return 204 + CORS headers."""
+    resp = client.options(CALL_URL, headers={"Origin": APP_ORIGIN})
+    assert resp.status_code == 204
+    assert resp.headers["Access-Control-Allow-Origin"] == APP_ORIGIN
+    assert resp.headers["Access-Control-Allow-Methods"] == "GET, POST, PUT, DELETE, PATCH, OPTIONS"
+    assert resp.headers["Access-Control-Allow-Headers"] == "Content-Type, Authorization"
+
+
+def test_options_unknown_origin_returns_403(client: TestClient[Litestar]) -> None:
+    """OPTIONS with an Origin that doesn't match any app should be rejected."""
+    resp = client.options(CALL_URL, headers={"Origin": "evil.example.com"})
+    assert resp.status_code == 403
+    assert "Access-Control-Allow-Origin" not in resp.headers
+
+
+def test_options_no_origin_returns_403(client: TestClient[Litestar]) -> None:
+    """OPTIONS without an Origin header should be rejected."""
+    resp = client.options(CALL_URL)
+    assert resp.status_code == 403
+    assert "Access-Control-Allow-Origin" not in resp.headers

--- a/compute_space/src/compute_space/web/routes/services_v2.py
+++ b/compute_space/src/compute_space/web/routes/services_v2.py
@@ -504,9 +504,9 @@ def _installer_permission_denied(
 
 services_v2_routes = Router(
     path="/",
-    # service_call_cors MUST come before service_call: Litestar v2.21.1 processes
-    # handlers in order and auto-generates an OPTIONS handler after the first
-    # handler that doesn't include OPTIONS, silently shadowing any explicit
-    # OPTIONS handler that appears later in the list.
+    # service_call_cors MUST come before service_call: Litestar v2.21.1 has a
+    # bug where registering a non-OPTIONS handler first causes an auto-generated
+    # OPTIONS handler to be appended, which then silently overwrites any explicit
+    # OPTIONS handler via last-writer-wins in route_handler_method_map.
     route_handlers=[service_call_cors, service_call, service_call_ws, oauth_callback_proxy_v2],
 )

--- a/compute_space/src/compute_space/web/routes/services_v2.py
+++ b/compute_space/src/compute_space/web/routes/services_v2.py
@@ -191,7 +191,7 @@ async def service_call_cors(request: Request[Any, Any, Any], _shortname: str, _r
     origin = request.headers.get("Origin", None)
     # block CORS preflight if Origin is not a known app - no auth headers yet but we can at least verify this,
     # to help avoid XSRF from external sites.
-    if origin is None or get_app_from_hostname(origin) is not None:
+    if origin is None or get_app_from_hostname(origin) is None:
         return Response(content="Forbidden", status_code=403, media_type=MediaType.TEXT)
     return Response(content="", status_code=204, headers=_cors_headers(origin))
 
@@ -504,5 +504,9 @@ def _installer_permission_denied(
 
 services_v2_routes = Router(
     path="/",
-    route_handlers=[service_call, service_call_cors, service_call_ws, oauth_callback_proxy_v2],
+    # service_call_cors MUST come before service_call: Litestar v2.21.1 processes
+    # handlers in order and auto-generates an OPTIONS handler after the first
+    # handler that doesn't include OPTIONS, silently shadowing any explicit
+    # OPTIONS handler that appears later in the list.
+    route_handlers=[service_call_cors, service_call, service_call_ws, oauth_callback_proxy_v2],
 )

--- a/compute_space/src/compute_space/web/routes/services_v2.py
+++ b/compute_space/src/compute_space/web/routes/services_v2.py
@@ -185,8 +185,8 @@ def _add_cors_response_headers(response: ASGIResponse, request: Request[Any, Any
             response.headers.add(k, v)
 
 
-@route(_CALL_PATH, http_method=[HttpMethod.OPTIONS], status_code=204)
-async def service_call_cors(request: Request[Any, Any, Any], _shortname: str, _rest: str) -> Response[str]:
+@route(_CALL_PATH, http_method=[HttpMethod.OPTIONS])
+async def service_call_cors(request: Request[Any, Any, Any], shortname: str, rest: str) -> Response[str]:
     """Hande CORS preflight HTTP OPTIONS request, respond with appropriate CORS headers."""
     origin = request.headers.get("Origin", None)
     # block CORS preflight if Origin is not a known app - no auth headers yet but we can at least verify this,


### PR DESCRIPTION
## Summary

Four bugs in the `service_call_cors` OPTIONS handler, all of which prevented it from ever executing:

1. **Logic inversion**: `get_app_from_hostname(origin) is not None` blocked known apps and allowed external origins. Flipped to `is None`.

2. **Invalid decorator**: `status_code=204` combined with `-> Response[str]` return type caused Litestar to reject the handler at registration time (`ImproperlyConfiguredException`). Removed the decorator status_code since the handler sets it explicitly on each Response.

3. **Parameter name mismatch**: `_shortname`/`_rest` didn't match the path template `{shortname}/{rest}`, so Litestar treated them as query params and returned 400 on every request.

4. **Handler ordering**: Litestar v2.21.1 has a bug where the auto-generated OPTIONS handler silently overwrites explicit ones. Root cause: `Router.__init__` registers handlers one at a time. When `service_call` (GET/POST/etc.) is registered first, `HTTPRoute.__init__` appends an auto-generated `options_handler`. Later, when `Litestar.__init__` reads `route_handler_method_map` to build the final routes, this property iterates `route_handlers` and uses plain dict assignment (`route_map[path][method] = handler`) — last-writer-wins. The auto-generated handler appears last in the list (it was appended), so it overwrites the explicit one. Reordered so `service_call_cors` is registered first.

## How I verified

- Traced through Litestar v2.21.1 source to identify the root cause
- Tested on zack-dev instance: before fix, all OPTIONS requests returned identical 204 with `Allow` header and no CORS headers (auto-generated handler signature)
- Reproduced with a minimal test case locally
- Added `test_cors_preflight.py` with 3 tests: all 3 fail on old code, all 3 pass on fixed code
- All 13 existing installer route tests continue to pass

## Litestar upstream issue

Planning to open an issue. The bug is in `Router.route_handler_method_map` (line 277 of `router.py`): it uses last-writer-wins dict assignment when building the method→handler map. Auto-generated handlers are appended to the end of `route_handlers` in `HTTPRoute.__init__`, so they always overwrite explicit handlers for the same method.

## Test plan

- [x] Tests pass locally: `pytest -x compute_space/src/compute_space/tests/test_cors_preflight.py`
- [x] Tests fail on old code, pass on new code
- [x] Existing installer route tests unaffected
- [ ] Deploy to zack-dev, send OPTIONS with known app origin → expect 204 + CORS headers
- [ ] Send OPTIONS with unknown origin → expect 403
- [ ] Send OPTIONS with no origin → expect 403

🤖 Generated with [Claude Code](https://claude.com/claude-code)