### PR TITLE
Add NVIDIA GPU passthrough via CDI

### DIFF
--- a/ansible/setup.yml
+++ b/ansible/setup.yml
@@ -28,6 +28,7 @@
     ansible_python_interpreter: /usr/bin/python3
   tasks:
     - import_tasks: tasks/apt_packages.yml
+    - import_tasks: tasks/gpu.yml
     - import_tasks: tasks/containers.yml
 
 - name: Dev environment

--- a/ansible/tasks/gpu.yml
+++ b/ansible/tasks/gpu.yml
@@ -16,13 +16,16 @@
 - name: Install NVIDIA driver and container toolkit
   when: _has_nvidia.rc == 0
   block:
-    - name: Install NVIDIA driver
+    - name: Install ubuntu-drivers-common
       apt:
-        name:
-          - nvidia-driver-560
-          - nvidia-utils-560
+        name: ubuntu-drivers-common
         state: present
         update_cache: yes
+
+    - name: Auto-install recommended NVIDIA driver
+      command: ubuntu-drivers install --gpgpu
+      register: _driver_install
+      changed_when: "'is already installed' not in _driver_install.stdout"
 
     - name: Add NVIDIA container toolkit GPG key
       shell: |
@@ -45,16 +48,15 @@
         state: present
         update_cache: yes
 
-    - name: Generate CDI spec for rootless podman
-      shell: nvidia-ctk cdi generate --output=/etc/cdi/nvidia.yaml
-      args:
-        creates: /etc/cdi/nvidia.yaml
-
-    - name: Ensure CDI spec directory is readable
+    - name: Ensure CDI spec directory exists
       file:
         path: /etc/cdi
         state: directory
         mode: "0755"
+
+    - name: Generate CDI spec for rootless podman
+      command: nvidia-ctk cdi generate --output=/etc/cdi/nvidia.yaml
+      changed_when: true
 
     - name: Ensure CDI spec is readable
       file:

--- a/ansible/tasks/gpu.yml
+++ b/ansible/tasks/gpu.yml
@@ -27,6 +27,27 @@
       register: _driver_install
       changed_when: "'is already installed' not in _driver_install.stdout"
 
+    - name: Load NVIDIA kernel module
+      command: modprobe nvidia
+      register: _modprobe
+      ignore_errors: true
+      changed_when: false
+
+    - name: Check if NVIDIA driver is loaded
+      command: nvidia-smi
+      register: _nvidia_smi
+      ignore_errors: true
+      changed_when: false
+
+    - name: Reboot to load NVIDIA driver (if not loaded)
+      reboot:
+        reboot_timeout: 300
+      when: _nvidia_smi.rc != 0
+
+    - name: Verify NVIDIA driver after reboot
+      command: nvidia-smi
+      changed_when: false
+
     - name: Add NVIDIA container toolkit GPG key
       shell: |
         curl -fsSL https://nvidia.github.io/libnvidia-container/gpgkey | \

--- a/ansible/tasks/gpu.yml
+++ b/ansible/tasks/gpu.yml
@@ -1,0 +1,62 @@
+---
+# NVIDIA GPU support for containerized apps.
+#
+# Installs the NVIDIA driver and container toolkit, then generates a CDI
+# (Container Device Interface) spec so rootless podman can pass GPUs into
+# containers with `--device nvidia.com/gpu=all`.
+#
+# Skipped entirely when no NVIDIA GPU is detected on the host.
+
+- name: Check for NVIDIA GPU
+  shell: lspci | grep -qi nvidia
+  register: _has_nvidia
+  ignore_errors: true
+  changed_when: false
+
+- name: Install NVIDIA driver and container toolkit
+  when: _has_nvidia.rc == 0
+  block:
+    - name: Install NVIDIA driver
+      apt:
+        name:
+          - nvidia-driver-560
+          - nvidia-utils-560
+        state: present
+        update_cache: yes
+
+    - name: Add NVIDIA container toolkit GPG key
+      shell: |
+        curl -fsSL https://nvidia.github.io/libnvidia-container/gpgkey | \
+          gpg --dearmor -o /usr/share/keyrings/nvidia-container-toolkit-keyring.gpg
+      args:
+        creates: /usr/share/keyrings/nvidia-container-toolkit-keyring.gpg
+
+    - name: Add NVIDIA container toolkit repository
+      shell: |
+        curl -s -L https://nvidia.github.io/libnvidia-container/stable/deb/nvidia-container-toolkit.list | \
+          sed 's#deb https://#deb [signed-by=/usr/share/keyrings/nvidia-container-toolkit-keyring.gpg] https://#g' | \
+          tee /etc/apt/sources.list.d/nvidia-container-toolkit.list
+      args:
+        creates: /etc/apt/sources.list.d/nvidia-container-toolkit.list
+
+    - name: Install NVIDIA container toolkit
+      apt:
+        name: nvidia-container-toolkit
+        state: present
+        update_cache: yes
+
+    - name: Generate CDI spec for rootless podman
+      shell: nvidia-ctk cdi generate --output=/etc/cdi/nvidia.yaml
+      args:
+        creates: /etc/cdi/nvidia.yaml
+
+    - name: Ensure CDI spec directory is readable
+      file:
+        path: /etc/cdi
+        state: directory
+        mode: "0755"
+
+    - name: Ensure CDI spec is readable
+      file:
+        path: /etc/cdi/nvidia.yaml
+        mode: "0644"

--- a/ansible/tasks/gpu.yml
+++ b/ansible/tasks/gpu.yml
@@ -18,23 +18,42 @@
   block:
     # Kernel headers are required for DKMS to build the NVIDIA kernel module
     # against the running kernel (especially on cloud kernels like linux-aws).
-    - name: Install kernel headers and DKMS
+    - name: Install kernel headers and build dependencies
       apt:
         name:
           - "linux-headers-{{ ansible_kernel }}"
+          - "linux-modules-extra-{{ ansible_kernel }}"
           - dkms
+          - build-essential
         state: present
         update_cache: yes
+      register: _headers_install
+      # Some cloud images don't have matching headers in default repos.
+      # Fall back gracefully -- the NVIDIA DKMS package may still work
+      # if headers were pre-installed or available via a different source.
+      ignore_errors: true
 
-    - name: Install ubuntu-drivers-common
-      apt:
-        name: ubuntu-drivers-common
+    - name: Add NVIDIA driver PPA
+      apt_repository:
+        repo: ppa:graphics-drivers/ppa
         state: present
+        update_cache: yes
+      ignore_errors: true
 
-    - name: Auto-install recommended NVIDIA driver
+    - name: Install NVIDIA driver (server variant for datacenter GPUs)
+      apt:
+        name:
+          - nvidia-driver-570-server
+          - nvidia-utils-570-server
+        state: present
+        update_cache: yes
+      register: _driver_pkg
+      ignore_errors: true
+
+    - name: Fallback to auto-install if server driver unavailable
       command: ubuntu-drivers install --gpgpu
-      register: _driver_install
-      changed_when: "'is already installed' not in _driver_install.stdout"
+      when: _driver_pkg.failed | default(false)
+      register: _driver_auto
 
     - name: Load NVIDIA kernel module
       command: modprobe nvidia

--- a/ansible/tasks/gpu.yml
+++ b/ansible/tasks/gpu.yml
@@ -16,11 +16,20 @@
 - name: Install NVIDIA driver and container toolkit
   when: _has_nvidia.rc == 0
   block:
+    # Kernel headers are required for DKMS to build the NVIDIA kernel module
+    # against the running kernel (especially on cloud kernels like linux-aws).
+    - name: Install kernel headers and DKMS
+      apt:
+        name:
+          - "linux-headers-{{ ansible_kernel }}"
+          - dkms
+        state: present
+        update_cache: yes
+
     - name: Install ubuntu-drivers-common
       apt:
         name: ubuntu-drivers-common
         state: present
-        update_cache: yes
 
     - name: Auto-install recommended NVIDIA driver
       command: ubuntu-drivers install --gpgpu
@@ -33,18 +42,12 @@
       ignore_errors: true
       changed_when: false
 
-    - name: Check if NVIDIA driver is loaded
-      command: nvidia-smi
-      register: _nvidia_smi
-      ignore_errors: true
-      changed_when: false
-
-    - name: Reboot to load NVIDIA driver (if not loaded)
+    - name: Reboot to load NVIDIA driver (if modprobe failed)
       reboot:
         reboot_timeout: 300
-      when: _nvidia_smi.rc != 0
+      when: _modprobe.rc != 0
 
-    - name: Verify NVIDIA driver after reboot
+    - name: Verify NVIDIA driver is loaded
       command: nvidia-smi
       changed_when: false
 

--- a/compute_space/src/compute_space/core/containers.py
+++ b/compute_space/src/compute_space/core/containers.py
@@ -24,8 +24,7 @@ import sqlite3
 import subprocess
 
 from compute_space.core.logging import logger
-from compute_space.core.manifest import AppManifest
-from compute_space.core.manifest import PortMapping
+from compute_space.core.manifest import AppManifest, PortMapping
 
 CONTAINER_ROOT = "/data"
 
@@ -72,7 +71,9 @@ _BUILD_CACHE_CORRUPT_FRAGMENTS_UNCONDITIONAL = (
 # The "missing local layer blob" error from containers-storage.  The
 # full "content digest" prefix rules out registry-side "not found"
 # errors that happen to mention a sha256 digest.
-_MISSING_LAYER_RE = re.compile(r"content digest sha256:[0-9a-f]+:\s*not found", re.IGNORECASE)
+_MISSING_LAYER_RE = re.compile(
+    r"content digest sha256:[0-9a-f]+:\s*not found", re.IGNORECASE
+)
 
 
 def _is_build_cache_corrupt_line(line: str) -> bool:
@@ -103,10 +104,15 @@ def container_runtime_available() -> bool:
     except FileNotFoundError:
         return False
     except subprocess.TimeoutExpired:
-        logger.warning("podman --version timed out after 5s; treating podman as unavailable")
+        logger.warning(
+            "podman --version timed out after 5s; treating podman as unavailable"
+        )
         return False
     except OSError as e:
-        logger.warning("podman --version failed with OSError (%s); treating podman as unavailable", e)
+        logger.warning(
+            "podman --version failed with OSError (%s); treating podman as unavailable",
+            e,
+        )
         return False
     return result.returncode == 0
 
@@ -131,7 +137,9 @@ def _is_build_cache_corrupt(output: str) -> bool:
 def _raise_if_build_cache_corrupt(output: str) -> None:
     """Raise a tagged RuntimeError if ``output`` matches a cache-corruption pattern."""
     if _is_build_cache_corrupt(output):
-        raise RuntimeError(f"{BUILD_CACHE_CORRUPT_MARKER} Container build cache is corrupted.")
+        raise RuntimeError(
+            f"{BUILD_CACHE_CORRUPT_MARKER} Container build cache is corrupted."
+        )
 
 
 def build_image(
@@ -160,7 +168,9 @@ def build_image(
     if temp_data_dir:
         # Stream build output line-by-line so the dashboard can show progress.
         build_output = ""
-        with subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True) as proc:
+        with subprocess.Popen(
+            cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True
+        ) as proc:
             try:
                 assert proc.stdout is not None
                 for line in proc.stdout:
@@ -172,12 +182,16 @@ def build_image(
                 try:
                     proc.wait(timeout=5)
                 except subprocess.TimeoutExpired:
-                    logger.warning("Build process %d did not exit within 5s of SIGKILL", proc.pid)
+                    logger.warning(
+                        "Build process %d did not exit within 5s of SIGKILL", proc.pid
+                    )
                 raise
         if proc.returncode != 0:
             _raise_if_build_cache_corrupt(build_output)
             tail = build_output[-2000:] if len(build_output) > 2000 else build_output
-            raise RuntimeError(f"Container build failed (exit code {proc.returncode}):\n{tail}")
+            raise RuntimeError(
+                f"Container build failed (exit code {proc.returncode}):\n{tail}"
+            )
     else:
         result = subprocess.run(cmd, capture_output=True, text=True, timeout=300)
         if result.returncode != 0:
@@ -191,7 +205,9 @@ def build_image(
     return image_tag
 
 
-def _bind_mount_arg(host_path: str, container_path: str, *, read_only: bool = False) -> str:
+def _bind_mount_arg(
+    host_path: str, container_path: str, *, read_only: bool = False
+) -> str:
     """Render a ``-v`` value with ``:idmap`` (or ``:ro,idmap`` for read-only)."""
     options = "ro,idmap" if read_only else "idmap"
     return f"{host_path}:{container_path}:{options}"
@@ -261,7 +277,9 @@ def run_container(
         #
         # WARNING: this disables ALL network isolation.  The container can
         # reach any port on the host including other apps' loopback ports.
-        logger.warning("App %s uses network_host — all network isolation is disabled", app_name)
+        logger.warning(
+            "App %s uses network_host — all network isolation is disabled", app_name
+        )
         cmd.append("--network=host")
     else:
         cmd.extend(
@@ -290,7 +308,14 @@ def run_container(
 
     if manifest.access_all_data:
         # Opt-in full access to every app's data.
-        cmd.extend(["-v", _bind_mount_arg(os.path.join(data_dir, "app_data"), f"{CONTAINER_ROOT}/app_data")])
+        cmd.extend(
+            [
+                "-v",
+                _bind_mount_arg(
+                    os.path.join(data_dir, "app_data"), f"{CONTAINER_ROOT}/app_data"
+                ),
+            ]
+        )
         cmd.extend(
             [
                 "-v",
@@ -303,7 +328,9 @@ def run_container(
         # access_all_data is permissive — skip the archive mount when
         # the tier isn't configured rather than refusing to start.
         if os.path.isdir(archive_dir):
-            cmd.extend(["-v", _bind_mount_arg(archive_dir, f"{CONTAINER_ROOT}/app_archive")])
+            cmd.extend(
+                ["-v", _bind_mount_arg(archive_dir, f"{CONTAINER_ROOT}/app_archive")]
+            )
         os.makedirs(vm_data_dir, exist_ok=True)
         cmd.extend(["-v", _bind_mount_arg(vm_data_dir, c_vm_data)])
     else:
@@ -358,7 +385,9 @@ def run_container(
         cmd.append(image_tag)
 
     logger.info("Running container: %s", " ".join(cmd))
-    _append_log(app_name, temp_data_dir, f"=== Starting container: {container_name} ===\n")
+    _append_log(
+        app_name, temp_data_dir, f"=== Starting container: {container_name} ===\n"
+    )
 
     # Remove any stale container with the same name so podman run doesn't
     # fail with a name conflict.
@@ -392,12 +421,22 @@ def stop_container(container_id: str) -> None:
             timeout=20,
         )
         if result.returncode != 0:
-            logger.warning("podman stop %s exited %d, escalating to kill", container_id, result.returncode)
-            subprocess.run(["podman", "kill", container_id], capture_output=True, timeout=10)
+            logger.warning(
+                "podman stop %s exited %d, escalating to kill",
+                container_id,
+                result.returncode,
+            )
+            subprocess.run(
+                ["podman", "kill", container_id], capture_output=True, timeout=10
+            )
     except subprocess.TimeoutExpired:
         logger.warning("podman stop %s timed out, escalating to kill", container_id)
-        subprocess.run(["podman", "kill", container_id], capture_output=True, timeout=10)
-    subprocess.run(["podman", "rm", "-f", container_id], capture_output=True, timeout=30)
+        subprocess.run(
+            ["podman", "kill", container_id], capture_output=True, timeout=10
+        )
+    subprocess.run(
+        ["podman", "rm", "-f", container_id], capture_output=True, timeout=30
+    )
 
 
 def stop_app_process(app_row: sqlite3.Row) -> None:
@@ -491,6 +530,8 @@ def get_docker_logs(
         except subprocess.TimeoutExpired:
             logger.warning("podman logs timed out after 10s for %s", container_id)
         except OSError as e:
-            logger.warning("podman logs failed for %s with OSError: %s", container_id, e)
+            logger.warning(
+                "podman logs failed for %s with OSError: %s", container_id, e
+            )
 
     return "\n".join(parts) if parts else ""

--- a/compute_space/src/compute_space/core/containers.py
+++ b/compute_space/src/compute_space/core/containers.py
@@ -335,6 +335,12 @@ def run_container(
     for device in manifest.devices:
         cmd.extend(["--device", device])
 
+    # GPU passthrough via CDI (Container Device Interface).  When `gpu = true`
+    # in the manifest, request all NVIDIA GPUs.  Requires the NVIDIA Container
+    # Toolkit and a generated CDI spec on the host (see ansible/tasks/gpu.yml).
+    if manifest.gpu:
+        cmd.extend(["--device", "nvidia.com/gpu=all"])
+
     if manifest.network_host:
         # Tell the app which port the router expects it on.  With host
         # networking the container can't use its manifest port if it

--- a/compute_space/src/compute_space/core/containers.py
+++ b/compute_space/src/compute_space/core/containers.py
@@ -24,7 +24,8 @@ import sqlite3
 import subprocess
 
 from compute_space.core.logging import logger
-from compute_space.core.manifest import AppManifest, PortMapping
+from compute_space.core.manifest import AppManifest
+from compute_space.core.manifest import PortMapping
 
 CONTAINER_ROOT = "/data"
 
@@ -71,9 +72,7 @@ _BUILD_CACHE_CORRUPT_FRAGMENTS_UNCONDITIONAL = (
 # The "missing local layer blob" error from containers-storage.  The
 # full "content digest" prefix rules out registry-side "not found"
 # errors that happen to mention a sha256 digest.
-_MISSING_LAYER_RE = re.compile(
-    r"content digest sha256:[0-9a-f]+:\s*not found", re.IGNORECASE
-)
+_MISSING_LAYER_RE = re.compile(r"content digest sha256:[0-9a-f]+:\s*not found", re.IGNORECASE)
 
 
 def _is_build_cache_corrupt_line(line: str) -> bool:
@@ -104,9 +103,7 @@ def container_runtime_available() -> bool:
     except FileNotFoundError:
         return False
     except subprocess.TimeoutExpired:
-        logger.warning(
-            "podman --version timed out after 5s; treating podman as unavailable"
-        )
+        logger.warning("podman --version timed out after 5s; treating podman as unavailable")
         return False
     except OSError as e:
         logger.warning(
@@ -137,9 +134,7 @@ def _is_build_cache_corrupt(output: str) -> bool:
 def _raise_if_build_cache_corrupt(output: str) -> None:
     """Raise a tagged RuntimeError if ``output`` matches a cache-corruption pattern."""
     if _is_build_cache_corrupt(output):
-        raise RuntimeError(
-            f"{BUILD_CACHE_CORRUPT_MARKER} Container build cache is corrupted."
-        )
+        raise RuntimeError(f"{BUILD_CACHE_CORRUPT_MARKER} Container build cache is corrupted.")
 
 
 def build_image(
@@ -168,9 +163,7 @@ def build_image(
     if temp_data_dir:
         # Stream build output line-by-line so the dashboard can show progress.
         build_output = ""
-        with subprocess.Popen(
-            cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True
-        ) as proc:
+        with subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True) as proc:
             try:
                 assert proc.stdout is not None
                 for line in proc.stdout:
@@ -182,16 +175,12 @@ def build_image(
                 try:
                     proc.wait(timeout=5)
                 except subprocess.TimeoutExpired:
-                    logger.warning(
-                        "Build process %d did not exit within 5s of SIGKILL", proc.pid
-                    )
+                    logger.warning("Build process %d did not exit within 5s of SIGKILL", proc.pid)
                 raise
         if proc.returncode != 0:
             _raise_if_build_cache_corrupt(build_output)
             tail = build_output[-2000:] if len(build_output) > 2000 else build_output
-            raise RuntimeError(
-                f"Container build failed (exit code {proc.returncode}):\n{tail}"
-            )
+            raise RuntimeError(f"Container build failed (exit code {proc.returncode}):\n{tail}")
     else:
         result = subprocess.run(cmd, capture_output=True, text=True, timeout=300)
         if result.returncode != 0:
@@ -205,9 +194,7 @@ def build_image(
     return image_tag
 
 
-def _bind_mount_arg(
-    host_path: str, container_path: str, *, read_only: bool = False
-) -> str:
+def _bind_mount_arg(host_path: str, container_path: str, *, read_only: bool = False) -> str:
     """Render a ``-v`` value with ``:idmap`` (or ``:ro,idmap`` for read-only)."""
     options = "ro,idmap" if read_only else "idmap"
     return f"{host_path}:{container_path}:{options}"
@@ -277,9 +264,7 @@ def run_container(
         #
         # WARNING: this disables ALL network isolation.  The container can
         # reach any port on the host including other apps' loopback ports.
-        logger.warning(
-            "App %s uses network_host — all network isolation is disabled", app_name
-        )
+        logger.warning("App %s uses network_host — all network isolation is disabled", app_name)
         cmd.append("--network=host")
     else:
         cmd.extend(
@@ -311,9 +296,7 @@ def run_container(
         cmd.extend(
             [
                 "-v",
-                _bind_mount_arg(
-                    os.path.join(data_dir, "app_data"), f"{CONTAINER_ROOT}/app_data"
-                ),
+                _bind_mount_arg(os.path.join(data_dir, "app_data"), f"{CONTAINER_ROOT}/app_data"),
             ]
         )
         cmd.extend(
@@ -328,9 +311,7 @@ def run_container(
         # access_all_data is permissive — skip the archive mount when
         # the tier isn't configured rather than refusing to start.
         if os.path.isdir(archive_dir):
-            cmd.extend(
-                ["-v", _bind_mount_arg(archive_dir, f"{CONTAINER_ROOT}/app_archive")]
-            )
+            cmd.extend(["-v", _bind_mount_arg(archive_dir, f"{CONTAINER_ROOT}/app_archive")])
         os.makedirs(vm_data_dir, exist_ok=True)
         cmd.extend(["-v", _bind_mount_arg(vm_data_dir, c_vm_data)])
     else:
@@ -385,9 +366,7 @@ def run_container(
         cmd.append(image_tag)
 
     logger.info("Running container: %s", " ".join(cmd))
-    _append_log(
-        app_name, temp_data_dir, f"=== Starting container: {container_name} ===\n"
-    )
+    _append_log(app_name, temp_data_dir, f"=== Starting container: {container_name} ===\n")
 
     # Remove any stale container with the same name so podman run doesn't
     # fail with a name conflict.
@@ -426,17 +405,11 @@ def stop_container(container_id: str) -> None:
                 container_id,
                 result.returncode,
             )
-            subprocess.run(
-                ["podman", "kill", container_id], capture_output=True, timeout=10
-            )
+            subprocess.run(["podman", "kill", container_id], capture_output=True, timeout=10)
     except subprocess.TimeoutExpired:
         logger.warning("podman stop %s timed out, escalating to kill", container_id)
-        subprocess.run(
-            ["podman", "kill", container_id], capture_output=True, timeout=10
-        )
-    subprocess.run(
-        ["podman", "rm", "-f", container_id], capture_output=True, timeout=30
-    )
+        subprocess.run(["podman", "kill", container_id], capture_output=True, timeout=10)
+    subprocess.run(["podman", "rm", "-f", container_id], capture_output=True, timeout=30)
 
 
 def stop_app_process(app_row: sqlite3.Row) -> None:
@@ -530,8 +503,6 @@ def get_docker_logs(
         except subprocess.TimeoutExpired:
             logger.warning("podman logs timed out after 10s for %s", container_id)
         except OSError as e:
-            logger.warning(
-                "podman logs failed for %s with OSError: %s", container_id, e
-            )
+            logger.warning("podman logs failed for %s with OSError: %s", container_id, e)
 
     return "\n".join(parts) if parts else ""

--- a/compute_space/src/compute_space/tests/test_containers.py
+++ b/compute_space/src/compute_space/tests/test_containers.py
@@ -11,13 +11,18 @@ import os
 import subprocess
 
 import pytest
+
 from compute_space.core import containers
-from compute_space.core.containers import (DEFAULT_CAPABILITIES,
-                                           _bind_mount_arg, build_image,
-                                           get_docker_logs,
-                                           is_container_running, remove_image,
-                                           run_container, stop_container)
-from compute_space.core.manifest import AppManifest, PortMapping
+from compute_space.core.containers import DEFAULT_CAPABILITIES
+from compute_space.core.containers import _bind_mount_arg
+from compute_space.core.containers import build_image
+from compute_space.core.containers import get_docker_logs
+from compute_space.core.containers import is_container_running
+from compute_space.core.containers import remove_image
+from compute_space.core.containers import run_container
+from compute_space.core.containers import stop_container
+from compute_space.core.manifest import AppManifest
+from compute_space.core.manifest import PortMapping
 
 
 class _FakeCompleted:
@@ -177,9 +182,7 @@ def test_build_image_non_streaming_path_inspects_stdout_too(
     assert str(exc_info.value).startswith(containers.BUILD_CACHE_CORRUPT_MARKER)
 
 
-def test_build_image_streaming_path_reaps_child_on_timeout(
-    tmp_path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_build_image_streaming_path_reaps_child_on_timeout(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
     """Regression guard for the zombie-safety fix: when proc.wait(timeout=
     300) raises TimeoutExpired in the streaming path, build_image must
     call proc.kill() followed by a bounded proc.wait().  A kill without
@@ -206,9 +209,7 @@ def test_build_image_streaming_path_reaps_child_on_timeout(
                 # well-behaved kill that does reap.
                 return self.returncode
             # The first wait (the 300s build wait) is the one that times out.
-            raise subprocess.TimeoutExpired(
-                cmd=["podman", "build"], timeout=timeout or 0
-            )
+            raise subprocess.TimeoutExpired(cmd=["podman", "build"], timeout=timeout or 0)
 
         def kill(self) -> None:
             kill_calls.append(self.pid)
@@ -229,9 +230,7 @@ def test_build_image_streaming_path_reaps_child_on_timeout(
 
     # Must have invoked kill and then a bounded wait with timeout=5.
     assert kill_calls == [99999], f"expected one kill, got {kill_calls}"
-    assert (
-        5 in wait_calls
-    ), f"expected bounded wait(timeout=5) after kill, got {wait_calls}"
+    assert 5 in wait_calls, f"expected bounded wait(timeout=5) after kill, got {wait_calls}"
 
 
 @pytest.mark.parametrize(
@@ -272,9 +271,9 @@ def test_build_image_does_not_misclassify_innocuous_output_as_cache_corrupt(
     with pytest.raises(RuntimeError) as exc_info:
         build_image("myapp", "/tmp/repo", "Dockerfile", temp_data_dir=None)
     msg = str(exc_info.value)
-    assert (
-        containers.BUILD_CACHE_CORRUPT_MARKER not in msg
-    ), f"Expected generic build failure, got cache-corrupt marker for output: {innocuous_output!r}"
+    assert containers.BUILD_CACHE_CORRUPT_MARKER not in msg, (
+        f"Expected generic build failure, got cache-corrupt marker for output: {innocuous_output!r}"
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -322,9 +321,7 @@ def _run_and_capture(
     os.makedirs(data_dir, exist_ok=True)
     os.makedirs(temp_data_dir, exist_ok=True)
     os.makedirs(archive_dir, exist_ok=True)
-    os.makedirs(
-        os.path.join(temp_data_dir, "app_temp_data", manifest.name), exist_ok=True
-    )
+    os.makedirs(os.path.join(temp_data_dir, "app_temp_data", manifest.name), exist_ok=True)
 
     run_container(
         manifest.name,
@@ -343,9 +340,7 @@ def _run_and_capture(
     return run_cmds[0]
 
 
-def test_run_container_has_hardening_flags(
-    tmp_path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_run_container_has_hardening_flags(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
     manifest = _basic_manifest()
     argv = _run_and_capture(monkeypatch, manifest=manifest, tmp_path=tmp_path)
     assert "--cap-drop=ALL" in argv
@@ -354,25 +349,19 @@ def test_run_container_has_hardening_flags(
     assert "--add-host=host.containers.internal:host-gateway" in argv
 
 
-def test_run_container_mounts_use_idmap_option(
-    tmp_path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_run_container_mounts_use_idmap_option(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
     manifest = _basic_manifest(app_data=True, app_temp_data=True, access_vm_data=True)
     argv = _run_and_capture(monkeypatch, manifest=manifest, tmp_path=tmp_path)
     # Every -v argument value should have :idmap (or :ro,idmap) as its
     # options suffix so container-root writes land on disk under the host
     # user, not under the mapped subuid.
-    volume_args = [
-        arg for prev, arg in zip(argv, argv[1:], strict=False) if prev == "-v"
-    ]
+    volume_args = [arg for prev, arg in zip(argv, argv[1:], strict=False) if prev == "-v"]
     assert volume_args  # The test manifest requested three mounts.
     for v in volume_args:
         assert v.endswith(":idmap") or v.endswith(":ro,idmap"), v
 
 
-def test_run_container_adds_manifest_capabilities(
-    tmp_path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_run_container_adds_manifest_capabilities(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
     manifest = _basic_manifest(capabilities=["NET_ADMIN", "NET_RAW"])
     argv = _run_and_capture(monkeypatch, manifest=manifest, tmp_path=tmp_path)
     # --cap-drop=ALL must come before the --cap-add entries.
@@ -398,9 +387,7 @@ def test_run_container_grants_docker_default_capabilities_by_default(
     drop_idx = argv.index("--cap-drop=ALL")
     for cap in sorted(DEFAULT_CAPABILITIES):
         pair_idx = argv.index(cap)
-        assert (
-            argv[pair_idx - 1] == "--cap-add"
-        ), f"{cap}: expected --cap-add, got {argv[pair_idx - 1]!r}"
+        assert argv[pair_idx - 1] == "--cap-add", f"{cap}: expected --cap-add, got {argv[pair_idx - 1]!r}"
         assert pair_idx > drop_idx, f"{cap}: --cap-drop=ALL must precede --cap-add"
 
 
@@ -418,15 +405,11 @@ def test_run_container_does_not_duplicate_baseline_caps_from_manifest(
 
     # The redundant cap appears exactly once (from the baseline loop);
     # NET_ADMIN appears exactly once (from the manifest loop).
-    assert (
-        argv.count(redundant) == 1
-    ), f"expected one {redundant}, got {argv.count(redundant)}"
+    assert argv.count(redundant) == 1, f"expected one {redundant}, got {argv.count(redundant)}"
     assert argv.count("NET_ADMIN") == 1
 
 
-def test_run_container_adds_manifest_devices(
-    tmp_path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_run_container_adds_manifest_devices(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
     """``manifest.devices`` entries must be passed to podman as
     ``--device <entry>`` pairs.  Symmetric to the capabilities test:
     the manifest validator restricts devices to SAFE_DEVICE_PATHS at
@@ -445,9 +428,7 @@ def test_run_container_adds_manifest_devices(
         )
 
 
-def test_run_container_gpu_passthrough(
-    tmp_path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_run_container_gpu_passthrough(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
     """When ``gpu = True`` in the manifest, podman must receive a
     ``--device nvidia.com/gpu=all`` flag for CDI-based GPU passthrough."""
     manifest = _basic_manifest(gpu=True)
@@ -456,27 +437,19 @@ def test_run_container_gpu_passthrough(
     cdi_device = "nvidia.com/gpu=all"
     assert cdi_device in argv, f"Expected {cdi_device!r} in podman argv when gpu=True"
     pair_idx = argv.index(cdi_device)
-    assert (
-        argv[pair_idx - 1] == "--device"
-    ), f"CDI device {cdi_device!r} must appear as the value of a --device flag"
+    assert argv[pair_idx - 1] == "--device", f"CDI device {cdi_device!r} must appear as the value of a --device flag"
 
 
-def test_run_container_no_gpu_by_default(
-    tmp_path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_run_container_no_gpu_by_default(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
     """When ``gpu`` is not set (default False), no GPU device flag should
     appear in the podman argv."""
     manifest = _basic_manifest()
     argv = _run_and_capture(monkeypatch, manifest=manifest, tmp_path=tmp_path)
 
-    assert (
-        "nvidia.com/gpu=all" not in argv
-    ), "nvidia.com/gpu=all should not appear in podman argv when gpu is not set"
+    assert "nvidia.com/gpu=all" not in argv, "nvidia.com/gpu=all should not appear in podman argv when gpu is not set"
 
 
-def test_run_container_access_all_data_mounts_parent_dirs(
-    tmp_path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_run_container_access_all_data_mounts_parent_dirs(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
     """With access_all_data, the app sees /data/app_data/ and
     /data/app_temp_data/ as whole-namespace parent mounts, not just its
     own subdir.  This is security-sensitive because a typo here would
@@ -484,9 +457,7 @@ def test_run_container_access_all_data_mounts_parent_dirs(
     manifest = _basic_manifest(access_all_data=True)
     argv = _run_and_capture(monkeypatch, manifest=manifest, tmp_path=tmp_path)
 
-    volume_args = [
-        arg for prev, arg in zip(argv, argv[1:], strict=False) if prev == "-v"
-    ]
+    volume_args = [arg for prev, arg in zip(argv, argv[1:], strict=False) if prev == "-v"]
     # Every mount must be idmap (rw or ro).
     for v in volume_args:
         assert v.endswith(":idmap") or v.endswith(":ro,idmap"), v
@@ -500,14 +471,10 @@ def test_run_container_access_all_data_mounts_parent_dirs(
     # silently swapping it to ro would break every app that relies on
     # /data/vm_data as shared scratch space.
     vm_mount = next(v for v in volume_args if v.endswith(":/data/vm_data:idmap"))
-    assert (
-        "ro" not in vm_mount.rsplit(":", 1)[1]
-    ), f"vm_data should be rw under access_all_data, got {vm_mount}"
+    assert "ro" not in vm_mount.rsplit(":", 1)[1], f"vm_data should be rw under access_all_data, got {vm_mount}"
 
 
-def test_run_container_access_vm_data_mounts_vm_data_read_only(
-    tmp_path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_run_container_access_vm_data_mounts_vm_data_read_only(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
     """access_vm_data (without access_all_data) grants only a read-only
     view of /data/vm_data.  The distinction matters: this is what lets
     apps read shared state without being able to corrupt it, and a
@@ -517,57 +484,41 @@ def test_run_container_access_vm_data_mounts_vm_data_read_only(
     manifest = _basic_manifest(access_vm_data=True)
     argv = _run_and_capture(monkeypatch, manifest=manifest, tmp_path=tmp_path)
 
-    volume_args = [
-        arg for prev, arg in zip(argv, argv[1:], strict=False) if prev == "-v"
-    ]
+    volume_args = [arg for prev, arg in zip(argv, argv[1:], strict=False) if prev == "-v"]
     vm_mounts = [v for v in volume_args if "/data/vm_data" in v]
     assert len(vm_mounts) == 1, vm_mounts
     assert vm_mounts[0].endswith(":ro,idmap"), vm_mounts[0]
 
 
-def test_run_container_app_archive_mounts_per_app_subdir(
-    tmp_path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_run_container_app_archive_mounts_per_app_subdir(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
     """Apps opting in via [data].app_archive get a per-app bind mount at /data/app_archive/<name>/ (host source: operator-configured archive_dir, container path same regardless of backing). A regression mounting the parent instead would expose every app's archive contents to every app."""
     manifest = _basic_manifest(app_data=True, app_archive=True)
     argv = _run_and_capture(monkeypatch, manifest=manifest, tmp_path=tmp_path)
 
-    volume_args = [
-        arg for prev, arg in zip(argv, argv[1:], strict=False) if prev == "-v"
-    ]
+    volume_args = [arg for prev, arg in zip(argv, argv[1:], strict=False) if prev == "-v"]
     archive_mounts = [v for v in volume_args if "/data/app_archive" in v]
     assert len(archive_mounts) == 1, archive_mounts
 
-    assert archive_mounts[0].endswith(
-        f":/data/app_archive/{manifest.name}:idmap"
-    ), archive_mounts[0]
+    assert archive_mounts[0].endswith(f":/data/app_archive/{manifest.name}:idmap"), archive_mounts[0]
 
     assert f"archive/{manifest.name}:" in archive_mounts[0], archive_mounts[0]
 
 
-def test_run_container_app_archive_off_by_default(
-    tmp_path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_run_container_app_archive_off_by_default(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
     """Apps that don't opt into app_archive get NO archive bind mount; a regression that always mounted the archive tier would surface operator-configured backings to apps that never asked for it."""
     manifest = _basic_manifest(app_data=True)
     argv = _run_and_capture(monkeypatch, manifest=manifest, tmp_path=tmp_path)
 
-    volume_args = [
-        arg for prev, arg in zip(argv, argv[1:], strict=False) if prev == "-v"
-    ]
+    volume_args = [arg for prev, arg in zip(argv, argv[1:], strict=False) if prev == "-v"]
     assert not any("/data/app_archive" in v for v in volume_args)
 
 
-def test_run_container_access_all_data_mounts_archive_parent(
-    tmp_path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_run_container_access_all_data_mounts_archive_parent(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
     """``access_all_data`` mounts the parent ``/data/app_archive`` directory (not a single per-app subdir), mirroring how app_data is mounted under access_all_data."""
     manifest = _basic_manifest(access_all_data=True)
     argv = _run_and_capture(monkeypatch, manifest=manifest, tmp_path=tmp_path)
 
-    volume_args = [
-        arg for prev, arg in zip(argv, argv[1:], strict=False) if prev == "-v"
-    ]
+    volume_args = [arg for prev, arg in zip(argv, argv[1:], strict=False) if prev == "-v"]
     targets = [v.rsplit(":", 2)[1] for v in volume_args]
     assert "/data/app_archive" in targets
     assert f"/data/app_archive/{manifest.name}" not in targets
@@ -593,9 +544,7 @@ def test_run_container_access_all_data_skips_archive_mount_when_archive_dir_miss
     archive_dir = str(tmp_path / "archive-not-mounted")
     os.makedirs(data_dir, exist_ok=True)
     os.makedirs(temp_data_dir, exist_ok=True)
-    os.makedirs(
-        os.path.join(temp_data_dir, "app_temp_data", manifest.name), exist_ok=True
-    )
+    os.makedirs(os.path.join(temp_data_dir, "app_temp_data", manifest.name), exist_ok=True)
 
     run_container(
         manifest.name,
@@ -611,9 +560,7 @@ def test_run_container_access_all_data_skips_archive_mount_when_archive_dir_miss
     assert len(run_cmds) == 1
     argv = run_cmds[0]
 
-    volume_args = [
-        arg for prev, arg in zip(argv, argv[1:], strict=False) if prev == "-v"
-    ]
+    volume_args = [arg for prev, arg in zip(argv, argv[1:], strict=False) if prev == "-v"]
     archive_mounts = [v for v in volume_args if "/data/app_archive" in v]
     assert archive_mounts == [], f"expected no archive mount, got {archive_mounts}"
 
@@ -624,16 +571,12 @@ def test_run_container_app_archive_env_var_translated_to_container_path(
     """``OPENHOST_APP_ARCHIVE_DIR`` in env_vars must be translated from the host path to the in-container path before being stamped on the podman run argv — same host-vs-container translation pattern as ``OPENHOST_APP_DATA_DIR`` and ``OPENHOST_APP_TEMP_DIR``."""
     manifest = _basic_manifest(app_data=True, app_archive=True)
     env_vars = {"OPENHOST_APP_ARCHIVE_DIR": "/some/host/archive/myapp"}
-    argv = _run_and_capture(
-        monkeypatch, manifest=manifest, tmp_path=tmp_path, env_vars=env_vars
-    )
+    argv = _run_and_capture(monkeypatch, manifest=manifest, tmp_path=tmp_path, env_vars=env_vars)
 
     e_values = [arg for prev, arg in zip(argv, argv[1:], strict=False) if prev == "-e"]
     archive_env = [e for e in e_values if e.startswith("OPENHOST_APP_ARCHIVE_DIR=")]
     assert len(archive_env) == 1, archive_env
-    assert (
-        archive_env[0] == f"OPENHOST_APP_ARCHIVE_DIR=/data/app_archive/{manifest.name}"
-    )
+    assert archive_env[0] == f"OPENHOST_APP_ARCHIVE_DIR=/data/app_archive/{manifest.name}"
 
 
 def test_run_container_port_mappings_bind_tcp_and_udp_on_all_interfaces(
@@ -821,9 +764,7 @@ def test_get_docker_logs_returns_empty_when_no_build_log_and_no_container(
     assert output == ""
 
 
-def test_get_docker_logs_appends_podman_logs_when_container_id_set(
-    tmp_path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_get_docker_logs_appends_podman_logs_when_container_id_set(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
     """With a container id, get_docker_logs should also run ``podman logs
     --tail <N>`` and concatenate the output under a 'Container logs' header."""
     _make_build_log(tmp_path, "notes", "=== Build complete ===\n")
@@ -844,9 +785,7 @@ def test_get_docker_logs_appends_podman_logs_when_container_id_set(
     assert "app stdout line" in output
 
 
-def test_get_docker_logs_strips_ansi_escape_sequences(
-    tmp_path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_get_docker_logs_strips_ansi_escape_sequences(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
     """Color codes and carriage returns from podman logs should be
     stripped before we hand the text back to the dashboard (which
     otherwise renders them as garbage text)."""
@@ -883,10 +822,7 @@ def test_bind_mount_arg_ro_emits_ro_idmap() -> None:
     ordering (``ro,idmap``) matters for operator readability of
     ``podman ps`` output; pin the canonical rendering here even though
     podman parses the options order-independently."""
-    assert (
-        _bind_mount_arg("/srv/data", "/data", read_only=True)
-        == "/srv/data:/data:ro,idmap"
-    )
+    assert _bind_mount_arg("/srv/data", "/data", read_only=True) == "/srv/data:/data:ro,idmap"
 
 
 def test_bind_mount_arg_preserves_absolute_paths_verbatim() -> None:

--- a/compute_space/src/compute_space/tests/test_containers.py
+++ b/compute_space/src/compute_space/tests/test_containers.py
@@ -426,6 +426,31 @@ def test_run_container_adds_manifest_devices(tmp_path, monkeypatch: pytest.Monke
         )
 
 
+def test_run_container_gpu_passthrough(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """When ``gpu = True`` in the manifest, podman must receive a
+    ``--device nvidia.com/gpu=all`` flag for CDI-based GPU passthrough."""
+    manifest = _basic_manifest(gpu=True)
+    argv = _run_and_capture(monkeypatch, manifest=manifest, tmp_path=tmp_path)
+
+    cdi_device = "nvidia.com/gpu=all"
+    assert cdi_device in argv, f"Expected {cdi_device!r} in podman argv when gpu=True"
+    pair_idx = argv.index(cdi_device)
+    assert argv[pair_idx - 1] == "--device", (
+        f"CDI device {cdi_device!r} must appear as the value of a --device flag"
+    )
+
+
+def test_run_container_no_gpu_by_default(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """When ``gpu`` is not set (default False), no GPU device flag should
+    appear in the podman argv."""
+    manifest = _basic_manifest()
+    argv = _run_and_capture(monkeypatch, manifest=manifest, tmp_path=tmp_path)
+
+    assert "nvidia.com/gpu=all" not in argv, (
+        "nvidia.com/gpu=all should not appear in podman argv when gpu is not set"
+    )
+
+
 def test_run_container_access_all_data_mounts_parent_dirs(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
     """With access_all_data, the app sees /data/app_data/ and
     /data/app_temp_data/ as whole-namespace parent mounts, not just its

--- a/compute_space/src/compute_space/tests/test_containers.py
+++ b/compute_space/src/compute_space/tests/test_containers.py
@@ -11,18 +11,13 @@ import os
 import subprocess
 
 import pytest
-
 from compute_space.core import containers
-from compute_space.core.containers import DEFAULT_CAPABILITIES
-from compute_space.core.containers import _bind_mount_arg
-from compute_space.core.containers import build_image
-from compute_space.core.containers import get_docker_logs
-from compute_space.core.containers import is_container_running
-from compute_space.core.containers import remove_image
-from compute_space.core.containers import run_container
-from compute_space.core.containers import stop_container
-from compute_space.core.manifest import AppManifest
-from compute_space.core.manifest import PortMapping
+from compute_space.core.containers import (DEFAULT_CAPABILITIES,
+                                           _bind_mount_arg, build_image,
+                                           get_docker_logs,
+                                           is_container_running, remove_image,
+                                           run_container, stop_container)
+from compute_space.core.manifest import AppManifest, PortMapping
 
 
 class _FakeCompleted:
@@ -156,7 +151,9 @@ def test_build_image_generic_failure_does_not_use_cache_marker(
     assert "Dockerfile not found" in msg
 
 
-def test_build_image_non_streaming_path_inspects_stdout_too(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_build_image_non_streaming_path_inspects_stdout_too(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """The non-streaming build path (temp_data_dir=None) concatenates
     stdout and stderr before running the cache-corrupt check so it
     catches corruption indicators regardless of which channel podman
@@ -180,7 +177,9 @@ def test_build_image_non_streaming_path_inspects_stdout_too(monkeypatch: pytest.
     assert str(exc_info.value).startswith(containers.BUILD_CACHE_CORRUPT_MARKER)
 
 
-def test_build_image_streaming_path_reaps_child_on_timeout(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_build_image_streaming_path_reaps_child_on_timeout(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """Regression guard for the zombie-safety fix: when proc.wait(timeout=
     300) raises TimeoutExpired in the streaming path, build_image must
     call proc.kill() followed by a bounded proc.wait().  A kill without
@@ -207,7 +206,9 @@ def test_build_image_streaming_path_reaps_child_on_timeout(tmp_path, monkeypatch
                 # well-behaved kill that does reap.
                 return self.returncode
             # The first wait (the 300s build wait) is the one that times out.
-            raise subprocess.TimeoutExpired(cmd=["podman", "build"], timeout=timeout or 0)
+            raise subprocess.TimeoutExpired(
+                cmd=["podman", "build"], timeout=timeout or 0
+            )
 
         def kill(self) -> None:
             kill_calls.append(self.pid)
@@ -228,7 +229,9 @@ def test_build_image_streaming_path_reaps_child_on_timeout(tmp_path, monkeypatch
 
     # Must have invoked kill and then a bounded wait with timeout=5.
     assert kill_calls == [99999], f"expected one kill, got {kill_calls}"
-    assert 5 in wait_calls, f"expected bounded wait(timeout=5) after kill, got {wait_calls}"
+    assert (
+        5 in wait_calls
+    ), f"expected bounded wait(timeout=5) after kill, got {wait_calls}"
 
 
 @pytest.mark.parametrize(
@@ -269,9 +272,9 @@ def test_build_image_does_not_misclassify_innocuous_output_as_cache_corrupt(
     with pytest.raises(RuntimeError) as exc_info:
         build_image("myapp", "/tmp/repo", "Dockerfile", temp_data_dir=None)
     msg = str(exc_info.value)
-    assert containers.BUILD_CACHE_CORRUPT_MARKER not in msg, (
-        f"Expected generic build failure, got cache-corrupt marker for output: {innocuous_output!r}"
-    )
+    assert (
+        containers.BUILD_CACHE_CORRUPT_MARKER not in msg
+    ), f"Expected generic build failure, got cache-corrupt marker for output: {innocuous_output!r}"
 
 
 # ---------------------------------------------------------------------------
@@ -319,7 +322,9 @@ def _run_and_capture(
     os.makedirs(data_dir, exist_ok=True)
     os.makedirs(temp_data_dir, exist_ok=True)
     os.makedirs(archive_dir, exist_ok=True)
-    os.makedirs(os.path.join(temp_data_dir, "app_temp_data", manifest.name), exist_ok=True)
+    os.makedirs(
+        os.path.join(temp_data_dir, "app_temp_data", manifest.name), exist_ok=True
+    )
 
     run_container(
         manifest.name,
@@ -338,7 +343,9 @@ def _run_and_capture(
     return run_cmds[0]
 
 
-def test_run_container_has_hardening_flags(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_run_container_has_hardening_flags(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     manifest = _basic_manifest()
     argv = _run_and_capture(monkeypatch, manifest=manifest, tmp_path=tmp_path)
     assert "--cap-drop=ALL" in argv
@@ -347,19 +354,25 @@ def test_run_container_has_hardening_flags(tmp_path, monkeypatch: pytest.MonkeyP
     assert "--add-host=host.containers.internal:host-gateway" in argv
 
 
-def test_run_container_mounts_use_idmap_option(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_run_container_mounts_use_idmap_option(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     manifest = _basic_manifest(app_data=True, app_temp_data=True, access_vm_data=True)
     argv = _run_and_capture(monkeypatch, manifest=manifest, tmp_path=tmp_path)
     # Every -v argument value should have :idmap (or :ro,idmap) as its
     # options suffix so container-root writes land on disk under the host
     # user, not under the mapped subuid.
-    volume_args = [arg for prev, arg in zip(argv, argv[1:], strict=False) if prev == "-v"]
+    volume_args = [
+        arg for prev, arg in zip(argv, argv[1:], strict=False) if prev == "-v"
+    ]
     assert volume_args  # The test manifest requested three mounts.
     for v in volume_args:
         assert v.endswith(":idmap") or v.endswith(":ro,idmap"), v
 
 
-def test_run_container_adds_manifest_capabilities(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_run_container_adds_manifest_capabilities(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     manifest = _basic_manifest(capabilities=["NET_ADMIN", "NET_RAW"])
     argv = _run_and_capture(monkeypatch, manifest=manifest, tmp_path=tmp_path)
     # --cap-drop=ALL must come before the --cap-add entries.
@@ -385,7 +398,9 @@ def test_run_container_grants_docker_default_capabilities_by_default(
     drop_idx = argv.index("--cap-drop=ALL")
     for cap in sorted(DEFAULT_CAPABILITIES):
         pair_idx = argv.index(cap)
-        assert argv[pair_idx - 1] == "--cap-add", f"{cap}: expected --cap-add, got {argv[pair_idx - 1]!r}"
+        assert (
+            argv[pair_idx - 1] == "--cap-add"
+        ), f"{cap}: expected --cap-add, got {argv[pair_idx - 1]!r}"
         assert pair_idx > drop_idx, f"{cap}: --cap-drop=ALL must precede --cap-add"
 
 
@@ -403,11 +418,15 @@ def test_run_container_does_not_duplicate_baseline_caps_from_manifest(
 
     # The redundant cap appears exactly once (from the baseline loop);
     # NET_ADMIN appears exactly once (from the manifest loop).
-    assert argv.count(redundant) == 1, f"expected one {redundant}, got {argv.count(redundant)}"
+    assert (
+        argv.count(redundant) == 1
+    ), f"expected one {redundant}, got {argv.count(redundant)}"
     assert argv.count("NET_ADMIN") == 1
 
 
-def test_run_container_adds_manifest_devices(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_run_container_adds_manifest_devices(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """``manifest.devices`` entries must be passed to podman as
     ``--device <entry>`` pairs.  Symmetric to the capabilities test:
     the manifest validator restricts devices to SAFE_DEVICE_PATHS at
@@ -426,7 +445,9 @@ def test_run_container_adds_manifest_devices(tmp_path, monkeypatch: pytest.Monke
         )
 
 
-def test_run_container_gpu_passthrough(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_run_container_gpu_passthrough(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """When ``gpu = True`` in the manifest, podman must receive a
     ``--device nvidia.com/gpu=all`` flag for CDI-based GPU passthrough."""
     manifest = _basic_manifest(gpu=True)
@@ -435,23 +456,27 @@ def test_run_container_gpu_passthrough(tmp_path, monkeypatch: pytest.MonkeyPatch
     cdi_device = "nvidia.com/gpu=all"
     assert cdi_device in argv, f"Expected {cdi_device!r} in podman argv when gpu=True"
     pair_idx = argv.index(cdi_device)
-    assert argv[pair_idx - 1] == "--device", (
-        f"CDI device {cdi_device!r} must appear as the value of a --device flag"
-    )
+    assert (
+        argv[pair_idx - 1] == "--device"
+    ), f"CDI device {cdi_device!r} must appear as the value of a --device flag"
 
 
-def test_run_container_no_gpu_by_default(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_run_container_no_gpu_by_default(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """When ``gpu`` is not set (default False), no GPU device flag should
     appear in the podman argv."""
     manifest = _basic_manifest()
     argv = _run_and_capture(monkeypatch, manifest=manifest, tmp_path=tmp_path)
 
-    assert "nvidia.com/gpu=all" not in argv, (
-        "nvidia.com/gpu=all should not appear in podman argv when gpu is not set"
-    )
+    assert (
+        "nvidia.com/gpu=all" not in argv
+    ), "nvidia.com/gpu=all should not appear in podman argv when gpu is not set"
 
 
-def test_run_container_access_all_data_mounts_parent_dirs(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_run_container_access_all_data_mounts_parent_dirs(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """With access_all_data, the app sees /data/app_data/ and
     /data/app_temp_data/ as whole-namespace parent mounts, not just its
     own subdir.  This is security-sensitive because a typo here would
@@ -459,7 +484,9 @@ def test_run_container_access_all_data_mounts_parent_dirs(tmp_path, monkeypatch:
     manifest = _basic_manifest(access_all_data=True)
     argv = _run_and_capture(monkeypatch, manifest=manifest, tmp_path=tmp_path)
 
-    volume_args = [arg for prev, arg in zip(argv, argv[1:], strict=False) if prev == "-v"]
+    volume_args = [
+        arg for prev, arg in zip(argv, argv[1:], strict=False) if prev == "-v"
+    ]
     # Every mount must be idmap (rw or ro).
     for v in volume_args:
         assert v.endswith(":idmap") or v.endswith(":ro,idmap"), v
@@ -473,10 +500,14 @@ def test_run_container_access_all_data_mounts_parent_dirs(tmp_path, monkeypatch:
     # silently swapping it to ro would break every app that relies on
     # /data/vm_data as shared scratch space.
     vm_mount = next(v for v in volume_args if v.endswith(":/data/vm_data:idmap"))
-    assert "ro" not in vm_mount.rsplit(":", 1)[1], f"vm_data should be rw under access_all_data, got {vm_mount}"
+    assert (
+        "ro" not in vm_mount.rsplit(":", 1)[1]
+    ), f"vm_data should be rw under access_all_data, got {vm_mount}"
 
 
-def test_run_container_access_vm_data_mounts_vm_data_read_only(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_run_container_access_vm_data_mounts_vm_data_read_only(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """access_vm_data (without access_all_data) grants only a read-only
     view of /data/vm_data.  The distinction matters: this is what lets
     apps read shared state without being able to corrupt it, and a
@@ -486,41 +517,57 @@ def test_run_container_access_vm_data_mounts_vm_data_read_only(tmp_path, monkeyp
     manifest = _basic_manifest(access_vm_data=True)
     argv = _run_and_capture(monkeypatch, manifest=manifest, tmp_path=tmp_path)
 
-    volume_args = [arg for prev, arg in zip(argv, argv[1:], strict=False) if prev == "-v"]
+    volume_args = [
+        arg for prev, arg in zip(argv, argv[1:], strict=False) if prev == "-v"
+    ]
     vm_mounts = [v for v in volume_args if "/data/vm_data" in v]
     assert len(vm_mounts) == 1, vm_mounts
     assert vm_mounts[0].endswith(":ro,idmap"), vm_mounts[0]
 
 
-def test_run_container_app_archive_mounts_per_app_subdir(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_run_container_app_archive_mounts_per_app_subdir(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """Apps opting in via [data].app_archive get a per-app bind mount at /data/app_archive/<name>/ (host source: operator-configured archive_dir, container path same regardless of backing). A regression mounting the parent instead would expose every app's archive contents to every app."""
     manifest = _basic_manifest(app_data=True, app_archive=True)
     argv = _run_and_capture(monkeypatch, manifest=manifest, tmp_path=tmp_path)
 
-    volume_args = [arg for prev, arg in zip(argv, argv[1:], strict=False) if prev == "-v"]
+    volume_args = [
+        arg for prev, arg in zip(argv, argv[1:], strict=False) if prev == "-v"
+    ]
     archive_mounts = [v for v in volume_args if "/data/app_archive" in v]
     assert len(archive_mounts) == 1, archive_mounts
 
-    assert archive_mounts[0].endswith(f":/data/app_archive/{manifest.name}:idmap"), archive_mounts[0]
+    assert archive_mounts[0].endswith(
+        f":/data/app_archive/{manifest.name}:idmap"
+    ), archive_mounts[0]
 
     assert f"archive/{manifest.name}:" in archive_mounts[0], archive_mounts[0]
 
 
-def test_run_container_app_archive_off_by_default(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_run_container_app_archive_off_by_default(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """Apps that don't opt into app_archive get NO archive bind mount; a regression that always mounted the archive tier would surface operator-configured backings to apps that never asked for it."""
     manifest = _basic_manifest(app_data=True)
     argv = _run_and_capture(monkeypatch, manifest=manifest, tmp_path=tmp_path)
 
-    volume_args = [arg for prev, arg in zip(argv, argv[1:], strict=False) if prev == "-v"]
+    volume_args = [
+        arg for prev, arg in zip(argv, argv[1:], strict=False) if prev == "-v"
+    ]
     assert not any("/data/app_archive" in v for v in volume_args)
 
 
-def test_run_container_access_all_data_mounts_archive_parent(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_run_container_access_all_data_mounts_archive_parent(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """``access_all_data`` mounts the parent ``/data/app_archive`` directory (not a single per-app subdir), mirroring how app_data is mounted under access_all_data."""
     manifest = _basic_manifest(access_all_data=True)
     argv = _run_and_capture(monkeypatch, manifest=manifest, tmp_path=tmp_path)
 
-    volume_args = [arg for prev, arg in zip(argv, argv[1:], strict=False) if prev == "-v"]
+    volume_args = [
+        arg for prev, arg in zip(argv, argv[1:], strict=False) if prev == "-v"
+    ]
     targets = [v.rsplit(":", 2)[1] for v in volume_args]
     assert "/data/app_archive" in targets
     assert f"/data/app_archive/{manifest.name}" not in targets
@@ -546,7 +593,9 @@ def test_run_container_access_all_data_skips_archive_mount_when_archive_dir_miss
     archive_dir = str(tmp_path / "archive-not-mounted")
     os.makedirs(data_dir, exist_ok=True)
     os.makedirs(temp_data_dir, exist_ok=True)
-    os.makedirs(os.path.join(temp_data_dir, "app_temp_data", manifest.name), exist_ok=True)
+    os.makedirs(
+        os.path.join(temp_data_dir, "app_temp_data", manifest.name), exist_ok=True
+    )
 
     run_container(
         manifest.name,
@@ -562,7 +611,9 @@ def test_run_container_access_all_data_skips_archive_mount_when_archive_dir_miss
     assert len(run_cmds) == 1
     argv = run_cmds[0]
 
-    volume_args = [arg for prev, arg in zip(argv, argv[1:], strict=False) if prev == "-v"]
+    volume_args = [
+        arg for prev, arg in zip(argv, argv[1:], strict=False) if prev == "-v"
+    ]
     archive_mounts = [v for v in volume_args if "/data/app_archive" in v]
     assert archive_mounts == [], f"expected no archive mount, got {archive_mounts}"
 
@@ -573,12 +624,16 @@ def test_run_container_app_archive_env_var_translated_to_container_path(
     """``OPENHOST_APP_ARCHIVE_DIR`` in env_vars must be translated from the host path to the in-container path before being stamped on the podman run argv — same host-vs-container translation pattern as ``OPENHOST_APP_DATA_DIR`` and ``OPENHOST_APP_TEMP_DIR``."""
     manifest = _basic_manifest(app_data=True, app_archive=True)
     env_vars = {"OPENHOST_APP_ARCHIVE_DIR": "/some/host/archive/myapp"}
-    argv = _run_and_capture(monkeypatch, manifest=manifest, tmp_path=tmp_path, env_vars=env_vars)
+    argv = _run_and_capture(
+        monkeypatch, manifest=manifest, tmp_path=tmp_path, env_vars=env_vars
+    )
 
     e_values = [arg for prev, arg in zip(argv, argv[1:], strict=False) if prev == "-e"]
     archive_env = [e for e in e_values if e.startswith("OPENHOST_APP_ARCHIVE_DIR=")]
     assert len(archive_env) == 1, archive_env
-    assert archive_env[0] == f"OPENHOST_APP_ARCHIVE_DIR=/data/app_archive/{manifest.name}"
+    assert (
+        archive_env[0] == f"OPENHOST_APP_ARCHIVE_DIR=/data/app_archive/{manifest.name}"
+    )
 
 
 def test_run_container_port_mappings_bind_tcp_and_udp_on_all_interfaces(
@@ -631,7 +686,9 @@ def test_stop_container_calls_podman(monkeypatch: pytest.MonkeyPatch) -> None:
     ]
 
 
-def test_stop_container_escalates_to_kill_on_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_stop_container_escalates_to_kill_on_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     calls: list[list[str]] = []
 
     def fake_run(cmd, **_):  # type: ignore[no-untyped-def]
@@ -650,7 +707,9 @@ def test_stop_container_escalates_to_kill_on_failure(monkeypatch: pytest.MonkeyP
     ]
 
 
-def test_stop_container_escalates_to_kill_on_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_stop_container_escalates_to_kill_on_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     calls: list[list[str]] = []
 
     def fake_run(cmd, **kwargs):  # type: ignore[no-untyped-def]
@@ -682,7 +741,9 @@ def test_remove_image_calls_podman_rmi(monkeypatch: pytest.MonkeyPatch) -> None:
     assert calls == [["podman", "rmi", "openhost-myapp:latest"]]
 
 
-def test_is_container_running_returns_false_on_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_is_container_running_returns_false_on_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     def fake_run(cmd, **_):  # type: ignore[no-untyped-def]
         return _FakeCompleted(1, stderr="no such container")
 
@@ -748,7 +809,9 @@ def test_get_docker_logs_returns_build_log_when_no_container(tmp_path) -> None:
     assert "=== Container logs ===" not in output
 
 
-def test_get_docker_logs_returns_empty_when_no_build_log_and_no_container(tmp_path) -> None:
+def test_get_docker_logs_returns_empty_when_no_build_log_and_no_container(
+    tmp_path,
+) -> None:
     """Fresh app that failed before any _append_log call has neither
     a build log file nor a container id.  The function's os.path.exists
     guard must short-circuit both branches and return "" rather than
@@ -758,7 +821,9 @@ def test_get_docker_logs_returns_empty_when_no_build_log_and_no_container(tmp_pa
     assert output == ""
 
 
-def test_get_docker_logs_appends_podman_logs_when_container_id_set(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_get_docker_logs_appends_podman_logs_when_container_id_set(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """With a container id, get_docker_logs should also run ``podman logs
     --tail <N>`` and concatenate the output under a 'Container logs' header."""
     _make_build_log(tmp_path, "notes", "=== Build complete ===\n")
@@ -779,7 +844,9 @@ def test_get_docker_logs_appends_podman_logs_when_container_id_set(tmp_path, mon
     assert "app stdout line" in output
 
 
-def test_get_docker_logs_strips_ansi_escape_sequences(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_get_docker_logs_strips_ansi_escape_sequences(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """Color codes and carriage returns from podman logs should be
     stripped before we hand the text back to the dashboard (which
     otherwise renders them as garbage text)."""
@@ -816,7 +883,10 @@ def test_bind_mount_arg_ro_emits_ro_idmap() -> None:
     ordering (``ro,idmap``) matters for operator readability of
     ``podman ps`` output; pin the canonical rendering here even though
     podman parses the options order-independently."""
-    assert _bind_mount_arg("/srv/data", "/data", read_only=True) == "/srv/data:/data:ro,idmap"
+    assert (
+        _bind_mount_arg("/srv/data", "/data", read_only=True)
+        == "/srv/data:/data:ro,idmap"
+    )
 
 
 def test_bind_mount_arg_preserves_absolute_paths_verbatim() -> None:


### PR DESCRIPTION
When gpu = true in the app manifest, passes --device nvidia.com/gpu=all to podman for CDI-based GPU passthrough.

Changes:
- containers.py: add CDI device flag when manifest.gpu is true
- ansible/tasks/gpu.yml: new task to install NVIDIA drivers and container toolkit, generate CDI spec (skipped on hosts without NVIDIA GPUs)
- setup.yml: include gpu.yml before containers.yml
- test_containers.py: tests for GPU device flag presence/absence

The gpu field already existed in the manifest schema but had no runtime effect. This wires it up.