### PR TITLE
Wait for DNS propagation before ACME challenge validation

### DIFF
--- a/compute_space/src/compute_space/core/tls/util.py
+++ b/compute_space/src/compute_space/core/tls/util.py
@@ -1,5 +1,6 @@
 import datetime
 import json
+import subprocess
 import time
 from pathlib import Path
 
@@ -40,6 +41,48 @@ def _create_csr(private_key: ec.EllipticCurvePrivateKey, domains: str | list[str
         .add_extension(x509.SubjectAlternativeName(san_names), critical=False)
         .sign(private_key, hashes.SHA256())
     )
+
+
+def _wait_for_txt_propagation(
+    zone_domain: str,
+    expected_values: list[str],
+    timeout: float = 120,
+    interval: float = 5,
+    resolver: str = "8.8.8.8",
+) -> bool:
+    """Poll an external resolver until all expected TXT values are visible.
+
+    Returns True if all values were found, False on timeout.  On timeout the
+    caller should proceed anyway — the ACME retry loop is the fallback.
+    """
+    qname = f"_acme-challenge.{zone_domain}"
+    deadline = time.monotonic() + timeout
+    expected_set = set(expected_values)
+
+    while time.monotonic() < deadline:
+        try:
+            result = subprocess.run(
+                ["dig", f"@{resolver}", qname, "TXT", "+short", "+timeout=5", "+tries=1"],
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
+            found = set()
+            for line in result.stdout.strip().splitlines():
+                # dig +short TXT output looks like: "token-value-here"
+                found.add(line.strip().strip('"'))
+            if expected_set <= found:
+                logger.info(f"DNS propagation confirmed: {qname} has all {len(expected_set)} expected TXT value(s)")
+                return True
+        except (subprocess.TimeoutExpired, FileNotFoundError):
+            pass
+
+        remaining = deadline - time.monotonic()
+        logger.info(f"Waiting for DNS propagation of {qname} ({remaining:.0f}s remaining)")
+        time.sleep(interval)
+
+    logger.warning(f"DNS propagation timeout: {qname} not fully visible after {timeout}s, proceeding anyway")
+    return False
 
 
 def _acquire_cert_dns01(
@@ -127,6 +170,13 @@ def _acquire_cert_dns01(
 
                 # Wait for CoreDNS to pick up the zone file change (reload interval = 2s)
                 time.sleep(3)
+
+                # Wait until an external resolver can see our TXT records before
+                # telling the ACME server to validate.  Without this, the ACME
+                # server's resolvers may get NXDOMAIN if the NS delegation from
+                # the parent zone hasn't propagated yet.
+                zone_domain = domains[0].lstrip("*.")
+                _wait_for_txt_propagation(zone_domain, validation_values)
 
                 # Now answer all challenges
                 for challenge_body in pending_challenges:


### PR DESCRIPTION
## Summary

- Fixes flaky e2e test failures on EC2 where ACME DNS-01 cert acquisition fails with NXDOMAIN because the NS delegation from Route53 hasn't propagated to external resolvers yet
- After writing TXT records to CoreDNS and waiting for reload, now polls `dig @8.8.8.8` until the records are visible externally (120s timeout, 5s interval)
- On timeout, proceeds anyway — the existing ACME retry loop (3 attempts with 30/60/90s waits) remains as fallback
- No new dependencies; uses `dig` which is standard on all target Linux systems

## Test plan

- [x] All 588 existing tests pass
- [x] Pre-commit hooks (ruff, mypy) pass
- [ ] Verify next EC2 e2e run passes consistently

🤖 Generated with [Claude Code](https://claude.com/claude-code)