### PR TITLE
Edit-this-app button + migration log newline fix

### DIFF
--- a/compute_space/src/compute_space/web/routes/pages/apps.py
+++ b/compute_space/src/compute_space/web/routes/pages/apps.py
@@ -1,7 +1,7 @@
 import json
 import sqlite3
+from pathlib import Path
 
-from compute_space.core.services_v2 import ServiceNotAvailable, resolve_provider
 from litestar import Router
 from litestar import get
 from litestar.exceptions import HTTPException
@@ -12,9 +12,16 @@ from compute_space.core.app_id import is_valid_app_name
 from compute_space.core.apps import list_builtin_apps
 from compute_space.core.auth.permissions_v2 import get_all_permissions_v2
 from compute_space.core.containers import get_docker_logs
+from compute_space.core.git_ops import get_head_sha
+from compute_space.core.git_ops import parse_repo_url
 from compute_space.core.logging import logger
 from compute_space.core.manifest import parse_manifest_from_string
+from compute_space.core.services_v2 import ServiceNotAvailable
+from compute_space.core.services_v2 import resolve_provider
 from compute_space.web.auth.auth import require_owner_auth
+
+EDIT_APP_SERVICE_URL = "github.com/imbue-openhost/claude-code-container/services/open-workspace"
+EDIT_APP_VERSION_SPEC = "<1.0"
 
 
 @get(["/", "/dashboard"], guards=[require_owner_auth])
@@ -67,16 +74,7 @@ async def app_detail(app_name: str, db: sqlite3.Connection, config: Config, next
         except Exception:
             logger.opt(exception=True).warning("Failed to parse manifest for permission display (app %s)", app_id)
 
-    # check if we have a redigstered service.
-    # otherwise default back to a repo link,
-    # edit_app_url = app_row["repo_url"]
-    edit_app_url = 'https://google.com'
-    try:
-        # if there's a provider for the open-workspace service, have a button to link to it.
-        provider = resolve_provider('github.com/imbue-openhost/claude-code-container/services/open-workspace', '<1.0', db)
-        logger.info(provider)
-    except ServiceNotAvailable:
-        pass
+    edit_app = await _resolve_edit_app(app_row["repo_url"], app_row["repo_path"], db, config)
 
     return Template(
         template_name="app_detail.html",
@@ -89,9 +87,52 @@ async def app_detail(app_name: str, db: sqlite3.Connection, config: Config, next
             "next_url": next,
             "granted_permissions": granted_perms,
             "ungranted_permissions": ungranted_perms,
-            "editAppURL": edit_app_url,
+            "edit_app": edit_app,
         },
     )
+
+
+async def _resolve_edit_app(
+    repo_url: str | None,
+    repo_path: str,
+    db: sqlite3.Connection,
+    config: Config,
+) -> dict[str, str] | None:
+    """Describe an "Edit this app" affordance for the template.
+
+    Returns one of:
+      - ``{"mode": "service", "action": ..., "repo": ..., "ref": ...}`` — POST to
+        a provider of the open-workspace service (see
+        github.com/imbue-openhost/claude-code-container/services/open-workspace).
+      - ``{"mode": "repo", "href": ...}`` — fallback link to the repo URL.
+      - ``None`` — no actionable URL available.
+    """
+    if not repo_url:
+        return None
+    base_url, ref_from_url = parse_repo_url(repo_url)
+    ref = ref_from_url
+    if not ref:
+        try:
+            ref = await get_head_sha(Path(repo_path))
+        except Exception:
+            logger.opt(exception=True).warning("Failed to read HEAD sha for %s", repo_path)
+
+    try:
+        provider_app_id, _, _, endpoint = resolve_provider(EDIT_APP_SERVICE_URL, EDIT_APP_VERSION_SPEC, db)
+    except ServiceNotAvailable:
+        return {"mode": "repo", "href": base_url}
+
+    if not ref:
+        return {"mode": "repo", "href": base_url}
+
+    provider_row = db.execute("SELECT name FROM apps WHERE app_id = ?", (provider_app_id,)).fetchone()
+    if not provider_row:
+        logger.warning("resolve_provider returned unknown app_id %s", provider_app_id)
+        return {"mode": "repo", "href": base_url}
+
+    proto = "https" if config.tls_enabled else "http"
+    action = f"{proto}://{provider_row['name']}.{config.zone_domain}{endpoint}"
+    return {"mode": "service", "action": action, "repo": base_url, "ref": ref}
 
 
 @get("/add_app", guards=[require_owner_auth])

--- a/compute_space/src/compute_space/web/routes/pages/apps.py
+++ b/compute_space/src/compute_space/web/routes/pages/apps.py
@@ -1,6 +1,7 @@
 import json
 import sqlite3
 
+from compute_space.core.services_v2 import ServiceNotAvailable, resolve_provider
 from litestar import Router
 from litestar import get
 from litestar.exceptions import HTTPException
@@ -66,6 +67,16 @@ async def app_detail(app_name: str, db: sqlite3.Connection, config: Config, next
         except Exception:
             logger.opt(exception=True).warning("Failed to parse manifest for permission display (app %s)", app_id)
 
+    # check if we have a redigstered service.
+    # otherwise default back to a repo link,
+    edit_app_url = app_row["repo_url"]
+    try:
+        # if there's a provider for the open-workspace service, have a button to link to it.
+        provider = resolve_provider('github.com/imbue-openhost/claude-code-container/services/open-workspace', '<1.0', db)
+        
+    except ServiceNotAvailable:
+        pass
+
     return Template(
         template_name="app_detail.html",
         context={
@@ -77,6 +88,7 @@ async def app_detail(app_name: str, db: sqlite3.Connection, config: Config, next
             "next_url": next,
             "granted_permissions": granted_perms,
             "ungranted_permissions": ungranted_perms,
+            "editAppURL": edit_app_url,
         },
     )
 

--- a/compute_space/src/compute_space/web/routes/pages/apps.py
+++ b/compute_space/src/compute_space/web/routes/pages/apps.py
@@ -111,6 +111,7 @@ async def _resolve_edit_app(
     if not repo_url:
         return None
     base_url, ref_from_url = parse_repo_url(repo_url)
+    repo_link_fallback = {"mode": "repo", "href": base_url}
     ref = ref_from_url
     if not ref:
         try:
@@ -121,15 +122,15 @@ async def _resolve_edit_app(
     try:
         provider_app_id, _, _, endpoint = resolve_provider(EDIT_APP_SERVICE_URL, EDIT_APP_VERSION_SPEC, db)
     except ServiceNotAvailable:
-        return {"mode": "repo", "href": base_url}
+        return repo_link_fallback
 
     if not ref:
-        return {"mode": "repo", "href": base_url}
+        return repo_link_fallback
 
     provider_row = db.execute("SELECT name FROM apps WHERE app_id = ?", (provider_app_id,)).fetchone()
     if not provider_row:
         logger.warning("resolve_provider returned unknown app_id %s", provider_app_id)
-        return {"mode": "repo", "href": base_url}
+        return repo_link_fallback
 
     proto = "https" if config.tls_enabled else "http"
     # Pass repo+ref in the query string too: the openhost router 302's

--- a/compute_space/src/compute_space/web/routes/pages/apps.py
+++ b/compute_space/src/compute_space/web/routes/pages/apps.py
@@ -1,6 +1,7 @@
 import json
 import sqlite3
 from pathlib import Path
+from urllib.parse import urlencode
 
 from litestar import Router
 from litestar import get
@@ -131,7 +132,12 @@ async def _resolve_edit_app(
         return {"mode": "repo", "href": base_url}
 
     proto = "https" if config.tls_enabled else "http"
-    action = f"{proto}://{provider_row['name']}.{config.zone_domain}{endpoint.rstrip('/')}/"
+    # Pass repo+ref in the query string too: the openhost router 302's
+    # unauthenticated POSTs to /login, and the post-login redirect comes back
+    # as a GET (only 307/308 preserve method), dropping the form body. Query
+    # params survive the bounce, and the provider falls back to them.
+    qs = urlencode({"repo": base_url, "ref": ref})
+    action = f"{proto}://{provider_row['name']}.{config.zone_domain}{endpoint}?{qs}"
     return {"mode": "service", "action": action, "repo": base_url, "ref": ref}
 
 

--- a/compute_space/src/compute_space/web/routes/pages/apps.py
+++ b/compute_space/src/compute_space/web/routes/pages/apps.py
@@ -69,11 +69,12 @@ async def app_detail(app_name: str, db: sqlite3.Connection, config: Config, next
 
     # check if we have a redigstered service.
     # otherwise default back to a repo link,
-    edit_app_url = app_row["repo_url"]
+    # edit_app_url = app_row["repo_url"]
+    edit_app_url = 'https://google.com'
     try:
         # if there's a provider for the open-workspace service, have a button to link to it.
         provider = resolve_provider('github.com/imbue-openhost/claude-code-container/services/open-workspace', '<1.0', db)
-        
+        logger.info(provider)
     except ServiceNotAvailable:
         pass
 

--- a/compute_space/src/compute_space/web/routes/pages/apps.py
+++ b/compute_space/src/compute_space/web/routes/pages/apps.py
@@ -131,7 +131,7 @@ async def _resolve_edit_app(
         return {"mode": "repo", "href": base_url}
 
     proto = "https" if config.tls_enabled else "http"
-    action = f"{proto}://{provider_row['name']}.{config.zone_domain}{endpoint}"
+    action = f"{proto}://{provider_row['name']}.{config.zone_domain}{endpoint.rstrip('/')}/"
     return {"mode": "service", "action": action, "repo": base_url, "ref": ref}
 
 

--- a/compute_space/src/compute_space/web/templates/app_detail.html
+++ b/compute_space/src/compute_space/web/templates/app_detail.html
@@ -118,7 +118,17 @@
   <button class="btn" onclick="appAction('/stop_app/{{ app.app_id }}', null, {label: 'Stopping'})">Stop App</button>
   <button class="btn" onclick="appAction('/reload_app/{{ app.app_id }}', null, {label: 'Reloading'})">Reload App</button>
   <button class="btn" onclick="appAction('/reload_app/{{ app.app_id }}', {update: true}, {label: 'Updating &amp; reloading'})">Update &amp; Reload</button>
-  <a href="{{ editAppURL }}" class="btn">Edit this app</a>
+  {% if edit_app %}
+    {% if edit_app.mode == 'service' %}
+      <form method="POST" action="{{ edit_app.action }}" target="_blank" style="display:inline;">
+        <input type="hidden" name="repo" value="{{ edit_app.repo }}">
+        <input type="hidden" name="ref" value="{{ edit_app.ref }}">
+        <button class="btn" type="submit">Edit this app</button>
+      </form>
+    {% else %}
+      <a href="{{ edit_app.href }}" class="btn" target="_blank" rel="noopener">Edit this app</a>
+    {% endif %}
+  {% endif %}
   <button class="btn" onclick="if(confirm('Remove {{ app.name }} but keep its databases and files? You can re-deploy later to the same app name to reuse the data.')) appAction('/remove_app/{{ app.app_id }}', {keep_data: true}, {isRemove: true, label: 'Removing (keeping data)'})">Remove App (Keep Data)</button>
   <button class="btn btn-danger" onclick="if(confirm('Remove {{ app.name }}? This deletes all app data permanently.')) appAction('/remove_app/{{ app.app_id }}', {}, {isRemove: true, label: 'Removing'})">Remove App &amp; Data</button>
   <span id="app-action-msg" style="margin-left:0.5em;"></span>

--- a/compute_space/src/compute_space/web/templates/app_detail.html
+++ b/compute_space/src/compute_space/web/templates/app_detail.html
@@ -118,6 +118,7 @@
   <button class="btn" onclick="appAction('/stop_app/{{ app.app_id }}', null, {label: 'Stopping'})">Stop App</button>
   <button class="btn" onclick="appAction('/reload_app/{{ app.app_id }}', null, {label: 'Reloading'})">Reload App</button>
   <button class="btn" onclick="appAction('/reload_app/{{ app.app_id }}', {update: true}, {label: 'Updating &amp; reloading'})">Update &amp; Reload</button>
+  <a href="{{ editAppURL }}" class="btn">Edit this app</a>
   <button class="btn" onclick="if(confirm('Remove {{ app.name }} but keep its databases and files? You can re-deploy later to the same app name to reuse the data.')) appAction('/remove_app/{{ app.app_id }}', {keep_data: true}, {isRemove: true, label: 'Removing (keeping data)'})">Remove App (Keep Data)</button>
   <button class="btn btn-danger" onclick="if(confirm('Remove {{ app.name }}? This deletes all app data permanently.')) appAction('/remove_app/{{ app.app_id }}', {}, {isRemove: true, label: 'Removing'})">Remove App &amp; Data</button>
   <span id="app-action-msg" style="margin-left:0.5em;"></span>

--- a/openhost_system_agent/src/openhost_system_agent/migrations/migration_log.py
+++ b/openhost_system_agent/src/openhost_system_agent/migrations/migration_log.py
@@ -53,6 +53,13 @@ def current_host_version(entries: list[MigrationLogEntry]) -> int:
 
 def append_entry(path: str, entry: MigrationLogEntry) -> None:
     line = json.dumps(attr.asdict(entry), separators=(",", ":")) + "\n"
-    Path(path).parent.mkdir(parents=True, exist_ok=True)
-    with open(path, "a") as f:
+    p = Path(path)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    # If the existing file doesn't end in a newline (e.g. an external writer
+    # forgot one), prepend one so we don't run two JSON objects together on
+    # the same line — read_log would then skip both as malformed.
+    existing = p.read_bytes() if p.exists() else b""
+    if existing and not existing.endswith(b"\n"):
+        line = "\n" + line
+    with open(p, "a") as f:
         f.write(line)

--- a/openhost_system_agent/src/openhost_system_agent/tests/test_migration_log.py
+++ b/openhost_system_agent/src/openhost_system_agent/tests/test_migration_log.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from openhost_system_agent.migrations.migration_log import MigrationLogEntry
+from openhost_system_agent.migrations.migration_log import append_entry
+from openhost_system_agent.migrations.migration_log import read_log
+
+
+def test_append_inserts_newline_if_file_missing_one(tmp_path: Path) -> None:
+    """An external writer (ansible, manual edit) may leave the file without a
+    trailing newline; appending must not concatenate two JSON objects."""
+    log = tmp_path / "migrations.jsonl"
+    log.write_text('{"version":1,"timestamp":"t1","success":true,"error":null}')
+
+    append_entry(str(log), MigrationLogEntry(version=2, timestamp="t2", success=True, error=None))
+
+    entries = read_log(str(log))
+    assert [e.version for e in entries] == [1, 2]
+    assert log.read_text().count("\n") == 2
+
+
+def test_append_does_not_double_newline(tmp_path: Path) -> None:
+    log = tmp_path / "migrations.jsonl"
+    log.write_text('{"version":1,"timestamp":"t1","success":true,"error":null}\n')
+
+    append_entry(str(log), MigrationLogEntry(version=2, timestamp="t2", success=True, error=None))
+
+    assert log.read_text().count("\n") == 2


### PR DESCRIPTION
## Summary
- New **Edit this app** button on the app detail page that POSTs to a provider of the `…/open-workspace` service if one is registered, falling back to a plain link to the repo URL.
- Resolves the provider via `resolve_provider()`, then constructs a POST form per the [open-workspace OpenAPI spec](https://github.com/imbue-openhost/claude-code-container/blob/main/services/open-workspace/openapi.yaml). `repo`+`ref` are also passed in the query string so they survive the openhost router's 302→/login bounce (which downgrades the return hop to a GET and drops the form body).
- **Defensive fix in `migration_log.append_entry`**: if the existing file doesn't end in a newline (e.g. a manual edit during recovery), prepend one before appending. Hit this on a dev host where a hand-seeded v1 line lacked a trailing `\n` and v2 got concatenated onto it, making both lines unparseable and the agent report "No migration history found" despite valid data being present.

## Test plan
- [ ] CI green
- [ ] Manual: deploy this branch, install claude-workbench, click "Edit this app" on an app with a repo_url → opens a workspace in a new tab
- [ ] Manual: uninstall claude-workbench, button falls back to a plain repo link
- [ ] Manual: app with no repo_url → button is omitted