### PR TITLE
Escalate to podman kill when container stop hangs

### DIFF
--- a/compute_space/src/compute_space/core/containers.py
+++ b/compute_space/src/compute_space/core/containers.py
@@ -340,8 +340,24 @@ def run_container(
 
 
 def stop_container(container_id: str) -> None:
-    """Stop and remove a container by ID or name.  Idempotent."""
-    subprocess.run(["podman", "stop", container_id], capture_output=True, timeout=30)
+    """Stop and remove a container by ID or name.  Idempotent.
+
+    Gives the container 10s to exit gracefully (SIGTERM via ``podman stop
+    -t 10``).  If that times out or fails, escalates to ``podman kill``
+    (SIGKILL) before removing.
+    """
+    try:
+        result = subprocess.run(
+            ["podman", "stop", "-t", "10", container_id],
+            capture_output=True,
+            timeout=20,
+        )
+        if result.returncode != 0:
+            logger.warning("podman stop %s exited %d, escalating to kill", container_id, result.returncode)
+            subprocess.run(["podman", "kill", container_id], capture_output=True, timeout=10)
+    except subprocess.TimeoutExpired:
+        logger.warning("podman stop %s timed out, escalating to kill", container_id)
+        subprocess.run(["podman", "kill", container_id], capture_output=True, timeout=10)
     subprocess.run(["podman", "rm", "-f", container_id], capture_output=True, timeout=30)
 
 

--- a/compute_space/src/compute_space/tests/test_containers.py
+++ b/compute_space/src/compute_space/tests/test_containers.py
@@ -601,7 +601,45 @@ def test_stop_container_calls_podman(monkeypatch: pytest.MonkeyPatch) -> None:
 
     stop_container("abc123")
     assert calls == [
-        ["podman", "stop", "abc123"],
+        ["podman", "stop", "-t", "10", "abc123"],
+        ["podman", "rm", "-f", "abc123"],
+    ]
+
+
+def test_stop_container_escalates_to_kill_on_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[list[str]] = []
+
+    def fake_run(cmd, **_):  # type: ignore[no-untyped-def]
+        calls.append(list(cmd))
+        if cmd[:2] == ["podman", "stop"]:
+            return _FakeCompleted(125)
+        return _FakeCompleted(0)
+
+    _patch_subprocess_run(monkeypatch, fake_run)
+
+    stop_container("abc123")
+    assert calls == [
+        ["podman", "stop", "-t", "10", "abc123"],
+        ["podman", "kill", "abc123"],
+        ["podman", "rm", "-f", "abc123"],
+    ]
+
+
+def test_stop_container_escalates_to_kill_on_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[list[str]] = []
+
+    def fake_run(cmd, **kwargs):  # type: ignore[no-untyped-def]
+        calls.append(list(cmd))
+        if cmd[:2] == ["podman", "stop"]:
+            raise subprocess.TimeoutExpired(cmd, kwargs.get("timeout", 20))
+        return _FakeCompleted(0)
+
+    _patch_subprocess_run(monkeypatch, fake_run)
+
+    stop_container("abc123")
+    assert calls == [
+        ["podman", "stop", "-t", "10", "abc123"],
+        ["podman", "kill", "abc123"],
         ["podman", "rm", "-f", "abc123"],
     ]
 


### PR DESCRIPTION
## Summary

- `stop_container` now passes `-t 10` to `podman stop` for an explicit 10s SIGTERM grace period (down from relying on podman's default + a 30s subprocess timeout)
- If `podman stop` exits non-zero or times out, escalates to `podman kill` (SIGKILL) before running `podman rm -f`
- Prevents hung containers from stalling the `/stop_app` endpoint — the root cause of flaky EC2 e2e timeouts (test_08_stop_app and cascading failures)

## Test plan

- [x] Existing `test_stop_container_calls_podman` updated for new args
- [x] New `test_stop_container_escalates_to_kill_on_failure` — verifies kill on non-zero exit
- [x] New `test_stop_container_escalates_to_kill_on_timeout` — verifies kill on subprocess timeout
- [x] Full test suite passes (585 passed, 32 skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)