### PR TITLE
Replace JuiceFS child process with systemd service for auto-restart

### DIFF
--- a/ansible/tasks/setup_openhost_service.yml
+++ b/ansible/tasks/setup_openhost_service.yml
@@ -36,12 +36,26 @@
     host_uid: "{{ ansible_facts['getent_passwd'].host[1] }}"
   register: service_file
 
+# JuiceFS archive-tier mount: a dedicated systemd service with
+# Restart=always so the FUSE mount recovers automatically if the
+# JuiceFS process is OOM-killed or crashes.  Installed disabled;
+# compute_space enables it when the operator configures S3.
+- name: Install openhost-juicefs systemd service
+  become: yes
+  become_user: root
+  template:
+    src: templates/openhost-juicefs.service.j2
+    dest: /etc/systemd/system/openhost-juicefs.service
+  vars:
+    juicefs_env_file: /home/host/.openhost/local_compute_space/persistent_data/openhost/juicefs/juicefs.env
+  register: juicefs_service_file
+
 - name: Reload systemd
   become: yes
   become_user: root
   systemd:
     daemon_reload: yes
-  when: service_file.changed
+  when: service_file.changed or juicefs_service_file.changed
 
 - name: Enable openhost service
   become: yes
@@ -49,3 +63,7 @@
   systemd:
     name: openhost
     enabled: yes
+
+# Do NOT enable openhost-juicefs here; it stays disabled until the
+# operator configures the archive backend via the dashboard.  The
+# compute_space code enables + starts it at that point.

--- a/ansible/templates/openhost-juicefs.service.j2
+++ b/ansible/templates/openhost-juicefs.service.j2
@@ -1,0 +1,28 @@
+[Unit]
+Description=OpenHost JuiceFS Archive Mount
+After=network-online.target
+Wants=network-online.target
+# Start before the main service so the FUSE mount is ready when
+# compute_space boots and calls attach_on_startup.
+Before=openhost.service
+
+[Service]
+Type=simple
+User=host
+# All dynamic values (binary path, meta DSN, mount point, S3 creds)
+# live in the env file written by compute_space at configure time.
+# The service stays installed-but-disabled until the operator
+# configures the archive backend; compute_space then writes the env
+# file and enables/starts this unit.
+EnvironmentFile={{ juicefs_env_file }}
+ExecStart=$JUICEFS_BINARY --no-agent mount --no-usage-report -o allow_other $JUICEFS_META_DSN $JUICEFS_MOUNT_DIR
+ExecStop=$JUICEFS_BINARY umount $JUICEFS_MOUNT_DIR
+Restart=always
+RestartSec=5
+# JuiceFS logs to ~/.juicefs/juicefs.log; keep stdout/stderr quiet
+# so journald doesn't duplicate everything.
+StandardOutput=null
+StandardError=journal
+
+[Install]
+WantedBy=multi-user.target

--- a/ansible/templates/openhost-juicefs.service.j2
+++ b/ansible/templates/openhost-juicefs.service.j2
@@ -9,14 +9,16 @@ Before=openhost.service
 [Service]
 Type=simple
 User=host
-# All dynamic values (binary path, meta DSN, mount point, S3 creds)
-# live in the env file written by compute_space at configure time.
-# The service stays installed-but-disabled until the operator
-# configures the archive backend; compute_space then writes the env
-# file and enables/starts this unit.
+# S3 credentials (ACCESS_KEY / SECRET_KEY) live in the env file
+# written by compute_space at configure time.  The service stays
+# installed-but-disabled until the operator configures the archive
+# backend; compute_space then writes the env file and
+# enables/starts this unit.
 EnvironmentFile={{ juicefs_env_file }}
-ExecStart=$JUICEFS_BINARY --no-agent mount --no-usage-report -o allow_other $JUICEFS_META_DSN $JUICEFS_MOUNT_DIR
-ExecStop=$JUICEFS_BINARY umount $JUICEFS_MOUNT_DIR
+# systemd does not shell-expand $VAR in ExecStart; we use /bin/sh
+# so the env vars from EnvironmentFile are expanded correctly.
+ExecStart=/bin/sh -c '"$JUICEFS_BINARY" --no-agent mount --no-usage-report -o allow_other "$JUICEFS_META_DSN" "$JUICEFS_MOUNT_DIR"'
+ExecStop=/bin/sh -c '"$JUICEFS_BINARY" umount "$JUICEFS_MOUNT_DIR"'
 Restart=always
 RestartSec=5
 # JuiceFS logs to ~/.juicefs/juicefs.log; keep stdout/stderr quiet

--- a/compute_space/src/compute_space/core/archive_backend.py
+++ b/compute_space/src/compute_space/core/archive_backend.py
@@ -10,7 +10,6 @@ import shutil
 import sqlite3
 import subprocess
 import tarfile
-import threading
 import time
 import tomllib
 import urllib.error
@@ -23,6 +22,11 @@ import botocore.exceptions  # noqa: F401  -- imported for ``except`` matching do
 
 from compute_space.config import Config
 from compute_space.core.logging import logger
+
+# Name of the systemd unit that manages the JuiceFS FUSE mount.
+# Installed by ansible (disabled); enabled by compute_space when the
+# operator configures the archive backend.
+JUICEFS_SERVICE = "openhost-juicefs"
 
 # Pin a specific JuiceFS release; sha256 is verified before extract so a
 # compromised release page can't swap the tarball.
@@ -183,8 +187,61 @@ def format_volume(
         )
 
 
-_mount_lock = threading.Lock()
-_mount_proc: subprocess.Popen[bytes] | None = None
+def _juicefs_env_file(config: Config) -> str:
+    """Path to the systemd EnvironmentFile for the JuiceFS service.
+
+    Contains JUICEFS_BINARY, JUICEFS_META_DSN, JUICEFS_MOUNT_DIR, and
+    the S3 credentials (ACCESS_KEY / SECRET_KEY).  Written by
+    ``_write_env_file`` at configure/attach time; read by the
+    ``openhost-juicefs.service`` systemd unit.
+    """
+    return os.path.join(config.openhost_data_path, "juicefs", "juicefs.env")
+
+
+def _write_env_file(
+    config: Config,
+    s3_access_key_id: str,
+    s3_secret_access_key: str,
+) -> None:
+    """Write (or overwrite) the systemd EnvironmentFile for JuiceFS.
+
+    The file is mode 0600 so only the ``host`` user can read the S3
+    credentials.  Parent directories are created if missing.
+    """
+    env_path = _juicefs_env_file(config)
+    os.makedirs(os.path.dirname(env_path), exist_ok=True)
+    content = (
+        f"JUICEFS_BINARY={_juicefs_binary(config)}\n"
+        f"JUICEFS_META_DSN={_format_meta_dsn(config)}\n"
+        f"JUICEFS_MOUNT_DIR={juicefs_mount_dir(config)}\n"
+        f"ACCESS_KEY={s3_access_key_id}\n"
+        f"SECRET_KEY={s3_secret_access_key}\n"
+    )
+    # Atomic-ish write: write to a temp file then rename so a crash
+    # mid-write doesn't leave a truncated env file.
+    tmp_path = env_path + ".tmp"
+    fd = os.open(tmp_path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    try:
+        os.write(fd, content.encode())
+    finally:
+        os.close(fd)
+    os.rename(tmp_path, env_path)
+    logger.info("Wrote JuiceFS env file at %s", env_path)
+
+
+def _systemctl(*args: str, timeout: int = 30) -> subprocess.CompletedProcess[str]:
+    """Run a ``systemctl`` command and return the result.
+
+    Raises ``RuntimeError`` on non-zero exit.
+    """
+    cmd = ["sudo", "systemctl", *args]
+    result = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"systemctl {' '.join(args)} failed (rc={result.returncode}): "
+            f"{result.stderr.strip() or result.stdout.strip()}"
+        )
+    return result
 
 
 def is_mounted(mount_point: str) -> bool:
@@ -209,123 +266,80 @@ def mount(
     s3_access_key_id: str,
     s3_secret_access_key: str,
 ) -> None:
-    """Start ``juicefs mount`` as a supervised child process.  Idempotent."""
-    global _mount_proc
+    """Start the JuiceFS mount via systemd.  Idempotent.
+
+    Writes the EnvironmentFile (binary path, meta DSN, mount dir, S3
+    creds), then enables and starts the ``openhost-juicefs`` systemd
+    service.  systemd's ``Restart=always`` handles automatic recovery
+    if the FUSE process is OOM-killed or crashes.
+    """
     mount_point = juicefs_mount_dir(config)
     os.makedirs(mount_point, exist_ok=True)
 
-    with _mount_lock:
+    if is_mounted(mount_point):
+        logger.info("juicefs already mounted at %s", mount_point)
+        return
+
+    _write_env_file(config, s3_access_key_id, s3_secret_access_key)
+
+    logger.info("Starting %s systemd service", JUICEFS_SERVICE)
+    # daemon-reload in case the unit file was just installed or updated.
+    _systemctl("daemon-reload")
+    _systemctl("enable", "--now", JUICEFS_SERVICE)
+
+    # Wait for the mount to appear (systemd starts the process
+    # asynchronously; the FUSE handshake takes a moment).
+    deadline = time.time() + 15
+    while time.time() < deadline:
         if is_mounted(mount_point):
-            logger.info("juicefs already mounted at %s", mount_point)
+            logger.info("juicefs mount ready at %s (via systemd)", mount_point)
             return
-        env = os.environ.copy()
-        # Creds via env, not argv, to keep them out of ``ps``.
-        env["ACCESS_KEY"] = s3_access_key_id
-        env["SECRET_KEY"] = s3_secret_access_key
-        cmd = [
-            _juicefs_binary(config),
-            # --no-agent: mount spawns two processes that each bind 6060/6061
-            # for pprof, which the security audit flags as unexpected.
-            "--no-agent",
-            "mount",
-            "--no-usage-report",
-            # -o allow_other: rootless podman maps container uids into a
-            # subuid range (e.g. container 1000 -> host 100999), so without
-            # allow_other those container processes can't traverse the FUSE
-            # mount at all.  POSIX dir-mode permissions on per-app subdirs
-            # still gate writes; this just opens up FUSE-level traversal.
-            # Requires user_allow_other in /etc/fuse.conf, which the
-            # ansible setup playbook configures.
-            "-o",
-            "allow_other",
-            _format_meta_dsn(config),
-            mount_point,
-        ]
-        logger.info("Starting juicefs mount at %s", mount_point)
-        # DEVNULL stdout/stderr: a long-lived mount filling a 64 KiB pipe
-        # buffer would freeze; juicefs has its own log file anyway.
-        _mount_proc = subprocess.Popen(
-            cmd,
-            env=env,
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL,
+        time.sleep(0.2)
+
+    # Check if the service failed to start.
+    try:
+        status = subprocess.run(
+            ["systemctl", "is-active", JUICEFS_SERVICE],
+            capture_output=True, text=True, timeout=5,
         )
-        deadline = time.time() + 15
-        while time.time() < deadline:
-            if is_mounted(mount_point):
-                logger.info("juicefs mount ready at %s", mount_point)
-                return
-            rc = _mount_proc.poll()
-            if rc is not None:
-                _mount_proc = None
-                raise RuntimeError(f"juicefs mount exited early (rc={rc}); check ~/.juicefs/juicefs.log")
-            time.sleep(0.2)
-        # Kill the stuck child so it doesn't hold the mount-point lock and
-        # block retries.
-        try:
-            _mount_proc.terminate()
-            try:
-                _mount_proc.wait(timeout=5)
-            except subprocess.TimeoutExpired:
-                _mount_proc.kill()
-                _mount_proc.wait(timeout=5)
-        except Exception:
-            logger.exception("Failed to terminate stuck juicefs mount process")
-        finally:
-            _mount_proc = None
-        raise RuntimeError(f"juicefs mount did not become ready within 15s at {mount_point}")
+        svc_state = status.stdout.strip()
+    except Exception:
+        svc_state = "unknown"
+
+    raise RuntimeError(
+        f"juicefs mount did not become ready within 15s at {mount_point} "
+        f"(service state: {svc_state}); check journalctl -u {JUICEFS_SERVICE}"
+    )
 
 
 def umount(config: Config) -> None:
-    """Unmount the JuiceFS mount and reap the supervised process.
+    """Stop the JuiceFS systemd service and unmount.
 
-    Surfaces a busy-FS failure rather than swallowing it; we deliberately
-    don't have root, so lazy unmount isn't an option.  Idempotent.
+    Surfaces a failed-stop rather than swallowing it.  Idempotent.
     """
-    global _mount_proc
     mount_point = juicefs_mount_dir(config)
 
-    with _mount_lock:
-        if not is_mounted(mount_point):
-            if _mount_proc is not None and _mount_proc.poll() is None:
-                _mount_proc.terminate()
-                try:
-                    _mount_proc.wait(timeout=5)
-                except subprocess.TimeoutExpired:
-                    _mount_proc.kill()
-                    try:
-                        _mount_proc.wait(timeout=5)
-                    except subprocess.TimeoutExpired:
-                        logger.error("juicefs mount process did not exit after SIGKILL")
-            _mount_proc = None
-            return
-        cmd = [_juicefs_binary(config), "umount", mount_point]
-        # Always clear _mount_proc on any exit path so a retry doesn't
-        # inherit a stale handle.
+    if not is_mounted(mount_point):
+        # Service might be stopped already; ensure it's disabled so it
+        # doesn't auto-start on next boot.
         try:
-            try:
-                result = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
-            except subprocess.TimeoutExpired as exc:
-                raise RuntimeError(f"juicefs umount of {mount_point} timed out after 30s") from exc
-            if result.returncode != 0:
-                raise RuntimeError(
-                    f"juicefs umount of {mount_point} failed "
-                    f"(rc={result.returncode}); ensure all containers "
-                    f"using the archive tier are stopped before switching "
-                    f"backends.  Original: {result.stderr.strip()}"
-                )
-            logger.info("juicefs unmounted from %s", mount_point)
-        finally:
-            if _mount_proc is not None:
-                try:
-                    _mount_proc.wait(timeout=5)
-                except subprocess.TimeoutExpired:
-                    _mount_proc.kill()
-                    try:
-                        _mount_proc.wait(timeout=5)
-                    except subprocess.TimeoutExpired:
-                        logger.error("juicefs mount process did not exit after SIGKILL")
-            _mount_proc = None
+            _systemctl("disable", "--now", JUICEFS_SERVICE)
+        except RuntimeError:
+            pass  # already stopped/disabled
+        return
+
+    logger.info("Stopping %s systemd service", JUICEFS_SERVICE)
+    try:
+        _systemctl("stop", JUICEFS_SERVICE, timeout=30)
+    except RuntimeError as exc:
+        raise RuntimeError(
+            f"Failed to stop {JUICEFS_SERVICE}; ensure all containers "
+            f"using the archive tier are stopped before switching "
+            f"backends.  Original: {exc}"
+        ) from exc
+
+    _systemctl("disable", JUICEFS_SERVICE)
+    logger.info("juicefs unmounted from %s (via systemd)", mount_point)
 
 
 @attr.s(auto_attribs=True, frozen=True)
@@ -416,7 +430,15 @@ def _set_state_message(db: sqlite3.Connection, message: str | None) -> None:
 
 def attach_on_startup(config: Config, db: sqlite3.Connection) -> None:
     """Bring the archive backend back online at boot.  Failures don't crash boot;
-    they're surfaced via state_message so the dashboard stays reachable."""
+    they're surfaced via state_message so the dashboard stays reachable.
+
+    With the systemd service (``openhost-juicefs.service``), the mount is
+    normally started by systemd before this process even boots (the unit
+    has ``Before=openhost.service``).  This function handles the case where
+    the service hasn't started yet (first boot after configuration, or if
+    the env file is stale/missing) by writing a fresh env file and
+    ensuring the service is enabled + started.
+    """
     state = read_state(db)
     if state.backend != "s3":
         return

--- a/compute_space/src/compute_space/core/archive_backend.py
+++ b/compute_space/src/compute_space/core/archive_backend.py
@@ -301,7 +301,9 @@ def mount(
     try:
         status = subprocess.run(
             ["systemctl", "is-active", JUICEFS_SERVICE],
-            capture_output=True, text=True, timeout=5,
+            capture_output=True,
+            text=True,
+            timeout=5,
         )
         svc_state = status.stdout.strip()
     except Exception:

--- a/compute_space/src/compute_space/core/archive_backend.py
+++ b/compute_space/src/compute_space/core/archive_backend.py
@@ -287,14 +287,15 @@ def mount(
     _systemctl("daemon-reload")
     _systemctl("enable", "--now", JUICEFS_SERVICE)
 
-    # Wait for the mount to appear (systemd starts the process
-    # asynchronously; the FUSE handshake takes a moment).
-    deadline = time.time() + 15
+    # Wait for the mount to appear.  systemd starts the process
+    # asynchronously; the FUSE handshake + initial S3 connection
+    # can take 15-30s on high-latency links (e.g. Hetzner -> us-west-2).
+    deadline = time.time() + 30
     while time.time() < deadline:
         if is_mounted(mount_point):
             logger.info("juicefs mount ready at %s (via systemd)", mount_point)
             return
-        time.sleep(0.2)
+        time.sleep(0.5)
 
     # Check if the service failed to start.
     try:
@@ -307,7 +308,7 @@ def mount(
         svc_state = "unknown"
 
     raise RuntimeError(
-        f"juicefs mount did not become ready within 15s at {mount_point} "
+        f"juicefs mount did not become ready within 30s at {mount_point} "
         f"(service state: {svc_state}); check journalctl -u {JUICEFS_SERVICE}"
     )
 

--- a/compute_space/src/compute_space/tests/test_archive_backend.py
+++ b/compute_space/src/compute_space/tests/test_archive_backend.py
@@ -136,81 +136,46 @@ def test_format_volume_creates_state_dir_for_meta_db(cfg):
     assert captured["state_dir_exists"] is True
 
 
-def test_mount_passes_no_agent_flag(cfg):
-    captured = {}
+def test_mount_writes_env_file_and_starts_service(cfg):
+    """mount() must write the env file with the correct binary, meta DSN,
+    mount dir, and S3 creds, then enable+start the systemd service."""
+    systemctl_calls: list[tuple[str, ...]] = []
 
-    class _FakeProc:
-        def __init__(self):
-            self.returncode = None
+    def fake_systemctl(*args, timeout=30):
+        systemctl_calls.append(args)
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
 
-        def poll(self):
-            return None
-
-        def terminate(self):
-            self.returncode = -15
-
-        def wait(self, timeout=None):
-            self.returncode = self.returncode or 0
-            return self.returncode
-
-        def kill(self):
-            self.returncode = -9
-
-    def fake_popen(cmd, env, stdout, stderr):
-        captured["cmd"] = cmd
-        return _FakeProc()
-
-    # is_mounted: False before Popen (so we actually start the process),
-    # True after (so the readiness loop sees it succeed immediately).
+    # is_mounted: False initially, True after systemctl start.
     is_mounted_calls = [False, True]
     with mock.patch.object(archive_backend, "_juicefs_binary", return_value="/usr/local/bin/juicefs"):
         with mock.patch.object(
             archive_backend, "is_mounted", side_effect=lambda mp: is_mounted_calls.pop(0) if is_mounted_calls else True
         ):
-            with mock.patch.object(subprocess, "Popen", side_effect=fake_popen):
+            with mock.patch.object(archive_backend, "_systemctl", side_effect=fake_systemctl):
                 archive_backend.mount(cfg, "ak", "sk")
-    cmd = captured["cmd"]
-    assert "--no-agent" in cmd
-    assert cmd.index("--no-agent") < cmd.index("mount")
+
+    # Verify env file was written with correct content.
+    env_path = archive_backend._juicefs_env_file(cfg)
+    assert os.path.isfile(env_path)
+    content = open(env_path).read()
+    assert "JUICEFS_BINARY=/usr/local/bin/juicefs" in content
+    assert "ACCESS_KEY=ak" in content
+    assert "SECRET_KEY=sk" in content
+    assert f"JUICEFS_MOUNT_DIR={cfg.app_archive_dir}" in content
+    # Mode must be 0600 (owner-only).
+    assert oct(os.stat(env_path).st_mode & 0o777) == "0o600"
+
+    # Verify systemctl calls: daemon-reload, then enable --now.
+    assert ("daemon-reload",) in systemctl_calls
+    assert ("enable", "--now", archive_backend.JUICEFS_SERVICE) in systemctl_calls
 
 
-def test_mount_passes_allow_other(cfg):
-    """Without -o allow_other the FUSE handler rejects requests from any
-    uid except the mount owner; rootless-podman remaps container uids into
-    a host subuid range, so app containers would all get EACCES on
-    /data/app_archive.  Regression test."""
-    captured: dict[str, list[str]] = {}
-
-    class _FakeProc:
-        returncode = None
-
-        def poll(self):
-            return None
-
-        def terminate(self):
-            self.returncode = -15
-
-        def wait(self, timeout=None):
-            self.returncode = self.returncode or 0
-            return self.returncode
-
-        def kill(self):
-            self.returncode = -9
-
-    def fake_popen(cmd, env, stdout, stderr):
-        captured["cmd"] = cmd
-        return _FakeProc()
-
-    is_mounted_calls = [False, True]
-    with mock.patch.object(archive_backend, "_juicefs_binary", return_value="/usr/local/bin/juicefs"):
-        with mock.patch.object(
-            archive_backend, "is_mounted", side_effect=lambda mp: is_mounted_calls.pop(0) if is_mounted_calls else True
-        ):
-            with mock.patch.object(subprocess, "Popen", side_effect=fake_popen):
-                archive_backend.mount(cfg, "ak", "sk")
-    cmd = captured["cmd"]
-    o_idx = cmd.index("-o")
-    assert cmd[o_idx + 1] == "allow_other"
+def test_mount_idempotent_when_already_mounted(cfg):
+    """mount() must be a no-op if the mount is already active."""
+    with mock.patch.object(archive_backend, "is_mounted", return_value=True):
+        with mock.patch.object(archive_backend, "_systemctl") as sctl:
+            archive_backend.mount(cfg, "ak", "sk")
+    sctl.assert_not_called()
 
 
 # --- on-disk layout helpers ----------------------------------------------


### PR DESCRIPTION
## Summary

JuiceFS FUSE mount was managed as a subprocess.Popen child of the main compute_space process. If the JuiceFS process was OOM-killed or crashed, the mount went stale (errno 107) with no recovery mechanism.

Now ansible installs an openhost-juicefs.service systemd unit with Restart=always / RestartSec=5. The Python code writes an EnvironmentFile with the binary path, meta DSN, mount dir, and S3 creds at configure time, then enables/starts the service via systemctl.

## Changes

- New ansible template: openhost-juicefs.service.j2 (system-level unit, installed disabled, enabled at configure time)
- Updated setup_openhost_service.yml to install the JuiceFS unit alongside the main openhost unit
- Replaced mount()/umount() in archive_backend.py to use systemctl enable/start/stop instead of subprocess.Popen
- Added _write_env_file() and _systemctl() helpers
- Removed _mount_lock/_mount_proc process supervision globals
- Updated tests to verify env file writing and systemctl calls

## Testing

Deployed to andrew-3 on Hetzner, configured S3 archive backend, killed the JuiceFS process with SIGKILL, and verified systemd automatically restarted it within 5 seconds with the FUSE mount fully recovered. All 519 unit tests pass.