### PR TITLE
Mark setup app /health restarting once setup completes

### DIFF
--- a/compute_space/src/compute_space/web/setup_app.py
+++ b/compute_space/src/compute_space/web/setup_app.py
@@ -35,7 +35,6 @@ from compute_space.core.updates import trigger_restart
 from compute_space.db import get_db
 from compute_space.web.auth.cookies import build_session_cookie
 
-
 # Set when setup_post succeeds. /health flips to 503 immediately so clients
 # polling for the post-restart main app don't see a stale 200 from the setup
 # app during the brief window before hypercorn actually drops the listener.

--- a/compute_space/src/compute_space/web/setup_app.py
+++ b/compute_space/src/compute_space/web/setup_app.py
@@ -36,6 +36,12 @@ from compute_space.db import get_db
 from compute_space.web.auth.cookies import build_session_cookie
 
 
+# Set when setup_post succeeds. /health flips to 503 immediately so clients
+# polling for the post-restart main app don't see a stale 200 from the setup
+# app during the brief window before hypercorn actually drops the listener.
+_setup_completed: bool = False
+
+
 def _verify_claim_token(claim_token: str, claim_token_path: str) -> bool:
     """Compare ``claim_token`` against the token written to ``claim_token_path``."""
     if not claim_token:
@@ -138,6 +144,9 @@ async def setup_post(request: Request[Any, Any, Any], config: Config) -> Respons
     response = Response(content=body, status_code=200, media_type=MediaType.HTML)
     response.set_cookie(build_session_cookie(session_token, cookie_domain=config.zone_domain_no_port))
 
+    global _setup_completed  # noqa: PLW0603
+    _setup_completed = True
+
     # Schedule the restart for after the response has been written so the
     # client actually receives the 200 + Set-Cookie before the listener drops.
     response.background = BackgroundTask(_trigger_restart_after_response)
@@ -157,7 +166,7 @@ def health() -> Response[dict[str, str]]:
     """Liveness probe.  Returns ``{"status": "ok"}`` (or 503 when restarting).
     Security audit data is only available via the authenticated
     ``/api/security-audit`` endpoint."""
-    if is_shutdown_pending():
+    if is_shutdown_pending() or _setup_completed:
         return Response(content={"status": "restarting"}, status_code=503)
     return Response(content={"status": "ok"})
 


### PR DESCRIPTION
## Summary

Fixes a race in `test_02_setup` that produced this failure:

```
>       assert r.status_code == 200
E       assert 404 == 200
E        +  where 404 = <Response [404]>.status_code
tests/test_e2e.py:130: AssertionError
```

## Root cause

Both `setup_app` and the main app expose `/health`. After a successful `POST /setup`:

1. `setup_post` returns a 200 + meta-refresh page + Set-Cookie.
2. A `BackgroundTask` (`_trigger_restart_after_response`) sleeps ~50ms, then calls `trigger_restart()`, which sets `_shutdown_event` and lets hypercorn begin graceful shutdown.
3. Only at step 2 does `is_shutdown_pending()` flip and `/health` return 503.

During that window the **setup app's** `/health` still answers 200. The e2e test polls `/health` with a fresh `requests.Session()` immediately after the POST:

```python
poll_endpoint(requests.Session(), f"{router_url}/health", timeout=120, interval=2, ...)
r = session.get(f"{router_url}/dashboard", timeout=10)
```

The poll latches onto the still-running setup app, returns immediately, and the next `GET /dashboard` hits the setup app — which has no `/dashboard` route — yielding 404.

## Fix

Flip a module-level `_setup_completed` flag the moment `setup_post` succeeds, and have `/health` check it alongside `is_shutdown_pending()`. `/health` now reports `{"status": "restarting"}` with status 503 immediately after setup completes, so the poll waits for the *actual* main app rather than the setup app's leftover listener.

The `BackgroundTask` + 50ms sleep are kept as-is — they exist to let the response flush before hypercorn drops the listener, which is independent of the health-signal race.

## Test plan

- [ ] Re-run cloud e2e suite; `test_02_setup` should reliably pass.
- [ ] Manual: confirm a fresh provision still sets the owner cookie and lands on `/dashboard`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)