### PR TITLE
Show provided services on app details page

### DIFF
--- a/compute_space/src/compute_space/web/routes/pages/apps.py
+++ b/compute_space/src/compute_space/web/routes/pages/apps.py
@@ -31,7 +31,7 @@ async def app_detail(app_id: str, db: sqlite3.Connection, config: Config, next: 
         "SELECT label, container_port, host_port FROM app_port_mappings WHERE app_id = ? ORDER BY label",
         (app_id,),
     ).fetchall()
-    services = db.execute(
+    services_provided = db.execute(
         "SELECT service_url, service_version FROM service_providers_v2 WHERE app_id = ? ORDER BY service_url",
         (app_id,),
     ).fetchall()
@@ -43,7 +43,7 @@ async def app_detail(app_id: str, db: sqlite3.Connection, config: Config, next: 
             "app": app_row,
             "databases": databases,
             "port_mappings": port_mappings,
-            "services": services,
+            "services_provided": services_provided,
             "logs": logs,
             "next_url": next,
         },

--- a/compute_space/src/compute_space/web/routes/pages/apps.py
+++ b/compute_space/src/compute_space/web/routes/pages/apps.py
@@ -31,6 +31,10 @@ async def app_detail(app_id: str, db: sqlite3.Connection, config: Config, next: 
         "SELECT label, container_port, host_port FROM app_port_mappings WHERE app_id = ? ORDER BY label",
         (app_id,),
     ).fetchall()
+    services = db.execute(
+        "SELECT service_url, service_version FROM service_providers_v2 WHERE app_id = ? ORDER BY service_url",
+        (app_id,),
+    ).fetchall()
     logs = get_docker_logs(app_name, config.temporary_data_dir, app_row["container_id"])
 
     return Template(
@@ -39,6 +43,7 @@ async def app_detail(app_id: str, db: sqlite3.Connection, config: Config, next: 
             "app": app_row,
             "databases": databases,
             "port_mappings": port_mappings,
+            "services": services,
             "logs": logs,
             "next_url": next,
         },

--- a/compute_space/src/compute_space/web/templates/app_detail.html
+++ b/compute_space/src/compute_space/web/templates/app_detail.html
@@ -56,7 +56,7 @@
 {% endif %}
 
 {% if services_provided %}
-<h3>Services</h3>
+<h3>Services Provided</h3>
 <table>
   <tr><th>Service URL</th><th>Version</th></tr>
   {% for svc in services_provided %}

--- a/compute_space/src/compute_space/web/templates/app_detail.html
+++ b/compute_space/src/compute_space/web/templates/app_detail.html
@@ -55,11 +55,11 @@
 </table>
 {% endif %}
 
-{% if services %}
+{% if services_provided %}
 <h3>Services</h3>
 <table>
   <tr><th>Service URL</th><th>Version</th></tr>
-  {% for svc in services %}
+  {% for svc in services_provided %}
   <tr>
     <td>{{ svc.service_url }}</td>
     <td>{{ svc.service_version }}</td>

--- a/compute_space/src/compute_space/web/templates/app_detail.html
+++ b/compute_space/src/compute_space/web/templates/app_detail.html
@@ -55,6 +55,19 @@
 </table>
 {% endif %}
 
+{% if services %}
+<h3>Services</h3>
+<table>
+  <tr><th>Service URL</th><th>Version</th></tr>
+  {% for svc in services %}
+  <tr>
+    <td>{{ svc.service_url }}</td>
+    <td>{{ svc.service_version }}</td>
+  </tr>
+  {% endfor %}
+</table>
+{% endif %}
+
 {% if databases %}
 <h3>SQLite Databases</h3>
 <table>


### PR DESCRIPTION
## Summary
- Query `service_providers_v2` for the app in the details page route and pass results to the template
- Render a "Services" section with Service URL and Version columns, matching the existing Port Mappings / SQLite Databases pattern
- Section is hidden when the app provides no services

## Test plan
- [ ] Deploy an app that provides a service (e.g. `oauth_provider`) and verify the Services section appears with correct URL and version
- [ ] View an app that does not provide services and verify the section is absent
- [ ] Run `pixi run -e dev pytest -x compute_space/tests/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)