### PR TITLE
Fix OAuth fallback masking real clone errors

### DIFF
--- a/compute_space/src/compute_space/core/apps.py
+++ b/compute_space/src/compute_space/core/apps.py
@@ -238,12 +238,13 @@ async def clone_with_github_fallback(
     manifest, tmp_dir, error = await clone_and_read_manifest(repo_url)
 
     if error and "github.com" in repo_url:
+        clone_error = error
         try:
             token = await get_oauth_token("github", ["repo"], return_to=return_to)
-        except ServiceNotAvailable as e:
-            return None, None, e.message, None
+        except ServiceNotAvailable:
+            return None, None, clone_error, None
         except OAuthAuthorizationRequired as e:
-            return None, None, error, e.authorize_url
+            return None, None, clone_error, e.authorize_url
         manifest, tmp_dir, error = await clone_and_read_manifest(repo_url, github_token=token)
 
     return manifest, tmp_dir, error, None

--- a/compute_space/src/compute_space/core/apps.py
+++ b/compute_space/src/compute_space/core/apps.py
@@ -241,10 +241,10 @@ async def clone_with_github_fallback(
         clone_error = error
         try:
             token = await get_oauth_token("github", ["repo"], return_to=return_to)
-        except ServiceNotAvailable:
-            return None, None, clone_error, None
+        except ServiceNotAvailable as e:
+            return None, None, f"{clone_error} (also failed to fetch GitHub OAuth token: {e.message})", None
         except OAuthAuthorizationRequired as e:
-            return None, None, clone_error, e.authorize_url
+            return None, None, f"{clone_error} (GitHub OAuth not configured: {e.authorize_url})", e.authorize_url
         manifest, tmp_dir, error = await clone_and_read_manifest(repo_url, github_token=token)
 
     return manifest, tmp_dir, error, None


### PR DESCRIPTION
## Summary

- When deploying a GitHub-hosted repo, if the initial `git clone` fails and the OAuth fallback also fails (e.g. no grant configured), the OAuth error was surfaced instead of the original clone error
- This made clone failures show a misleading `OAuth service returned unexpected status 403: {"error":"permission_required"...}` instead of the actual git error (e.g. `fatal: unable to update url base from redirection`)
- Fix: preserve the original clone error and return it when OAuth can't help

Verified on zack-dev by hot-patching the fix and retrying a deploy — the real clone error appeared correctly.

## Test plan

- [x] Manually verified on zack-dev instance
- [x] Pre-commit hooks pass (ruff, mypy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)