### PR TITLE
Fix archive health check blocking operations when S3 is not configured

### DIFF
--- a/compute_space/src/compute_space/core/archive_backend.py
+++ b/compute_space/src/compute_space/core/archive_backend.py
@@ -402,10 +402,16 @@ def manifest_uses_archive(manifest_raw: str) -> bool:
 
 
 def is_archive_dir_healthy(config: Config, db: sqlite3.Connection) -> bool:
-    """True iff the configured archive backing is live on the host."""
+    """True iff the archive backend is either unconfigured or live on the host.
+
+    When ``backend == "disabled"`` (S3 never configured) there is no archive
+    data to protect, so the check passes.  When ``backend == "s3"`` the
+    JuiceFS mount must be live — otherwise operations that would silently
+    orphan or skip S3-side data are blocked.
+    """
     state = read_state(db)
     if state.backend != "s3":
-        return False
+        return True
     return is_mounted(juicefs_mount_dir(config))
 
 

--- a/compute_space/src/compute_space/tests/test_archive_backend.py
+++ b/compute_space/src/compute_space/tests/test_archive_backend.py
@@ -305,8 +305,10 @@ def test_list_meta_dumps_handles_no_prefix():
 # --- is_archive_dir_healthy -----------------------------------------------
 
 
-def test_is_archive_dir_healthy_disabled_returns_false(cfg, db):
-    assert not archive_backend.is_archive_dir_healthy(cfg, db)
+def test_is_archive_dir_healthy_disabled_returns_true(cfg, db):
+    """When S3 is not configured there is no archive data to protect, so
+    the health check should pass to avoid blocking app operations."""
+    assert archive_backend.is_archive_dir_healthy(cfg, db)
 
 
 def test_is_archive_dir_healthy_s3_uses_is_mounted(cfg, db):


### PR DESCRIPTION
is_archive_dir_healthy returned False when the archive backend was disabled (S3 never configured), causing remove, rename, and deploy to fail for apps with access_all_data or app_archive even though there was no S3 data to protect.

Returns True when backend is disabled since there is nothing to be unhealthy about. The protection still applies when S3 IS configured but the JuiceFS mount is down.

Tested on a fresh instance (andrew-4): confirmed remove and rename of file-browser (access_all_data=true) fail before the fix, and keep_data=true remove works as expected workaround.