### PR TITLE
Normalize service URLs in manifest parsing

### DIFF
--- a/compute_space/src/compute_space/core/manifest.py
+++ b/compute_space/src/compute_space/core/manifest.py
@@ -74,6 +74,11 @@ SAFE_DEVICE_PATHS: frozenset[str] = frozenset(
 )
 
 
+def _normalize_service_url(url: str) -> str:
+    url = url.removeprefix("https://").removeprefix("http://")
+    return url.rstrip("/")
+
+
 @attr.s(auto_attribs=True, frozen=True)
 class PortMapping:
     """A structured port mapping declared in [[ports]]."""
@@ -85,14 +90,14 @@ class PortMapping:
 
 @attr.s(auto_attribs=True, frozen=True)
 class ServiceProvides:
-    service: str
+    service: str = attr.ib(converter=_normalize_service_url)
     version: str
     endpoint: str
 
 
 @attr.s(auto_attribs=True, frozen=True)
 class ServiceConsumes:
-    service: str
+    service: str = attr.ib(converter=_normalize_service_url)
     shortname: str
     version: str
     # Each grant is either an opaque string (e.g. "read") or a JSON structure

--- a/compute_space/src/compute_space/tests/test_manifest.py
+++ b/compute_space/src/compute_space/tests/test_manifest.py
@@ -446,6 +446,51 @@ grants = [
         with pytest.raises(ValueError, match=r"services\.v2"):
             parse_manifest_from_string(toml)
 
+    @pytest.mark.parametrize(
+        "raw, expected",
+        [
+            ("https://github.com/org/repo/services/secrets", "github.com/org/repo/services/secrets"),
+            ("http://github.com/org/repo/services/secrets", "github.com/org/repo/services/secrets"),
+            ("github.com/org/repo/services/secrets/", "github.com/org/repo/services/secrets"),
+            ("https://github.com/org/repo/services/secrets/", "github.com/org/repo/services/secrets"),
+            ("github.com/org/repo/services/secrets", "github.com/org/repo/services/secrets"),
+        ],
+    )
+    def test_provides_service_url_normalized(self, raw, expected):
+        toml = (
+            MINIMAL
+            + f"""
+[[services.v2.provides]]
+service = "{raw}"
+version = "0.1.0"
+endpoint = "/_svc/"
+"""
+        )
+        manifest = parse_manifest_from_string(toml)
+        assert manifest.provides_services_v2[0].service == expected
+
+    @pytest.mark.parametrize(
+        "raw, expected",
+        [
+            ("https://github.com/org/repo/services/oauth", "github.com/org/repo/services/oauth"),
+            ("github.com/org/repo/services/oauth/", "github.com/org/repo/services/oauth"),
+            ("https://github.com/org/repo/services/oauth/", "github.com/org/repo/services/oauth"),
+        ],
+    )
+    def test_consumes_service_url_normalized(self, raw, expected):
+        toml = (
+            MINIMAL
+            + f"""
+[[services.v2.consumes]]
+service = "{raw}"
+shortname = "oauth"
+version = ">=0.1.0"
+grants = []
+"""
+        )
+        manifest = parse_manifest_from_string(toml)
+        assert manifest.consumes_services_v2[0].service == expected
+
 
 class TestCapabilitiesValidation:
     """Rootless podman constraints on [runtime.container].capabilities."""


### PR DESCRIPTION
## Summary
- Add `_normalize_service_url` converter that strips `https://`/`http://` prefixes and trailing slashes from service URLs
- Applied as an attrs `converter` on the `service` field of both `ServiceProvides` and `ServiceConsumes`, so normalization happens at construction time regardless of call site
- Adds parametrized tests covering both providers and consumers

## Test plan
- [x] Existing `TestServicesV2Parsing` tests pass
- [x] New parametrized tests verify normalization for `https://`, `http://`, trailing `/`, combined, and already-clean URLs
- [x] Pre-commit hooks (ruff, mypy) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)