### PR TITLE
Expose openhost+app git branch/SHA via API and oh CLI

### DIFF
--- a/compute_space/src/compute_space/core/git_ops.py
+++ b/compute_space/src/compute_space/core/git_ops.py
@@ -65,6 +65,22 @@ def get_current_ref(repo_path: Path) -> str:
         return repo.head.commit.hexsha[:8]
 
 
+@async_wrap
+def get_head_sha(repo_path: Path) -> str:
+    """Return the full HEAD commit SHA."""
+    return git.Repo(repo_path).head.commit.hexsha
+
+
+@async_wrap
+def get_branch_name(repo_path: Path) -> str | None:
+    """Return the current branch name, or None if HEAD is detached."""
+    repo = git.Repo(repo_path)
+    try:
+        return repo.active_branch.name
+    except TypeError:
+        return None
+
+
 def _strip_credentials(url: str) -> str:
     """Remove userinfo (OAuth tokens, passwords) from a URL."""
     parsed = urllib.parse.urlparse(url)

--- a/compute_space/src/compute_space/web/routes/api/apps.py
+++ b/compute_space/src/compute_space/web/routes/api/apps.py
@@ -386,9 +386,7 @@ async def _read_app_git_info(repo_path: str | None) -> tuple[str | None, str | N
 async def app_status(app_id: str, db: sqlite3.Connection) -> Response[AppStatusResponse] | Response[ErrorResponse]:
     if not is_valid_app_id(app_id):
         return Response(content=ErrorResponse(error="Invalid app_id"), status_code=400)
-    app_row = db.execute(
-        "SELECT status, error_message, repo_path FROM apps WHERE app_id = ?", (app_id,)
-    ).fetchone()
+    app_row = db.execute("SELECT status, error_message, repo_path FROM apps WHERE app_id = ?", (app_id,)).fetchone()
     if not app_row:
         return Response(content=ErrorResponse(error="not found"), status_code=404)
     error_msg = app_row["error_message"]

--- a/compute_space/src/compute_space/web/routes/api/apps.py
+++ b/compute_space/src/compute_space/web/routes/api/apps.py
@@ -3,6 +3,7 @@ import os
 import re
 import shutil
 import sqlite3
+from pathlib import Path
 from threading import Thread
 from typing import Annotated
 from typing import Any
@@ -35,6 +36,9 @@ from compute_space.core.containers import BUILD_CACHE_CORRUPT_MARKER
 from compute_space.core.containers import get_docker_logs
 from compute_space.core.containers import stop_app_process
 from compute_space.core.containers import stop_container
+from compute_space.core.git_ops import get_branch_name
+from compute_space.core.git_ops import get_head_sha
+from compute_space.core.git_ops import is_dirty
 from compute_space.core.logging import logger
 from compute_space.core.manifest import parse_manifest
 from compute_space.core.oauth import OAuthAuthorizationRequired
@@ -122,6 +126,13 @@ class AppStatusResponse:
     status: str
     error: str | None
     error_kind: str | None
+    # Git info for the app's checked-out repo. All None when the app has no
+    # git repo on disk (e.g. builtin apps copied from the apps/ directory)
+    # or when the .git read fails for any reason. ``git_branch`` is None when
+    # HEAD is detached even if ``git_sha`` is populated.
+    git_branch: str | None = None
+    git_sha: str | None = None
+    git_dirty: bool | None = None
 
 
 @attr.s(auto_attribs=True, frozen=True)
@@ -355,11 +366,29 @@ async def api_apps(db: sqlite3.Connection) -> list[AppSummary]:
     ]
 
 
+async def _read_app_git_info(repo_path: str | None) -> tuple[str | None, str | None, bool | None]:
+    """Return (branch, sha, dirty) for an app's repo, or (None, None, None) on any error."""
+    if not repo_path:
+        return None, None, None
+    path = Path(repo_path)
+    if not (path / ".git").exists():
+        return None, None, None
+    try:
+        branch = await get_branch_name(path)
+        sha = await get_head_sha(path)
+        dirty = await is_dirty(path)
+    except Exception:
+        return None, None, None
+    return branch, sha, dirty
+
+
 @get("/api/app_status/{app_id:str}", guards=[require_owner_auth])
 async def app_status(app_id: str, db: sqlite3.Connection) -> Response[AppStatusResponse] | Response[ErrorResponse]:
     if not is_valid_app_id(app_id):
         return Response(content=ErrorResponse(error="Invalid app_id"), status_code=400)
-    app_row = db.execute("SELECT status, error_message FROM apps WHERE app_id = ?", (app_id,)).fetchone()
+    app_row = db.execute(
+        "SELECT status, error_message, repo_path FROM apps WHERE app_id = ?", (app_id,)
+    ).fetchone()
     if not app_row:
         return Response(content=ErrorResponse(error="not found"), status_code=404)
     error_msg = app_row["error_message"]
@@ -370,8 +399,16 @@ async def app_status(app_id: str, db: sqlite3.Connection) -> Response[AppStatusR
     if error_msg and (BUILD_CACHE_CORRUPT_MARKER in error_msg or "[CACHE_CORRUPT]" in error_msg):
         error_kind = "build_cache_corrupt"
         error_msg = "Container build cache is corrupted."
+    git_branch, git_sha, git_dirty = await _read_app_git_info(app_row["repo_path"])
     return Response(
-        content=AppStatusResponse(status=app_row["status"], error=error_msg, error_kind=error_kind),
+        content=AppStatusResponse(
+            status=app_row["status"],
+            error=error_msg,
+            error_kind=error_kind,
+            git_branch=git_branch,
+            git_sha=git_sha,
+            git_dirty=git_dirty,
+        ),
         status_code=200,
         media_type=MediaType.JSON,
     )

--- a/compute_space/src/compute_space/web/routes/api/system.py
+++ b/compute_space/src/compute_space/web/routes/api/system.py
@@ -14,6 +14,7 @@ from litestar import delete
 from litestar import get
 from litestar import post
 
+from compute_space import OPENHOST_PROJECT_DIR
 from compute_space.config import Config
 from compute_space.core.auth.security_audit import AuditResult
 from compute_space.core.auth.security_audit import ListeningPort
@@ -21,6 +22,9 @@ from compute_space.core.auth.security_audit import is_sshd_active
 from compute_space.core.auth.security_audit import list_listening_ports
 from compute_space.core.auth.security_audit import run_audit
 from compute_space.core.containers import drop_docker_build_cache
+from compute_space.core.git_ops import get_branch_name
+from compute_space.core.git_ops import get_head_sha
+from compute_space.core.git_ops import is_dirty
 from compute_space.core.logging import get_log_path
 from compute_space.core.storage import is_guard_paused
 from compute_space.core.storage import set_guard_paused
@@ -104,6 +108,17 @@ class SshStatusResponse:
 class DropCacheOk:
     ok: bool  # always True
     output: str
+
+
+@attr.s(auto_attribs=True, frozen=True)
+class VersionInfo:
+    """Git info for the running openhost checkout. ``branch`` is None when HEAD is detached.
+    ``sha`` is empty when the install isn't a git checkout (e.g. tarball deploys)."""
+
+    branch: str | None
+    sha: str
+    short_sha: str
+    dirty: bool
 
 
 # ─── API Tokens ────────────────────────────────────────────────────────────
@@ -260,6 +275,21 @@ def drop_docker_cache() -> Response[DropCacheOk] | Response[ErrorResponse]:
     return Response(content=DropCacheOk(ok=True, output=output), status_code=200, media_type=MediaType.JSON)
 
 
+@get("/api/version", guards=[require_owner_auth])
+async def api_version() -> VersionInfo:
+    """Return git branch/SHA of the running openhost checkout.
+
+    If openhost wasn't installed via git, sha/short_sha are empty and dirty is False.
+    """
+    try:
+        sha = await get_head_sha(OPENHOST_PROJECT_DIR)
+        branch = await get_branch_name(OPENHOST_PROJECT_DIR)
+        dirty = await is_dirty(OPENHOST_PROJECT_DIR)
+    except Exception:
+        return VersionInfo(branch=None, sha="", short_sha="", dirty=False)
+    return VersionInfo(branch=branch, sha=sha, short_sha=sha[:8], dirty=dirty)
+
+
 @post("/restart_router", status_code=200, guards=[require_owner_auth], sync_to_thread=False)
 def restart_router() -> OkResponse:
     """Restart the router systemd service to pick up code changes."""
@@ -291,6 +321,7 @@ system_routes = Router(
         ssh_status,
         toggle_ssh,
         drop_docker_cache,
+        api_version,
         restart_router,
     ],
 )

--- a/compute_space_cli/src/compute_space_cli/main.py
+++ b/compute_space_cli/src/compute_space_cli/main.py
@@ -145,7 +145,7 @@ class AppCmd:
         if sha:
             branch = result.get("git_branch") or "(detached HEAD)"
             dirty = " (dirty)" if result.get("git_dirty") else ""
-            print(f"  git: {branch} @ {sha[:8]}{dirty}")
+            print(f"  git: {branch} @ {sha}{dirty}")
 
     @cappa.command(name="logs")
     def logs(

--- a/compute_space_cli/src/compute_space_cli/main.py
+++ b/compute_space_cli/src/compute_space_cli/main.py
@@ -141,6 +141,11 @@ class AppCmd:
         print(f"{app_name}: {result.get('status', 'unknown')}")
         if result.get("error"):
             print(f"  error: {result['error']}")
+        sha = result.get("git_sha")
+        if sha:
+            branch = result.get("git_branch") or "(detached HEAD)"
+            dirty = " (dirty)" if result.get("git_dirty") else ""
+            print(f"  git: {branch} @ {sha[:8]}{dirty}")
 
     @cappa.command(name="logs")
     def logs(
@@ -528,6 +533,22 @@ class InstanceCmd:
         raise SystemExit(subprocess.call(cmd))
 
 
+@cappa.command(name="version", help="Show the git branch/SHA of the running openhost.")
+@attrs.define
+class Version:
+    def __call__(self, cfg: Annotated[config.Instance, Dep(resolve_instance)]) -> None:
+        result = make_api_request(cfg.url, cfg.token, "GET", "/api/version").json()
+        sha = result.get("sha") or ""
+        short = result.get("short_sha") or (sha[:8] if sha else "")
+        branch = result.get("branch") or "(detached HEAD)"
+        if not sha:
+            print(f"{cfg.url}: openhost is not a git checkout — no version info available")
+            return
+        dirty = " (dirty)" if result.get("dirty") else ""
+        print(f"{cfg.url}: {branch} @ {short}{dirty}")
+        print(f"  full sha: {sha}")
+
+
 @cappa.command(name="curl", help="curl with your OpenHost bearer token injected.")
 @attrs.define
 class Curl:
@@ -548,7 +569,7 @@ class Curl:
 @cappa.command(name="oh", help="OpenHost compute space CLI — manage things in your compute space.")
 @attrs.define
 class Oh:
-    subcommand: cappa.Subcommands[Status | AppCmd | TokensCmd | LogsCmd | InstanceCmd | Curl]
+    subcommand: cappa.Subcommands[Status | AppCmd | TokensCmd | LogsCmd | InstanceCmd | Curl | Version]
     instance: Annotated[
         str | None,
         cappa.Arg(long=True, default=None, propagate=True, help="Target a specific named instance"),


### PR DESCRIPTION
## Summary

Adds a way to see what exact branch/SHA both openhost itself and each running app are on.

**New API surface:**
- `GET /api/version` (owner auth) — `{branch, sha, short_sha, dirty}` for the running openhost checkout. Returns blanks if openhost wasn't installed via git.
- `GET /api/app_status/{app_id}` is extended with `git_branch`, `git_sha`, `git_dirty`, read at request time from the app's on-disk `repo_path`. All None for non-git apps (e.g. builtins copied from `apps/`).

**New CLI:**
- `oh version` — prints `<branch> @ <short_sha>` (with `(dirty)` suffix if applicable) plus full SHA.
- `oh app status <name>` now also prints `git: <branch> @ <short_sha>` if the app has a git checkout.

**Helpers:**
- `core.git_ops.get_head_sha()` — full HEAD SHA.
- `core.git_ops.get_branch_name()` — branch or None when detached. (Existing `get_current_ref` collapses these into one return value, which wasn't useful for the API.)

## Test plan

- [ ] `oh version` against a real instance prints branch/short SHA matching `git -C <openhost> rev-parse --abbrev-ref HEAD` and `... HEAD`.
- [ ] `oh app status <git-installed-app>` prints the app's branch/sha.
- [ ] `oh app status <builtin-app>` (no `.git` in `repo_path`) prints status only, no git line.
- [ ] `GET /api/version` requires owner auth (401 without token).
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)