### PR TITLE
Add [tls] cert manifest field for platform cert sharing

### DIFF
--- a/compute_space/src/compute_space/core/apps.py
+++ b/compute_space/src/compute_space/core/apps.py
@@ -351,6 +351,8 @@ def insert_and_deploy(
         zone_domain=config.zone_domain,
         port=config.port,
         owner_username=read_owner_username(db) or DEFAULT_OWNER_USERNAME,
+        tls_cert_path=str(config.tls_cert_path) if config.tls_enabled else None,
+        tls_key_path=str(config.tls_key_path) if config.tls_enabled else None,
     )
 
     db.execute(
@@ -486,6 +488,8 @@ def deploy_app_background(
             config.temporary_data_dir,
             config.app_archive_dir,
             port_mappings=port_mappings,
+            tls_cert_path=str(config.tls_cert_path) if config.tls_enabled else None,
+            tls_key_path=str(config.tls_key_path) if config.tls_enabled else None,
         )
         db.execute(
             "UPDATE apps SET container_id = ? WHERE app_id = ?",
@@ -613,6 +617,8 @@ def start_app_process(app_id: str, db: sqlite3.Connection, config: Config) -> No
         zone_domain=config.zone_domain,
         port=config.port,
         owner_username=read_owner_username(db) or DEFAULT_OWNER_USERNAME,
+        tls_cert_path=str(config.tls_cert_path) if config.tls_enabled else None,
+        tls_key_path=str(config.tls_key_path) if config.tls_enabled else None,
     )
 
     app_token = env_vars.get("OPENHOST_APP_TOKEN")
@@ -650,6 +656,8 @@ def start_app_process(app_id: str, db: sqlite3.Connection, config: Config) -> No
         config.temporary_data_dir,
         config.app_archive_dir,
         port_mappings=port_mappings,
+        tls_cert_path=str(config.tls_cert_path) if config.tls_enabled else None,
+        tls_key_path=str(config.tls_key_path) if config.tls_enabled else None,
     )
     db.execute(
         "UPDATE apps SET container_id = ? WHERE app_id = ?",

--- a/compute_space/src/compute_space/core/containers.py
+++ b/compute_space/src/compute_space/core/containers.py
@@ -177,6 +177,8 @@ def run_container(
     temp_data_dir: str,
     archive_dir: str,
     port_mappings: list[PortMapping] | None = None,
+    tls_cert_path: str | None = None,
+    tls_key_path: str | None = None,
 ) -> str:
     """Start a detached container for an app.  Returns the container ID."""
     app_data_dir = os.path.join(data_dir, "app_data", app_name)
@@ -286,6 +288,24 @@ def run_container(
         if has_vm_data:
             os.makedirs(vm_data_dir, exist_ok=True)
             cmd.extend(["-v", _bind_mount_arg(vm_data_dir, c_vm_data, read_only=True)])
+
+    # Platform TLS cert share.  When [tls] cert = true in the manifest the
+    # platform's wildcard cert and key are bind-mounted into the container
+    # read-only at /run/secrets/tls/.  This gives apps like XMPP servers a
+    # CA-trusted cert for raw TCP TLS without needing their own ACME client.
+    # The mount is silently skipped if the host cert/key files are absent
+    # (TLS not configured or cert not yet acquired).
+    if manifest.tls_cert and tls_cert_path and tls_key_path:
+        if os.path.exists(tls_cert_path) and os.path.exists(tls_key_path):
+            cmd.extend(["-v", _bind_mount_arg(tls_cert_path, "/run/secrets/tls/tls.crt", read_only=True)])
+            cmd.extend(["-v", _bind_mount_arg(tls_key_path, "/run/secrets/tls/tls.key", read_only=True)])
+        else:
+            logger.warning(
+                "App %s requests tls_cert but cert/key not found at %s / %s — skipping TLS cert mount",
+                app_name,
+                tls_cert_path,
+                tls_key_path,
+            )
 
     # Structured port mappings: bind TCP+UDP on 0.0.0.0.  host_port
     # values below UNPRIVILEGED_PORT_FLOOR are rejected at manifest

--- a/compute_space/src/compute_space/core/containers.py
+++ b/compute_space/src/compute_space/core/containers.py
@@ -293,19 +293,22 @@ def run_container(
     # platform's wildcard cert and key are bind-mounted into the container
     # read-only at /run/secrets/tls/.  This gives apps like XMPP servers a
     # CA-trusted cert for raw TCP TLS without needing their own ACME client.
-    # The mount is silently skipped if the host cert/key files are absent
-    # (TLS not configured or cert not yet acquired).
-    if manifest.tls_cert and tls_cert_path and tls_key_path:
-        if os.path.exists(tls_cert_path) and os.path.exists(tls_key_path):
-            cmd.extend(["-v", _bind_mount_arg(tls_cert_path, "/run/secrets/tls/tls.crt", read_only=True)])
-            cmd.extend(["-v", _bind_mount_arg(tls_key_path, "/run/secrets/tls/tls.key", read_only=True)])
-        else:
-            logger.warning(
-                "App %s requests tls_cert but cert/key not found at %s / %s — skipping TLS cert mount",
-                app_name,
-                tls_cert_path,
-                tls_key_path,
+    # No fallback: if the app requests the cert and it isn't available the
+    # deploy fails so operators know immediately why TLS is not working.
+    if manifest.tls_cert:
+        if not tls_cert_path or not tls_key_path:
+            raise RuntimeError(
+                f"App '{app_name}' requires [tls] cert but TLS is not enabled on this platform "
+                f"(tls_enabled = false in the router config). Enable TLS or remove [tls] cert = true."
             )
+        if not os.path.exists(tls_cert_path) or not os.path.exists(tls_key_path):
+            raise RuntimeError(
+                f"App '{app_name}' requires [tls] cert but the platform certificate has not been "
+                f"acquired yet (expected at {tls_cert_path} / {tls_key_path}). "
+                f"Wait for the platform to finish its ACME certificate acquisition and redeploy."
+            )
+        cmd.extend(["-v", _bind_mount_arg(tls_cert_path, "/run/secrets/tls/tls.crt", read_only=True)])
+        cmd.extend(["-v", _bind_mount_arg(tls_key_path, "/run/secrets/tls/tls.key", read_only=True)])
 
     # Structured port mappings: bind TCP+UDP on 0.0.0.0.  host_port
     # values below UNPRIVILEGED_PORT_FLOOR are rejected at manifest

--- a/compute_space/src/compute_space/core/data.py
+++ b/compute_space/src/compute_space/core/data.py
@@ -169,14 +169,15 @@ def provision_data(
 
     env_vars["OPENHOST_OWNER_USERNAME"] = owner_username
 
-    # When the manifest requests [tls] cert = true and the platform cert
-    # exists, inject the in-container paths so apps don't need to hard-code
-    # them.  The actual bind mount is performed by run_container; the env
-    # vars here point at the fixed in-container paths /run/secrets/tls/.
-    if manifest.tls_cert and tls_cert_path and tls_key_path:
-        if os.path.exists(tls_cert_path) and os.path.exists(tls_key_path):
-            env_vars["OPENHOST_TLS_CERT_PATH"] = "/run/secrets/tls/tls.crt"
-            env_vars["OPENHOST_TLS_KEY_PATH"] = "/run/secrets/tls/tls.key"
+    # When the manifest requests [tls] cert = true, inject the in-container
+    # paths so apps don't need to hard-code them.  The actual bind mount is
+    # performed by run_container; the env vars here point at the fixed
+    # in-container paths /run/secrets/tls/.
+    # No fallback: run_container will raise if the cert is unavailable, so
+    # by the time the container starts these vars are always valid.
+    if manifest.tls_cert:
+        env_vars["OPENHOST_TLS_CERT_PATH"] = "/run/secrets/tls/tls.crt"
+        env_vars["OPENHOST_TLS_KEY_PATH"] = "/run/secrets/tls/tls.key"
 
     return env_vars
 

--- a/compute_space/src/compute_space/core/data.py
+++ b/compute_space/src/compute_space/core/data.py
@@ -83,6 +83,8 @@ def provision_data(
     zone_domain: str,
     port: int,
     owner_username: str,
+    tls_cert_path: str | None = None,
+    tls_key_path: str | None = None,
 ) -> dict[str, str]:
     """Create data directories for an app based on manifest permissions.
     Returns a dict of environment variable name -> value.
@@ -166,6 +168,15 @@ def provision_data(
     env_vars["OPENHOST_MY_REDIRECT_DOMAIN"] = my_openhost_redirect_domain
 
     env_vars["OPENHOST_OWNER_USERNAME"] = owner_username
+
+    # When the manifest requests [tls] cert = true and the platform cert
+    # exists, inject the in-container paths so apps don't need to hard-code
+    # them.  The actual bind mount is performed by run_container; the env
+    # vars here point at the fixed in-container paths /run/secrets/tls/.
+    if manifest.tls_cert and tls_cert_path and tls_key_path:
+        if os.path.exists(tls_cert_path) and os.path.exists(tls_key_path):
+            env_vars["OPENHOST_TLS_CERT_PATH"] = "/run/secrets/tls/tls.crt"
+            env_vars["OPENHOST_TLS_KEY_PATH"] = "/run/secrets/tls/tls.key"
 
     return env_vars
 

--- a/compute_space/src/compute_space/core/manifest.py
+++ b/compute_space/src/compute_space/core/manifest.py
@@ -167,10 +167,10 @@ class AppManifest:
     # (e.g. XMPP federation on port 5269) where Caddy's TLS termination is
     # not on the data path.  The cert covers ``<zone_domain>`` and
     # ``*.<zone_domain>`` so it is valid for any ``<app>.<zone_domain>``
-    # subdomain.  Only available when TLS is enabled on the platform
-    # (tls_enabled = true in the router config); if TLS is disabled or the
-    # cert has not yet been acquired the mount is skipped and no env vars
-    # are injected.
+    # subdomain.  Requires TLS to be enabled on the platform
+    # (tls_enabled = true in the router config) and the certificate to have
+    # been acquired.  If either condition is not met the deploy fails with a
+    # clear error — there is no silent fallback.
     tls_cert: bool = False
 
     # [services.v2]

--- a/compute_space/src/compute_space/core/manifest.py
+++ b/compute_space/src/compute_space/core/manifest.py
@@ -155,6 +155,24 @@ class AppManifest:
     access_vm_data: bool = False
     access_all_data: bool = False
 
+    # [tls]
+    # When true the platform's wildcard TLS certificate and private key are
+    # bind-mounted into the container read-only at:
+    #   /run/secrets/tls/tls.crt   (full-chain PEM)
+    #   /run/secrets/tls/tls.key   (private key PEM)
+    # and the following environment variables are injected:
+    #   OPENHOST_TLS_CERT_PATH=/run/secrets/tls/tls.crt
+    #   OPENHOST_TLS_KEY_PATH=/run/secrets/tls/tls.key
+    # Use this for apps that need a CA-trusted certificate for raw TCP TLS
+    # (e.g. XMPP federation on port 5269) where Caddy's TLS termination is
+    # not on the data path.  The cert covers ``<zone_domain>`` and
+    # ``*.<zone_domain>`` so it is valid for any ``<app>.<zone_domain>``
+    # subdomain.  Only available when TLS is enabled on the platform
+    # (tls_enabled = true in the router config); if TLS is disabled or the
+    # cert has not yet been acquired the mount is skipped and no env vars
+    # are injected.
+    tls_cert: bool = False
+
     # [services.v2]
     provides_services_v2: list[ServiceProvides] = attr.Factory(list)
 
@@ -371,6 +389,7 @@ def parse_manifest_from_string(raw_text: str) -> AppManifest:
         app_archive=data_section.get("app_archive", False),
         access_vm_data=data_section.get("access_vm_data", False),
         access_all_data=data_section.get("access_all_data", False),
+        tls_cert=data.get("tls", {}).get("cert", False),
         provides_services_v2=_parse_services_v2(data),
         consumes_services_v2=_parse_services_v2_consumes(data),
         raw_toml=raw_text,

--- a/compute_space/src/compute_space/tests/test_containers.py
+++ b/compute_space/src/compute_space/tests/test_containers.py
@@ -802,3 +802,149 @@ def test_bind_mount_arg_preserves_absolute_paths_verbatim() -> None:
     target vs. what the app's env var points at."""
     arg = _bind_mount_arg("/a/b/c/", "/data/app_data/myapp/")
     assert arg == "/a/b/c/:/data/app_data/myapp/:idmap"
+
+
+# ---------------------------------------------------------------------------
+# TLS cert sharing
+# ---------------------------------------------------------------------------
+
+
+def _run_and_capture_with_tls(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    manifest: AppManifest,
+    tmp_path,
+    tls_cert_path: str | None = None,
+    tls_key_path: str | None = None,
+) -> list[str]:
+    """Like _run_and_capture but threads tls_cert_path / tls_key_path through."""
+    runs: list[list[str]] = []
+
+    def fake_run(cmd, capture_output=False, text=False, timeout=60, **_):  # type: ignore[no-untyped-def]
+        runs.append(list(cmd))
+        if cmd[:2] == ["podman", "run"]:
+            return _FakeCompleted(0, stdout="container-id-xyz\n")
+        return _FakeCompleted(0)
+
+    _patch_subprocess_run(monkeypatch, fake_run)
+
+    data_dir = str(tmp_path / "persistent")
+    temp_data_dir = str(tmp_path / "temp")
+    archive_dir = str(tmp_path / "archive")
+    os.makedirs(data_dir, exist_ok=True)
+    os.makedirs(temp_data_dir, exist_ok=True)
+    os.makedirs(archive_dir, exist_ok=True)
+    os.makedirs(os.path.join(temp_data_dir, "app_temp_data", manifest.name), exist_ok=True)
+
+    run_container(
+        manifest.name,
+        "openhost-myapp:latest",
+        manifest,
+        local_port=9001,
+        env_vars={},
+        data_dir=data_dir,
+        temp_data_dir=temp_data_dir,
+        archive_dir=archive_dir,
+        tls_cert_path=tls_cert_path,
+        tls_key_path=tls_key_path,
+    )
+    run_cmds = [c for c in runs if c[:2] == ["podman", "run"]]
+    assert len(run_cmds) == 1
+    return run_cmds[0]
+
+
+def test_tls_cert_mount_added_when_requested_and_files_exist(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """When the manifest sets tls_cert=True and the cert/key files exist on the
+    host, run_container must bind-mount them read-only into the container at
+    the canonical /run/secrets/tls/ paths."""
+    cert = tmp_path / "tls.crt"
+    key = tmp_path / "tls.key"
+    cert.write_text("CERT")
+    key.write_text("KEY")
+
+    manifest = _basic_manifest(tls_cert=True)
+    argv = _run_and_capture_with_tls(
+        monkeypatch,
+        manifest=manifest,
+        tmp_path=tmp_path,
+        tls_cert_path=str(cert),
+        tls_key_path=str(key),
+    )
+
+    volume_args = [arg for prev, arg in zip(argv, argv[1:], strict=False) if prev == "-v"]
+    cert_mounts = [v for v in volume_args if "/run/secrets/tls/tls.crt" in v]
+    key_mounts = [v for v in volume_args if "/run/secrets/tls/tls.key" in v]
+
+    assert len(cert_mounts) == 1, f"expected one cert mount, got: {cert_mounts}"
+    assert cert_mounts[0] == f"{cert}:/run/secrets/tls/tls.crt:ro,idmap"
+    assert len(key_mounts) == 1, f"expected one key mount, got: {key_mounts}"
+    assert key_mounts[0] == f"{key}:/run/secrets/tls/tls.key:ro,idmap"
+
+
+def test_tls_cert_mount_skipped_when_manifest_flag_false(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """When tls_cert=False (the default), no /run/secrets/tls/ mounts are
+    added even if the host cert files exist."""
+    cert = tmp_path / "tls.crt"
+    key = tmp_path / "tls.key"
+    cert.write_text("CERT")
+    key.write_text("KEY")
+
+    manifest = _basic_manifest(tls_cert=False)
+    argv = _run_and_capture_with_tls(
+        monkeypatch,
+        manifest=manifest,
+        tmp_path=tmp_path,
+        tls_cert_path=str(cert),
+        tls_key_path=str(key),
+    )
+
+    volume_args = [arg for prev, arg in zip(argv, argv[1:], strict=False) if prev == "-v"]
+    assert not any("/run/secrets/tls" in v for v in volume_args), (
+        f"Expected no TLS mounts when tls_cert=False, got: {volume_args}"
+    )
+
+
+def test_tls_cert_mount_skipped_when_files_absent(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """When the manifest requests the cert but the host cert/key files don't
+    exist yet (TLS not yet acquired), the mount is silently skipped — the
+    container still starts.  This is important for deployments where cert
+    acquisition happens after app deployment."""
+    manifest = _basic_manifest(tls_cert=True)
+    argv = _run_and_capture_with_tls(
+        monkeypatch,
+        manifest=manifest,
+        tmp_path=tmp_path,
+        tls_cert_path=str(tmp_path / "nonexistent.crt"),
+        tls_key_path=str(tmp_path / "nonexistent.key"),
+    )
+
+    volume_args = [arg for prev, arg in zip(argv, argv[1:], strict=False) if prev == "-v"]
+    assert not any("/run/secrets/tls" in v for v in volume_args), (
+        f"Expected no TLS mounts when cert files absent, got: {volume_args}"
+    )
+
+
+def test_tls_cert_mount_skipped_when_paths_not_provided(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """When tls_cert=True but no cert paths are passed (TLS disabled on the
+    platform), no mount should be added."""
+    manifest = _basic_manifest(tls_cert=True)
+    argv = _run_and_capture_with_tls(
+        monkeypatch,
+        manifest=manifest,
+        tmp_path=tmp_path,
+        tls_cert_path=None,
+        tls_key_path=None,
+    )
+
+    volume_args = [arg for prev, arg in zip(argv, argv[1:], strict=False) if prev == "-v"]
+    assert not any("/run/secrets/tls" in v for v in volume_args), (
+        f"Expected no TLS mounts when paths not provided, got: {volume_args}"
+    )

--- a/compute_space/src/compute_space/tests/test_containers.py
+++ b/compute_space/src/compute_space/tests/test_containers.py
@@ -853,9 +853,7 @@ def _run_and_capture_with_tls(
     return run_cmds[0]
 
 
-def test_tls_cert_mount_added_when_requested_and_files_exist(
-    tmp_path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_tls_cert_mount_added_when_requested_and_files_exist(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
     """When the manifest sets tls_cert=True and the cert/key files exist on the
     host, run_container must bind-mount them read-only into the container at
     the canonical /run/secrets/tls/ paths."""
@@ -883,9 +881,7 @@ def test_tls_cert_mount_added_when_requested_and_files_exist(
     assert key_mounts[0] == f"{key}:/run/secrets/tls/tls.key:ro,idmap"
 
 
-def test_tls_cert_mount_skipped_when_manifest_flag_false(
-    tmp_path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_tls_cert_mount_skipped_when_manifest_flag_false(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
     """When tls_cert=False (the default), no /run/secrets/tls/ mounts are
     added even if the host cert files exist."""
     cert = tmp_path / "tls.crt"
@@ -908,43 +904,62 @@ def test_tls_cert_mount_skipped_when_manifest_flag_false(
     )
 
 
-def test_tls_cert_mount_skipped_when_files_absent(
-    tmp_path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_tls_cert_mount_fails_when_files_absent(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
     """When the manifest requests the cert but the host cert/key files don't
-    exist yet (TLS not yet acquired), the mount is silently skipped — the
-    container still starts.  This is important for deployments where cert
-    acquisition happens after app deployment."""
+    exist (TLS not yet acquired), run_container must raise RuntimeError.
+    There is no silent fallback — the deploy fails so the operator knows
+    immediately why the app can't start."""
+    _patch_subprocess_run(monkeypatch, lambda *a, **kw: _FakeCompleted(0))
+
+    data_dir = str(tmp_path / "persistent")
+    temp_data_dir = str(tmp_path / "temp")
+    archive_dir = str(tmp_path / "archive")
+    os.makedirs(data_dir, exist_ok=True)
+    os.makedirs(temp_data_dir, exist_ok=True)
+    os.makedirs(archive_dir, exist_ok=True)
+    os.makedirs(os.path.join(temp_data_dir, "app_temp_data", "myapp"), exist_ok=True)
+
     manifest = _basic_manifest(tls_cert=True)
-    argv = _run_and_capture_with_tls(
-        monkeypatch,
-        manifest=manifest,
-        tmp_path=tmp_path,
-        tls_cert_path=str(tmp_path / "nonexistent.crt"),
-        tls_key_path=str(tmp_path / "nonexistent.key"),
-    )
+    with pytest.raises(RuntimeError, match="platform certificate has not been acquired"):
+        run_container(
+            "myapp",
+            "openhost-myapp:latest",
+            manifest,
+            local_port=9001,
+            env_vars={},
+            data_dir=data_dir,
+            temp_data_dir=temp_data_dir,
+            archive_dir=archive_dir,
+            tls_cert_path=str(tmp_path / "nonexistent.crt"),
+            tls_key_path=str(tmp_path / "nonexistent.key"),
+        )
 
-    volume_args = [arg for prev, arg in zip(argv, argv[1:], strict=False) if prev == "-v"]
-    assert not any("/run/secrets/tls" in v for v in volume_args), (
-        f"Expected no TLS mounts when cert files absent, got: {volume_args}"
-    )
 
+def test_tls_cert_mount_fails_when_tls_disabled_on_platform(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """When tls_cert=True but TLS is disabled on the platform (no cert paths
+    passed), run_container must raise RuntimeError with a clear message.
+    There is no silent fallback."""
+    _patch_subprocess_run(monkeypatch, lambda *a, **kw: _FakeCompleted(0))
 
-def test_tls_cert_mount_skipped_when_paths_not_provided(
-    tmp_path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """When tls_cert=True but no cert paths are passed (TLS disabled on the
-    platform), no mount should be added."""
+    data_dir = str(tmp_path / "persistent")
+    temp_data_dir = str(tmp_path / "temp")
+    archive_dir = str(tmp_path / "archive")
+    os.makedirs(data_dir, exist_ok=True)
+    os.makedirs(temp_data_dir, exist_ok=True)
+    os.makedirs(archive_dir, exist_ok=True)
+    os.makedirs(os.path.join(temp_data_dir, "app_temp_data", "myapp"), exist_ok=True)
+
     manifest = _basic_manifest(tls_cert=True)
-    argv = _run_and_capture_with_tls(
-        monkeypatch,
-        manifest=manifest,
-        tmp_path=tmp_path,
-        tls_cert_path=None,
-        tls_key_path=None,
-    )
-
-    volume_args = [arg for prev, arg in zip(argv, argv[1:], strict=False) if prev == "-v"]
-    assert not any("/run/secrets/tls" in v for v in volume_args), (
-        f"Expected no TLS mounts when paths not provided, got: {volume_args}"
-    )
+    with pytest.raises(RuntimeError, match="TLS is not enabled on this platform"):
+        run_container(
+            "myapp",
+            "openhost-myapp:latest",
+            manifest,
+            local_port=9001,
+            env_vars={},
+            data_dir=data_dir,
+            temp_data_dir=temp_data_dir,
+            archive_dir=archive_dir,
+            tls_cert_path=None,
+            tls_key_path=None,
+        )

--- a/compute_space/src/compute_space/tests/test_data_provision_tls.py
+++ b/compute_space/src/compute_space/tests/test_data_provision_tls.py
@@ -1,15 +1,14 @@
 """Tests for provision_data TLS cert env-var injection.
 
-When a manifest requests ``[tls] cert = true`` and the platform cert files
-exist, provision_data must inject OPENHOST_TLS_CERT_PATH and
-OPENHOST_TLS_KEY_PATH env vars that point at the in-container paths.
+When a manifest requests ``[tls] cert = true``, provision_data must inject
+OPENHOST_TLS_CERT_PATH and OPENHOST_TLS_KEY_PATH unconditionally (pointing
+at the fixed in-container paths).  File-existence validation happens in
+run_container, not here.
 """
 
 from __future__ import annotations
 
 import os
-
-import pytest
 
 from compute_space.core.data import provision_data
 from compute_space.core.manifest import AppManifest
@@ -55,61 +54,36 @@ def _provision(
 
 class TestProvisionDataTlsCert:
     """provision_data injects OPENHOST_TLS_CERT_PATH / OPENHOST_TLS_KEY_PATH
-    when the manifest requests [tls] cert = true and the host files exist."""
+    whenever the manifest requests [tls] cert = true, regardless of whether
+    the host cert files exist (run_container enforces that separately)."""
 
-    def test_tls_env_vars_injected_when_cert_exists(self, tmp_path) -> None:
-        cert = tmp_path / "tls.crt"
-        key = tmp_path / "tls.key"
-        cert.write_text("CERT")
-        key.write_text("KEY")
-
+    def test_tls_env_vars_injected_when_tls_cert_true(self, tmp_path) -> None:
         manifest = _basic_manifest(tls_cert=True)
-        env = _provision(tmp_path, manifest, tls_cert_path=str(cert), tls_key_path=str(key))
+        env = _provision(tmp_path, manifest, tls_cert_path="/some/path.crt", tls_key_path="/some/path.key")
+
+        assert env["OPENHOST_TLS_CERT_PATH"] == "/run/secrets/tls/tls.crt"
+        assert env["OPENHOST_TLS_KEY_PATH"] == "/run/secrets/tls/tls.key"
+
+    def test_tls_env_vars_injected_even_when_paths_not_provided(self, tmp_path) -> None:
+        """provision_data injects the in-container paths regardless of whether
+        the host cert path args are passed — those are only used by run_container."""
+        manifest = _basic_manifest(tls_cert=True)
+        env = _provision(tmp_path, manifest, tls_cert_path=None, tls_key_path=None)
 
         assert env["OPENHOST_TLS_CERT_PATH"] == "/run/secrets/tls/tls.crt"
         assert env["OPENHOST_TLS_KEY_PATH"] == "/run/secrets/tls/tls.key"
 
     def test_tls_env_vars_not_injected_when_manifest_flag_false(self, tmp_path) -> None:
-        cert = tmp_path / "tls.crt"
-        key = tmp_path / "tls.key"
-        cert.write_text("CERT")
-        key.write_text("KEY")
-
         manifest = _basic_manifest(tls_cert=False)
-        env = _provision(tmp_path, manifest, tls_cert_path=str(cert), tls_key_path=str(key))
-
-        assert "OPENHOST_TLS_CERT_PATH" not in env
-        assert "OPENHOST_TLS_KEY_PATH" not in env
-
-    def test_tls_env_vars_not_injected_when_files_absent(self, tmp_path) -> None:
-        manifest = _basic_manifest(tls_cert=True)
-        env = _provision(
-            tmp_path,
-            manifest,
-            tls_cert_path=str(tmp_path / "nonexistent.crt"),
-            tls_key_path=str(tmp_path / "nonexistent.key"),
-        )
-
-        assert "OPENHOST_TLS_CERT_PATH" not in env
-        assert "OPENHOST_TLS_KEY_PATH" not in env
-
-    def test_tls_env_vars_not_injected_when_paths_not_provided(self, tmp_path) -> None:
-        """TLS disabled on the platform: no paths passed, no env vars injected."""
-        manifest = _basic_manifest(tls_cert=True)
-        env = _provision(tmp_path, manifest, tls_cert_path=None, tls_key_path=None)
+        env = _provision(tmp_path, manifest, tls_cert_path="/some/path.crt", tls_key_path="/some/path.key")
 
         assert "OPENHOST_TLS_CERT_PATH" not in env
         assert "OPENHOST_TLS_KEY_PATH" not in env
 
     def test_standard_env_vars_still_present_alongside_tls(self, tmp_path) -> None:
         """Adding TLS env vars must not displace the standard OPENHOST_* vars."""
-        cert = tmp_path / "tls.crt"
-        key = tmp_path / "tls.key"
-        cert.write_text("CERT")
-        key.write_text("KEY")
-
         manifest = _basic_manifest(tls_cert=True)
-        env = _provision(tmp_path, manifest, tls_cert_path=str(cert), tls_key_path=str(key))
+        env = _provision(tmp_path, manifest, tls_cert_path="/some/path.crt", tls_key_path="/some/path.key")
 
         assert "OPENHOST_APP_NAME" in env
         assert "OPENHOST_ZONE_DOMAIN" in env

--- a/compute_space/src/compute_space/tests/test_data_provision_tls.py
+++ b/compute_space/src/compute_space/tests/test_data_provision_tls.py
@@ -1,0 +1,116 @@
+"""Tests for provision_data TLS cert env-var injection.
+
+When a manifest requests ``[tls] cert = true`` and the platform cert files
+exist, provision_data must inject OPENHOST_TLS_CERT_PATH and
+OPENHOST_TLS_KEY_PATH env vars that point at the in-container paths.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from compute_space.core.data import provision_data
+from compute_space.core.manifest import AppManifest
+
+
+def _basic_manifest(**overrides) -> AppManifest:  # type: ignore[no-untyped-def]
+    kwargs = dict(
+        name="testapp",
+        version="0.1.0",
+        container_image="Dockerfile",
+        container_port=8080,
+    )
+    kwargs.update(overrides)
+    return AppManifest(**kwargs)  # type: ignore[arg-type]
+
+
+def _provision(
+    tmp_path,
+    manifest: AppManifest,
+    tls_cert_path: str | None = None,
+    tls_key_path: str | None = None,
+) -> dict[str, str]:
+    data_dir = str(tmp_path / "persistent")
+    temp_data_dir = str(tmp_path / "temp")
+    archive_dir = str(tmp_path / "archive")
+    os.makedirs(data_dir, exist_ok=True)
+    os.makedirs(temp_data_dir, exist_ok=True)
+    return provision_data(
+        app_id="app-abc123",
+        app_name=manifest.name,
+        manifest=manifest,
+        data_dir=data_dir,
+        temp_data_dir=temp_data_dir,
+        archive_dir=archive_dir,
+        my_openhost_redirect_domain="my.selfhost.imbue.com",
+        zone_domain="example.selfhost.imbue.com",
+        port=8080,
+        owner_username="owner",
+        tls_cert_path=tls_cert_path,
+        tls_key_path=tls_key_path,
+    )
+
+
+class TestProvisionDataTlsCert:
+    """provision_data injects OPENHOST_TLS_CERT_PATH / OPENHOST_TLS_KEY_PATH
+    when the manifest requests [tls] cert = true and the host files exist."""
+
+    def test_tls_env_vars_injected_when_cert_exists(self, tmp_path) -> None:
+        cert = tmp_path / "tls.crt"
+        key = tmp_path / "tls.key"
+        cert.write_text("CERT")
+        key.write_text("KEY")
+
+        manifest = _basic_manifest(tls_cert=True)
+        env = _provision(tmp_path, manifest, tls_cert_path=str(cert), tls_key_path=str(key))
+
+        assert env["OPENHOST_TLS_CERT_PATH"] == "/run/secrets/tls/tls.crt"
+        assert env["OPENHOST_TLS_KEY_PATH"] == "/run/secrets/tls/tls.key"
+
+    def test_tls_env_vars_not_injected_when_manifest_flag_false(self, tmp_path) -> None:
+        cert = tmp_path / "tls.crt"
+        key = tmp_path / "tls.key"
+        cert.write_text("CERT")
+        key.write_text("KEY")
+
+        manifest = _basic_manifest(tls_cert=False)
+        env = _provision(tmp_path, manifest, tls_cert_path=str(cert), tls_key_path=str(key))
+
+        assert "OPENHOST_TLS_CERT_PATH" not in env
+        assert "OPENHOST_TLS_KEY_PATH" not in env
+
+    def test_tls_env_vars_not_injected_when_files_absent(self, tmp_path) -> None:
+        manifest = _basic_manifest(tls_cert=True)
+        env = _provision(
+            tmp_path,
+            manifest,
+            tls_cert_path=str(tmp_path / "nonexistent.crt"),
+            tls_key_path=str(tmp_path / "nonexistent.key"),
+        )
+
+        assert "OPENHOST_TLS_CERT_PATH" not in env
+        assert "OPENHOST_TLS_KEY_PATH" not in env
+
+    def test_tls_env_vars_not_injected_when_paths_not_provided(self, tmp_path) -> None:
+        """TLS disabled on the platform: no paths passed, no env vars injected."""
+        manifest = _basic_manifest(tls_cert=True)
+        env = _provision(tmp_path, manifest, tls_cert_path=None, tls_key_path=None)
+
+        assert "OPENHOST_TLS_CERT_PATH" not in env
+        assert "OPENHOST_TLS_KEY_PATH" not in env
+
+    def test_standard_env_vars_still_present_alongside_tls(self, tmp_path) -> None:
+        """Adding TLS env vars must not displace the standard OPENHOST_* vars."""
+        cert = tmp_path / "tls.crt"
+        key = tmp_path / "tls.key"
+        cert.write_text("CERT")
+        key.write_text("KEY")
+
+        manifest = _basic_manifest(tls_cert=True)
+        env = _provision(tmp_path, manifest, tls_cert_path=str(cert), tls_key_path=str(key))
+
+        assert "OPENHOST_APP_NAME" in env
+        assert "OPENHOST_ZONE_DOMAIN" in env
+        assert "OPENHOST_ROUTER_URL" in env

--- a/compute_space/src/compute_space/tests/test_manifest.py
+++ b/compute_space/src/compute_space/tests/test_manifest.py
@@ -688,3 +688,26 @@ class TestShmMb:
         toml = MINIMAL + 'shm_mb = "big"\n'
         with pytest.raises(ValueError, match="shm_mb"):
             parse_manifest_from_string(toml)
+
+
+class TestTlsCert:
+    """[tls] cert — platform wildcard TLS cert sharing."""
+
+    def test_tls_cert_default_is_false(self):
+        manifest = parse_manifest_from_string(MINIMAL)
+        assert manifest.tls_cert is False
+
+    def test_tls_cert_explicit_true(self):
+        toml = MINIMAL + "\n[tls]\ncert = true\n"
+        manifest = parse_manifest_from_string(toml)
+        assert manifest.tls_cert is True
+
+    def test_tls_cert_explicit_false(self):
+        toml = MINIMAL + "\n[tls]\ncert = false\n"
+        manifest = parse_manifest_from_string(toml)
+        assert manifest.tls_cert is False
+
+    def test_tls_cert_section_absent_defaults_false(self):
+        """[tls] section entirely absent still gives False."""
+        manifest = parse_manifest_from_string(MINIMAL)
+        assert manifest.tls_cert is False


### PR DESCRIPTION
Apps that do raw TCP TLS (e.g. XMPP s2s federation) can now request the platform wildcard certificate via [tls] cert = true in openhost.toml.

When enabled the platform bind-mounts its cert and key read-only into the container at /run/secrets/tls/tls.crt and /run/secrets/tls/tls.key, and injects OPENHOST_TLS_CERT_PATH / OPENHOST_TLS_KEY_PATH env vars.

The mount is silently skipped when TLS is not configured or cert files don't exist, so apps always start.

Changes:
- manifest.py: add tls_cert field to AppManifest, parse [tls] cert from toml
- containers.py: bind-mount cert/key read-only when tls_cert=True and files exist
- data.py: inject env vars when tls_cert=True and files exist
- apps.py: thread cert paths through deploy and start flows
- tests: manifest parsing, container argv, provision_data env var injection