### PR TITLE
Use ansible_facts dict for getent_passwd lookup

### DIFF
--- a/ansible/tasks/setup_openhost_service.yml
+++ b/ansible/tasks/setup_openhost_service.yml
@@ -33,7 +33,7 @@
     src: templates/openhost.service.j2
     dest: /etc/systemd/system/openhost.service
   vars:
-    host_uid: "{{ getent_passwd.host[1] }}"
+    host_uid: "{{ ansible_facts['getent_passwd'].host[1] }}"
   register: service_file
 
 - name: Reload systemd


### PR DESCRIPTION
Re-opening as a new PR — previous #130 ended up marked merged when the test branch briefly absorbed it; force-pushing the test branch back orphaned that merge, but GitHub won't reopen a merged PR.

## Summary

Fixes an Ansible deprecation warning seen during a fresh openhost provision:

```
[DEPRECATION WARNING]: INJECT_FACTS_AS_VARS default to True is deprecated, top-level facts will not be auto injected after the change. This feature will be removed from ansible-core version 2.24.
Origin: ansible/tasks/setup_openhost_service.yml:36:15

34     dest: /etc/systemd/system/openhost.service
35   vars:
36     host_uid: "{{ getent_passwd.host[1] }}"
                 ^ column 15

Use ansible_facts["fact_name"] (no ansible_ prefix) instead.
```

Changes `getent_passwd.host[1]` to `ansible_facts['getent_passwd'].host[1]`. Same value today; the latter is the form that survives the deprecation.

## Docs

- [INJECT_FACTS_AS_VARS](https://docs.ansible.com/ansible/latest/reference_appendices/config.html#inject-facts-as-vars) — confirms facts remain available under `ansible_facts['<name>']` after the top-level injection is removed.
- [getent module](https://docs.ansible.com/ansible/latest/collections/ansible/builtin/getent_module.html) — sets a fact `getent_<database>`; the docs' own example uses `ansible_facts.getent_passwd`.

## Stack

Stacked on top of #132. Merge that first.

## Test plan

- [ ] Re-run the openhost provision and confirm the deprecation warning is gone and `host_uid` still resolves correctly.