### PR TITLE
Allow apps to call specific service providers

### DIFF
--- a/compute_space/src/compute_space/tests/test_provider_selection.py
+++ b/compute_space/src/compute_space/tests/test_provider_selection.py
@@ -1,0 +1,229 @@
+"""Tests for provider selection via X-OpenHost-Provider header and app-auth on the discovery endpoint."""
+
+from __future__ import annotations
+
+import hashlib
+import sqlite3
+from pathlib import Path
+from unittest.mock import AsyncMock
+from unittest.mock import patch
+
+import pytest
+from litestar import Litestar
+from litestar.di import Provide
+from litestar.response.base import ASGIResponse
+from litestar.testing import TestClient
+
+from compute_space.config import provide_config
+from compute_space.core.app_id import new_app_id
+from compute_space.db import provide_db
+from compute_space.db.connection import init_db
+from compute_space.web.routes.api.services_v2 import api_services_v2_routes
+from compute_space.web.routes.services_v2 import services_v2_routes
+
+from .conftest import _make_test_config
+
+SVC_DATA = "github.com/org/repo/services/data"
+
+CONSUMER_TOKEN = "test-consumer-token"
+CONSUMER_APP_ID = "ConsumerApp01"
+CONSUMER_MANIFEST = f"""
+[app]
+name = "data-aggregator"
+version = "0.1.0"
+
+[runtime.container]
+image = "Dockerfile"
+port = 8080
+
+[[services.v2.consumes]]
+service = "{SVC_DATA}"
+shortname = "data"
+version = ">=0.1.0"
+grants = []
+"""
+
+
+def _seed_consumer(db_path: str) -> None:
+    db = sqlite3.connect(db_path)
+    try:
+        db.row_factory = sqlite3.Row
+        db.execute(
+            """INSERT INTO apps (app_id, name, version, repo_path, local_port, status, manifest_raw)
+               VALUES (?, ?, ?, ?, ?, ?, ?)""",
+            (CONSUMER_APP_ID, "data-aggregator", "0.1.0", "/tmp/data-aggregator", 19500, "running", CONSUMER_MANIFEST),
+        )
+        token_hash = hashlib.sha256(CONSUMER_TOKEN.encode()).hexdigest()
+        db.execute("INSERT INTO app_tokens (app_id, token_hash) VALUES (?, ?)", (CONSUMER_APP_ID, token_hash))
+        db.commit()
+    finally:
+        db.close()
+
+
+def _seed_providers(db_path: str) -> tuple[str, str]:
+    """Seed two providers for SVC_DATA. Returns (provider_a_id, provider_b_id)."""
+    db = sqlite3.connect(db_path)
+    try:
+        db.row_factory = sqlite3.Row
+        a_id = new_app_id()
+        b_id = new_app_id()
+        for app_id, name, port, version in [
+            (a_id, "data-provider-a", 19001, "0.2.0"),
+            (b_id, "data-provider-b", 19002, "0.3.0"),
+        ]:
+            db.execute(
+                """INSERT INTO apps (app_id, name, version, repo_path, local_port, status)
+                   VALUES (?, ?, ?, ?, ?, ?)""",
+                (app_id, name, "0.0.0", f"/tmp/{name}", port, "running"),
+            )
+            db.execute(
+                "INSERT INTO service_providers_v2 (service_url, app_id, service_version, endpoint) VALUES (?, ?, ?, ?)",
+                (SVC_DATA, app_id, version, "/api/"),
+            )
+        # provider A is the default
+        db.execute("INSERT INTO service_defaults (service_url, app_id) VALUES (?, ?)", (SVC_DATA, a_id))
+        db.commit()
+        return a_id, b_id
+    finally:
+        db.close()
+
+
+def _make_proxy_app() -> Litestar:
+    return Litestar(
+        route_handlers=[services_v2_routes],
+        dependencies={
+            "config": Provide(provide_config, sync_to_thread=False),
+            "db": Provide(provide_db),
+        },
+        openapi_config=None,
+    )
+
+
+def _make_api_app() -> Litestar:
+    return Litestar(
+        route_handlers=[api_services_v2_routes],
+        dependencies={
+            "config": Provide(provide_config, sync_to_thread=False),
+            "db": Provide(provide_db),
+        },
+        openapi_config=None,
+    )
+
+
+def _auth_headers(token: str = CONSUMER_TOKEN) -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}"}
+
+
+@pytest.fixture
+def cfg(tmp_path: Path) -> object:
+    return _make_test_config(tmp_path, port=20600)
+
+
+# ---------------------------------------------------------------------------
+# X-OpenHost-Provider header
+# ---------------------------------------------------------------------------
+
+
+class TestProviderSelectionHeader:
+    """Verify the X-OpenHost-Provider header routes to a specific provider."""
+
+    def test_call_with_provider_header_routes_to_that_provider(self, cfg: object) -> None:
+        init_db(cfg.db_path)  # type: ignore[attr-defined]
+        _seed_consumer(cfg.db_path)  # type: ignore[attr-defined]
+        _a_id, b_id = _seed_providers(cfg.db_path)  # type: ignore[attr-defined]
+
+        fake_response = ASGIResponse(body=b'{"ok": true}', status_code=200)
+        with (
+            patch(
+                "compute_space.web.routes.services_v2.proxy_http_request",
+                new_callable=AsyncMock,
+                return_value=fake_response,
+            ) as mock_proxy,
+            TestClient(app=_make_proxy_app()) as client,
+        ):
+            resp = client.get(
+                "/api/services/v2/call/data/endpoint",
+                headers={**_auth_headers(), "X-OpenHost-Provider": b_id},
+            )
+            assert resp.status_code == 200
+            # Verify the proxy was called with provider B's port (19002)
+            assert mock_proxy.called
+            _, kwargs = mock_proxy.call_args
+            assert kwargs["target_port"] == 19002
+
+    def test_call_without_header_uses_default_provider(self, cfg: object) -> None:
+        init_db(cfg.db_path)  # type: ignore[attr-defined]
+        _seed_consumer(cfg.db_path)  # type: ignore[attr-defined]
+        _seed_providers(cfg.db_path)  # type: ignore[attr-defined]
+
+        fake_response = ASGIResponse(body=b'{"ok": true}', status_code=200)
+        with (
+            patch(
+                "compute_space.web.routes.services_v2.proxy_http_request",
+                new_callable=AsyncMock,
+                return_value=fake_response,
+            ) as mock_proxy,
+            TestClient(app=_make_proxy_app()) as client,
+        ):
+            resp = client.get(
+                "/api/services/v2/call/data/endpoint",
+                headers=_auth_headers(),
+            )
+            assert resp.status_code == 200
+            _, kwargs = mock_proxy.call_args
+            # Default provider A is on port 19001
+            assert kwargs["target_port"] == 19001
+
+    def test_call_with_unknown_provider_returns_503(self, cfg: object) -> None:
+        init_db(cfg.db_path)  # type: ignore[attr-defined]
+        _seed_consumer(cfg.db_path)  # type: ignore[attr-defined]
+        _seed_providers(cfg.db_path)  # type: ignore[attr-defined]
+
+        with TestClient(app=_make_proxy_app()) as client:
+            resp = client.get(
+                "/api/services/v2/call/data/endpoint",
+                headers={**_auth_headers(), "X-OpenHost-Provider": "nonexistent-app-id"},
+            )
+            assert resp.status_code == 503
+            assert resp.json()["error"] == "service_not_available"
+
+
+# ---------------------------------------------------------------------------
+# App auth on discovery endpoint
+# ---------------------------------------------------------------------------
+
+
+class TestDiscoverProvidersAppAuth:
+    """Verify that apps can call GET /api/services/v2/providers with a bearer token."""
+
+    def test_app_can_discover_providers(self, cfg: object) -> None:
+        init_db(cfg.db_path)  # type: ignore[attr-defined]
+        _seed_consumer(cfg.db_path)  # type: ignore[attr-defined]
+        a_id, b_id = _seed_providers(cfg.db_path)  # type: ignore[attr-defined]
+
+        with TestClient(app=_make_api_app()) as client:
+            resp = client.get(
+                "/api/services/v2/providers",
+                params={"service": SVC_DATA},
+                headers=_auth_headers(),
+            )
+            assert resp.status_code == 200
+            providers = resp.json()["providers"]
+            assert len(providers) == 2
+            app_ids = {p["app_id"] for p in providers}
+            assert a_id in app_ids
+            assert b_id in app_ids
+            # Verify default flag
+            defaults = [p for p in providers if p["is_default"]]
+            assert len(defaults) == 1
+            assert defaults[0]["app_id"] == a_id
+
+    def test_unauthenticated_discovery_returns_401(self, cfg: object) -> None:
+        init_db(cfg.db_path)  # type: ignore[attr-defined]
+
+        with TestClient(app=_make_api_app()) as client:
+            resp = client.get(
+                "/api/services/v2/providers",
+                params={"service": SVC_DATA},
+            )
+            assert resp.status_code == 401

--- a/compute_space/src/compute_space/web/auth/auth.py
+++ b/compute_space/src/compute_space/web/auth/auth.py
@@ -132,6 +132,16 @@ def require_app_auth(connection: AnyConnection, _route_handler: BaseRouteHandler
     verify_app_auth(connection)
 
 
+def require_owner_or_app_auth(connection: AnyConnection, _route_handler: BaseRouteHandler) -> None:
+    """Guard that passes if the caller is either an owner (user/API key) or an app."""
+    try:
+        verify_owner_auth(connection)
+        return
+    except NotAuthorizedException:
+        pass
+    verify_app_auth(connection)
+
+
 def build_login_url(netloc: str, path: str, query: str) -> str:
     """Build an absolute ``/login?next=<original>`` URL on the zone domain.
 

--- a/compute_space/src/compute_space/web/routes/api/services_v2.py
+++ b/compute_space/src/compute_space/web/routes/api/services_v2.py
@@ -8,6 +8,7 @@ from litestar import post
 from litestar.exceptions import HTTPException
 
 from compute_space.web.auth.auth import require_owner_auth
+from compute_space.web.auth.auth import require_owner_or_app_auth
 
 
 @attr.s(auto_attribs=True, frozen=True)
@@ -79,7 +80,7 @@ async def list_services_v2(db: sqlite3.Connection) -> list[ProviderV2]:
     ]
 
 
-@get("/api/services/v2/providers", guards=[require_owner_auth])
+@get("/api/services/v2/providers", guards=[require_owner_or_app_auth])
 async def discover_providers(db: sqlite3.Connection, service: str) -> DiscoverProvidersResponse:
     """Discover providers for a service, optionally filtered by version specifier."""
 

--- a/compute_space/src/compute_space/web/routes/services_v2.py
+++ b/compute_space/src/compute_space/web/routes/services_v2.py
@@ -213,7 +213,11 @@ class ServiceRequest:
 
 
 def _service_call_common(
-    consumer_app_id: str, shortname: str, rest: str, db: sqlite3.Connection
+    consumer_app_id: str,
+    shortname: str,
+    rest: str,
+    db: sqlite3.Connection,
+    provider_app_id: str | None = None,
 ) -> ServiceRequest | InstallerServiceRequest:
     service_url, version_spec = lookup_shortname(consumer_app_id, shortname, db)
 
@@ -223,7 +227,9 @@ def _service_call_common(
             version_spec=version_spec,
         )
     else:
-        provider_app_id, provider_port, _, provider_endpoint = resolve_provider(service_url, version_spec, db)
+        provider_app_id, provider_port, _, provider_endpoint = resolve_provider(
+            service_url, version_spec, db, provider_app_id=provider_app_id
+        )
         # `rest` is captured as "/sub/path" (leading slash); fold into the
         # provider's endpoint.
         target_path = provider_endpoint.rstrip("/") + "/" + rest.lstrip("/")
@@ -253,9 +259,10 @@ async def service_call(
     consumer's manifest.
     """
     consumer_app_id = verify_app_auth(request)
+    provider_override = request.headers.get("X-OpenHost-Provider") or None
 
     try:
-        resolved = _service_call_common(consumer_app_id, shortname, rest, db)
+        resolved = _service_call_common(consumer_app_id, shortname, rest, db, provider_app_id=provider_override)
     except ShortnameNotDeclared as e:
         return _asgi_json_error("shortname_not_declared", e.message, 404)
     except ServiceNotAvailable as e:
@@ -292,8 +299,10 @@ async def service_call_ws(socket: WebSocket[Any, Any, Any], shortname: str, rest
         await socket.close(code=4401, reason="Missing or invalid authorization")
         return
 
+    provider_override = socket.headers.get("X-OpenHost-Provider") or None
+
     try:
-        resolved = _service_call_common(consumer_app_id, shortname, rest, db)
+        resolved = _service_call_common(consumer_app_id, shortname, rest, db, provider_app_id=provider_override)
     except ShortnameNotDeclared as e:
         await socket.accept()
         await socket.close(code=4404, reason=e.message)

--- a/docs/src/cross_app_services.md
+++ b/docs/src/cross_app_services.md
@@ -73,6 +73,22 @@ Each service URL has a configured default provider - by default it's first app i
 
 If the resolved default's version doesn't satisfy the consumer's version specifier, the router returns 503 `service_not_available`.
 
+#### Calling a specific provider
+
+To call a non-default provider, include the `X-OpenHost-Provider` header with the target app's `app_id`:
+
+```
+GET [OPENHOST_ROUTER_URL]/api/services/v2/call/<shortname>/<rest>
+Authorization: Bearer $OPENHOST_APP_TOKEN
+X-OpenHost-Provider: <provider_app_id>
+```
+
+If the specified provider doesn't exist for that service, or its version doesn't match the consumer's version specifier, the router returns 503 `service_not_available`. Omitting the header uses the default provider as before.
+
+#### Discovering providers
+
+Apps can list all providers for a service using the discovery endpoint (see Management API below). This is useful when aggregating data across multiple providers of the same service.
+
 ### Permissions
 
 Permissions are **opaque grant payloads** (strings or JSON objects), scoped per `(consumer_app, service_url)`. The router stores grants and forwards the granted set (those that apply to the calling app and service URL) to the provider on every call — but **the provider is what enforces access**, not the router. This lets services define whatever permission shape they need.
@@ -171,7 +187,7 @@ The `grant` field on these endpoints is whatever shape the service defines — p
 Each service URL has at most one default provider (set automatically to the first app to register; the owner can change it). Calls without an explicit provider use this default.
 
 - `GET /api/services/v2/defaults` — list all `(service_url, app_name)` defaults.
-- `GET /api/services/v2/providers?service=<url>` — list every registered provider for a service, with `is_default`, `service_version`, `endpoint`, and app `status`.
+- `GET /api/services/v2/providers?service=<url>` — list every registered provider for a service, with `is_default`, `service_version`, `endpoint`, and app `status`. Accepts both owner auth and app bearer tokens, so consumer apps can discover providers at runtime.
 - `POST /api/services/v2/defaults` — set the default. Body: `{service_url, app_name}`. 404 if `app_name` doesn't actually provide that service.
 - `DELETE /api/services/v2/defaults` — clear the default. Body: `{service_url}`. After this, calls to the service return 503 until a new default is set (or another provider is installed).
 


### PR DESCRIPTION
## Summary

- Apps can now target a non-default provider by including the `X-OpenHost-Provider: <app_id>` header on service calls (HTTP and WebSocket). Omitting the header preserves existing default-provider behavior.
- The discovery endpoint (`GET /api/services/v2/providers`) now accepts app bearer tokens in addition to owner auth, so consumer apps can list all providers for a service at runtime.
- Added `require_owner_or_app_auth` guard for endpoints that should accept either auth type.

## Test plan

- [x] New test: calling with `X-OpenHost-Provider` routes to the specified provider
- [x] New test: calling without the header still uses the default provider
- [x] New test: calling with an unknown provider returns 503
- [x] New test: app bearer token can call the discovery endpoint
- [x] New test: unauthenticated discovery returns 401
- [x] All 509 existing tests pass with no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)