### PR TITLE
Redesign data manifest flags: access_all_app_data, access_all_archive, access_all_data; app_data defaults on

### DIFF
--- a/apps/file_browser/openhost.toml
+++ b/apps/file_browser/openhost.toml
@@ -13,4 +13,5 @@ memory_mb = 64
 cpu_millicores = 100
 
 [data]
-access_all_data = true
+access_all_app_data = true
+access_all_archive = true

--- a/apps/file_browser/openhost.toml
+++ b/apps/file_browser/openhost.toml
@@ -13,5 +13,4 @@ memory_mb = 64
 cpu_millicores = 100
 
 [data]
-access_all_app_data = true
-access_all_archive = true
+access_all_data = true

--- a/compute_space/src/compute_space/core/archive_backend.py
+++ b/compute_space/src/compute_space/core/archive_backend.py
@@ -398,13 +398,13 @@ def manifest_requires_archive(manifest_raw: str) -> bool:
 def manifest_uses_archive(manifest_raw: str) -> bool:
     """Return True if the app receives the archive mount.
 
-    ``app_archive`` is a hard requirement; ``access_all_archive`` is
-    permissive but still causes the app to receive the archive bind-mount
-    when the tier is live, so destructive removal still needs the archive
-    healthy to delete S3 bytes.
+    ``app_archive`` is a hard requirement; ``access_all_archive`` and the
+    convenience alias ``access_all_data`` are permissive but still cause
+    the app to receive the archive bind-mount when the tier is live, so
+    destructive removal still needs the archive healthy to delete S3 bytes.
     """
     data = _data_section(manifest_raw)
-    return bool(data.get("app_archive") or data.get("access_all_archive"))
+    return bool(data.get("app_archive") or data.get("access_all_archive") or data.get("access_all_data"))
 
 
 def is_archive_dir_healthy(config: Config, db: sqlite3.Connection) -> bool:

--- a/compute_space/src/compute_space/core/archive_backend.py
+++ b/compute_space/src/compute_space/core/archive_backend.py
@@ -396,9 +396,19 @@ def manifest_requires_archive(manifest_raw: str) -> bool:
 
 
 def manifest_uses_archive(manifest_raw: str) -> bool:
-    """``app_archive`` OR ``access_all_data`` means the app gets the archive mount."""
+    """Return True if the app receives the archive mount.
+
+    ``app_archive`` is a hard requirement; ``access_all_archive`` and
+    ``access_all_data`` (deprecated) are permissive but still cause the
+    app to receive the archive bind-mount when the tier is live, so
+    destructive removal still needs the archive healthy to delete S3 bytes.
+    """
     data = _data_section(manifest_raw)
-    return bool(data.get("app_archive") or data.get("access_all_data"))
+    return bool(
+        data.get("app_archive")
+        or data.get("access_all_archive")
+        or data.get("access_all_data")
+    )
 
 
 def is_archive_dir_healthy(config: Config, db: sqlite3.Connection) -> bool:

--- a/compute_space/src/compute_space/core/archive_backend.py
+++ b/compute_space/src/compute_space/core/archive_backend.py
@@ -404,11 +404,7 @@ def manifest_uses_archive(manifest_raw: str) -> bool:
     destructive removal still needs the archive healthy to delete S3 bytes.
     """
     data = _data_section(manifest_raw)
-    return bool(
-        data.get("app_archive")
-        or data.get("access_all_archive")
-        or data.get("access_all_data")
-    )
+    return bool(data.get("app_archive") or data.get("access_all_archive") or data.get("access_all_data"))
 
 
 def is_archive_dir_healthy(config: Config, db: sqlite3.Connection) -> bool:

--- a/compute_space/src/compute_space/core/archive_backend.py
+++ b/compute_space/src/compute_space/core/archive_backend.py
@@ -398,13 +398,13 @@ def manifest_requires_archive(manifest_raw: str) -> bool:
 def manifest_uses_archive(manifest_raw: str) -> bool:
     """Return True if the app receives the archive mount.
 
-    ``app_archive`` is a hard requirement; ``access_all_archive`` and
-    ``access_all_data`` (deprecated) are permissive but still cause the
-    app to receive the archive bind-mount when the tier is live, so
-    destructive removal still needs the archive healthy to delete S3 bytes.
+    ``app_archive`` is a hard requirement; ``access_all_archive`` is
+    permissive but still causes the app to receive the archive bind-mount
+    when the tier is live, so destructive removal still needs the archive
+    healthy to delete S3 bytes.
     """
     data = _data_section(manifest_raw)
-    return bool(data.get("app_archive") or data.get("access_all_archive") or data.get("access_all_data"))
+    return bool(data.get("app_archive") or data.get("access_all_archive"))
 
 
 def is_archive_dir_healthy(config: Config, db: sqlite3.Connection) -> bool:

--- a/compute_space/src/compute_space/core/containers.py
+++ b/compute_space/src/compute_space/core/containers.py
@@ -185,10 +185,14 @@ def run_container(
     vm_data_dir = os.path.join(data_dir, "vm_data")
     container_name = f"openhost-{app_name}"
 
-    has_app_data = manifest.app_data or manifest.sqlite_dbs or manifest.access_all_data
-    has_app_temp = manifest.app_temp_data or manifest.access_all_data
-    has_app_archive = manifest.app_archive or manifest.access_all_data
-    has_vm_data = manifest.access_vm_data or manifest.access_all_data
+    # access_all_data (deprecated) expands to access_all_app_data + access_all_archive.
+    wants_all_app_data = manifest.access_all_app_data or manifest.access_all_data
+    wants_all_archive = manifest.access_all_archive or manifest.access_all_data
+
+    has_app_data = manifest.app_data or manifest.sqlite_dbs or wants_all_app_data
+    has_app_temp = manifest.app_temp_data or wants_all_app_data
+    has_app_archive = manifest.app_archive or wants_all_archive
+    has_vm_data = manifest.access_vm_data or wants_all_app_data
 
     c_app_data = f"{CONTAINER_ROOT}/app_data/{app_name}"
     c_app_temp = f"{CONTAINER_ROOT}/app_temp_data/{app_name}"
@@ -258,8 +262,8 @@ def run_container(
     for cap in sorted(DEFAULT_CAPABILITIES):
         cmd.extend(["--cap-add", cap])
 
-    if manifest.access_all_data:
-        # Opt-in full access to every app's data.
+    if wants_all_app_data:
+        # Mount the full parent dirs so the app can see all apps' data/temp.
         cmd.extend(["-v", _bind_mount_arg(os.path.join(data_dir, "app_data"), f"{CONTAINER_ROOT}/app_data")])
         cmd.extend(
             [
@@ -270,10 +274,7 @@ def run_container(
                 ),
             ]
         )
-        # access_all_data is permissive — skip the archive mount when
-        # the tier isn't configured rather than refusing to start.
-        if os.path.isdir(archive_dir):
-            cmd.extend(["-v", _bind_mount_arg(archive_dir, f"{CONTAINER_ROOT}/app_archive")])
+        # vm_data is rw under wants_all_app_data (admin-level access).
         os.makedirs(vm_data_dir, exist_ok=True)
         cmd.extend(["-v", _bind_mount_arg(vm_data_dir, c_vm_data)])
     else:
@@ -281,11 +282,17 @@ def run_container(
             cmd.extend(["-v", _bind_mount_arg(app_data_dir, c_app_data)])
         if has_app_temp:
             cmd.extend(["-v", _bind_mount_arg(app_temp_dir, c_app_temp)])
-        if has_app_archive:
-            cmd.extend(["-v", _bind_mount_arg(app_archive_dir, c_app_archive)])
         if has_vm_data:
             os.makedirs(vm_data_dir, exist_ok=True)
             cmd.extend(["-v", _bind_mount_arg(vm_data_dir, c_vm_data, read_only=True)])
+
+    if wants_all_archive:
+        # access_all_archive / access_all_data is permissive — skip the archive
+        # mount when the tier isn't configured rather than refusing to start.
+        if os.path.isdir(archive_dir):
+            cmd.extend(["-v", _bind_mount_arg(archive_dir, f"{CONTAINER_ROOT}/app_archive")])
+    elif has_app_archive:
+        cmd.extend(["-v", _bind_mount_arg(app_archive_dir, c_app_archive)])
 
     # Structured port mappings: bind TCP+UDP on 0.0.0.0.  host_port
     # values below UNPRIVILEGED_PORT_FLOOR are rejected at manifest

--- a/compute_space/src/compute_space/core/containers.py
+++ b/compute_space/src/compute_space/core/containers.py
@@ -4,7 +4,7 @@ Every container runs under the unprivileged ``host`` user in podman's
 default rootless user namespace.  Host bind mounts use ``:idmap`` so
 container-root writes land on disk owned by the ``host`` user.  Each
 app sees only its own ``/data/...`` subdirectory unless it requests
-``access_all_data``.
+``access_all_app_data`` or ``access_all_archive``.
 
 Security defaults: ``--cap-drop=ALL`` then re-add ``DEFAULT_CAPABILITIES``
 (Docker's default set) plus anything the manifest requests from
@@ -185,9 +185,8 @@ def run_container(
     vm_data_dir = os.path.join(data_dir, "vm_data")
     container_name = f"openhost-{app_name}"
 
-    # access_all_data (deprecated) expands to access_all_app_data + access_all_archive.
-    wants_all_app_data = manifest.access_all_app_data or manifest.access_all_data
-    wants_all_archive = manifest.access_all_archive or manifest.access_all_data
+    wants_all_app_data = manifest.access_all_app_data
+    wants_all_archive = manifest.access_all_archive
 
     has_app_data = manifest.app_data or manifest.sqlite_dbs or wants_all_app_data
     has_app_temp = manifest.app_temp_data or wants_all_app_data
@@ -287,8 +286,8 @@ def run_container(
             cmd.extend(["-v", _bind_mount_arg(vm_data_dir, c_vm_data, read_only=True)])
 
     if wants_all_archive:
-        # access_all_archive / access_all_data is permissive — skip the archive
-        # mount when the tier isn't configured rather than refusing to start.
+        # access_all_archive is permissive — skip the archive mount when
+        # the tier isn't configured rather than refusing to start.
         if os.path.isdir(archive_dir):
             cmd.extend(["-v", _bind_mount_arg(archive_dir, f"{CONTAINER_ROOT}/app_archive")])
     elif has_app_archive:

--- a/compute_space/src/compute_space/core/containers.py
+++ b/compute_space/src/compute_space/core/containers.py
@@ -4,7 +4,8 @@ Every container runs under the unprivileged ``host`` user in podman's
 default rootless user namespace.  Host bind mounts use ``:idmap`` so
 container-root writes land on disk owned by the ``host`` user.  Each
 app sees only its own ``/data/...`` subdirectory unless it requests
-``access_all_app_data`` or ``access_all_archive``.
+``access_all_app_data``, ``access_all_archive``, or the convenience
+shorthand ``access_all_data`` (which implies both).
 
 Security defaults: ``--cap-drop=ALL`` then re-add ``DEFAULT_CAPABILITIES``
 (Docker's default set) plus anything the manifest requests from

--- a/compute_space/src/compute_space/core/data.py
+++ b/compute_space/src/compute_space/core/data.py
@@ -97,12 +97,10 @@ def provision_data(
     app_archive_dir = os.path.join(archive_dir, app_name)
     env_vars = {}
 
-    # access_all_data (deprecated) expands to access_all_app_data + access_all_archive.
-    wants_all_app_data = manifest.access_all_app_data or manifest.access_all_data
-    wants_all_archive = manifest.access_all_archive or manifest.access_all_data
-
     # Determine if permanent data dir is needed:
     # app_data defaults true; also enabled by sqlite entries or cross-app access.
+    wants_all_app_data = manifest.access_all_app_data
+    wants_all_archive = manifest.access_all_archive
     needs_app_data = manifest.app_data or manifest.sqlite_dbs or wants_all_app_data
 
     if needs_app_data:
@@ -141,8 +139,8 @@ def provision_data(
         os.makedirs(app_archive_dir, exist_ok=True)
         env_vars["OPENHOST_APP_ARCHIVE_DIR"] = app_archive_dir
     elif wants_all_archive and archive_available:
-        # access_all_archive / access_all_data is permissive — skip the archive
-        # mount when the tier isn't configured rather than refusing to provision.
+        # access_all_archive is permissive — skip the archive mount when
+        # the tier isn't configured rather than refusing to provision.
         os.makedirs(app_archive_dir, exist_ok=True)
         env_vars["OPENHOST_APP_ARCHIVE_DIR"] = app_archive_dir
 

--- a/compute_space/src/compute_space/core/data.py
+++ b/compute_space/src/compute_space/core/data.py
@@ -89,7 +89,9 @@ def provision_data(
 
     By default, apps receive a permanent data directory (app_data defaults
     to True).  Additional storage tiers must be explicitly requested via
-    app_temp_data, app_archive, access_all_app_data, or access_all_archive.
+    app_temp_data, app_archive, access_all_app_data, access_all_archive,
+    or the convenience shorthand access_all_data (which implies both
+    access_all_app_data and access_all_archive).
     SQLite entries also implicitly enable app_data.
     """
     app_data_dir = os.path.join(data_dir, "app_data", app_name)

--- a/compute_space/src/compute_space/core/data.py
+++ b/compute_space/src/compute_space/core/data.py
@@ -96,9 +96,13 @@ def provision_data(
     app_archive_dir = os.path.join(archive_dir, app_name)
     env_vars = {}
 
+    # access_all_data (deprecated) expands to access_all_app_data + access_all_archive.
+    wants_all_app_data = manifest.access_all_app_data or manifest.access_all_data
+    wants_all_archive = manifest.access_all_archive or manifest.access_all_data
+
     # Determine if permanent data dir is needed:
-    # explicitly requested, has sqlite entries, or access_all_data
-    needs_app_data = manifest.app_data or manifest.sqlite_dbs or manifest.access_all_data
+    # app_data defaults true; also enabled by sqlite entries or cross-app access.
+    needs_app_data = manifest.app_data or manifest.sqlite_dbs or wants_all_app_data
 
     if needs_app_data:
         os.makedirs(app_data_dir, exist_ok=True)
@@ -117,7 +121,7 @@ def provision_data(
             if upper_key != env_key:
                 env_vars[upper_key] = db_path
 
-    if manifest.app_temp_data or manifest.access_all_data:
+    if manifest.app_temp_data or wants_all_app_data:
         os.makedirs(app_temp_dir, exist_ok=True)
         env_vars["OPENHOST_APP_TEMP_DIR"] = app_temp_dir
 
@@ -135,9 +139,9 @@ def provision_data(
             )
         os.makedirs(app_archive_dir, exist_ok=True)
         env_vars["OPENHOST_APP_ARCHIVE_DIR"] = app_archive_dir
-    elif manifest.access_all_data and archive_available:
-        # access_all_data is permissive — skip the archive mount when
-        # the tier isn't configured rather than refusing to provision.
+    elif wants_all_archive and archive_available:
+        # access_all_archive / access_all_data is permissive — skip the archive
+        # mount when the tier isn't configured rather than refusing to provision.
         os.makedirs(app_archive_dir, exist_ok=True)
         env_vars["OPENHOST_APP_ARCHIVE_DIR"] = app_archive_dir
 

--- a/compute_space/src/compute_space/core/data.py
+++ b/compute_space/src/compute_space/core/data.py
@@ -87,9 +87,10 @@ def provision_data(
     """Create data directories for an app based on manifest permissions.
     Returns a dict of environment variable name -> value.
 
-    Apps only get filesystem access to directories they explicitly request
-    via app_data, app_temp_data, and app_archive flags in [data].  SQLite
-    entries implicitly enable app_data.
+    By default, apps receive a permanent data directory (app_data defaults
+    to True).  Additional storage tiers must be explicitly requested via
+    app_temp_data, app_archive, access_all_app_data, or access_all_archive.
+    SQLite entries also implicitly enable app_data.
     """
     app_data_dir = os.path.join(data_dir, "app_data", app_name)
     app_temp_dir = os.path.join(temp_data_dir, "app_temp_data", app_name)

--- a/compute_space/src/compute_space/core/manifest.py
+++ b/compute_space/src/compute_space/core/manifest.py
@@ -155,8 +155,6 @@ class AppManifest:
     access_vm_data: bool = False
     access_all_app_data: bool = False
     access_all_archive: bool = False
-    # Deprecated: use access_all_app_data + access_all_archive instead.
-    access_all_data: bool = False
 
     # [services.v2]
     provides_services_v2: list[ServiceProvides] = attr.Factory(list)
@@ -375,7 +373,6 @@ def parse_manifest_from_string(raw_text: str) -> AppManifest:
         access_vm_data=data_section.get("access_vm_data", False),
         access_all_app_data=data_section.get("access_all_app_data", False),
         access_all_archive=data_section.get("access_all_archive", False),
-        access_all_data=data_section.get("access_all_data", False),
         provides_services_v2=_parse_services_v2(data),
         consumes_services_v2=_parse_services_v2_consumes(data),
         raw_toml=raw_text,

--- a/compute_space/src/compute_space/core/manifest.py
+++ b/compute_space/src/compute_space/core/manifest.py
@@ -156,8 +156,7 @@ class AppManifest:
     # Granular cross-app data flags (preferred):
     access_all_app_data: bool = False
     access_all_archive: bool = False
-    # Backwards-compatible alias for access_all_app_data + access_all_archive.
-    # Prefer the granular flags in new manifests.
+    # Convenience shorthand: equivalent to access_all_app_data + access_all_archive.
     access_all_data: bool = False
 
     # [services.v2]

--- a/compute_space/src/compute_space/core/manifest.py
+++ b/compute_space/src/compute_space/core/manifest.py
@@ -149,10 +149,13 @@ class AppManifest:
 
     # [data]
     sqlite_dbs: list[str] = attr.Factory(list)
-    app_data: bool = False
+    app_data: bool = True
     app_temp_data: bool = False
     app_archive: bool = False
     access_vm_data: bool = False
+    access_all_app_data: bool = False
+    access_all_archive: bool = False
+    # Deprecated: use access_all_app_data + access_all_archive instead.
     access_all_data: bool = False
 
     # [services.v2]
@@ -366,10 +369,12 @@ def parse_manifest_from_string(raw_text: str) -> AppManifest:
         cpu_millicores=resources.get("cpu_millicores", 100),
         gpu=resources.get("gpu", False),
         sqlite_dbs=data_section.get("sqlite", []),
-        app_data=data_section.get("app_data", False),
+        app_data=data_section.get("app_data", True),
         app_temp_data=data_section.get("app_temp_data", False),
         app_archive=data_section.get("app_archive", False),
         access_vm_data=data_section.get("access_vm_data", False),
+        access_all_app_data=data_section.get("access_all_app_data", False),
+        access_all_archive=data_section.get("access_all_archive", False),
         access_all_data=data_section.get("access_all_data", False),
         provides_services_v2=_parse_services_v2(data),
         consumes_services_v2=_parse_services_v2_consumes(data),

--- a/compute_space/src/compute_space/core/manifest.py
+++ b/compute_space/src/compute_space/core/manifest.py
@@ -376,7 +376,8 @@ def parse_manifest_from_string(raw_text: str) -> AppManifest:
         app_archive=data_section.get("app_archive", False),
         access_vm_data=data_section.get("access_vm_data", False),
         access_all_data=data_section.get("access_all_data", False),
-        access_all_app_data=data_section.get("access_all_app_data", False) or data_section.get("access_all_data", False),
+        access_all_app_data=data_section.get("access_all_app_data", False)
+        or data_section.get("access_all_data", False),
         access_all_archive=data_section.get("access_all_archive", False) or data_section.get("access_all_data", False),
         provides_services_v2=_parse_services_v2(data),
         consumes_services_v2=_parse_services_v2_consumes(data),

--- a/compute_space/src/compute_space/core/manifest.py
+++ b/compute_space/src/compute_space/core/manifest.py
@@ -156,8 +156,8 @@ class AppManifest:
     # Granular cross-app data flags (preferred):
     access_all_app_data: bool = False
     access_all_archive: bool = False
-    # Convenience flag: equivalent to access_all_app_data + access_all_archive.
-    # Kept for backwards compatibility with existing app manifests.
+    # Backwards-compatible alias for access_all_app_data + access_all_archive.
+    # Prefer the granular flags in new manifests.
     access_all_data: bool = False
 
     # [services.v2]
@@ -350,6 +350,7 @@ def parse_manifest_from_string(raw_text: str) -> AppManifest:
             app_name,
         )
 
+    _compat_all_data = data_section.get("access_all_data", False)
     return AppManifest(
         name=app_name,
         version=app_section["version"],
@@ -375,10 +376,9 @@ def parse_manifest_from_string(raw_text: str) -> AppManifest:
         app_temp_data=data_section.get("app_temp_data", False),
         app_archive=data_section.get("app_archive", False),
         access_vm_data=data_section.get("access_vm_data", False),
-        access_all_data=data_section.get("access_all_data", False),
-        access_all_app_data=data_section.get("access_all_app_data", False)
-        or data_section.get("access_all_data", False),
-        access_all_archive=data_section.get("access_all_archive", False) or data_section.get("access_all_data", False),
+        access_all_data=_compat_all_data,
+        access_all_app_data=data_section.get("access_all_app_data", False) or _compat_all_data,
+        access_all_archive=data_section.get("access_all_archive", False) or _compat_all_data,
         provides_services_v2=_parse_services_v2(data),
         consumes_services_v2=_parse_services_v2_consumes(data),
         raw_toml=raw_text,

--- a/compute_space/src/compute_space/core/manifest.py
+++ b/compute_space/src/compute_space/core/manifest.py
@@ -153,8 +153,12 @@ class AppManifest:
     app_temp_data: bool = False
     app_archive: bool = False
     access_vm_data: bool = False
+    # Granular cross-app data flags (preferred):
     access_all_app_data: bool = False
     access_all_archive: bool = False
+    # Convenience flag: equivalent to access_all_app_data + access_all_archive.
+    # Kept for backwards compatibility with existing app manifests.
+    access_all_data: bool = False
 
     # [services.v2]
     provides_services_v2: list[ServiceProvides] = attr.Factory(list)
@@ -371,8 +375,9 @@ def parse_manifest_from_string(raw_text: str) -> AppManifest:
         app_temp_data=data_section.get("app_temp_data", False),
         app_archive=data_section.get("app_archive", False),
         access_vm_data=data_section.get("access_vm_data", False),
-        access_all_app_data=data_section.get("access_all_app_data", False),
-        access_all_archive=data_section.get("access_all_archive", False),
+        access_all_data=data_section.get("access_all_data", False),
+        access_all_app_data=data_section.get("access_all_app_data", False) or data_section.get("access_all_data", False),
+        access_all_archive=data_section.get("access_all_archive", False) or data_section.get("access_all_data", False),
         provides_services_v2=_parse_services_v2(data),
         consumes_services_v2=_parse_services_v2_consumes(data),
         raw_toml=raw_text,

--- a/compute_space/src/compute_space/tests/test_api_archive_backend.py
+++ b/compute_space/src/compute_space/tests/test_api_archive_backend.py
@@ -286,25 +286,22 @@ def test_test_connection_succeeds(client: TestClient[Litestar], cookies: dict[st
 
 def test_manifest_requires_archive_only_matches_app_archive_true() -> None:
     """``manifest_requires_archive`` (install/reload gates) keys on
-    ``app_archive = true`` only; access_all_archive and access_all_data are
-    permissive so they don't block installs on archive-less zones."""
+    ``app_archive = true`` only; access_all_archive is permissive so it
+    doesn't block installs on archive-less zones."""
     assert archive_backend.manifest_requires_archive("[data]\napp_archive = true\n")
-    assert not archive_backend.manifest_requires_archive("[data]\naccess_all_data = true\n")
     assert not archive_backend.manifest_requires_archive("[data]\naccess_all_archive = true\n")
     assert not archive_backend.manifest_requires_archive("[data]\naccess_all_app_data = true\n")
     assert not archive_backend.manifest_requires_archive("[data]\napp_data = true\n")
     assert not archive_backend.manifest_requires_archive("")
     # Anchor on TOML key=value shape so substring matching can't false-match.
     assert not archive_backend.manifest_requires_archive("[data]\napp_archive = false\napp_data = true\n")
-    assert archive_backend.manifest_requires_archive("[data]\napp_archive = true\naccess_all_data = true\n")
+    assert archive_backend.manifest_requires_archive("[data]\napp_archive = true\naccess_all_archive = true\n")
 
 
 def test_manifest_uses_archive_matches_either_flag() -> None:
-    """``manifest_uses_archive`` is broader: any of app_archive, access_all_archive,
-    or the deprecated access_all_data qualify, since all result in the archive mount
-    being granted to the container."""
+    """``manifest_uses_archive`` is broader: app_archive and access_all_archive
+    both qualify, since both result in the archive mount being granted to the container."""
     assert archive_backend.manifest_uses_archive("[data]\napp_archive = true\n")
-    assert archive_backend.manifest_uses_archive("[data]\naccess_all_data = true\n")
     assert archive_backend.manifest_uses_archive("[data]\naccess_all_archive = true\n")
     assert not archive_backend.manifest_uses_archive("[data]\napp_data = true\n")
     assert not archive_backend.manifest_uses_archive("[data]\napp_archive = false\napp_data = true\n")
@@ -315,7 +312,7 @@ def test_manifest_uses_archive_matches_either_flag() -> None:
 # --- install/reload gates (api/apps endpoints' archive backend checks) ----
 
 
-def _archive_manifest(name: str, *, app_archive: bool, access_all_data: bool = False) -> AppManifest:
+def _archive_manifest(name: str, *, app_archive: bool, access_all_archive: bool = False) -> AppManifest:
     return AppManifest(
         name=name,
         version="1.0",
@@ -329,7 +326,7 @@ def _archive_manifest(name: str, *, app_archive: bool, access_all_data: bool = F
         gpu=False,
         app_data=True,
         app_archive=app_archive,
-        access_all_data=access_all_data,
+        access_all_archive=access_all_archive,
         access_vm_data=False,
         app_temp_data=False,
         public_paths=["/"],
@@ -378,10 +375,10 @@ def test_add_app_refuses_archive_app_when_backend_disabled(
     assert "S3" in body["error"] or "system page" in body["error"].lower()
 
 
-def test_add_app_allows_access_all_data_when_backend_disabled(
+def test_add_app_allows_access_all_archive_when_backend_disabled(
     apps_client: TestClient[Litestar], cookies: dict[str, str], tmp_path: Path
 ) -> None:
-    """``access_all_data = true`` (without ``app_archive``) does NOT need a
+    """``access_all_archive = true`` (without ``app_archive``) does NOT need a
     configured archive backend — the app silently goes without the mount."""
     fake_clone_dir = str(tmp_path / "clone-aad")
     os.makedirs(fake_clone_dir)
@@ -389,7 +386,7 @@ def test_add_app_allows_access_all_data_when_backend_disabled(
         mock.patch.object(
             apps_routes,
             "parse_manifest",
-            return_value=_archive_manifest("seer", app_archive=False, access_all_data=True),
+            return_value=_archive_manifest("seer", app_archive=False, access_all_archive=True),
         ),
         mock.patch.object(apps_routes, "validate_manifest", return_value=None),
         mock.patch.object(apps_routes, "insert_and_deploy", return_value="seer"),
@@ -434,10 +431,10 @@ def test_reload_app_refuses_when_archive_unhealthy(
     assert resp.status_code == 503
 
 
-def test_reload_app_allows_access_all_data_when_archive_unhealthy(
+def test_reload_app_allows_access_all_archive_when_archive_unhealthy(
     cfg: Any, apps_client: TestClient[Litestar], cookies: dict[str, str]
 ) -> None:
-    """access_all_data apps can still reload while the archive is unhealthy
+    """access_all_archive apps can still reload while the archive is unhealthy
     — they just see the archive when it's available."""
     seer_id = new_app_id()
     db = sqlite3.connect(cfg.db_path)
@@ -448,7 +445,7 @@ def test_reload_app_allows_access_all_data_when_archive_unhealthy(
         db.execute(
             "INSERT INTO apps (app_id, name, version, repo_path, local_port, status, manifest_raw) "
             "VALUES (?, 'seer', '1.0', '/r/seer', 19603, 'running', "
-            "'[data]\naccess_all_data = true\n')",
+            "'[data]\naccess_all_archive = true\n')",
             (seer_id,),
         )
         db.commit()

--- a/compute_space/src/compute_space/tests/test_api_archive_backend.py
+++ b/compute_space/src/compute_space/tests/test_api_archive_backend.py
@@ -286,10 +286,12 @@ def test_test_connection_succeeds(client: TestClient[Litestar], cookies: dict[st
 
 def test_manifest_requires_archive_only_matches_app_archive_true() -> None:
     """``manifest_requires_archive`` (install/reload gates) keys on
-    ``app_archive = true`` only; ``access_all_data = true`` doesn't qualify
-    so apps like the backup app aren't blocked on archive-less zones."""
+    ``app_archive = true`` only; access_all_archive and access_all_data are
+    permissive so they don't block installs on archive-less zones."""
     assert archive_backend.manifest_requires_archive("[data]\napp_archive = true\n")
     assert not archive_backend.manifest_requires_archive("[data]\naccess_all_data = true\n")
+    assert not archive_backend.manifest_requires_archive("[data]\naccess_all_archive = true\n")
+    assert not archive_backend.manifest_requires_archive("[data]\naccess_all_app_data = true\n")
     assert not archive_backend.manifest_requires_archive("[data]\napp_data = true\n")
     assert not archive_backend.manifest_requires_archive("")
     # Anchor on TOML key=value shape so substring matching can't false-match.
@@ -298,12 +300,16 @@ def test_manifest_requires_archive_only_matches_app_archive_true() -> None:
 
 
 def test_manifest_uses_archive_matches_either_flag() -> None:
-    """``manifest_uses_archive`` is broader: either flag qualifies, since
-    both result in the archive mount being granted to the container."""
+    """``manifest_uses_archive`` is broader: any of app_archive, access_all_archive,
+    or the deprecated access_all_data qualify, since all result in the archive mount
+    being granted to the container."""
     assert archive_backend.manifest_uses_archive("[data]\napp_archive = true\n")
     assert archive_backend.manifest_uses_archive("[data]\naccess_all_data = true\n")
+    assert archive_backend.manifest_uses_archive("[data]\naccess_all_archive = true\n")
     assert not archive_backend.manifest_uses_archive("[data]\napp_data = true\n")
     assert not archive_backend.manifest_uses_archive("[data]\napp_archive = false\napp_data = true\n")
+    # access_all_app_data alone does NOT imply archive access.
+    assert not archive_backend.manifest_uses_archive("[data]\naccess_all_app_data = true\n")
 
 
 # --- install/reload gates (api/apps endpoints' archive backend checks) ----

--- a/compute_space/src/compute_space/tests/test_api_archive_backend.py
+++ b/compute_space/src/compute_space/tests/test_api_archive_backend.py
@@ -307,6 +307,8 @@ def test_manifest_uses_archive_matches_either_flag() -> None:
     assert not archive_backend.manifest_uses_archive("[data]\napp_archive = false\napp_data = true\n")
     # access_all_app_data alone does NOT imply archive access.
     assert not archive_backend.manifest_uses_archive("[data]\naccess_all_app_data = true\n")
+    # access_all_data (backwards-compat alias) DOES imply archive access.
+    assert archive_backend.manifest_uses_archive("[data]\naccess_all_data = true\n")
 
 
 # --- install/reload gates (api/apps endpoints' archive backend checks) ----

--- a/compute_space/src/compute_space/tests/test_app_archive.py
+++ b/compute_space/src/compute_space/tests/test_app_archive.py
@@ -93,15 +93,15 @@ def test_provision_data_skips_archive_when_not_opted_in(tmp_path) -> None:
     assert not (archive_dir / manifest.name).exists()
 
 
-def test_provision_data_archive_subdir_under_access_all_data(tmp_path) -> None:
-    """Under ``access_all_data`` (which grants every tier), provision_data must still create the per-app subdir so the app's files have a stable location inside the archive namespace; the parent bind-mount in the container exposes that subdir at its existing path."""
+def test_provision_data_archive_subdir_under_access_all_archive(tmp_path) -> None:
+    """Under ``access_all_archive``, provision_data must still create the per-app subdir so the app's files have a stable location inside the archive namespace; the parent bind-mount in the container exposes that subdir at its existing path."""
     data_dir = tmp_path / "persistent"
     temp_dir = tmp_path / "temp"
     archive_dir = tmp_path / "archive"
     for d in (data_dir, temp_dir, archive_dir):
         d.mkdir()
 
-    manifest = _manifest(access_all_data=True)
+    manifest = _manifest(access_all_archive=True)
     env = provision_data(
         app_id="archiveapp-id",
         app_name=manifest.name,
@@ -143,15 +143,15 @@ def test_provision_data_refuses_when_archive_dir_missing(tmp_path) -> None:
         )
 
 
-def test_provision_data_skips_archive_for_access_all_data_when_archive_dir_missing(tmp_path) -> None:
-    """``access_all_data`` is permissive: provisioning must not fail when the archive backend is disabled or the mount has dropped, in contrast to ``app_archive = true`` which is a hard requirement."""
+def test_provision_data_skips_archive_for_access_all_archive_when_archive_dir_missing(tmp_path) -> None:
+    """``access_all_archive`` is permissive: provisioning must not fail when the archive backend is disabled or the mount has dropped, in contrast to ``app_archive = true`` which is a hard requirement."""
     data_dir = tmp_path / "persistent"
     temp_dir = tmp_path / "temp"
     archive_dir = tmp_path / "doesnt-exist"
     data_dir.mkdir()
     temp_dir.mkdir()
 
-    manifest = _manifest(access_all_data=True)
+    manifest = _manifest(access_all_archive=True)
     env = provision_data(
         app_id="archiveapp-id",
         app_name=manifest.name,

--- a/compute_space/src/compute_space/tests/test_containers.py
+++ b/compute_space/src/compute_space/tests/test_containers.py
@@ -542,6 +542,89 @@ def test_run_container_access_all_data_skips_archive_mount_when_archive_dir_miss
     assert archive_mounts == [], f"expected no archive mount, got {archive_mounts}"
 
 
+def test_run_container_access_all_archive_mounts_archive_parent(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """``access_all_archive`` mounts the parent ``/data/app_archive`` directory (full archive namespace), analogous to ``access_all_app_data`` for app_data."""
+    manifest = _basic_manifest(access_all_archive=True)
+    argv = _run_and_capture(monkeypatch, manifest=manifest, tmp_path=tmp_path)
+
+    volume_args = [arg for prev, arg in zip(argv, argv[1:], strict=False) if prev == "-v"]
+    targets = [v.rsplit(":", 2)[1] for v in volume_args]
+    assert "/data/app_archive" in targets
+    assert f"/data/app_archive/{manifest.name}" not in targets
+
+
+def test_run_container_access_all_archive_skips_archive_when_missing(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``access_all_archive`` is permissive: no archive mount when JuiceFS not configured."""
+    runs: list[list[str]] = []
+
+    def fake_run(cmd, capture_output=False, text=False, timeout=60, **_):  # type: ignore[no-untyped-def]
+        runs.append(list(cmd))
+        if cmd[:2] == ["podman", "run"]:
+            return _FakeCompleted(0, stdout="container-id-xyz\n")
+        return _FakeCompleted(0)
+
+    _patch_subprocess_run(monkeypatch, fake_run)
+
+    manifest = _basic_manifest(access_all_archive=True)
+    data_dir = str(tmp_path / "persistent")
+    temp_data_dir = str(tmp_path / "temp")
+    archive_dir = str(tmp_path / "archive-not-mounted")
+    os.makedirs(data_dir, exist_ok=True)
+    os.makedirs(temp_data_dir, exist_ok=True)
+    os.makedirs(os.path.join(temp_data_dir, "app_temp_data", manifest.name), exist_ok=True)
+
+    run_container(
+        manifest.name,
+        "openhost-myapp:latest",
+        manifest,
+        local_port=9001,
+        env_vars={},
+        data_dir=data_dir,
+        temp_data_dir=temp_data_dir,
+        archive_dir=archive_dir,
+    )
+    run_cmds = [c for c in runs if c[:2] == ["podman", "run"]]
+    argv = run_cmds[0]
+    volume_args = [arg for prev, arg in zip(argv, argv[1:], strict=False) if prev == "-v"]
+    assert not any("/data/app_archive" in v for v in volume_args)
+
+
+def test_run_container_access_all_app_data_mounts_parent_dirs(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """``access_all_app_data`` mounts the full app_data and app_temp_data parent directories, not just the per-app subdir."""
+    manifest = _basic_manifest(access_all_app_data=True)
+    argv = _run_and_capture(monkeypatch, manifest=manifest, tmp_path=tmp_path)
+
+    volume_args = [arg for prev, arg in zip(argv, argv[1:], strict=False) if prev == "-v"]
+    targets = [v.rsplit(":", 2)[1] for v in volume_args]
+    assert "/data/app_data" in targets
+    assert "/data/app_temp_data" in targets
+    # vm_data must be rw under access_all_app_data.
+    vm_mount = next(v for v in volume_args if v.endswith(":/data/vm_data:idmap"))
+    assert "ro" not in vm_mount.rsplit(":", 1)[1]
+    # No per-app subdir.
+    assert f"/data/app_data/{manifest.name}" not in targets
+
+
+def test_run_container_access_all_app_data_does_not_mount_archive(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """``access_all_app_data`` alone must NOT mount the archive — archive access requires ``access_all_archive`` or ``app_archive``."""
+    manifest = _basic_manifest(access_all_app_data=True)
+    argv = _run_and_capture(monkeypatch, manifest=manifest, tmp_path=tmp_path)
+
+    volume_args = [arg for prev, arg in zip(argv, argv[1:], strict=False) if prev == "-v"]
+    assert not any("/data/app_archive" in v for v in volume_args)
+
+
+def test_run_container_app_data_opt_out(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Apps can explicitly opt out of app_data with ``app_data = false``."""
+    manifest = _basic_manifest(app_data=False)
+    argv = _run_and_capture(monkeypatch, manifest=manifest, tmp_path=tmp_path)
+
+    volume_args = [arg for prev, arg in zip(argv, argv[1:], strict=False) if prev == "-v"]
+    assert not any(f"/data/app_data/{manifest.name}" in v for v in volume_args)
+
+
 def test_run_container_app_archive_env_var_translated_to_container_path(
     tmp_path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/compute_space/src/compute_space/tests/test_containers.py
+++ b/compute_space/src/compute_space/tests/test_containers.py
@@ -427,11 +427,11 @@ def test_run_container_adds_manifest_devices(tmp_path, monkeypatch: pytest.Monke
 
 
 def test_run_container_access_all_data_mounts_parent_dirs(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
-    """With access_all_data, the app sees /data/app_data/ and
+    """With access_all_app_data, the app sees /data/app_data/ and
     /data/app_temp_data/ as whole-namespace parent mounts, not just its
     own subdir.  This is security-sensitive because a typo here would
     expose every app's data to every app; pin the exact mount layout."""
-    manifest = _basic_manifest(access_all_data=True)
+    manifest = _basic_manifest(access_all_app_data=True)
     argv = _run_and_capture(monkeypatch, manifest=manifest, tmp_path=tmp_path)
 
     volume_args = [arg for prev, arg in zip(argv, argv[1:], strict=False) if prev == "-v"]
@@ -444,15 +444,15 @@ def test_run_container_access_all_data_mounts_parent_dirs(tmp_path, monkeypatch:
     targets = [v.rsplit(":", 2)[1] for v in volume_args]
     assert "/data/app_data" in targets
     assert "/data/app_temp_data" in targets
-    # With access_all_data, vm_data is explicitly mounted rw.  Pin this —
+    # With access_all_app_data, vm_data is explicitly mounted rw.  Pin this —
     # silently swapping it to ro would break every app that relies on
     # /data/vm_data as shared scratch space.
     vm_mount = next(v for v in volume_args if v.endswith(":/data/vm_data:idmap"))
-    assert "ro" not in vm_mount.rsplit(":", 1)[1], f"vm_data should be rw under access_all_data, got {vm_mount}"
+    assert "ro" not in vm_mount.rsplit(":", 1)[1], f"vm_data should be rw under access_all_app_data, got {vm_mount}"
 
 
 def test_run_container_access_vm_data_mounts_vm_data_read_only(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
-    """access_vm_data (without access_all_data) grants only a read-only
+    """access_vm_data (without access_all_app_data) grants only a read-only
     view of /data/vm_data.  The distinction matters: this is what lets
     apps read shared state without being able to corrupt it, and a
     regression swapping in rw here would turn a security-critical mount
@@ -491,8 +491,8 @@ def test_run_container_app_archive_off_by_default(tmp_path, monkeypatch: pytest.
 
 
 def test_run_container_access_all_data_mounts_archive_parent(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
-    """``access_all_data`` mounts the parent ``/data/app_archive`` directory (not a single per-app subdir), mirroring how app_data is mounted under access_all_data."""
-    manifest = _basic_manifest(access_all_data=True)
+    """``access_all_archive`` mounts the parent ``/data/app_archive`` directory (not a single per-app subdir)."""
+    manifest = _basic_manifest(access_all_archive=True)
     argv = _run_and_capture(monkeypatch, manifest=manifest, tmp_path=tmp_path)
 
     volume_args = [arg for prev, arg in zip(argv, argv[1:], strict=False) if prev == "-v"]
@@ -504,7 +504,7 @@ def test_run_container_access_all_data_mounts_archive_parent(tmp_path, monkeypat
 def test_run_container_access_all_data_skips_archive_mount_when_archive_dir_missing(
     tmp_path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """``access_all_data`` is permissive: when the archive tier isn't configured or its mount has dropped, the container must still start without the archive bind, otherwise apps like the backup app would be locked out on every archive-less zone."""
+    """``access_all_archive`` is permissive: when the archive tier isn't configured or its mount has dropped, the container must still start without the archive bind."""
     runs: list[list[str]] = []
 
     def fake_run(cmd, capture_output=False, text=False, timeout=60, **_):  # type: ignore[no-untyped-def]
@@ -515,7 +515,7 @@ def test_run_container_access_all_data_skips_archive_mount_when_archive_dir_miss
 
     _patch_subprocess_run(monkeypatch, fake_run)
 
-    manifest = _basic_manifest(access_all_data=True)
+    manifest = _basic_manifest(access_all_archive=True)
     data_dir = str(tmp_path / "persistent")
     temp_data_dir = str(tmp_path / "temp")
     archive_dir = str(tmp_path / "archive-not-mounted")

--- a/compute_space/src/compute_space/tests/test_containers.py
+++ b/compute_space/src/compute_space/tests/test_containers.py
@@ -426,31 +426,6 @@ def test_run_container_adds_manifest_devices(tmp_path, monkeypatch: pytest.Monke
         )
 
 
-def test_run_container_access_all_data_mounts_parent_dirs(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
-    """With access_all_app_data, the app sees /data/app_data/ and
-    /data/app_temp_data/ as whole-namespace parent mounts, not just its
-    own subdir.  This is security-sensitive because a typo here would
-    expose every app's data to every app; pin the exact mount layout."""
-    manifest = _basic_manifest(access_all_app_data=True)
-    argv = _run_and_capture(monkeypatch, manifest=manifest, tmp_path=tmp_path)
-
-    volume_args = [arg for prev, arg in zip(argv, argv[1:], strict=False) if prev == "-v"]
-    # Every mount must be idmap (rw or ro).
-    for v in volume_args:
-        assert v.endswith(":idmap") or v.endswith(":ro,idmap"), v
-
-    # Specifically, the app_data/app_temp_data parent mounts must be the
-    # *parent* directories, not the per-app subdirectories.
-    targets = [v.rsplit(":", 2)[1] for v in volume_args]
-    assert "/data/app_data" in targets
-    assert "/data/app_temp_data" in targets
-    # With access_all_app_data, vm_data is explicitly mounted rw.  Pin this —
-    # silently swapping it to ro would break every app that relies on
-    # /data/vm_data as shared scratch space.
-    vm_mount = next(v for v in volume_args if v.endswith(":/data/vm_data:idmap"))
-    assert "ro" not in vm_mount.rsplit(":", 1)[1], f"vm_data should be rw under access_all_app_data, got {vm_mount}"
-
-
 def test_run_container_access_vm_data_mounts_vm_data_read_only(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
     """access_vm_data (without access_all_app_data) grants only a read-only
     view of /data/vm_data.  The distinction matters: this is what lets
@@ -488,58 +463,6 @@ def test_run_container_app_archive_off_by_default(tmp_path, monkeypatch: pytest.
 
     volume_args = [arg for prev, arg in zip(argv, argv[1:], strict=False) if prev == "-v"]
     assert not any("/data/app_archive" in v for v in volume_args)
-
-
-def test_run_container_access_all_data_mounts_archive_parent(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
-    """``access_all_archive`` mounts the parent ``/data/app_archive`` directory (not a single per-app subdir)."""
-    manifest = _basic_manifest(access_all_archive=True)
-    argv = _run_and_capture(monkeypatch, manifest=manifest, tmp_path=tmp_path)
-
-    volume_args = [arg for prev, arg in zip(argv, argv[1:], strict=False) if prev == "-v"]
-    targets = [v.rsplit(":", 2)[1] for v in volume_args]
-    assert "/data/app_archive" in targets
-    assert f"/data/app_archive/{manifest.name}" not in targets
-
-
-def test_run_container_access_all_data_skips_archive_mount_when_archive_dir_missing(
-    tmp_path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """``access_all_archive`` is permissive: when the archive tier isn't configured or its mount has dropped, the container must still start without the archive bind."""
-    runs: list[list[str]] = []
-
-    def fake_run(cmd, capture_output=False, text=False, timeout=60, **_):  # type: ignore[no-untyped-def]
-        runs.append(list(cmd))
-        if cmd[:2] == ["podman", "run"]:
-            return _FakeCompleted(0, stdout="container-id-xyz\n")
-        return _FakeCompleted(0)
-
-    _patch_subprocess_run(monkeypatch, fake_run)
-
-    manifest = _basic_manifest(access_all_archive=True)
-    data_dir = str(tmp_path / "persistent")
-    temp_data_dir = str(tmp_path / "temp")
-    archive_dir = str(tmp_path / "archive-not-mounted")
-    os.makedirs(data_dir, exist_ok=True)
-    os.makedirs(temp_data_dir, exist_ok=True)
-    os.makedirs(os.path.join(temp_data_dir, "app_temp_data", manifest.name), exist_ok=True)
-
-    run_container(
-        manifest.name,
-        "openhost-myapp:latest",
-        manifest,
-        local_port=9001,
-        env_vars={},
-        data_dir=data_dir,
-        temp_data_dir=temp_data_dir,
-        archive_dir=archive_dir,
-    )
-    run_cmds = [c for c in runs if c[:2] == ["podman", "run"]]
-    assert len(run_cmds) == 1
-    argv = run_cmds[0]
-
-    volume_args = [arg for prev, arg in zip(argv, argv[1:], strict=False) if prev == "-v"]
-    archive_mounts = [v for v in volume_args if "/data/app_archive" in v]
-    assert archive_mounts == [], f"expected no archive mount, got {archive_mounts}"
 
 
 def test_run_container_access_all_archive_mounts_archive_parent(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/compute_space/src/compute_space/tests/test_manifest.py
+++ b/compute_space/src/compute_space/tests/test_manifest.py
@@ -45,13 +45,15 @@ class TestDefaults:
         manifest = parse_manifest_from_string(MINIMAL)
         assert manifest.hidden is False
 
-    def test_data_flags_default_to_false(self):
+    def test_data_flags_defaults(self):
         manifest = parse_manifest_from_string(MINIMAL)
-        assert manifest.app_data is False
+        assert manifest.app_data is True  # default on
         assert manifest.app_temp_data is False
         assert manifest.app_archive is False
         assert manifest.access_vm_data is False
-        assert manifest.access_all_data is False
+        assert manifest.access_all_app_data is False
+        assert manifest.access_all_archive is False
+        assert manifest.access_all_data is False  # deprecated alias still False by default
 
     def test_sqlite_default_empty(self):
         manifest = parse_manifest_from_string(MINIMAL)
@@ -665,6 +667,27 @@ class TestAppArchive:
         manifest = parse_manifest_from_string(toml)
         assert manifest.app_archive is True
         assert manifest.access_all_data is True
+
+    def test_access_all_app_data_parsed(self):
+        toml = MINIMAL + "\n[data]\naccess_all_app_data = true\n"
+        manifest = parse_manifest_from_string(toml)
+        assert manifest.access_all_app_data is True
+        assert manifest.access_all_archive is False
+
+    def test_access_all_archive_parsed(self):
+        toml = MINIMAL + "\n[data]\naccess_all_archive = true\n"
+        manifest = parse_manifest_from_string(toml)
+        assert manifest.access_all_archive is True
+        assert manifest.access_all_app_data is False
+
+    def test_app_data_opt_out(self):
+        toml = MINIMAL + "\n[data]\napp_data = false\n"
+        manifest = parse_manifest_from_string(toml)
+        assert manifest.app_data is False
+
+    def test_app_data_default_true(self):
+        manifest = parse_manifest_from_string(MINIMAL)
+        assert manifest.app_data is True
 
 
 class TestShmMb:

--- a/compute_space/src/compute_space/tests/test_manifest.py
+++ b/compute_space/src/compute_space/tests/test_manifest.py
@@ -53,7 +53,6 @@ class TestDefaults:
         assert manifest.access_vm_data is False
         assert manifest.access_all_app_data is False
         assert manifest.access_all_archive is False
-        assert manifest.access_all_data is False  # deprecated alias still False by default
 
     def test_sqlite_default_empty(self):
         manifest = parse_manifest_from_string(MINIMAL)
@@ -661,12 +660,6 @@ class TestAppArchive:
         toml = MINIMAL + "\n[data]\napp_archive = true\n"
         manifest = parse_manifest_from_string(toml)
         assert manifest.app_archive is True
-
-    def test_app_archive_with_access_all_data(self):
-        toml = MINIMAL + "\n[data]\naccess_all_data = true\napp_archive = true\n"
-        manifest = parse_manifest_from_string(toml)
-        assert manifest.app_archive is True
-        assert manifest.access_all_data is True
 
     def test_access_all_app_data_parsed(self):
         toml = MINIMAL + "\n[data]\naccess_all_app_data = true\n"

--- a/compute_space/src/compute_space/tests/test_manifest.py
+++ b/compute_space/src/compute_space/tests/test_manifest.py
@@ -53,6 +53,7 @@ class TestDefaults:
         assert manifest.access_vm_data is False
         assert manifest.access_all_app_data is False
         assert manifest.access_all_archive is False
+        assert manifest.access_all_data is False
 
     def test_sqlite_default_empty(self):
         manifest = parse_manifest_from_string(MINIMAL)
@@ -672,6 +673,26 @@ class TestAppArchive:
         manifest = parse_manifest_from_string(toml)
         assert manifest.access_all_archive is True
         assert manifest.access_all_app_data is False
+
+    def test_access_all_data_implies_both_granular_flags(self):
+        """access_all_data = true must set both access_all_app_data and access_all_archive."""
+        toml = MINIMAL + "\n[data]\naccess_all_data = true\n"
+        manifest = parse_manifest_from_string(toml)
+        assert manifest.access_all_data is True
+        assert manifest.access_all_app_data is True
+        assert manifest.access_all_archive is True
+
+    def test_access_all_data_false_by_default(self):
+        manifest = parse_manifest_from_string(MINIMAL)
+        assert manifest.access_all_data is False
+
+    def test_access_all_data_does_not_override_granular_false(self):
+        """When access_all_data is false, granular flags retain their own values."""
+        toml = MINIMAL + "\n[data]\naccess_all_data = false\naccess_all_app_data = true\n"
+        manifest = parse_manifest_from_string(toml)
+        assert manifest.access_all_data is False
+        assert manifest.access_all_app_data is True
+        assert manifest.access_all_archive is False
 
     def test_app_data_opt_out(self):
         toml = MINIMAL + "\n[data]\napp_data = false\n"

--- a/compute_space/src/compute_space/tests/test_rename_app.py
+++ b/compute_space/src/compute_space/tests/test_rename_app.py
@@ -266,7 +266,7 @@ def test_rename_rollback_continues_when_a_rollback_rename_itself_fails(cfg_facto
 
 def test_rename_non_archive_app_works_with_disabled_backend(cfg_factory: Any) -> None:
     """An app that doesn't use the archive tier (no app_archive, no
-    access_all_data) must rename successfully on a fresh zone where the
+    access_all_archive) must rename successfully on a fresh zone where the
     archive backend is the default 'disabled'.  Pre-fix, the gate
     blocked all renames whenever the backend was unhealthy."""
     cfg = cfg_factory(20305)

--- a/compute_space/src/compute_space/web/templates/add_app.html
+++ b/compute_space/src/compute_space/web/templates/add_app.html
@@ -169,9 +169,9 @@ function renderManifest(m, url) {
     row('SQLite databases', m.sqlite_dbs.map(esc).join(', '));
   }
 
-  const wantsAllAppData = m.access_all_app_data || m.access_all_data;
-  const wantsAllArchive = m.access_all_archive || m.access_all_data;
-  const hasFs = m.app_data || m.app_temp_data || m.access_vm_data || m.access_all_data || m.access_all_app_data || m.access_all_archive || m.app_archive || m.sqlite_dbs.length;
+  const wantsAllAppData = m.access_all_app_data;
+  const wantsAllArchive = m.access_all_archive;
+  const hasFs = m.app_data || m.app_temp_data || m.access_vm_data || m.access_all_app_data || m.access_all_archive || m.app_archive || m.sqlite_dbs.length;
   if (hasFs) {
     section('Filesystem Permissions', '#fff3cd');
     if (wantsAllAppData) {

--- a/compute_space/src/compute_space/web/templates/add_app.html
+++ b/compute_space/src/compute_space/web/templates/add_app.html
@@ -169,23 +169,28 @@ function renderManifest(m, url) {
     row('SQLite databases', m.sqlite_dbs.map(esc).join(', '));
   }
 
+  const wantsAllData = m.access_all_data;
   const wantsAllAppData = m.access_all_app_data;
   const wantsAllArchive = m.access_all_archive;
-  const hasFs = m.app_data || m.app_temp_data || m.access_vm_data || m.access_all_app_data || m.access_all_archive || m.app_archive || m.sqlite_dbs.length;
+  const hasFs = m.app_data || m.app_temp_data || m.access_vm_data || m.access_all_data || m.access_all_app_data || m.access_all_archive || m.app_archive || m.sqlite_dbs.length;
   if (hasFs) {
     section('Filesystem Permissions', '#fff3cd');
-    if (wantsAllAppData) {
-      row('Full app data access', 'Read/write to ALL apps\u2019 permanent data, temporary data, and VM data (rw)');
+    if (wantsAllData) {
+      row('Full data access', 'Read/write to ALL apps\u2019 permanent data, temporary data, VM data, and archive data (rw)');
     } else {
-      if (m.app_data || m.sqlite_dbs.length)
-        row('Permanent data', "Read/write to app's own permanent data directory");
-      if (m.app_temp_data) row('Temporary data', "Read/write to app's own temporary data directory");
-      if (m.access_vm_data) row('VM data', 'Read-only access to VM shared data');
-    }
-    if (wantsAllArchive) {
-      row('Full archive access', 'Read/write to ALL apps\u2019 archive data (when S3 backend is configured)');
-    } else if (m.app_archive) {
-      row('Archive data', "Read/write to app's own archive directory (requires S3 backend)");
+      if (wantsAllAppData) {
+        row('Full app data access', 'Read/write to ALL apps\u2019 permanent data, temporary data, and VM data (rw)');
+      } else {
+        if (m.app_data || m.sqlite_dbs.length)
+          row('Permanent data', "Read/write to app's own permanent data directory");
+        if (m.app_temp_data) row('Temporary data', "Read/write to app's own temporary data directory");
+        if (m.access_vm_data) row('VM data', 'Read-only access to VM shared data');
+      }
+      if (wantsAllArchive) {
+        row('Full archive access', 'Read/write to ALL apps\u2019 archive data (when S3 backend is configured)');
+      } else if (m.app_archive) {
+        row('Archive data', "Read/write to app's own archive directory (requires S3 backend)");
+      }
     }
   }
 

--- a/compute_space/src/compute_space/web/templates/add_app.html
+++ b/compute_space/src/compute_space/web/templates/add_app.html
@@ -169,16 +169,23 @@ function renderManifest(m, url) {
     row('SQLite databases', m.sqlite_dbs.map(esc).join(', '));
   }
 
-  const hasFs = m.app_data || m.app_temp_data || m.access_vm_data || m.access_all_data || m.sqlite_dbs.length;
+  const wantsAllAppData = m.access_all_app_data || m.access_all_data;
+  const wantsAllArchive = m.access_all_archive || m.access_all_data;
+  const hasFs = m.app_data || m.app_temp_data || m.access_vm_data || m.access_all_data || m.access_all_app_data || m.access_all_archive || m.app_archive || m.sqlite_dbs.length;
   if (hasFs) {
     section('Filesystem Permissions', '#fff3cd');
-    if (m.access_all_data) {
-      row('Full data access', 'Read/write to all permanent data, temporary data, and VM data');
+    if (wantsAllAppData) {
+      row('Full app data access', 'Read/write to ALL apps\u2019 permanent data, temporary data, and VM data (rw)');
     } else {
       if (m.app_data || m.sqlite_dbs.length)
         row('Permanent data', "Read/write to app's own permanent data directory");
       if (m.app_temp_data) row('Temporary data', "Read/write to app's own temporary data directory");
       if (m.access_vm_data) row('VM data', 'Read-only access to VM shared data');
+    }
+    if (wantsAllArchive) {
+      row('Full archive access', 'Read/write to ALL apps\u2019 archive data (when S3 backend is configured)');
+    } else if (m.app_archive) {
+      row('Archive data', "Read/write to app's own archive directory (requires S3 backend)");
     }
   }
 

--- a/docs/src/creating_an_app.md
+++ b/docs/src/creating_an_app.md
@@ -127,7 +127,7 @@ Apps receive a persistent data directory by default. You can opt out or request 
 - **`access_vm_data = true`** — read-only access to the VM's shared data at `/data/vm_data/`.
 - **`access_all_app_data = true`** — full rw access to all apps' persistent and temp data parent directories, plus rw vm_data. For admin tools like file browsers.
 - **`access_all_archive = true`** — full access to all apps' archive parent directory. Permissive: silently skipped when JuiceFS is not configured. For backup tools.
-- **`access_all_data = true`** — deprecated alias for `access_all_app_data = true` + `access_all_archive = true`. Still fully supported; prefer the granular flags in new manifests.
+- **`access_all_data = true`** — convenience shorthand for `access_all_app_data = true` + `access_all_archive = true`.
 
 
 The host operator can optionally set `storage_min_free_mb` in the OpenHost config to require a minimum amount of free persistent storage. When free space drops below this threshold, running apps are stopped until space is freed. The storage guard can be temporarily paused from the System page to allow starting a file-browser app for cleanup.

--- a/docs/src/creating_an_app.md
+++ b/docs/src/creating_an_app.md
@@ -127,6 +127,7 @@ Apps receive a persistent data directory by default. You can opt out or request 
 - **`access_vm_data = true`** — read-only access to the VM's shared data at `/data/vm_data/`.
 - **`access_all_app_data = true`** — full rw access to all apps' persistent and temp data parent directories, plus rw vm_data. For admin tools like file browsers.
 - **`access_all_archive = true`** — full access to all apps' archive parent directory. Permissive: silently skipped when JuiceFS is not configured. For backup tools.
+- **`access_all_data = true`** — deprecated alias for `access_all_app_data = true` + `access_all_archive = true`. Still fully supported; prefer the granular flags in new manifests.
 
 
 The host operator can optionally set `storage_min_free_mb` in the OpenHost config to require a minimum amount of free persistent storage. When free space drops below this threshold, running apps are stopped until space is freed. The storage guard can be temporarily paused from the System page to allow starting a file-browser app for cleanup.

--- a/docs/src/creating_an_app.md
+++ b/docs/src/creating_an_app.md
@@ -127,7 +127,7 @@ Apps receive a persistent data directory by default. You can opt out or request 
 - **`access_vm_data = true`** — read-only access to the VM's shared data at `/data/vm_data/`.
 - **`access_all_app_data = true`** — full rw access to all apps' persistent and temp data parent directories, plus rw vm_data. For admin tools like file browsers.
 - **`access_all_archive = true`** — full access to all apps' archive parent directory. Permissive: silently skipped when JuiceFS is not configured. For backup tools.
-- **`access_all_data = true`** — **Deprecated.** Equivalent to `access_all_app_data = true` + `access_all_archive = true`.
+
 
 The host operator can optionally set `storage_min_free_mb` in the OpenHost config to require a minimum amount of free persistent storage. When free space drops below this threshold, running apps are stopped until space is freed. The storage guard can be temporarily paused from the System page to allow starting a file-browser app for cleanup.
 

--- a/docs/src/creating_an_app.md
+++ b/docs/src/creating_an_app.md
@@ -111,20 +111,23 @@ The router injects these environment variables into your app:
 | `OPENHOST_ROUTER_URL` | `http://host.containers.internal:8080` | internal URL of the router, used for constructing service requests. |
 | `OPENHOST_ZONE_DOMAIN` | `user.host.imbue.com` | The compute space's domain                                                                                      |
 | `OPENHOST_MY_REDIRECT_DOMAIN` | `my.selfhost.imbue.com` | The shared `my.*` OAuth redirect domain. This hosts a browser-local page that redirects the user to their zone. |
-| `OPENHOST_APP_DATA_DIR` | `/data/app_data/my-app` | Path to the app's persistent data directory. Set when `app_data`, `sqlite`, or `access_all_data` is requested   |
-| `OPENHOST_APP_TEMP_DIR` | `/data/app_temp_data/my-app` | Path to the app's temporary data directory. Set when `app_temp_data` or `access_all_data` is requested          |
+| `OPENHOST_APP_DATA_DIR` | `/data/app_data/my-app` | Path to the app's persistent data directory. Set when `app_data` (default on), `sqlite`, or `access_all_app_data` is requested   |
+| `OPENHOST_APP_TEMP_DIR` | `/data/app_temp_data/my-app` | Path to the app's temporary data directory. Set when `app_temp_data` or `access_all_app_data` is requested          |
 | `OPENHOST_SQLITE_<NAME>` | `/data/app_data/my-app/sqlite/main.db` (for `sqlite = ["main"]`) | Path to a provisioned SQLite database file. Set once per entry in `sqlite`                                      |
 | `OPENHOST_OWNER_USERNAME` | `alice` | The compute space owner's chosen display name. Use to seed SSO account names. Defaults to `owner` if not explicitly configured. |
 
 ### Data storage
 
-Apps have no filesystem access by default. Request what you need in the `[data]` section of your manifest:
+Apps receive a persistent data directory by default. You can opt out or request additional storage in the `[data]` section of your manifest:
 
+- **`app_data = true`** (default) — mounts a persistent directory at `/data/app_data/{app_name}/`. Backed up. Set `false` to opt out.
 - **`sqlite = ["db_name"]`** — Provisions a SQLite database. Access the file at `OPENHOST_SQLITE_<NAME>`.
-- **`app_data = true`** — mounts a persistent directory at `/data/app_data/{app_name}/`. Backed up.
 - **`app_temp_data = true`** — mounts a temporary directory at `/data/app_temp_data/{app_name}/`. Not backed up, can be recreated.
+- **`app_archive = true`** — mounts an elastic archive directory at `/data/app_archive/{app_name}/`. S3-backed via JuiceFS. Requires the operator to configure the archive backend first.
 - **`access_vm_data = true`** — read-only access to the VM's shared data at `/data/vm_data/`.
-- **`access_all_data = true`** — full access to all data directories (all apps' data + VM data).
+- **`access_all_app_data = true`** — full rw access to all apps' persistent and temp data parent directories, plus rw vm_data. For admin tools like file browsers.
+- **`access_all_archive = true`** — full access to all apps' archive parent directory. Permissive: silently skipped when JuiceFS is not configured. For backup tools.
+- **`access_all_data = true`** — **Deprecated.** Equivalent to `access_all_app_data = true` + `access_all_archive = true`.
 
 The host operator can optionally set `storage_min_free_mb` in the OpenHost config to require a minimum amount of free persistent storage. When free space drops below this threshold, running apps are stopped until space is freed. The storage guard can be temporarily paused from the System page to allow starting a file-browser app for cleanup.
 

--- a/docs/src/manifest_spec.md
+++ b/docs/src/manifest_spec.md
@@ -55,16 +55,18 @@ Rootless podman can bind ports >= 25 only; `host_port` values below 25 are rejec
 
 | Field | Type | Required | Default | Description |
 |-------|------|----------|---------|-------------|
-| `app_data` | boolean | no | false | Request access to permanent filesystem directory (backed up) |
+| `app_data` | boolean | no | **true** | Request access to permanent filesystem directory (backed up). Set `false` to explicitly opt out. |
 | `app_temp_data` | boolean | no | false | Request access to temporary filesystem directory (not backed up) |
 | `app_archive` | boolean | no | false | Request access to the elastic archive directory for bulk content. Backed by S3 (via JuiceFS) once the operator configures it from the dashboard; apps with this flag won't install until S3 is configured. |
 | `sqlite` | string[] | no | [] | SQLite database names to provision (implicitly enables `app_data`) |
-| `access_vm_data` | boolean | no | false | Whether the app can access the VM's shared data directory |
-| `access_all_data` | boolean | no | false | Full access to permanent data, temp data, archive, and vm data |
+| `access_vm_data` | boolean | no | false | Whether the app can access the VM's shared data directory (read-only) |
+| `access_all_app_data` | boolean | no | false | Mount all apps' permanent data and temp data parent directories (rw). Also grants rw access to vm_data. For admin tools like file browsers. |
+| `access_all_archive` | boolean | no | false | Mount all apps' archive parent directory. Permissive: silently skipped when JuiceFS is not configured. For backup tools. |
+| `access_all_data` | boolean | no | false | **Deprecated.** Equivalent to `access_all_app_data = true` + `access_all_archive = true`. |
 
 ## Data Directory Structure
 
-Apps have three storage areas, each with different durability + size + latency tradeoffs. **By default, apps have no filesystem access.** Each must be explicitly requested:
+Apps have three storage areas, each with different durability + size + latency tradeoffs. **By default, apps receive a permanent data directory (`app_data`).** Other tiers must be explicitly requested:
 
 - **Permanent data** (`/data/app_data/{app_name}/`) — local disk. Small, fast, backed up. Enabled by `app_data = true` or by requesting `sqlite` entries. **SQLite databases must live here**, not in `app_archive`: the archive tier may be backed by a network FS with close-to-open consistency that corrupts SQLite WAL.
 - **Temporary data** (`/data/app_temp_data/{app_name}/`) — local disk scratch. Not backed up, recreatable. Enabled by `app_temp_data = true`.
@@ -75,7 +77,7 @@ The archive tier is disabled by default. The operator configures it one-shot fro
 
 The host operator can optionally set `storage_min_free_mb` in the OpenHost config to require a minimum amount of free disk space. When free space drops below this threshold, the storage guard stops running apps until space is freed.
 
-All data dirs live under `/data/` in the container. All apps see the same path structure regardless of permissions — only the dirs they have access to are mounted. With `access_all_data`, the parent dirs are mounted instead (`/data/app_data/`, `/data/app_temp_data/`, `/data/app_archive/`) so the app can see all apps' data.
+All data dirs live under `/data/` in the container. All apps see the same path structure regardless of permissions — only the dirs they have access to are mounted. With `access_all_app_data`, the parent dirs `/data/app_data/` and `/data/app_temp_data/` are mounted so the app can see all apps' data. With `access_all_archive`, the `/data/app_archive/` parent is mounted. The deprecated `access_all_data` is equivalent to both flags combined.
 
 ## Environment Variable Injection
 
@@ -170,5 +172,6 @@ port = 5000
 command = "/data -A"
 
 [data]
-access_all_data = true
+access_all_app_data = true
+access_all_archive = true
 ```

--- a/docs/src/manifest_spec.md
+++ b/docs/src/manifest_spec.md
@@ -62,6 +62,7 @@ Rootless podman can bind ports >= 25 only; `host_port` values below 25 are rejec
 | `access_vm_data` | boolean | no | false | Whether the app can access the VM's shared data directory (read-only) |
 | `access_all_app_data` | boolean | no | false | Mount all apps' permanent data and temp data parent directories (rw). Also grants rw access to vm_data. For admin tools like file browsers. |
 | `access_all_archive` | boolean | no | false | Mount all apps' archive parent directory. Permissive: silently skipped when JuiceFS is not configured. For backup tools. |
+| `access_all_data` | boolean | no | false | Deprecated alias for `access_all_app_data = true` + `access_all_archive = true`. Still fully supported; prefer the granular flags in new manifests. |
 
 
 ## Data Directory Structure

--- a/docs/src/manifest_spec.md
+++ b/docs/src/manifest_spec.md
@@ -62,7 +62,7 @@ Rootless podman can bind ports >= 25 only; `host_port` values below 25 are rejec
 | `access_vm_data` | boolean | no | false | Whether the app can access the VM's shared data directory (read-only) |
 | `access_all_app_data` | boolean | no | false | Mount all apps' permanent data and temp data parent directories (rw). Also grants rw access to vm_data. For admin tools like file browsers. |
 | `access_all_archive` | boolean | no | false | Mount all apps' archive parent directory. Permissive: silently skipped when JuiceFS is not configured. For backup tools. |
-| `access_all_data` | boolean | no | false | Deprecated alias for `access_all_app_data = true` + `access_all_archive = true`. Still fully supported; prefer the granular flags in new manifests. |
+| `access_all_data` | boolean | no | false | Convenience shorthand for `access_all_app_data = true` + `access_all_archive = true`. |
 
 
 ## Data Directory Structure

--- a/docs/src/manifest_spec.md
+++ b/docs/src/manifest_spec.md
@@ -62,7 +62,7 @@ Rootless podman can bind ports >= 25 only; `host_port` values below 25 are rejec
 | `access_vm_data` | boolean | no | false | Whether the app can access the VM's shared data directory (read-only) |
 | `access_all_app_data` | boolean | no | false | Mount all apps' permanent data and temp data parent directories (rw). Also grants rw access to vm_data. For admin tools like file browsers. |
 | `access_all_archive` | boolean | no | false | Mount all apps' archive parent directory. Permissive: silently skipped when JuiceFS is not configured. For backup tools. |
-| `access_all_data` | boolean | no | false | **Deprecated.** Equivalent to `access_all_app_data = true` + `access_all_archive = true`. |
+
 
 ## Data Directory Structure
 
@@ -77,7 +77,7 @@ The archive tier is disabled by default. The operator configures it one-shot fro
 
 The host operator can optionally set `storage_min_free_mb` in the OpenHost config to require a minimum amount of free disk space. When free space drops below this threshold, the storage guard stops running apps until space is freed.
 
-All data dirs live under `/data/` in the container. All apps see the same path structure regardless of permissions — only the dirs they have access to are mounted. With `access_all_app_data`, the parent dirs `/data/app_data/` and `/data/app_temp_data/` are mounted so the app can see all apps' data. With `access_all_archive`, the `/data/app_archive/` parent is mounted. The deprecated `access_all_data` is equivalent to both flags combined.
+All data dirs live under `/data/` in the container. All apps see the same path structure regardless of permissions — only the dirs they have access to are mounted. With `access_all_app_data`, the parent dirs `/data/app_data/` and `/data/app_temp_data/` are mounted so the app can see all apps' data. With `access_all_archive`, the `/data/app_archive/` parent is mounted.
 
 ## Environment Variable Injection
 


### PR DESCRIPTION
Add access_all_app_data and access_all_archive as granular flags. Restore access_all_data as a first-class convenience flag that implies both. app_data defaults to true.

access_all_app_data mounts all apps permanent and temp data dirs (rw) plus rw vm_data.
access_all_archive mounts all apps archive parent dir, permissive (skips if JuiceFS not configured).
access_all_data implies both access_all_app_data and access_all_archive, preserving backwards compatibility.
app_data defaults true; opt out with app_data = false.
manifest_uses_archive now checks access_all_archive and access_all_data, fixing the uninstall block when JuiceFS is configured but unmounted for apps that only need access_all_app_data.
file_browser uses access_all_data = true.
Consent UI updated to show correct permissions for all flags.
527 tests passing, new tests for access_all_data semantics.