### PR TITLE
Key the app detail route by app name instead of app id

### DIFF
--- a/compute_space/src/compute_space/core/app_id.py
+++ b/compute_space/src/compute_space/core/app_id.py
@@ -4,7 +4,7 @@ import re
 import secrets
 
 # App names are DNS-label-like: lowercase alphanumeric, hyphens allowed but not
-# at the edges.  Kept in sync with the check in apps.validate_manifest.
+# at the edges.
 _APP_NAME_RE = re.compile(r"^[a-z0-9]([a-z0-9-]*[a-z0-9])?$")
 
 # Bitcoin base58 alphabet: omits 0, O, I, l to avoid visual ambiguity.

--- a/compute_space/src/compute_space/core/app_id.py
+++ b/compute_space/src/compute_space/core/app_id.py
@@ -1,6 +1,11 @@
 """Here to avoid a circular import in migrations if we put this in apps.py"""
 
+import re
 import secrets
+
+# App names are DNS-label-like: lowercase alphanumeric, hyphens allowed but not
+# at the edges.  Kept in sync with the check in apps.validate_manifest.
+_APP_NAME_RE = re.compile(r"^[a-z0-9]([a-z0-9-]*[a-z0-9])?$")
 
 # Bitcoin base58 alphabet: omits 0, O, I, l to avoid visual ambiguity.
 _BASE58_ALPHABET = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz"
@@ -26,3 +31,8 @@ def new_app_id() -> str:
 def is_valid_app_id(s: str) -> bool:
     """True iff s is exactly APP_ID_LENGTH chars, all from the base58 alphabet."""
     return len(s) == APP_ID_LENGTH and all(c in _BASE58_SET for c in s)
+
+
+def is_valid_app_name(s: str) -> bool:
+    """True iff s is a valid app name (lowercase alphanumeric, interior hyphens)."""
+    return bool(_APP_NAME_RE.match(s))

--- a/compute_space/src/compute_space/core/apps.py
+++ b/compute_space/src/compute_space/core/apps.py
@@ -2,7 +2,6 @@ import asyncio
 import hashlib
 import json
 import os
-import re
 import shutil
 import sqlite3
 import subprocess
@@ -17,6 +16,7 @@ import httpx
 import compute_space.core.storage as storage
 from compute_space.config import Config
 from compute_space.config import get_config
+from compute_space.core.app_id import is_valid_app_name
 from compute_space.core.app_id import new_app_id
 from compute_space.core.auth.auth import DEFAULT_OWNER_USERNAME
 from compute_space.core.auth.auth import read_owner_username
@@ -265,7 +265,7 @@ def validate_manifest(manifest: AppManifest, db: sqlite3.Connection, app_name: s
     if app_name is None:
         app_name = manifest.name
 
-    if not re.match(r"^[a-z0-9]([a-z0-9-]*[a-z0-9])?$", app_name):
+    if not is_valid_app_name(app_name):
         return "App name must be lowercase alphanumeric (hyphens allowed, not at start/end)"
 
     if f"/{app_name}" in RESERVED_PATHS:

--- a/compute_space/src/compute_space/tests/test_integration.py
+++ b/compute_space/src/compute_space/tests/test_integration.py
@@ -920,7 +920,7 @@ class TestContainerRestart:
 
             app_id = app_id_for(session, self.BASE_URL, self.APP_NAME)
             assert app_id is not None, "App row should exist after rebuild"
-            r = session.get(f"{self.BASE_URL}/app_detail/{app_id}")
+            r = session.get(f"{self.BASE_URL}/app_detail/{self.APP_NAME}")
             assert r.status_code == 200
 
             # Poll the DB for status='running' (background thread may
@@ -1006,7 +1006,7 @@ class TestContainerE2E:
         while time.time() < deadline:
             app_id = app_id_for(admin_session, base_url, "test-app")
             if app_id:
-                r = admin_session.get(f"{base_url}/app_detail/{app_id}")
+                r = admin_session.get(f"{base_url}/app_detail/test-app")
                 if r.status_code == 200 and "running" in r.text:
                     break
             time.sleep(2)
@@ -1445,7 +1445,7 @@ class TestGitUrlDeployE2E:
             app_id = app_id_for(admin_session, base_url, self.APP_NAME)
             if app_id:
                 r = admin_session.get(
-                    f"{base_url}/app_detail/{app_id}",
+                    f"{base_url}/app_detail/{self.APP_NAME}",
                 )
                 if r.status_code == 200 and "running" in r.text:
                     break

--- a/compute_space/src/compute_space/web/routes/api/apps.py
+++ b/compute_space/src/compute_space/web/routes/api/apps.py
@@ -489,7 +489,7 @@ async def _reload_app_impl(
                     )
                     db.commit()
                     if continue_oauth:
-                        return Redirect(path=f"/app_detail/{app_id}")
+                        return Redirect(path=f"/app_detail/{app_name}")
                     return Response(content=OkResponse(ok=True), status_code=200, media_type=MediaType.JSON)
                 except OAuthAuthorizationRequired as e:
                     lf.write("No token available; redirecting to oauth flow\n")
@@ -511,7 +511,7 @@ async def _reload_app_impl(
                 )
                 db.commit()
                 if continue_oauth:
-                    return Redirect(path=f"/app_detail/{app_id}")
+                    return Redirect(path=f"/app_detail/{app_name}")
                 return Response(content=OkResponse(ok=True), status_code=200, media_type=MediaType.JSON)
 
     await asyncio.to_thread(stop_app_process, app_row)
@@ -553,7 +553,10 @@ async def reload_app_after_oauth(
     so we don't truncate the log file again or re-prompt for OAuth."""
     if not continue_oauth_update:
         # GET without the flag isn't meaningful; nudge the operator back to /app_detail.
-        return Redirect(path=f"/app_detail/{app_id}")
+        row = db.execute("SELECT name FROM apps WHERE app_id = ?", (app_id,)).fetchone()
+        if not row:
+            return Redirect(path="/dashboard")
+        return Redirect(path=f"/app_detail/{row['name']}")
     return await _reload_app_impl(app_id, update=True, continue_oauth=True, db=db, config=config)
 
 

--- a/compute_space/src/compute_space/web/routes/pages/apps.py
+++ b/compute_space/src/compute_space/web/routes/pages/apps.py
@@ -7,7 +7,7 @@ from litestar.exceptions import HTTPException
 from litestar.response import Template
 
 from compute_space.config import Config
-from compute_space.core.app_id import is_valid_app_id
+from compute_space.core.app_id import is_valid_app_name
 from compute_space.core.apps import list_builtin_apps
 from compute_space.core.auth.permissions_v2 import get_all_permissions_v2
 from compute_space.core.containers import get_docker_logs
@@ -22,14 +22,14 @@ async def dashboard(db: sqlite3.Connection) -> Template:
     return Template(template_name="dashboard.html", context={"apps": apps_list})
 
 
-@get("/app_detail/{app_id:str}", guards=[require_owner_auth])
-async def app_detail(app_id: str, db: sqlite3.Connection, config: Config, next: str = "") -> Template:
-    if not is_valid_app_id(app_id):
-        raise HTTPException(detail="Invalid app_id", status_code=400)
-    app_row = db.execute("SELECT * FROM apps WHERE app_id = ?", (app_id,)).fetchone()
+@get("/app_detail/{app_name:str}", guards=[require_owner_auth])
+async def app_detail(app_name: str, db: sqlite3.Connection, config: Config, next: str = "") -> Template:
+    if not is_valid_app_name(app_name):
+        raise HTTPException(detail="Invalid app name", status_code=400)
+    app_row = db.execute("SELECT * FROM apps WHERE name = ?", (app_name,)).fetchone()
     if not app_row:
         raise HTTPException(detail="App not found", status_code=404)
-    app_name = app_row["name"]
+    app_id = app_row["app_id"]
     databases = db.execute("SELECT * FROM app_databases WHERE app_id = ?", (app_id,)).fetchall()
     port_mappings = db.execute(
         "SELECT label, container_port, host_port FROM app_port_mappings WHERE app_id = ? ORDER BY label",

--- a/compute_space/src/compute_space/web/static/js/app-detail.js
+++ b/compute_space/src/compute_space/web/static/js/app-detail.js
@@ -26,8 +26,8 @@ function saveName() {
     .then(function(r) { return r.json().then(function(d) { return {ok: r.ok, data: d}; }); })
     .then(function(res) {
       if (!res.ok) { errEl.textContent = res.data.error; return; }
-      // app_id is unchanged on rename; the URL stays the same. Reload to pick up the new name in headings.
-      window.location.href = config.appDetailUrl;
+      // The detail URL is keyed by name, so a rename changes it.
+      window.location.href = '/app_detail/' + encodeURIComponent(res.data.name);
     });
 }
 

--- a/compute_space/src/compute_space/web/templates/add_app.html
+++ b/compute_space/src/compute_space/web/templates/add_app.html
@@ -394,7 +394,7 @@ async function deployApp() {
     return;
   }
 
-  const detailUrl = '/app_detail/' + encodeURIComponent(data.app_id)
+  const detailUrl = '/app_detail/' + encodeURIComponent(data.app_name)
     + (nextUrl ? '?next=' + encodeURIComponent(nextUrl) : '');
   window.location = detailUrl;
 }

--- a/compute_space/src/compute_space/web/templates/app_detail.html
+++ b/compute_space/src/compute_space/web/templates/app_detail.html
@@ -151,7 +151,7 @@ async function grantPermission(btn) {
 <script id="page-config" type="application/json">
 {
   "renameAppUrl": "/rename_app/{{ app.app_id }}",
-  "appDetailUrl": "/app_detail/{{ app.app_id }}",
+  "appDetailUrl": "/app_detail/{{ app.name }}",
   "appLogsUrl": "/app_logs/{{ app.app_id }}",
   "appStatusUrl": "/api/app_status/{{ app.app_id }}",
   "appStatus": {{ app.status | tojson }},

--- a/compute_space/src/compute_space/web/templates/dashboard.html
+++ b/compute_space/src/compute_space/web/templates/dashboard.html
@@ -22,7 +22,7 @@
        the polling loop; server-side guards (409 on stop/reload/rename
        of a removing row) make stray clicks safe no-ops. #}
     <td class="app-actions">
-      <a href="/app_detail/{{ app.app_id }}">Details</a>
+      <a href="/app_detail/{{ app.name }}">Details</a>
       <button class="btn" onclick="appAction('{{ app.app_id }}', 'reload_app')">Reload</button>
       <button class="btn" onclick="reloadAndUpdate('{{ app.app_id }}')">Reload &amp; Update</button>
       <button class="btn btn-danger" onclick="if(confirm('Remove {{ app.name }} and delete all data permanently?')) appAction('{{ app.app_id }}', 'remove_app')">Remove</button>

--- a/compute_space_cli/src/compute_space_cli/main.py
+++ b/compute_space_cli/src/compute_space_cli/main.py
@@ -123,7 +123,7 @@ class AppCmd:
         app_id = body.get("app_id")
         app_name = body.get("app_name")
         print(f"Deploying {app_name}...")
-        print(f"  {cfg.url}/app_detail/{app_id}")
+        print(f"  {cfg.url}/app_detail/{app_name}")
         if not wait:
             print(f"Status: {body.get('status', 'submitted')}")
             return


### PR DESCRIPTION
## What

Changes the app detail route from being keyed by base58 app id to being keyed by app name.

Before: `https://zack-dev.selfhost.imbue.com/app_detail/eauCgE9jA8U9`
After: `https://zack-dev.selfhost.imbue.com/app_detail/my-app`

App names are `UNIQUE` in the DB and DNS-label-shaped (`^[a-z0-9]([a-z0-9-]*[a-z0-9])?$`), so they're safe and unambiguous as a path segment.

## Changes

- **`core/app_id.py`** — add `is_valid_app_name()` helper (mirrors the regex already used in `validate_manifest`).
- **`web/routes/pages/apps.py`** — route param `{app_id:str}` → `{app_name:str}`; validate the name, look up the row `WHERE name = ?`, derive `app_id` for downstream queries.
- **Templates** — `dashboard.html`, `app_detail.html` (`appDetailUrl`), `add_app.html` now build the URL from the app name.
- **`web/static/js/app-detail.js`** — after a rename, redirect to `/app_detail/<new-name>` (the old name-keyed URL would 404 otherwise).
- **`web/routes/api/apps.py`** — the three `/app_detail/...` redirects use the name.
- **`compute_space_cli/main.py`** — printed deploy URL uses the name.
- **`tests/test_integration.py`** — container e2e tests GET the detail page by name.

## Notes / trade-offs

- Other action routes (`/reload_app`, `/stop_app`, `/remove_app`, `/rename_app`, `/app_logs`, `/api/app_status`) remain id-keyed — they're internal POST/status endpoints, not the user-facing URL.
- Name-based URLs change when an app is renamed, so old bookmarks to a renamed app will 404 (the rename flow itself redirects to the new URL).

## Testing

Full lightweight suite passes (`pixi run -e dev pytest -x`): 595 passed, 32 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)