### PR TITLE
app_detail: open-workspace fallback for builtin apps

### DIFF
--- a/compute_space/src/compute_space/web/routes/pages/apps.py
+++ b/compute_space/src/compute_space/web/routes/pages/apps.py
@@ -14,6 +14,7 @@ from compute_space.core.apps import list_builtin_apps
 from compute_space.core.auth.permissions_v2 import get_all_permissions_v2
 from compute_space.core.containers import get_docker_logs
 from compute_space.core.git_ops import get_head_sha
+from compute_space.core.git_ops import get_remote_url
 from compute_space.core.git_ops import parse_repo_url
 from compute_space.core.logging import logger
 from compute_space.core.manifest import parse_manifest_from_string
@@ -110,6 +111,21 @@ async def _resolve_edit_app(
     """
     if not repo_url:
         return None
+    if repo_url.startswith("file://"):
+        # Builtin apps live in the openhost checkout itself (file:// to
+        # apps/<name>). A browser can't do anything useful with that path and
+        # the open-workspace provider can't clone it, so substitute the
+        # enclosing openhost repo — the user lands in the openhost checkout at
+        # the same commit and can navigate to apps/<name> from there.
+        try:
+            openhost_remote = await get_remote_url(config.openhost_repo_path)
+        except Exception:
+            logger.opt(exception=True).warning("Failed to read openhost remote URL for builtin app")
+            openhost_remote = None
+        if not openhost_remote:
+            return None
+        repo_url = openhost_remote
+        repo_path = str(config.openhost_repo_path)
     base_url, ref_from_url = parse_repo_url(repo_url)
     repo_link_fallback = {"mode": "repo", "href": base_url}
     ref = ref_from_url

--- a/compute_space/src/compute_space/web/templates/app_detail.html
+++ b/compute_space/src/compute_space/web/templates/app_detail.html
@@ -120,13 +120,13 @@
   <button class="btn" onclick="appAction('/reload_app/{{ app.app_id }}', {update: true}, {label: 'Updating &amp; reloading'})">Update &amp; Reload</button>
   {% if edit_app %}
     {% if edit_app.mode == 'service' %}
-      <form method="POST" action="{{ edit_app.action }}" target="_blank" style="display:inline;">
+      <form method="POST" action="{{ edit_app.action }}" target="_blank" style="display:contents;">
         <input type="hidden" name="repo" value="{{ edit_app.repo }}">
         <input type="hidden" name="ref" value="{{ edit_app.ref }}">
-        <button class="btn" type="submit">Edit this app</button>
+        <button class="btn" type="submit">Edit App</button>
       </form>
     {% else %}
-      <a href="{{ edit_app.href }}" class="btn" target="_blank" rel="noopener">Edit this app</a>
+      <a href="{{ edit_app.href }}" class="btn" target="_blank" rel="noopener">Edit App</a>
     {% endif %}
   {% endif %}
   <button class="btn" onclick="if(confirm('Remove {{ app.name }} but keep its databases and files? You can re-deploy later to the same app name to reuse the data.')) appAction('/remove_app/{{ app.app_id }}', {keep_data: true}, {isRemove: true, label: 'Removing (keeping data)'})">Remove App (Keep Data)</button>


### PR DESCRIPTION
## Summary
Builtin apps (the ones under ``apps/<name>`` shipped in the openhost repo) record their ``repo_url`` as ``file://<apps_dir>/<name>``. After #155 the "Edit this app" button is therefore broken for them — a browser can't open that path, and the open-workspace provider has no way to clone it.

Substitute the enclosing openhost repo: use ``get_remote_url(config.openhost_repo_path)`` and the openhost checkout's HEAD SHA, so the user lands in an openhost workspace at the same commit and can navigate to ``apps/<name>`` from there. If the openhost repo has no ``origin`` remote configured, the button is omitted.

## Test plan
- [ ] CI green
- [ ] Manual: click "Edit this app" on a builtin app → opens openhost workspace at current commit
- [ ] Manual: click "Edit this app" on a normal (cloned) app → unchanged behaviour