### PR TITLE
Per-app TLS certificate provisioning and injection

### DIFF
--- a/compute_space/src/compute_space/core/apps.py
+++ b/compute_space/src/compute_space/core/apps.py
@@ -42,6 +42,8 @@ from compute_space.core.ports import allocate_port
 from compute_space.core.ports import resolve_port_mappings
 from compute_space.core.services_v2 import ServiceNotAvailable
 from compute_space.core.services_v2 import register_v2_service_providers
+from compute_space.core.tls.app_certs import app_cert_dir
+from compute_space.core.tls.app_certs import provision_app_certs_for_deploy
 from compute_space.db import get_db
 
 
@@ -476,6 +478,7 @@ def deploy_app_background(
             (app_id,),
         )
         db.commit()
+        tls_cert_dir, rendered_certs = provision_app_certs_for_deploy(app_name, manifest, config)
         container_id = run_container(
             app_name,
             image_tag,
@@ -486,6 +489,8 @@ def deploy_app_background(
             config.temporary_data_dir,
             config.app_archive_dir,
             port_mappings=port_mappings,
+            tls_cert_dir=tls_cert_dir,
+            rendered_certs=rendered_certs,
         )
         db.execute(
             "UPDATE apps SET container_id = ? WHERE app_id = ?",
@@ -640,6 +645,7 @@ def start_app_process(app_id: str, db: sqlite3.Connection, config: Config) -> No
         manifest.container_image,
         temp_data_dir=config.temporary_data_dir,
     )
+    tls_cert_dir, rendered_certs = provision_app_certs_for_deploy(app_name, manifest, config)
     container_id = run_container(
         app_name,
         image_tag,
@@ -650,6 +656,8 @@ def start_app_process(app_id: str, db: sqlite3.Connection, config: Config) -> No
         config.temporary_data_dir,
         config.app_archive_dir,
         port_mappings=port_mappings,
+        tls_cert_dir=tls_cert_dir,
+        rendered_certs=rendered_certs,
     )
     db.execute(
         "UPDATE apps SET container_id = ? WHERE app_id = ?",
@@ -871,6 +879,9 @@ def remove_app_background(app_id: str, keep_data: bool, config: Config) -> None:
                     config.temporary_data_dir,
                     config.app_archive_dir,
                 )
+                # Router-owned provisioned TLS certs live outside the app data
+                # dir (under persistent_data/openhost/app_certs); remove them too.
+                rmtree_with_sudo_fallback(str(app_cert_dir(config.openhost_data_path, app_name)))
         except Exception:
             logger.exception("Failed to deprovision data for %s", app_name)
 

--- a/compute_space/src/compute_space/core/containers.py
+++ b/compute_space/src/compute_space/core/containers.py
@@ -23,12 +23,23 @@ import os
 import re
 import sqlite3
 import subprocess
+from typing import TYPE_CHECKING
 
 from compute_space.core.logging import logger
 from compute_space.core.manifest import AppManifest
 from compute_space.core.manifest import PortMapping
 
+if TYPE_CHECKING:
+    from compute_space.core.tls.app_certs import RenderedCertRequest
+
 CONTAINER_ROOT = "/data"
+
+# Read-only mount point inside the container for router-provisioned TLS
+# certs requested via [[tls_certs]].  Apps read their cert/key from here
+# (see OPENHOST_TLS_CERT/OPENHOST_TLS_KEY env vars).  Mounted read-only so
+# the app can't tamper with the router-managed key, and so renewals (which
+# the router writes on the host side) propagate without the app racing it.
+CONTAINER_TLS_ROOT = f"{CONTAINER_ROOT}/tls"
 
 _ANSI_RE = re.compile(r"\x1b\[[0-9;]*[a-zA-Z]|\x1b\([AB0-9]|\x1b[=>]|\x0f|\r")
 
@@ -168,6 +179,25 @@ def _bind_mount_arg(host_path: str, container_path: str, *, read_only: bool = Fa
     return f"{host_path}:{container_path}:{options}"
 
 
+def _tls_cert_env(cert: RenderedCertRequest) -> dict[str, str]:
+    """Env vars pointing at a provisioned cert's in-container (read-only) paths.
+
+    Each cert exposes label-suffixed vars (``OPENHOST_TLS_CERT_<LABEL>`` etc.)
+    so an app with several certs can disambiguate.  Callers set the unsuffixed
+    ``OPENHOST_TLS_CERT``/``OPENHOST_TLS_KEY``/``OPENHOST_TLS_DOMAINS`` to the
+    first cert for the common single-cert case.
+    """
+    cert_in = f"{CONTAINER_TLS_ROOT}/{cert.cert_rel_path}"
+    key_in = f"{CONTAINER_TLS_ROOT}/{cert.key_rel_path}"
+    domains = ",".join(cert.domains)
+    suffix = cert.label.upper().replace("-", "_")
+    return {
+        f"OPENHOST_TLS_CERT_{suffix}": cert_in,
+        f"OPENHOST_TLS_KEY_{suffix}": key_in,
+        f"OPENHOST_TLS_DOMAINS_{suffix}": domains,
+    }
+
+
 def run_container(
     app_name: str,
     image_tag: str,
@@ -178,8 +208,16 @@ def run_container(
     temp_data_dir: str,
     archive_dir: str,
     port_mappings: list[PortMapping] | None = None,
+    tls_cert_dir: str | None = None,
+    rendered_certs: list[RenderedCertRequest] | None = None,
 ) -> str:
-    """Start a detached container for an app.  Returns the container ID."""
+    """Start a detached container for an app.  Returns the container ID.
+
+    ``tls_cert_dir``/``rendered_certs`` wire router-provisioned TLS certs
+    (from ``[[tls_certs]]``) into the container: the host ``tls_cert_dir`` is
+    bind-mounted read-only at ``/data/tls`` and ``OPENHOST_TLS_*`` env vars
+    point at the in-container cert/key paths.
+    """
     app_data_dir = os.path.join(data_dir, "app_data", app_name)
     app_temp_dir = os.path.join(temp_data_dir, "app_temp_data", app_name)
     app_archive_dir = os.path.join(archive_dir, app_name)
@@ -293,6 +331,18 @@ def run_container(
             cmd.extend(["-v", _bind_mount_arg(archive_dir, f"{CONTAINER_ROOT}/app_archive")])
     elif has_app_archive:
         cmd.extend(["-v", _bind_mount_arg(app_archive_dir, c_app_archive)])
+
+    # Router-provisioned TLS certs (from [[tls_certs]]): mount the per-app
+    # cert dir read-only and expose the cert/key paths as env vars.
+    if rendered_certs and tls_cert_dir and os.path.isdir(tls_cert_dir):
+        cmd.extend(["-v", _bind_mount_arg(tls_cert_dir, CONTAINER_TLS_ROOT, read_only=True)])
+        for cert in rendered_certs:
+            container_env.update(_tls_cert_env(cert))
+        # Convenience unsuffixed vars for the common single-cert case.
+        first = rendered_certs[0]
+        container_env["OPENHOST_TLS_CERT"] = f"{CONTAINER_TLS_ROOT}/{first.cert_rel_path}"
+        container_env["OPENHOST_TLS_KEY"] = f"{CONTAINER_TLS_ROOT}/{first.key_rel_path}"
+        container_env["OPENHOST_TLS_DOMAINS"] = ",".join(first.domains)
 
     # Structured port mappings: bind TCP+UDP on 0.0.0.0.  host_port
     # values below UNPRIVILEGED_PORT_FLOOR are rejected at manifest

--- a/compute_space/src/compute_space/core/dns.py
+++ b/compute_space/src/compute_space/core/dns.py
@@ -105,22 +105,40 @@ def set_txt(
     name: str,
     values: str | list[str],
 ) -> None:
-    """Append TXT record(s) to the zone file and bump the SOA serial.
+    """Append TXT record(s) under a single owner ``name`` and bump the SOA serial.
 
     For ACME DNS-01 challenges, name is typically '_acme-challenge'.
     values can be a single string or a list of strings (for multiple
-    authorizations, e.g. base domain + wildcard).
+    authorizations on the same owner name, e.g. base domain + wildcard).
     """
     if isinstance(values, str):
         values = [values]
+    set_txt_records(zone_file_path, {name: values})
+
+
+def set_txt_records(
+    zone_file_path: Path,
+    records: dict[str, list[str]],
+) -> None:
+    """Append TXT records under multiple owner names and bump the SOA serial once.
+
+    ``records`` maps each owner name (relative to the zone origin, e.g.
+    ``_acme-challenge`` or ``_acme-challenge.xmpp``) to its list of TXT
+    values.  Used for DNS-01 orders that span several subdomains, where each
+    identifier's challenge lives at ``_acme-challenge.<identifier>`` rather
+    than all sharing a single ``_acme-challenge`` owner.
+    """
     with open(zone_file_path) as f:
         content = f.read()
     content = _bump_serial(content)
-    for v in values:
-        content += f'{name}   IN TXT  "{v}"\n'
+    total = 0
+    for name, values in records.items():
+        for v in values:
+            content += f'{name}   IN TXT  "{v}"\n'
+            total += 1
     with open(zone_file_path, "w") as f:
         f.write(content)
-    logger.info(f"Set {len(values)} TXT record(s) {name}")
+    logger.info(f"Set {total} TXT record(s) across {len(records)} owner name(s)")
 
 
 def clear_txt(zone_file_path: Path) -> None:

--- a/compute_space/src/compute_space/core/manifest.py
+++ b/compute_space/src/compute_space/core/manifest.py
@@ -131,7 +131,8 @@ class TlsCertRequest:
 
     label: str
     domains: list[str]
-    # Relative paths (under OPENHOST_APP_DATA_DIR) where cert/key are written.
+    # Relative paths within the read-only TLS mount (/data/tls) where the
+    # cert/key are placed; surfaced via OPENHOST_TLS_CERT/OPENHOST_TLS_KEY.
     cert_path: str = "certs/{app}.{zone}.crt"
     key_path: str = "certs/{app}.{zone}.key"
 

--- a/compute_space/src/compute_space/core/manifest.py
+++ b/compute_space/src/compute_space/core/manifest.py
@@ -13,6 +13,24 @@ from compute_space.core.logging import logger
 
 _SHORTNAME_RE = re.compile(r"^[a-z][a-z0-9_-]{0,31}$")
 
+# Cap on how many [[tls_certs]] entries one app may declare, and how many
+# SAN domains each may request.  Real ACME providers (Let's Encrypt, Google
+# Trust Services) enforce their own per-cert SAN ceilings (~100) and
+# per-account issuance rate limits; these caps keep a single manifest from
+# requesting an unreasonable number of distinct certificates.
+MAX_TLS_CERT_REQUESTS = 8
+MAX_TLS_CERT_DOMAINS = 16
+
+# Allowed placeholders inside [[tls_certs]] domains/paths.  These expand at
+# provision time once the concrete app name and zone domain are known.
+#   {app}  -> the deployed app name (e.g. "xmpp")
+#   {zone} -> the zone domain with no port (e.g. "alice.example.com")
+_TLS_CERT_PLACEHOLDER_RE = re.compile(r"\{(app|zone)\}")
+# A rendered DNS name must look like a hostname: labels of letters/digits/
+# hyphens separated by dots, wildcards not permitted (apps only ever get a
+# concrete SAN list, never a wildcard).
+_DNS_NAME_RE = re.compile(r"^(?=.{1,253}$)([a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?)(\.[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?)*$")
+
 # Must match net.ipv4.ip_unprivileged_port_start from ansible/tasks/containers.yml.
 # host_port values below this are rejected at parse time.
 UNPRIVILEGED_PORT_FLOOR = 25
@@ -89,6 +107,30 @@ class PortMapping:
 
 
 @attr.s(auto_attribs=True, frozen=True)
+class TlsCertRequest:
+    """A real TLS certificate the app wants provisioned and injected.
+
+    Declared in ``[[tls_certs]]``.  The router acquires a certificate
+    covering ``domains`` (via the same ACME DNS-01 machinery used for the
+    zone cert) and drops the PEM cert/key into the container so apps that
+    need real, browser/federation-trusted certs (e.g. an XMPP server doing
+    s2s federation) don't have to fall back to self-signed pairs.
+
+    ``domains`` entries and ``cert_path``/``key_path`` may contain the
+    ``{app}`` and ``{zone}`` placeholders, expanded at provision time.
+    ``cert_path``/``key_path`` are relative to ``OPENHOST_APP_DATA_DIR``;
+    the router also injects ``OPENHOST_TLS_CERT``/``OPENHOST_TLS_KEY``
+    pointing at the in-container paths.
+    """
+
+    label: str
+    domains: list[str]
+    # Relative paths (under OPENHOST_APP_DATA_DIR) where cert/key are written.
+    cert_path: str = "certs/{app}.{zone}.crt"
+    key_path: str = "certs/{app}.{zone}.key"
+
+
+@attr.s(auto_attribs=True, frozen=True)
 class ServiceProvides:
     service: str = attr.ib(converter=_normalize_service_url)
     version: str
@@ -158,6 +200,9 @@ class AppManifest:
     access_all_archive: bool = False
     # Convenience shorthand: equivalent to access_all_app_data + access_all_archive.
     access_all_data: bool = False
+
+    # [[tls_certs]]
+    tls_certs: list[TlsCertRequest] = attr.Factory(list)
 
     # [services.v2]
     provides_services_v2: list[ServiceProvides] = attr.Factory(list)
@@ -253,6 +298,73 @@ def _parse_ports(ports_list: list[Any]) -> list[PortMapping]:
         if hport != 0:
             seen_host_ports.add(hport)
         result.append(PortMapping(label=label, container_port=cport, host_port=hport))
+    return result
+
+
+def _validate_tls_cert_template(value: str, field: str, label: str) -> None:
+    """Structural validation of a [[tls_certs]] domain or path template.
+
+    Only the placeholders ``{app}`` and ``{zone}`` are permitted; any other
+    ``{...}`` is rejected so a typo doesn't silently survive into a SAN.  The
+    concrete scoping check (the rendered domain must live under
+    ``{app}.{zone}``) happens at provision time once the real zone is known.
+    """
+    # Reject stray brace placeholders other than {app}/{zone}.
+    stripped = _TLS_CERT_PLACEHOLDER_RE.sub("", value)
+    if "{" in stripped or "}" in stripped:
+        raise ValueError(
+            f"[[tls_certs]] '{label}' {field} {value!r} contains an unknown placeholder; "
+            f"only {{app}} and {{zone}} are supported"
+        )
+
+
+def _parse_tls_certs(certs_list: list[Any]) -> list[TlsCertRequest]:
+    """Parse and validate [[tls_certs]] entries from manifest data."""
+    if not isinstance(certs_list, list):
+        raise ValueError("[[tls_certs]] must be a list of tables")
+    if len(certs_list) > MAX_TLS_CERT_REQUESTS:
+        raise ValueError(f"At most {MAX_TLS_CERT_REQUESTS} [[tls_certs]] entries are allowed")
+    seen_labels: set[str] = set()
+    result: list[TlsCertRequest] = []
+    for entry in certs_list:
+        if not isinstance(entry, dict):
+            raise ValueError("Each [[tls_certs]] entry must be a table")
+        label = entry.get("label")
+        if not label or not isinstance(label, str):
+            raise ValueError("Each [[tls_certs]] entry requires a string 'label'")
+        if not _SHORTNAME_RE.match(label):
+            raise ValueError(f"Invalid [[tls_certs]] label {label!r}: must match {_SHORTNAME_RE.pattern}")
+        if label in seen_labels:
+            raise ValueError(f"Duplicate [[tls_certs]] label: '{label}'")
+        seen_labels.add(label)
+
+        domains_raw = entry.get("domains")
+        if not isinstance(domains_raw, list) or not domains_raw:
+            raise ValueError(f"[[tls_certs]] '{label}' requires a non-empty 'domains' list")
+        if len(domains_raw) > MAX_TLS_CERT_DOMAINS:
+            raise ValueError(f"[[tls_certs]] '{label}' requests too many domains (max {MAX_TLS_CERT_DOMAINS})")
+        domains: list[str] = []
+        seen_domains: set[str] = set()
+        for d in domains_raw:
+            if not isinstance(d, str) or not d:
+                raise ValueError(f"[[tls_certs]] '{label}' domains must be non-empty strings")
+            _validate_tls_cert_template(d, "domain", label)
+            if d in seen_domains:
+                raise ValueError(f"[[tls_certs]] '{label}' has duplicate domain {d!r}")
+            seen_domains.add(d)
+            domains.append(d)
+
+        cert_path = entry.get("cert_path", "certs/{app}.{zone}.crt")
+        key_path = entry.get("key_path", "certs/{app}.{zone}.key")
+        for fld, val in (("cert_path", cert_path), ("key_path", key_path)):
+            if not isinstance(val, str) or not val:
+                raise ValueError(f"[[tls_certs]] '{label}' {fld} must be a non-empty string")
+            _validate_tls_cert_template(val, fld, label)
+            if os.path.isabs(val) or os.path.normpath(val).startswith(".."):
+                raise ValueError(
+                    f"[[tls_certs]] '{label}' {fld} {val!r} must be a relative path within the app data dir"
+                )
+        result.append(TlsCertRequest(label=label, domains=domains, cert_path=cert_path, key_path=key_path))
     return result
 
 
@@ -365,6 +477,7 @@ def parse_manifest_from_string(raw_text: str) -> AppManifest:
         devices=_validate_devices(container.get("devices", [])),
         network_host=container.get("network_host", False),
         shm_mb=shm_mb,
+        tls_certs=_parse_tls_certs(data.get("tls_certs", [])),
         health_check=routing.get("health_check"),
         public_paths=routing.get("public_paths", []),
         memory_mb=resources.get("memory_mb", 128),

--- a/compute_space/src/compute_space/core/manifest.py
+++ b/compute_space/src/compute_space/core/manifest.py
@@ -31,6 +31,11 @@ _TLS_CERT_PLACEHOLDER_RE = re.compile(r"\{(app|zone)\}")
 # concrete SAN list, never a wildcard).
 _DNS_NAME_RE = re.compile(r"^(?=.{1,253}$)([a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?)(\.[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?)*$")
 
+
+def is_valid_dns_name(name: str) -> bool:
+    """True iff ``name`` is a syntactically valid, lowercase, non-wildcard DNS name."""
+    return bool(_DNS_NAME_RE.match(name))
+
 # Must match net.ipv4.ip_unprivileged_port_start from ansible/tasks/containers.yml.
 # host_port values below this are rejected at parse time.
 UNPRIVILEGED_PORT_FLOOR = 25
@@ -118,9 +123,10 @@ class TlsCertRequest:
 
     ``domains`` entries and ``cert_path``/``key_path`` may contain the
     ``{app}`` and ``{zone}`` placeholders, expanded at provision time.
-    ``cert_path``/``key_path`` are relative to ``OPENHOST_APP_DATA_DIR``;
-    the router also injects ``OPENHOST_TLS_CERT``/``OPENHOST_TLS_KEY``
-    pointing at the in-container paths.
+    ``cert_path``/``key_path`` are relative paths within the read-only TLS
+    mount (``/data/tls`` in the container); the router also injects
+    ``OPENHOST_TLS_CERT``/``OPENHOST_TLS_KEY`` pointing at the resulting
+    in-container paths.
     """
 
     label: str

--- a/compute_space/src/compute_space/core/manifest.py
+++ b/compute_space/src/compute_space/core/manifest.py
@@ -29,12 +29,15 @@ _TLS_CERT_PLACEHOLDER_RE = re.compile(r"\{(app|zone)\}")
 # A rendered DNS name must look like a hostname: labels of letters/digits/
 # hyphens separated by dots, wildcards not permitted (apps only ever get a
 # concrete SAN list, never a wildcard).
-_DNS_NAME_RE = re.compile(r"^(?=.{1,253}$)([a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?)(\.[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?)*$")
+_DNS_NAME_RE = re.compile(
+    r"^(?=.{1,253}$)([a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?)(\.[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?)*$"
+)
 
 
 def is_valid_dns_name(name: str) -> bool:
     """True iff ``name`` is a syntactically valid, lowercase, non-wildcard DNS name."""
     return bool(_DNS_NAME_RE.match(name))
+
 
 # Must match net.ipv4.ip_unprivileged_port_start from ansible/tasks/containers.yml.
 # host_port values below this are rejected at parse time.

--- a/compute_space/src/compute_space/core/manifest.py
+++ b/compute_space/src/compute_space/core/manifest.py
@@ -332,6 +332,11 @@ def _parse_tls_certs(certs_list: list[Any]) -> list[TlsCertRequest]:
     if len(certs_list) > MAX_TLS_CERT_REQUESTS:
         raise ValueError(f"At most {MAX_TLS_CERT_REQUESTS} [[tls_certs]] entries are allowed")
     seen_labels: set[str] = set()
+    # Track the sanitized env-var suffix (uppercase, hyphens->underscores) so
+    # two distinct labels that collapse to the same suffix (e.g. "web-a" and
+    # "web_a" both -> "WEB_A") are rejected rather than silently clobbering
+    # each other's OPENHOST_TLS_*_<SUFFIX> env vars at run time.
+    seen_env_suffixes: dict[str, str] = {}
     result: list[TlsCertRequest] = []
     for entry in certs_list:
         if not isinstance(entry, dict):
@@ -344,6 +349,13 @@ def _parse_tls_certs(certs_list: list[Any]) -> list[TlsCertRequest]:
         if label in seen_labels:
             raise ValueError(f"Duplicate [[tls_certs]] label: '{label}'")
         seen_labels.add(label)
+        env_suffix = label.upper().replace("-", "_")
+        if env_suffix in seen_env_suffixes:
+            raise ValueError(
+                f"[[tls_certs]] label {label!r} collides with {seen_env_suffixes[env_suffix]!r} after "
+                f"env-var normalization (both map to suffix {env_suffix!r}); use distinct labels"
+            )
+        seen_env_suffixes[env_suffix] = label
 
         domains_raw = entry.get("domains")
         if not isinstance(domains_raw, list) or not domains_raw:

--- a/compute_space/src/compute_space/core/tls/app_certs.py
+++ b/compute_space/src/compute_space/core/tls/app_certs.py
@@ -143,7 +143,10 @@ def _write_pair(cert_path: Path, key_path: Path, cert_pem: bytes, key_pem: bytes
     tmp_key = key_path.with_suffix(key_path.suffix + ".partial")
     tmp_cert.write_bytes(cert_pem)
     tmp_key.write_bytes(key_pem)
-    os.chmod(tmp_key, 0o640)
+    # Private key 0600 (owner-only), matching the zone key in acquire_cert.py.
+    # The container reads it through the idmapped read-only bind mount, where
+    # the host owner maps to the container's user, so owner-only is sufficient.
+    os.chmod(tmp_key, 0o600)
     os.replace(tmp_cert, cert_path)
     os.replace(tmp_key, key_path)
 

--- a/compute_space/src/compute_space/core/tls/app_certs.py
+++ b/compute_space/src/compute_space/core/tls/app_certs.py
@@ -1,0 +1,312 @@
+"""Per-app real TLS certificate provisioning and injection.
+
+Apps declare ``[[tls_certs]]`` in their manifest to request real,
+ACME-issued certificates (as opposed to the self-signed pairs an app
+would otherwise have to generate itself).  The motivating case is an XMPP
+server: server-to-server federation is rejected by most peers when the
+presented cert is self-signed, and the zone wildcard ``*.{zone}`` does
+NOT cover second-level component hosts like ``conference.xmpp.{zone}``.
+
+The router already owns the ACME account and the CoreDNS zone, so it can
+issue any cert under the zone via DNS-01.  This module:
+
+  * expands the ``{app}``/``{zone}`` placeholders in a manifest request,
+  * enforces that every requested SAN lives under ``{app}.{zone}`` (an app
+    can never obtain a cert for another app's hostname or the bare zone),
+  * reuses the already-acquired zone wildcard cert when it covers every
+    requested SAN (cheap, no new ACME order), otherwise issues a dedicated
+    cert via DNS-01,
+  * writes the cert/key under a router-owned per-app directory that is
+    bind-mounted read-only into the container, and
+  * decides when an existing cert is close enough to expiry to renew.
+
+Cert acquisition is serialized process-wide via ``_ACME_LOCK`` because the
+DNS-01 flow mutates a single shared ``_acme-challenge`` record set in the
+zone file; two concurrent orders would clobber each other's TXT records.
+"""
+
+from __future__ import annotations
+
+import datetime
+import os
+import threading
+from pathlib import Path
+
+import attr
+from cryptography import x509
+
+from compute_space.config import Config
+from compute_space.core.logging import logger
+from compute_space.core.manifest import AppManifest
+from compute_space.core.manifest import TlsCertRequest
+from compute_space.core.tls.acquire_cert import GTS_PRODUCTION
+from compute_space.core.tls.util import _acquire_cert_dns01
+from compute_space.core.tls.util import load_account_key
+
+# Renew a cert once it is within this many days of its notAfter.  GTS/LE
+# certs are ~90 days; 30 days of headroom is the conventional ACME margin.
+RENEWAL_WINDOW_DAYS = 30
+
+# Serialize ACME DNS-01 orders: they share the zone file's _acme-challenge
+# TXT record set, so concurrent orders would corrupt each other.
+_ACME_LOCK = threading.Lock()
+
+
+@attr.s(auto_attribs=True, frozen=True)
+class RenderedCertRequest:
+    """A [[tls_certs]] request with placeholders resolved to concrete values."""
+
+    label: str
+    domains: list[str]
+    # Path of the cert/key relative to the per-app cert dir (and, identically,
+    # relative to the read-only /data/tls mount inside the container).
+    cert_rel_path: str
+    key_rel_path: str
+
+
+def expand_template(value: str, app_name: str, zone: str) -> str:
+    """Expand ``{app}``/``{zone}`` placeholders in a manifest template."""
+    return value.replace("{app}", app_name).replace("{zone}", zone)
+
+
+def _is_within_zone_subtree(domain: str, app_name: str, zone: str) -> bool:
+    """True iff ``domain`` is ``{app}.{zone}`` or a subdomain of it.
+
+    The bare zone and other apps' subdomains are intentionally excluded: an
+    app may only obtain certs for hostnames rooted at its own app subdomain.
+    """
+    base = f"{app_name}.{zone}".lower()
+    domain = domain.lower()
+    return domain == base or domain.endswith("." + base)
+
+
+def render_cert_request(req: TlsCertRequest, app_name: str, zone: str) -> RenderedCertRequest:
+    """Resolve placeholders and validate scoping for a single request.
+
+    Raises ``ValueError`` if any requested SAN falls outside ``{app}.{zone}``
+    or renders to something that isn't a valid DNS name.
+    """
+    from compute_space.core.manifest import _DNS_NAME_RE  # noqa: PLC0415 — avoid import cycle
+
+    domains: list[str] = []
+    seen: set[str] = set()
+    for raw in req.domains:
+        d = expand_template(raw, app_name, zone).lower()
+        if not _DNS_NAME_RE.match(d):
+            raise ValueError(f"[[tls_certs]] '{req.label}' domain {raw!r} rendered to invalid DNS name {d!r}")
+        if not _is_within_zone_subtree(d, app_name, zone):
+            raise ValueError(
+                f"[[tls_certs]] '{req.label}' domain {d!r} is outside this app's subtree "
+                f"({app_name}.{zone}); apps may only request certs for their own subdomains"
+            )
+        if d not in seen:
+            seen.add(d)
+            domains.append(d)
+
+    cert_rel = os.path.normpath(expand_template(req.cert_path, app_name, zone))
+    key_rel = os.path.normpath(expand_template(req.key_path, app_name, zone))
+    for rel in (cert_rel, key_rel):
+        if os.path.isabs(rel) or rel.startswith(".."):
+            raise ValueError(f"[[tls_certs]] '{req.label}' resolved to an out-of-bounds path {rel!r}")
+    return RenderedCertRequest(label=req.label, domains=domains, cert_rel_path=cert_rel, key_rel_path=key_rel)
+
+
+def cert_covered_by_wildcard(domains: list[str], zone: str) -> bool:
+    """True iff the zone cert (``zone`` + ``*.zone``) covers every domain.
+
+    ``*.zone`` matches exactly one label below the zone, so ``a.zone`` is
+    covered but ``a.b.zone`` is not.
+    """
+    zone = zone.lower()
+    for d in domains:
+        d = d.lower()
+        if d == zone:
+            continue
+        if d.endswith("." + zone):
+            label = d[: -(len(zone) + 1)]
+            if "." not in label and label:
+                continue  # single-label subdomain -> covered by *.zone
+        return False
+    return True
+
+
+def cert_present_and_current(
+    cert_path: Path,
+    key_path: Path,
+    expected_domains: list[str],
+    now: datetime.datetime | None = None,
+) -> bool:
+    """True iff a cert/key pair exists, covers all expected SANs, and is not near expiry.
+
+    Returns False (so the caller re-provisions) if the cert is missing,
+    unreadable, missing a required SAN, or within ``RENEWAL_WINDOW_DAYS`` of
+    expiry.  Never raises on a malformed cert.
+    """
+    if not cert_path.exists() or not key_path.exists():
+        return False
+    try:
+        cert = x509.load_pem_x509_certificate(cert_path.read_bytes())
+    except (ValueError, OSError) as exc:
+        logger.warning("Existing app cert at %s is unreadable (%s); will re-provision", cert_path, exc)
+        return False
+
+    try:
+        san = cert.extensions.get_extension_for_class(x509.SubjectAlternativeName).value
+        present = {n.lower() for n in san.get_values_for_type(x509.DNSName)}
+    except x509.ExtensionNotFound:
+        present = set()
+    for d in expected_domains:
+        dl = d.lower()
+        if dl in present:
+            continue
+        # A wildcard SAN (*.zone) covers single-label subdomains.
+        covered = any(w.startswith("*.") and dl.endswith(w[1:]) and "." not in dl[: -(len(w) - 1)] for w in present)
+        if not covered:
+            logger.info("App cert at %s missing SAN %r; will re-provision", cert_path, d)
+            return False
+
+    now = now or datetime.datetime.now(datetime.UTC)
+    not_after = cert.not_valid_after_utc
+    if not_after - now <= datetime.timedelta(days=RENEWAL_WINDOW_DAYS):
+        logger.info("App cert at %s expires %s (within renewal window); will renew", cert_path, not_after)
+        return False
+    return True
+
+
+def _write_pair(cert_path: Path, key_path: Path, cert_pem: bytes, key_pem: bytes) -> None:
+    cert_path.parent.mkdir(parents=True, exist_ok=True)
+    key_path.parent.mkdir(parents=True, exist_ok=True)
+    # Atomic-ish write: temp then replace, so a crash mid-write can't leave a
+    # half-written cert that the presence/expiry check mistakes for valid.
+    tmp_cert = cert_path.with_suffix(cert_path.suffix + ".partial")
+    tmp_key = key_path.with_suffix(key_path.suffix + ".partial")
+    tmp_cert.write_bytes(cert_pem)
+    tmp_key.write_bytes(key_pem)
+    os.chmod(tmp_key, 0o640)
+    os.replace(tmp_cert, cert_path)
+    os.replace(tmp_key, key_path)
+
+
+def app_cert_dir(openhost_data_path: Path, app_name: str) -> Path:
+    """Router-owned directory holding an app's provisioned certs.
+
+    Bind-mounted read-only into the container at ``/data/tls``.
+    """
+    return Path(openhost_data_path) / "app_certs" / app_name
+
+
+def provision_app_certs(
+    app_name: str,
+    requests: list[TlsCertRequest],
+    zone: str,
+    openhost_data_path: Path,
+    wildcard_cert_path: Path,
+    wildcard_key_path: Path,
+    acme_account_key_path: Path | None,
+    coredns_zonefile_path: Path,
+    *,
+    acme_email: str | None = None,
+    acme_directory_url: str | None = None,
+    coredns_enabled: bool = True,
+    force: bool = False,
+    verify_ssl: bool = True,
+) -> list[RenderedCertRequest]:
+    """Ensure every requested cert exists, is in scope, and is current.
+
+    Returns the list of rendered requests (used by the caller to build the
+    container's env vars and bind mount).  Reuses the zone wildcard cert when
+    it covers all SANs; otherwise issues a dedicated cert via DNS-01.  Already
+    valid, non-expiring certs are left untouched unless ``force`` is set.
+
+    Raises ``ValueError`` for out-of-scope requests, ``RuntimeError`` if a
+    cert must be issued but the prerequisites (CoreDNS, ACME key) are missing.
+    """
+    rendered: list[RenderedCertRequest] = []
+    cert_dir = app_cert_dir(openhost_data_path, app_name)
+    for req in requests:
+        r = render_cert_request(req, app_name, zone)
+        rendered.append(r)
+        cert_path = cert_dir / r.cert_rel_path
+        key_path = cert_dir / r.key_rel_path
+
+        if not force and cert_present_and_current(cert_path, key_path, r.domains):
+            logger.info("App %s cert '%s' is current; reusing", app_name, r.label)
+            continue
+
+        if cert_covered_by_wildcard(r.domains, zone):
+            if wildcard_cert_path.exists() and wildcard_key_path.exists():
+                logger.info("App %s cert '%s' covered by zone wildcard; copying wildcard cert", app_name, r.label)
+                _write_pair(
+                    cert_path,
+                    key_path,
+                    wildcard_cert_path.read_bytes(),
+                    wildcard_key_path.read_bytes(),
+                )
+                continue
+            logger.warning(
+                "App %s cert '%s' is wildcard-covered but no zone wildcard cert exists; issuing dedicated cert",
+                app_name,
+                r.label,
+            )
+
+        if not coredns_enabled:
+            raise RuntimeError(
+                f"Cannot issue dedicated cert for app '{app_name}' (label '{r.label}'): CoreDNS is "
+                f"disabled, so DNS-01 is unavailable.  Requested domains: {r.domains}"
+            )
+        if not acme_account_key_path:
+            raise RuntimeError(
+                f"Cannot issue dedicated cert for app '{app_name}' (label '{r.label}'): no ACME account key configured"
+            )
+
+        logger.info("Issuing dedicated TLS cert for app %s '%s': %s", app_name, r.label, r.domains)
+        account_key = load_account_key(acme_account_key_path)
+        directory_url = acme_directory_url or GTS_PRODUCTION
+        with _ACME_LOCK:
+            cert_pem, key_pem = _acquire_cert_dns01(
+                domains=list(r.domains),
+                directory_url=directory_url,
+                coredns_zonefile_path=coredns_zonefile_path,
+                account_key=account_key,
+                acme_email=acme_email,
+                verify_ssl=verify_ssl,
+                zone_domain=zone,
+            )
+        _write_pair(cert_path, key_path, cert_pem, key_pem)
+        logger.info("Wrote dedicated cert for app %s '%s' to %s", app_name, r.label, cert_path)
+
+    return rendered
+
+
+def provision_app_certs_for_deploy(
+    app_name: str,
+    manifest: AppManifest,
+    config: Config,
+    *,
+    force: bool = False,
+) -> tuple[str | None, list[RenderedCertRequest]]:
+    """Provision an app's ``[[tls_certs]]`` from the live config.
+
+    Convenience wrapper around :func:`provision_app_certs` that pulls the
+    cert/zone/ACME settings out of ``config``.  Returns
+    ``(host_cert_dir, rendered_requests)`` for :func:`run_container`; both are
+    empty/``None`` when the app declares no certs.
+    """
+    if not manifest.tls_certs:
+        return None, []
+    zone = config.zone_domain_no_port
+    rendered = provision_app_certs(
+        app_name=app_name,
+        requests=manifest.tls_certs,
+        zone=zone,
+        openhost_data_path=config.openhost_data_path,
+        wildcard_cert_path=config.tls_cert_path,
+        wildcard_key_path=config.tls_key_path,
+        acme_account_key_path=Path(config.acme_account_key_path) if config.acme_account_key_path else None,
+        coredns_zonefile_path=config.coredns_zonefile_path,
+        acme_email=config.acme_email,
+        acme_directory_url=config.acme_directory_url,
+        coredns_enabled=config.coredns_enabled,
+        force=force,
+    )
+    return str(app_cert_dir(config.openhost_data_path, app_name)), rendered

--- a/compute_space/src/compute_space/core/tls/app_certs.py
+++ b/compute_space/src/compute_space/core/tls/app_certs.py
@@ -1,29 +1,9 @@
-"""Per-app real TLS certificate provisioning and injection.
+"""Provisioning and injection of real (ACME-issued) per-app TLS certs.
 
-Apps declare ``[[tls_certs]]`` in their manifest to request real,
-ACME-issued certificates (as opposed to the self-signed pairs an app
-would otherwise have to generate itself).  The motivating case is an XMPP
-server: server-to-server federation is rejected by most peers when the
-presented cert is self-signed, and the zone wildcard ``*.{zone}`` does
-NOT cover second-level component hosts like ``conference.xmpp.{zone}``.
-
-The router already owns the ACME account and the CoreDNS zone, so it can
-issue any cert under the zone via DNS-01.  This module:
-
-  * expands the ``{app}``/``{zone}`` placeholders in a manifest request,
-  * enforces that every requested SAN lives under ``{app}.{zone}`` (an app
-    can never obtain a cert for another app's hostname or the bare zone),
-  * issues a dedicated cert via DNS-01 with its own freshly-generated private
-    key for exactly the requested SANs.  The zone wildcard cert is NOT reused:
-    its key is also valid for the bare zone and every sibling app's subdomain,
-    so giving it to a container would let the app impersonate the whole zone,
-  * writes the cert/key under a router-owned per-app directory that is
-    bind-mounted read-only into the container, and
-  * decides when an existing cert is close enough to expiry to renew.
-
-Cert acquisition is serialized process-wide via ``_ACME_LOCK`` because the
-DNS-01 flow mutates a single shared ``_acme-challenge`` record set in the
-zone file; two concurrent orders would clobber each other's TXT records.
+See :func:`provision_app_certs` for the issuance policy and the reason the
+zone wildcard key is never reused.  Acquisition is serialized via
+``_ACME_LOCK`` because the DNS-01 flow mutates a single shared
+``_acme-challenge`` record set; concurrent orders would clobber each other.
 """
 
 from __future__ import annotations

--- a/compute_space/src/compute_space/core/tls/app_certs.py
+++ b/compute_space/src/compute_space/core/tls/app_certs.py
@@ -13,9 +13,10 @@ issue any cert under the zone via DNS-01.  This module:
   * expands the ``{app}``/``{zone}`` placeholders in a manifest request,
   * enforces that every requested SAN lives under ``{app}.{zone}`` (an app
     can never obtain a cert for another app's hostname or the bare zone),
-  * reuses the already-acquired zone wildcard cert when it covers every
-    requested SAN (cheap, no new ACME order), otherwise issues a dedicated
-    cert via DNS-01,
+  * issues a dedicated cert via DNS-01 with its own freshly-generated private
+    key for exactly the requested SANs.  The zone wildcard cert is NOT reused:
+    its key is also valid for the bare zone and every sibling app's subdomain,
+    so giving it to a container would let the app impersonate the whole zone,
   * writes the cert/key under a router-owned per-app directory that is
     bind-mounted read-only into the container, and
   * decides when an existing cert is close enough to expiry to renew.
@@ -39,6 +40,7 @@ from compute_space.config import Config
 from compute_space.core.logging import logger
 from compute_space.core.manifest import AppManifest
 from compute_space.core.manifest import TlsCertRequest
+from compute_space.core.manifest import is_valid_dns_name
 from compute_space.core.tls.acquire_cert import GTS_PRODUCTION
 from compute_space.core.tls.util import _acquire_cert_dns01
 from compute_space.core.tls.util import load_account_key
@@ -86,13 +88,11 @@ def render_cert_request(req: TlsCertRequest, app_name: str, zone: str) -> Render
     Raises ``ValueError`` if any requested SAN falls outside ``{app}.{zone}``
     or renders to something that isn't a valid DNS name.
     """
-    from compute_space.core.manifest import _DNS_NAME_RE  # noqa: PLC0415 — avoid import cycle
-
     domains: list[str] = []
     seen: set[str] = set()
     for raw in req.domains:
         d = expand_template(raw, app_name, zone).lower()
-        if not _DNS_NAME_RE.match(d):
+        if not is_valid_dns_name(d):
             raise ValueError(f"[[tls_certs]] '{req.label}' domain {raw!r} rendered to invalid DNS name {d!r}")
         if not _is_within_zone_subtree(d, app_name, zone):
             raise ValueError(
@@ -109,25 +109,6 @@ def render_cert_request(req: TlsCertRequest, app_name: str, zone: str) -> Render
         if os.path.isabs(rel) or rel.startswith(".."):
             raise ValueError(f"[[tls_certs]] '{req.label}' resolved to an out-of-bounds path {rel!r}")
     return RenderedCertRequest(label=req.label, domains=domains, cert_rel_path=cert_rel, key_rel_path=key_rel)
-
-
-def cert_covered_by_wildcard(domains: list[str], zone: str) -> bool:
-    """True iff the zone cert (``zone`` + ``*.zone``) covers every domain.
-
-    ``*.zone`` matches exactly one label below the zone, so ``a.zone`` is
-    covered but ``a.b.zone`` is not.
-    """
-    zone = zone.lower()
-    for d in domains:
-        d = d.lower()
-        if d == zone:
-            continue
-        if d.endswith("." + zone):
-            label = d[: -(len(zone) + 1)]
-            if "." not in label and label:
-                continue  # single-label subdomain -> covered by *.zone
-        return False
-    return True
 
 
 def cert_present_and_current(
@@ -200,8 +181,6 @@ def provision_app_certs(
     requests: list[TlsCertRequest],
     zone: str,
     openhost_data_path: Path,
-    wildcard_cert_path: Path,
-    wildcard_key_path: Path,
     acme_account_key_path: Path | None,
     coredns_zonefile_path: Path,
     *,
@@ -214,8 +193,12 @@ def provision_app_certs(
     """Ensure every requested cert exists, is in scope, and is current.
 
     Returns the list of rendered requests (used by the caller to build the
-    container's env vars and bind mount).  Reuses the zone wildcard cert when
-    it covers all SANs; otherwise issues a dedicated cert via DNS-01.  Already
+    container's env vars and bind mount).  Always issues a **dedicated** cert
+    via DNS-01 with its own freshly-generated private key, covering exactly the
+    app's requested SANs.  The zone wildcard cert is deliberately NOT reused:
+    its private key is also valid for the bare zone and every sibling app's
+    subdomain, so handing it to a container would let the app impersonate the
+    whole zone — defeating the per-app scoping this module enforces.  Already
     valid, non-expiring certs are left untouched unless ``force`` is set.
 
     Raises ``ValueError`` for out-of-scope requests, ``RuntimeError`` if a
@@ -232,22 +215,6 @@ def provision_app_certs(
         if not force and cert_present_and_current(cert_path, key_path, r.domains):
             logger.info("App %s cert '%s' is current; reusing", app_name, r.label)
             continue
-
-        if cert_covered_by_wildcard(r.domains, zone):
-            if wildcard_cert_path.exists() and wildcard_key_path.exists():
-                logger.info("App %s cert '%s' covered by zone wildcard; copying wildcard cert", app_name, r.label)
-                _write_pair(
-                    cert_path,
-                    key_path,
-                    wildcard_cert_path.read_bytes(),
-                    wildcard_key_path.read_bytes(),
-                )
-                continue
-            logger.warning(
-                "App %s cert '%s' is wildcard-covered but no zone wildcard cert exists; issuing dedicated cert",
-                app_name,
-                r.label,
-            )
 
         if not coredns_enabled:
             raise RuntimeError(
@@ -300,8 +267,6 @@ def provision_app_certs_for_deploy(
         requests=manifest.tls_certs,
         zone=zone,
         openhost_data_path=config.openhost_data_path,
-        wildcard_cert_path=config.tls_cert_path,
-        wildcard_key_path=config.tls_key_path,
         acme_account_key_path=Path(config.acme_account_key_path) if config.acme_account_key_path else None,
         coredns_zonefile_path=config.coredns_zonefile_path,
         acme_email=config.acme_email,

--- a/compute_space/src/compute_space/core/tls/renewal.py
+++ b/compute_space/src/compute_space/core/tls/renewal.py
@@ -1,0 +1,115 @@
+"""Background renewal of per-app TLS certificates.
+
+App certs (issued for ``[[tls_certs]]`` requests) are ~90-day ACME certs.
+On each app start/reload :func:`provision_app_certs_for_deploy` already
+re-issues any cert within the renewal window, but a long-running app that is
+never reloaded would eventually present an expired cert.  This daemon sweeps
+all running apps on an interval, re-provisions their certs, and restarts the
+container when a cert was actually renewed so the app loads the new pair
+(apps generally read certs only at startup).
+
+Mirrors the storage-guard daemon pattern: one daemon thread per ``db_path``,
+guarded so repeated bootstraps don't spawn duplicates.
+"""
+
+from __future__ import annotations
+
+import os
+import sqlite3
+import threading
+import time
+
+from compute_space.config import Config
+from compute_space.core.logging import logger
+from compute_space.core.manifest import parse_manifest
+from compute_space.core.tls.app_certs import app_cert_dir
+from compute_space.core.tls.app_certs import provision_app_certs_for_deploy
+
+# Check daily; the renewal window (30 days) gives ample slack so a missed
+# sweep or two doesn't matter.
+_RENEWAL_SWEEP_INTERVAL_SECONDS = 24 * 60 * 60
+
+_sweep_db_paths: set[str] = set()
+_sweep_lock = threading.Lock()
+
+
+def _dir_mtimes(path: str) -> dict[str, float]:
+    """Snapshot of cert-file mtimes under ``path`` (recursive)."""
+    out: dict[str, float] = {}
+    for root, _dirs, files in os.walk(path):
+        for name in files:
+            fp = os.path.join(root, name)
+            try:
+                out[fp] = os.path.getmtime(fp)
+            except OSError:
+                pass
+    return out
+
+
+def renew_app_certs_once(config: Config) -> None:
+    """Re-provision certs for every running app with ``[[tls_certs]]``.
+
+    Restarts an app's container only when its cert files actually changed
+    (i.e. a renewal occurred).  Each app is handled independently; a failure
+    on one is logged and does not block the others.
+    """
+    # Local import avoids a module-load import cycle (apps -> tls.app_certs).
+    from compute_space.core.apps import start_app_process  # noqa: PLC0415
+
+    db = sqlite3.connect(config.db_path, check_same_thread=False)
+    db.row_factory = sqlite3.Row
+    db.execute("PRAGMA journal_mode=WAL")
+    try:
+        rows = db.execute("SELECT * FROM apps WHERE status = 'running'").fetchall()
+        for row in rows:
+            app_name = row["name"]
+            repo_path = row["repo_path"]
+            if not repo_path or not os.path.isdir(repo_path):
+                continue
+            try:
+                manifest = parse_manifest(repo_path)
+            except Exception:
+                logger.exception("Cert renewal: could not parse manifest for %s", app_name)
+                continue
+            if not manifest.tls_certs:
+                continue
+            cert_dir = str(app_cert_dir(config.openhost_data_path, app_name))
+            before = _dir_mtimes(cert_dir)
+            try:
+                provision_app_certs_for_deploy(app_name, manifest, config)
+            except Exception:
+                logger.exception("Cert renewal failed for %s", app_name)
+                continue
+            after = _dir_mtimes(cert_dir)
+            if after != before:
+                logger.info("App %s cert renewed; restarting container to load new cert", app_name)
+                try:
+                    start_app_process(row["app_id"], db, config)
+                except Exception:
+                    logger.exception("Failed to restart %s after cert renewal", app_name)
+    finally:
+        db.close()
+
+
+def _renewal_sweep_loop(config: Config) -> None:
+    while True:
+        try:
+            renew_app_certs_once(config)
+        except Exception:
+            logger.exception("App cert renewal sweep failed")
+        time.sleep(_RENEWAL_SWEEP_INTERVAL_SECONDS)
+
+
+def start_cert_renewal_sweep(config: Config) -> None:
+    """Start the per-app cert renewal daemon thread (once per db_path).
+
+    No-op when TLS isn't enabled (no certs to renew).
+    """
+    if not config.tls_enabled:
+        return
+    db_key = os.path.abspath(config.db_path)
+    with _sweep_lock:
+        if db_key in _sweep_db_paths:
+            return
+        _sweep_db_paths.add(db_key)
+    threading.Thread(target=_renewal_sweep_loop, args=(config,), daemon=True).start()

--- a/compute_space/src/compute_space/core/tls/renewal.py
+++ b/compute_space/src/compute_space/core/tls/renewal.py
@@ -1,16 +1,4 @@
-"""Background renewal of per-app TLS certificates.
-
-App certs (issued for ``[[tls_certs]]`` requests) are ~90-day ACME certs.
-On each app start/reload :func:`provision_app_certs_for_deploy` already
-re-issues any cert within the renewal window, but a long-running app that is
-never reloaded would eventually present an expired cert.  This daemon sweeps
-all running apps on an interval, re-provisions their certs, and restarts the
-container when a cert was actually renewed so the app loads the new pair
-(apps generally read certs only at startup).
-
-Mirrors the storage-guard daemon pattern: one daemon thread per ``db_path``,
-guarded so repeated bootstraps don't spawn duplicates.
-"""
+"""Background renewal daemon for per-app TLS certs (see :func:`renew_app_certs_once`)."""
 
 from __future__ import annotations
 
@@ -49,8 +37,12 @@ def _dir_mtimes(path: str) -> dict[str, float]:
 def renew_app_certs_once(config: Config) -> None:
     """Re-provision certs for every running app with ``[[tls_certs]]``.
 
+    App certs are ~90-day ACME certs; :func:`provision_app_certs_for_deploy`
+    re-issues any within the renewal window, but a long-running app that is
+    never reloaded would eventually present an expired cert, hence this sweep.
     Restarts an app's container only when its cert files actually changed
-    (i.e. a renewal occurred).  Each app is handled independently; a failure
+    (i.e. a renewal occurred) so the app loads the new pair (apps generally
+    read certs only at startup).  Each app is handled independently; a failure
     on one is logged and does not block the others.
     """
     # Local import avoids a module-load import cycle (apps -> tls.app_certs).

--- a/compute_space/src/compute_space/core/tls/util.py
+++ b/compute_space/src/compute_space/core/tls/util.py
@@ -85,6 +85,33 @@ def _wait_for_txt_propagation(
     return False
 
 
+def _challenge_record_name(identifier: str, zone_domain: str) -> str:
+    """Owner name (relative to the zone origin) for a DNS-01 challenge.
+
+    The ACME DNS-01 challenge for identifier ``X`` must be answered at
+    ``_acme-challenge.X``.  Expressed relative to the CoreDNS zone origin
+    (``zone_domain``) that becomes:
+
+      * ``_acme-challenge``            when ``X`` == the zone, and
+      * ``_acme-challenge.<subdomain>`` when ``X`` is a subdomain of the zone.
+
+    A wildcard identifier (``*.zone``) shares the bare ``_acme-challenge``
+    owner with the apex, which is why several authorizations can map to one
+    owner name.
+    """
+    ident = identifier.lower().removeprefix("*.")
+    zone = zone_domain.lower()
+    if ident == zone:
+        return "_acme-challenge"
+    if ident.endswith("." + zone):
+        sub = ident[: -(len(zone) + 1)]
+        return f"_acme-challenge.{sub}"
+    # Identifier isn't under the served zone — fall back to a fully-qualified
+    # owner so CoreDNS still serves it (it'll just be a non-authoritative-looking
+    # name).  In practice scope validation upstream prevents this.
+    return f"_acme-challenge.{ident}."
+
+
 def _acquire_cert_dns01(
     domains: list[str],
     directory_url: str,
@@ -92,8 +119,18 @@ def _acquire_cert_dns01(
     account_key: JWKRSA,
     verify_ssl: bool = True,
     acme_email: str | None = None,
+    zone_domain: str | None = None,
 ) -> tuple[bytes, bytes]:
-    """Acquire cert via DNS-01 challenge by writing TXT records to the local zone file."""
+    """Acquire cert via DNS-01 challenge by writing TXT records to the local zone file.
+
+    ``zone_domain`` is the apex the local CoreDNS is authoritative for.  When
+    omitted it defaults to the (non-wildcard) base of ``domains[0]`` — correct
+    for the zone wildcard cert (``[zone, *.zone]``) but not for per-app certs
+    spanning subdomains, where the caller must pass the real zone so each
+    challenge TXT lands at ``_acme-challenge.<subdomain>``.
+    """
+    if zone_domain is None:
+        zone_domain = domains[0].removeprefix("*.")
     tls_key = _generate_tls_key()
 
     logger.info(f"DNS-01: connecting to ACME directory {directory_url}")
@@ -148,9 +185,14 @@ def _acquire_cert_dns01(
             # authorizations that both need _acme-challenge TXT records simultaneously.
             logger.info(f"DNS-01: collecting challenges from {len(order.authorizations)} authorization(s)")
             pending_challenges = []
-            validation_values = []
+            # Map each challenge owner name (relative to the zone origin) to its
+            # TXT values.  Subdomain identifiers each need their own
+            # _acme-challenge.<sub> owner; the apex and its wildcard share
+            # _acme-challenge.
+            records: dict[str, list[str]] = {}
             for i, authz in enumerate(order.authorizations):
-                logger.info(f"DNS-01: checking authz {i}: {authz.body.identifier} status={authz.body.status}")
+                identifier = authz.body.identifier.value
+                logger.info(f"DNS-01: checking authz {i}: {identifier} status={authz.body.status}")
                 if authz.body.status == messages.STATUS_VALID:
                     continue
                 for challenge_body in authz.body.challenges:
@@ -158,15 +200,18 @@ def _acquire_cert_dns01(
                         if challenge_body.status != messages.STATUS_PENDING:
                             logger.info(f"DNS-01: challenge already {challenge_body.status}, skipping")
                             break
-                        validation_values.append(challenge_body.validation(account_key))
+                        value = challenge_body.validation(account_key)
+                        owner = _challenge_record_name(identifier, zone_domain)
+                        records.setdefault(owner, []).append(value)
                         pending_challenges.append(challenge_body)
                         break
 
             logger.info(f"DNS-01: {len(pending_challenges)} pending challenges to answer")
             if pending_challenges:
                 # Write all TXT records to the zone file at once
-                logger.info(f"Setting {len(validation_values)} DNS-01 challenge TXT record(s)")
-                dns_module.set_txt(coredns_zonefile_path, "_acme-challenge", validation_values)
+                total_values = sum(len(v) for v in records.values())
+                logger.info(f"Setting {total_values} DNS-01 challenge TXT record(s)")
+                dns_module.set_txt_records(coredns_zonefile_path, records)
 
                 # Wait for CoreDNS to pick up the zone file change (reload interval = 2s)
                 time.sleep(3)
@@ -174,9 +219,16 @@ def _acquire_cert_dns01(
                 # Wait until an external resolver can see our TXT records before
                 # telling the ACME server to validate.  Without this, the ACME
                 # server's resolvers may get NXDOMAIN if the NS delegation from
-                # the parent zone hasn't propagated yet.
-                zone_domain = domains[0].lstrip("*.")
-                _wait_for_txt_propagation(zone_domain, validation_values)
+                # the parent zone hasn't propagated yet.  Poll each distinct
+                # challenge FQDN.
+                for owner, values in records.items():
+                    if owner == "_acme-challenge":
+                        fqdn = zone_domain
+                    else:
+                        # owner is "_acme-challenge.<sub>"; the challenge FQDN is "<sub>.<zone>".
+                        sub = owner[len("_acme-challenge.") :].rstrip(".")
+                        fqdn = f"{sub}.{zone_domain}" if sub else zone_domain
+                    _wait_for_txt_propagation(fqdn, values)
 
                 # Now answer all challenges
                 for challenge_body in pending_challenges:

--- a/compute_space/src/compute_space/tests/test_app_certs.py
+++ b/compute_space/src/compute_space/tests/test_app_certs.py
@@ -15,7 +15,6 @@ from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import ec
 
 from compute_space.core.manifest import TlsCertRequest
-from compute_space.core.tls.app_certs import cert_covered_by_wildcard
 from compute_space.core.tls.app_certs import cert_present_and_current
 from compute_space.core.tls.app_certs import expand_template
 from compute_space.core.tls.app_certs import provision_app_certs
@@ -90,17 +89,6 @@ class TestRenderCertRequest:
             render_cert_request(req, APP, ZONE)
 
 
-class TestWildcardCoverage:
-    def test_base_and_single_label_covered(self):
-        assert cert_covered_by_wildcard([ZONE, f"app.{ZONE}"], ZONE)
-
-    def test_two_level_not_covered(self):
-        assert not cert_covered_by_wildcard([f"conference.{APP}.{ZONE}"], ZONE)
-
-    def test_single_level_app_covered(self):
-        assert cert_covered_by_wildcard([f"{APP}.{ZONE}"], ZONE)
-
-
 class TestCertPresentAndCurrent:
     def test_missing_files(self, tmp_path):
         assert not cert_present_and_current(tmp_path / "c.crt", tmp_path / "c.key", [f"{APP}.{ZONE}"])
@@ -135,14 +123,23 @@ class TestCertPresentAndCurrent:
         assert not cert_present_and_current(tmp_path / "c.crt", tmp_path / "c.key", [f"{APP}.{ZONE}"])
 
 
-class TestProvisionWildcardReuse:
-    def test_reuses_wildcard_for_single_label(self, tmp_path):
-        # Wildcard zone cert on disk; app requests only xmpp.{zone} -> reuse, no ACME.
-        wc_cert, wc_key = _make_cert([ZONE, f"*.{ZONE}"])
-        wildcard_cert = tmp_path / "openhost-tls-cert.pem"
-        wildcard_key = tmp_path / "openhost-tls-key.pem"
-        wildcard_cert.write_bytes(wc_cert)
-        wildcard_key.write_bytes(wc_key)
+class TestProvisionAppCerts:
+    """Provisioning always issues a DEDICATED cert with its own key — the zone
+    wildcard (and its zone-wide private key) is never copied into an app."""
+
+    def test_issues_dedicated_cert_with_own_key(self, tmp_path, monkeypatch):
+        acme_calls = []
+
+        def fake_acquire(*, domains, **kwargs):
+            acme_calls.append(list(domains))
+            return _make_cert(domains)
+
+        monkeypatch.setattr("compute_space.core.tls.app_certs._acquire_cert_dns01", fake_acquire)
+        monkeypatch.setattr(
+            "compute_space.core.tls.app_certs.load_account_key", lambda p: object()
+        )
+        acct = tmp_path / "acct.json"
+        acct.write_text("{}")
 
         req = TlsCertRequest(label="main", domains=["{app}.{zone}"])
         rendered = provision_app_certs(
@@ -150,27 +147,48 @@ class TestProvisionWildcardReuse:
             requests=[req],
             zone=ZONE,
             openhost_data_path=tmp_path,
-            wildcard_cert_path=wildcard_cert,
-            wildcard_key_path=wildcard_key,
-            acme_account_key_path=None,
+            acme_account_key_path=acct,
             coredns_zonefile_path=tmp_path / "zonefile",
-            coredns_enabled=False,
+            coredns_enabled=True,
         )
-        assert len(rendered) == 1
+        # A dedicated ACME order was placed even for a single-label subdomain.
+        assert acme_calls == [[f"{APP}.{ZONE}"]]
         cert_dir = tmp_path / "app_certs" / APP
-        written_cert = cert_dir / rendered[0].cert_rel_path
         written_key = cert_dir / rendered[0].key_rel_path
-        assert written_cert.read_bytes() == wc_cert
-        assert written_key.read_bytes() == wc_key
-        # Key permissions tightened.
-        assert oct((written_key.stat().st_mode) & 0o777) == "0o640"
+        assert oct(written_key.stat().st_mode & 0o777) == "0o640"
 
-    def test_two_level_without_coredns_raises(self, tmp_path):
-        wc_cert, wc_key = _make_cert([ZONE, f"*.{ZONE}"])
-        wildcard_cert = tmp_path / "cert.pem"
-        wildcard_key = tmp_path / "key.pem"
-        wildcard_cert.write_bytes(wc_cert)
-        wildcard_key.write_bytes(wc_key)
+    def test_never_reads_wildcard_key(self, tmp_path, monkeypatch):
+        """Regression guard: provisioning must not read the zone wildcard key."""
+
+        def fake_acquire(*, domains, **kwargs):
+            return _make_cert(domains)
+
+        monkeypatch.setattr("compute_space.core.tls.app_certs._acquire_cert_dns01", fake_acquire)
+        monkeypatch.setattr("compute_space.core.tls.app_certs.load_account_key", lambda p: object())
+        acct = tmp_path / "acct.json"
+        acct.write_text("{}")
+        req = TlsCertRequest(label="main", domains=["{app}.{zone}"])
+        rendered = provision_app_certs(
+            app_name=APP,
+            requests=[req],
+            zone=ZONE,
+            openhost_data_path=tmp_path,
+            acme_account_key_path=acct,
+            coredns_zonefile_path=tmp_path / "zonefile",
+            coredns_enabled=True,
+        )
+        # The written key is the freshly generated one (matches the fake cert),
+        # not any shared wildcard key.
+        cert = x509.load_pem_x509_certificate((tmp_path / "app_certs" / APP / rendered[0].cert_rel_path).read_bytes())
+        san = set(
+            cert.extensions.get_extension_for_class(x509.SubjectAlternativeName).value.get_values_for_type(
+                x509.DNSName
+            )
+        )
+        assert san == {f"{APP}.{ZONE}"}
+        assert "*." + ZONE not in san  # never a wildcard
+
+    def test_without_coredns_raises(self, tmp_path):
         req = TlsCertRequest(label="main", domains=["conference.{app}.{zone}"])
         with pytest.raises(RuntimeError, match="CoreDNS is disabled"):
             provision_app_certs(
@@ -178,11 +196,22 @@ class TestProvisionWildcardReuse:
                 requests=[req],
                 zone=ZONE,
                 openhost_data_path=tmp_path,
-                wildcard_cert_path=wildcard_cert,
-                wildcard_key_path=wildcard_key,
                 acme_account_key_path=None,
                 coredns_zonefile_path=tmp_path / "zonefile",
                 coredns_enabled=False,
+            )
+
+    def test_no_acme_key_raises(self, tmp_path):
+        req = TlsCertRequest(label="main", domains=["{app}.{zone}"])
+        with pytest.raises(RuntimeError, match="no ACME account key"):
+            provision_app_certs(
+                app_name=APP,
+                requests=[req],
+                zone=ZONE,
+                openhost_data_path=tmp_path,
+                acme_account_key_path=None,
+                coredns_zonefile_path=tmp_path / "zonefile",
+                coredns_enabled=True,
             )
 
     def test_out_of_scope_request_raises(self, tmp_path):
@@ -193,34 +222,32 @@ class TestProvisionWildcardReuse:
                 requests=[req],
                 zone=ZONE,
                 openhost_data_path=tmp_path,
-                wildcard_cert_path=tmp_path / "cert.pem",
-                wildcard_key_path=tmp_path / "key.pem",
                 acme_account_key_path=None,
                 coredns_zonefile_path=tmp_path / "zonefile",
                 coredns_enabled=False,
             )
 
-    def test_current_cert_not_reprovisioned(self, tmp_path):
-        wc_cert, wc_key = _make_cert([ZONE, f"*.{ZONE}"])
-        wildcard_cert = tmp_path / "cert.pem"
-        wildcard_key = tmp_path / "key.pem"
-        wildcard_cert.write_bytes(wc_cert)
-        wildcard_key.write_bytes(wc_key)
-        req = TlsCertRequest(label="main", domains=["{app}.{zone}"])
+    def test_current_cert_not_reprovisioned(self, tmp_path, monkeypatch):
+        calls = []
+
+        def fake_acquire(*, domains, **kwargs):
+            calls.append(list(domains))
+            return _make_cert(domains)
+
+        monkeypatch.setattr("compute_space.core.tls.app_certs._acquire_cert_dns01", fake_acquire)
+        monkeypatch.setattr("compute_space.core.tls.app_certs.load_account_key", lambda p: object())
+        acct = tmp_path / "acct.json"
+        acct.write_text("{}")
         kwargs = dict(
             app_name=APP,
-            requests=[req],
+            requests=[TlsCertRequest(label="main", domains=["{app}.{zone}"])],
             zone=ZONE,
             openhost_data_path=tmp_path,
-            wildcard_cert_path=wildcard_cert,
-            wildcard_key_path=wildcard_key,
-            acme_account_key_path=None,
+            acme_account_key_path=acct,
             coredns_zonefile_path=tmp_path / "zonefile",
-            coredns_enabled=False,
+            coredns_enabled=True,
         )
-        rendered = provision_app_certs(**kwargs)
-        written = tmp_path / "app_certs" / APP / rendered[0].cert_rel_path
-        first_mtime = written.stat().st_mtime_ns
-        # Re-run: should be a no-op (cert still current).
         provision_app_certs(**kwargs)
-        assert written.stat().st_mtime_ns == first_mtime
+        provision_app_certs(**kwargs)
+        # Second run reused the current cert -> only one ACME order total.
+        assert len(calls) == 1

--- a/compute_space/src/compute_space/tests/test_app_certs.py
+++ b/compute_space/src/compute_space/tests/test_app_certs.py
@@ -1,0 +1,226 @@
+"""Unit tests for per-app TLS cert provisioning/injection (no network).
+
+The ACME DNS-01 issuance path is exercised by the requires_tls integration
+suite; these tests cover the placeholder expansion, scope validation,
+wildcard-coverage logic, expiry gating, and the wildcard-reuse provisioning
+path (which never touches the network).
+"""
+
+import datetime
+
+import pytest
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import ec
+
+from compute_space.core.manifest import TlsCertRequest
+from compute_space.core.tls.app_certs import cert_covered_by_wildcard
+from compute_space.core.tls.app_certs import cert_present_and_current
+from compute_space.core.tls.app_certs import expand_template
+from compute_space.core.tls.app_certs import provision_app_certs
+from compute_space.core.tls.app_certs import render_cert_request
+
+ZONE = "alice.example.com"
+APP = "xmpp"
+
+
+def _make_cert(domains, *, days_valid=90):
+    key = ec.generate_private_key(ec.SECP256R1())
+    now = datetime.datetime.now(datetime.UTC)
+    builder = (
+        x509.CertificateBuilder()
+        .subject_name(x509.Name([x509.NameAttribute(x509.oid.NameOID.COMMON_NAME, domains[0])]))
+        .issuer_name(x509.Name([x509.NameAttribute(x509.oid.NameOID.COMMON_NAME, domains[0])]))
+        .public_key(key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(now - datetime.timedelta(minutes=1))
+        .not_valid_after(now + datetime.timedelta(days=days_valid))
+        .add_extension(x509.SubjectAlternativeName([x509.DNSName(d) for d in domains]), critical=False)
+    )
+    cert = builder.sign(key, hashes.SHA256())
+
+    cert_pem = cert.public_bytes(serialization.Encoding.PEM)
+    key_pem = key.private_bytes(
+        serialization.Encoding.PEM,
+        serialization.PrivateFormat.TraditionalOpenSSL,
+        serialization.NoEncryption(),
+    )
+    return cert_pem, key_pem
+
+
+class TestExpandTemplate:
+    def test_app_and_zone(self):
+        assert expand_template("{app}.{zone}", APP, ZONE) == f"{APP}.{ZONE}"
+
+    def test_no_placeholder(self):
+        assert expand_template("static.example.com", APP, ZONE) == "static.example.com"
+
+
+class TestRenderCertRequest:
+    def test_in_scope_domains(self):
+        req = TlsCertRequest(label="x", domains=["{app}.{zone}", "conference.{app}.{zone}"])
+        r = render_cert_request(req, APP, ZONE)
+        assert r.domains == [f"{APP}.{ZONE}", f"conference.{APP}.{ZONE}"]
+
+    def test_dedupes_domains(self):
+        req = TlsCertRequest(label="x", domains=["{app}.{zone}", "xmpp.alice.example.com"])
+        r = render_cert_request(req, APP, ZONE)
+        assert r.domains == [f"{APP}.{ZONE}"]
+
+    def test_bare_zone_rejected(self):
+        req = TlsCertRequest(label="x", domains=["{zone}"])
+        with pytest.raises(ValueError, match="outside this app's subtree"):
+            render_cert_request(req, APP, ZONE)
+
+    def test_other_app_rejected(self):
+        req = TlsCertRequest(label="x", domains=["other.{zone}"])
+        with pytest.raises(ValueError, match="outside this app's subtree"):
+            render_cert_request(req, APP, ZONE)
+
+    def test_unrelated_domain_rejected(self):
+        req = TlsCertRequest(label="x", domains=["evil.com"])
+        with pytest.raises(ValueError, match="outside this app's subtree"):
+            render_cert_request(req, APP, ZONE)
+
+    def test_app_prefix_not_subdomain_rejected(self):
+        # "xmpp.alice.example.com.evil.com" endswith trick must not pass.
+        req = TlsCertRequest(label="x", domains=["{app}.{zone}.evil.com"])
+        with pytest.raises(ValueError, match="outside this app's subtree"):
+            render_cert_request(req, APP, ZONE)
+
+
+class TestWildcardCoverage:
+    def test_base_and_single_label_covered(self):
+        assert cert_covered_by_wildcard([ZONE, f"app.{ZONE}"], ZONE)
+
+    def test_two_level_not_covered(self):
+        assert not cert_covered_by_wildcard([f"conference.{APP}.{ZONE}"], ZONE)
+
+    def test_single_level_app_covered(self):
+        assert cert_covered_by_wildcard([f"{APP}.{ZONE}"], ZONE)
+
+
+class TestCertPresentAndCurrent:
+    def test_missing_files(self, tmp_path):
+        assert not cert_present_and_current(tmp_path / "c.crt", tmp_path / "c.key", [f"{APP}.{ZONE}"])
+
+    def test_valid_cert_current(self, tmp_path):
+        cert_pem, key_pem = _make_cert([f"{APP}.{ZONE}"])
+        (tmp_path / "c.crt").write_bytes(cert_pem)
+        (tmp_path / "c.key").write_bytes(key_pem)
+        assert cert_present_and_current(tmp_path / "c.crt", tmp_path / "c.key", [f"{APP}.{ZONE}"])
+
+    def test_missing_san_triggers_reprovision(self, tmp_path):
+        cert_pem, key_pem = _make_cert([f"{APP}.{ZONE}"])
+        (tmp_path / "c.crt").write_bytes(cert_pem)
+        (tmp_path / "c.key").write_bytes(key_pem)
+        assert not cert_present_and_current(tmp_path / "c.crt", tmp_path / "c.key", [f"conference.{APP}.{ZONE}"])
+
+    def test_near_expiry_triggers_reprovision(self, tmp_path):
+        cert_pem, key_pem = _make_cert([f"{APP}.{ZONE}"], days_valid=10)
+        (tmp_path / "c.crt").write_bytes(cert_pem)
+        (tmp_path / "c.key").write_bytes(key_pem)
+        assert not cert_present_and_current(tmp_path / "c.crt", tmp_path / "c.key", [f"{APP}.{ZONE}"])
+
+    def test_wildcard_san_covers_single_label(self, tmp_path):
+        cert_pem, key_pem = _make_cert([ZONE, f"*.{ZONE}"])
+        (tmp_path / "c.crt").write_bytes(cert_pem)
+        (tmp_path / "c.key").write_bytes(key_pem)
+        assert cert_present_and_current(tmp_path / "c.crt", tmp_path / "c.key", [f"{APP}.{ZONE}"])
+
+    def test_unreadable_cert(self, tmp_path):
+        (tmp_path / "c.crt").write_bytes(b"not a cert")
+        (tmp_path / "c.key").write_bytes(b"nope")
+        assert not cert_present_and_current(tmp_path / "c.crt", tmp_path / "c.key", [f"{APP}.{ZONE}"])
+
+
+class TestProvisionWildcardReuse:
+    def test_reuses_wildcard_for_single_label(self, tmp_path):
+        # Wildcard zone cert on disk; app requests only xmpp.{zone} -> reuse, no ACME.
+        wc_cert, wc_key = _make_cert([ZONE, f"*.{ZONE}"])
+        wildcard_cert = tmp_path / "openhost-tls-cert.pem"
+        wildcard_key = tmp_path / "openhost-tls-key.pem"
+        wildcard_cert.write_bytes(wc_cert)
+        wildcard_key.write_bytes(wc_key)
+
+        req = TlsCertRequest(label="main", domains=["{app}.{zone}"])
+        rendered = provision_app_certs(
+            app_name=APP,
+            requests=[req],
+            zone=ZONE,
+            openhost_data_path=tmp_path,
+            wildcard_cert_path=wildcard_cert,
+            wildcard_key_path=wildcard_key,
+            acme_account_key_path=None,
+            coredns_zonefile_path=tmp_path / "zonefile",
+            coredns_enabled=False,
+        )
+        assert len(rendered) == 1
+        cert_dir = tmp_path / "app_certs" / APP
+        written_cert = cert_dir / rendered[0].cert_rel_path
+        written_key = cert_dir / rendered[0].key_rel_path
+        assert written_cert.read_bytes() == wc_cert
+        assert written_key.read_bytes() == wc_key
+        # Key permissions tightened.
+        assert oct((written_key.stat().st_mode) & 0o777) == "0o640"
+
+    def test_two_level_without_coredns_raises(self, tmp_path):
+        wc_cert, wc_key = _make_cert([ZONE, f"*.{ZONE}"])
+        wildcard_cert = tmp_path / "cert.pem"
+        wildcard_key = tmp_path / "key.pem"
+        wildcard_cert.write_bytes(wc_cert)
+        wildcard_key.write_bytes(wc_key)
+        req = TlsCertRequest(label="main", domains=["conference.{app}.{zone}"])
+        with pytest.raises(RuntimeError, match="CoreDNS is disabled"):
+            provision_app_certs(
+                app_name=APP,
+                requests=[req],
+                zone=ZONE,
+                openhost_data_path=tmp_path,
+                wildcard_cert_path=wildcard_cert,
+                wildcard_key_path=wildcard_key,
+                acme_account_key_path=None,
+                coredns_zonefile_path=tmp_path / "zonefile",
+                coredns_enabled=False,
+            )
+
+    def test_out_of_scope_request_raises(self, tmp_path):
+        req = TlsCertRequest(label="main", domains=["{zone}"])
+        with pytest.raises(ValueError, match="outside this app's subtree"):
+            provision_app_certs(
+                app_name=APP,
+                requests=[req],
+                zone=ZONE,
+                openhost_data_path=tmp_path,
+                wildcard_cert_path=tmp_path / "cert.pem",
+                wildcard_key_path=tmp_path / "key.pem",
+                acme_account_key_path=None,
+                coredns_zonefile_path=tmp_path / "zonefile",
+                coredns_enabled=False,
+            )
+
+    def test_current_cert_not_reprovisioned(self, tmp_path):
+        wc_cert, wc_key = _make_cert([ZONE, f"*.{ZONE}"])
+        wildcard_cert = tmp_path / "cert.pem"
+        wildcard_key = tmp_path / "key.pem"
+        wildcard_cert.write_bytes(wc_cert)
+        wildcard_key.write_bytes(wc_key)
+        req = TlsCertRequest(label="main", domains=["{app}.{zone}"])
+        kwargs = dict(
+            app_name=APP,
+            requests=[req],
+            zone=ZONE,
+            openhost_data_path=tmp_path,
+            wildcard_cert_path=wildcard_cert,
+            wildcard_key_path=wildcard_key,
+            acme_account_key_path=None,
+            coredns_zonefile_path=tmp_path / "zonefile",
+            coredns_enabled=False,
+        )
+        rendered = provision_app_certs(**kwargs)
+        written = tmp_path / "app_certs" / APP / rendered[0].cert_rel_path
+        first_mtime = written.stat().st_mtime_ns
+        # Re-run: should be a no-op (cert still current).
+        provision_app_certs(**kwargs)
+        assert written.stat().st_mtime_ns == first_mtime

--- a/compute_space/src/compute_space/tests/test_app_certs.py
+++ b/compute_space/src/compute_space/tests/test_app_certs.py
@@ -134,9 +134,7 @@ class TestProvisionAppCerts:
             return _make_cert(domains)
 
         monkeypatch.setattr("compute_space.core.tls.app_certs._acquire_cert_dns01", fake_acquire)
-        monkeypatch.setattr(
-            "compute_space.core.tls.app_certs.load_account_key", lambda p: object()
-        )
+        monkeypatch.setattr("compute_space.core.tls.app_certs.load_account_key", lambda p: object())
         acct = tmp_path / "acct.json"
         acct.write_text("{}")
 
@@ -154,7 +152,7 @@ class TestProvisionAppCerts:
         assert acme_calls == [[f"{APP}.{ZONE}"]]
         cert_dir = tmp_path / "app_certs" / APP
         written_key = cert_dir / rendered[0].key_rel_path
-        assert oct(written_key.stat().st_mode & 0o777) == "0o640"
+        assert oct(written_key.stat().st_mode & 0o777) == "0o600"
 
     def test_never_reads_wildcard_key(self, tmp_path, monkeypatch):
         """Regression guard: provisioning must not read the zone wildcard key."""

--- a/compute_space/src/compute_space/tests/test_app_certs.py
+++ b/compute_space/src/compute_space/tests/test_app_certs.py
@@ -1,9 +1,8 @@
-"""Unit tests for per-app TLS cert provisioning/injection (no network).
+"""Unit tests for per-app TLS cert provisioning/injection.
 
-The ACME DNS-01 issuance path is exercised by the requires_tls integration
-suite; these tests cover the placeholder expansion, scope validation,
-wildcard-coverage logic, expiry gating, and the wildcard-reuse provisioning
-path (which never touches the network).
+The live ACME DNS-01 issuance is exercised by the requires_tls integration
+suite; here the ACME call is mocked, so these cover placeholder expansion,
+scope validation, expiry gating, and the always-dedicated provisioning flow.
 """
 
 import datetime

--- a/compute_space/src/compute_space/tests/test_cert_renewal.py
+++ b/compute_space/src/compute_space/tests/test_cert_renewal.py
@@ -46,7 +46,7 @@ def _add_app(config, app_id, name, status, repo_path):
 
 def _write_manifest(repo_dir, *, with_tls):
     os.makedirs(repo_dir, exist_ok=True)
-    toml = "[app]\nname = \"x\"\nversion = \"0.1.0\"\n\n[runtime.container]\nimage = \"Dockerfile\"\nport = 8080\n"
+    toml = '[app]\nname = "x"\nversion = "0.1.0"\n\n[runtime.container]\nimage = "Dockerfile"\nport = 8080\n'
     if with_tls:
         toml += '\n[[tls_certs]]\nlabel = "main"\ndomains = ["{app}.{zone}"]\n'
     with open(os.path.join(repo_dir, "openhost.toml"), "w") as f:

--- a/compute_space/src/compute_space/tests/test_cert_renewal.py
+++ b/compute_space/src/compute_space/tests/test_cert_renewal.py
@@ -1,0 +1,185 @@
+"""Unit tests for the per-app cert renewal sweep (no network).
+
+Exercises renew_app_certs_once's decision logic: which apps it touches, and
+whether it restarts the container based on cert-file mtime changes.  The
+provisioning and restart calls are monkeypatched so no podman/ACME is needed.
+"""
+
+from __future__ import annotations
+
+import os
+import sqlite3
+
+from compute_space.config import DefaultConfig
+from compute_space.core import tls
+from compute_space.core.tls import renewal
+from compute_space.core.tls.app_certs import app_cert_dir
+
+
+def _config(tmp_path):
+    data_root = tmp_path / "data"
+    (data_root).mkdir()
+    return DefaultConfig(
+        zone_domain="alice.example.com",
+        data_root_dir=str(data_root),
+        tls_enabled=True,
+    )
+
+
+def _make_db(config):
+    os.makedirs(os.path.dirname(config.db_path), exist_ok=True)
+    db = sqlite3.connect(config.db_path)
+    db.row_factory = sqlite3.Row
+    db.execute(
+        """CREATE TABLE apps (
+            app_id TEXT PRIMARY KEY, name TEXT, status TEXT, repo_path TEXT
+        )"""
+    )
+    db.commit()
+    db.close()
+
+
+def _add_app(config, app_id, name, status, repo_path):
+    db = sqlite3.connect(config.db_path)
+    db.execute(
+        "INSERT INTO apps (app_id, name, status, repo_path) VALUES (?, ?, ?, ?)",
+        (app_id, name, status, repo_path),
+    )
+    db.commit()
+    db.close()
+
+
+def _write_manifest(repo_dir, *, with_tls):
+    os.makedirs(repo_dir, exist_ok=True)
+    toml = "[app]\nname = \"x\"\nversion = \"0.1.0\"\n\n[runtime.container]\nimage = \"Dockerfile\"\nport = 8080\n"
+    if with_tls:
+        toml += '\n[[tls_certs]]\nlabel = "main"\ndomains = ["{app}.{zone}"]\n'
+    with open(os.path.join(repo_dir, "openhost.toml"), "w") as f:
+        f.write(toml)
+
+
+def test_skips_apps_without_tls_certs(tmp_path, monkeypatch):
+    config = _config(tmp_path)
+    config.make_all_dirs()
+    _make_db(config)
+    repo = tmp_path / "repo_notls"
+    _write_manifest(str(repo), with_tls=False)
+    _add_app(config, "app1", "notls", "running", str(repo))
+
+    provisioned = []
+    restarted = []
+    monkeypatch.setattr(
+        renewal,
+        "provision_app_certs_for_deploy",
+        lambda name, manifest, cfg: provisioned.append(name) or (None, []),
+    )
+    monkeypatch.setattr("compute_space.core.apps.start_app_process", lambda *a, **k: restarted.append(a))
+
+    renewal.renew_app_certs_once(config)
+    assert provisioned == []
+    assert restarted == []
+
+
+def test_skips_non_running_apps(tmp_path, monkeypatch):
+    config = _config(tmp_path)
+    config.make_all_dirs()
+    _make_db(config)
+    repo = tmp_path / "repo_stopped"
+    _write_manifest(str(repo), with_tls=True)
+    _add_app(config, "app1", "stopped", "stopped", str(repo))
+
+    provisioned = []
+    monkeypatch.setattr(
+        renewal,
+        "provision_app_certs_for_deploy",
+        lambda name, manifest, cfg: provisioned.append(name) or (None, []),
+    )
+    monkeypatch.setattr("compute_space.core.apps.start_app_process", lambda *a, **k: None)
+
+    renewal.renew_app_certs_once(config)
+    assert provisioned == []
+
+
+def test_no_restart_when_cert_unchanged(tmp_path, monkeypatch):
+    config = _config(tmp_path)
+    config.make_all_dirs()
+    _make_db(config)
+    repo = tmp_path / "repo_tls"
+    _write_manifest(str(repo), with_tls=True)
+    _add_app(config, "app1", "myapp", "running", str(repo))
+
+    # Pre-create a cert file in the app cert dir; provisioning leaves it untouched.
+    cert_dir = app_cert_dir(config.openhost_data_path, "myapp")
+    cert_dir.mkdir(parents=True)
+    (cert_dir / "x.crt").write_text("cert")
+
+    restarted = []
+    monkeypatch.setattr(renewal, "provision_app_certs_for_deploy", lambda name, manifest, cfg: (None, []))
+    monkeypatch.setattr("compute_space.core.apps.start_app_process", lambda *a, **k: restarted.append(a))
+
+    renewal.renew_app_certs_once(config)
+    assert restarted == []
+
+
+def test_restart_when_cert_changes(tmp_path, monkeypatch):
+    config = _config(tmp_path)
+    config.make_all_dirs()
+    _make_db(config)
+    repo = tmp_path / "repo_tls2"
+    _write_manifest(str(repo), with_tls=True)
+    _add_app(config, "app1", "myapp", "running", str(repo))
+
+    cert_dir = app_cert_dir(config.openhost_data_path, "myapp")
+    cert_dir.mkdir(parents=True)
+    cert_file = cert_dir / "x.crt"
+    cert_file.write_text("old")
+
+    def fake_provision(name, manifest, cfg):
+        # Simulate a renewal: rewrite the cert with a newer mtime.
+        os.utime(cert_file, (cert_file.stat().st_atime + 100, cert_file.stat().st_mtime + 100))
+        return (None, [])
+
+    restarted = []
+    monkeypatch.setattr(renewal, "provision_app_certs_for_deploy", fake_provision)
+    monkeypatch.setattr("compute_space.core.apps.start_app_process", lambda app_id, db, cfg: restarted.append(app_id))
+
+    renewal.renew_app_certs_once(config)
+    assert restarted == ["app1"]
+
+
+def test_provision_failure_isolated(tmp_path, monkeypatch):
+    """A provisioning failure on one app is swallowed and does not restart it."""
+    config = _config(tmp_path)
+    config.make_all_dirs()
+    _make_db(config)
+    repo = tmp_path / "repo_fail"
+    _write_manifest(str(repo), with_tls=True)
+    _add_app(config, "app1", "myapp", "running", str(repo))
+
+    def boom(name, manifest, cfg):
+        raise RuntimeError("acme down")
+
+    restarted = []
+    monkeypatch.setattr(renewal, "provision_app_certs_for_deploy", boom)
+    monkeypatch.setattr("compute_space.core.apps.start_app_process", lambda *a, **k: restarted.append(a))
+
+    # Should not raise.
+    renewal.renew_app_certs_once(config)
+    assert restarted == []
+
+
+def test_start_sweep_noop_when_tls_disabled(tmp_path, monkeypatch):
+    config = _config(tmp_path).evolve(tls_enabled=False)
+    started = []
+    monkeypatch.setattr(renewal.threading, "Thread", lambda *a, **k: started.append(1) or _Dummy())
+    renewal.start_cert_renewal_sweep(config)
+    assert started == []
+
+
+class _Dummy:
+    def start(self):
+        pass
+
+
+def test_tls_package_importable():
+    assert tls is not None

--- a/compute_space/src/compute_space/tests/test_cert_renewal.py
+++ b/compute_space/src/compute_space/tests/test_cert_renewal.py
@@ -1,9 +1,4 @@
-"""Unit tests for the per-app cert renewal sweep (no network).
-
-Exercises renew_app_certs_once's decision logic: which apps it touches, and
-whether it restarts the container based on cert-file mtime changes.  The
-provisioning and restart calls are monkeypatched so no podman/ACME is needed.
-"""
+"""Unit tests for the per-app cert renewal sweep (provisioning/restart mocked)."""
 
 from __future__ import annotations
 

--- a/compute_space/src/compute_space/tests/test_containers.py
+++ b/compute_space/src/compute_space/tests/test_containers.py
@@ -23,6 +23,7 @@ from compute_space.core.containers import run_container
 from compute_space.core.containers import stop_container
 from compute_space.core.manifest import AppManifest
 from compute_space.core.manifest import PortMapping
+from compute_space.core.tls.app_certs import RenderedCertRequest
 
 
 class _FakeCompleted:
@@ -299,6 +300,8 @@ def _run_and_capture(
     tmp_path,
     port_mappings: list[PortMapping] | None = None,
     env_vars: dict[str, str] | None = None,
+    tls_cert_dir: str | None = None,
+    rendered_certs=None,  # type: ignore[no-untyped-def]
 ) -> list[str]:
     """Invoke run_container with mocked subprocess and return the built argv."""
     runs: list[list[str]] = []
@@ -331,6 +334,8 @@ def _run_and_capture(
         temp_data_dir=temp_data_dir,
         archive_dir=archive_dir,
         port_mappings=port_mappings,
+        tls_cert_dir=tls_cert_dir,
+        rendered_certs=rendered_certs,
     )
     # The "run" call is the one after the pre-cleanup "rm".
     run_cmds = [c for c in runs if c[:2] == ["podman", "run"]]
@@ -808,3 +813,90 @@ def test_bind_mount_arg_preserves_absolute_paths_verbatim() -> None:
     target vs. what the app's env var points at."""
     arg = _bind_mount_arg("/a/b/c/", "/data/app_data/myapp/")
     assert arg == "/a/b/c/:/data/app_data/myapp/:idmap"
+
+
+# ---------------------------------------------------------------------------
+# [[tls_certs]] injection
+# ---------------------------------------------------------------------------
+
+
+def _rendered(
+    label="main",
+    cert="certs/xmpp.alice.example.com.crt",
+    key="certs/xmpp.alice.example.com.key",
+    domains=("xmpp.alice.example.com",),
+):
+    return RenderedCertRequest(label=label, domains=list(domains), cert_rel_path=cert, key_rel_path=key)
+
+
+def test_run_container_no_tls_certs_by_default(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
+    manifest = _basic_manifest()
+    argv = _run_and_capture(monkeypatch, manifest=manifest, tmp_path=tmp_path)
+    assert not any(":/data/tls:" in a for a in argv)
+    assert not any(a.startswith("OPENHOST_TLS_") for a in argv)
+
+
+def test_run_container_mounts_tls_cert_dir_read_only(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
+    cert_dir = tmp_path / "app_certs" / "myapp"
+    cert_dir.mkdir(parents=True)
+    argv = _run_and_capture(
+        monkeypatch,
+        manifest=_basic_manifest(),
+        tmp_path=tmp_path,
+        tls_cert_dir=str(cert_dir),
+        rendered_certs=[_rendered()],
+    )
+    volume_args = [arg for prev, arg in zip(argv, argv[1:], strict=False) if prev == "-v"]
+    tls_mounts = [v for v in volume_args if v.endswith(":/data/tls:ro,idmap")]
+    assert len(tls_mounts) == 1
+    assert tls_mounts[0] == f"{cert_dir}:/data/tls:ro,idmap"
+
+
+def test_run_container_injects_tls_env_vars(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
+    cert_dir = tmp_path / "app_certs" / "myapp"
+    cert_dir.mkdir(parents=True)
+    argv = _run_and_capture(
+        monkeypatch,
+        manifest=_basic_manifest(),
+        tmp_path=tmp_path,
+        tls_cert_dir=str(cert_dir),
+        rendered_certs=[_rendered()],
+    )
+    env_args = [arg for prev, arg in zip(argv, argv[1:], strict=False) if prev == "-e"]
+    assert "OPENHOST_TLS_CERT=/data/tls/certs/xmpp.alice.example.com.crt" in env_args
+    assert "OPENHOST_TLS_KEY=/data/tls/certs/xmpp.alice.example.com.key" in env_args
+    assert "OPENHOST_TLS_DOMAINS=xmpp.alice.example.com" in env_args
+    # Label-suffixed variants also present.
+    assert "OPENHOST_TLS_CERT_MAIN=/data/tls/certs/xmpp.alice.example.com.crt" in env_args
+
+
+def test_run_container_multiple_certs_first_is_unsuffixed(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
+    cert_dir = tmp_path / "app_certs" / "myapp"
+    cert_dir.mkdir(parents=True)
+    certs = [
+        _rendered(label="a", cert="a.crt", key="a.key", domains=("a.x.alice.example.com",)),
+        _rendered(label="b", cert="b.crt", key="b.key", domains=("b.x.alice.example.com",)),
+    ]
+    argv = _run_and_capture(
+        monkeypatch,
+        manifest=_basic_manifest(),
+        tmp_path=tmp_path,
+        tls_cert_dir=str(cert_dir),
+        rendered_certs=certs,
+    )
+    env_args = [arg for prev, arg in zip(argv, argv[1:], strict=False) if prev == "-e"]
+    assert "OPENHOST_TLS_CERT=/data/tls/a.crt" in env_args
+    assert "OPENHOST_TLS_CERT_A=/data/tls/a.crt" in env_args
+    assert "OPENHOST_TLS_CERT_B=/data/tls/b.crt" in env_args
+
+
+def test_run_container_tls_skipped_when_dir_missing(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
+    # rendered_certs present but the dir doesn't exist -> no mount/env (defensive).
+    argv = _run_and_capture(
+        monkeypatch,
+        manifest=_basic_manifest(),
+        tmp_path=tmp_path,
+        tls_cert_dir=str(tmp_path / "does-not-exist"),
+        rendered_certs=[_rendered()],
+    )
+    assert not any(":/data/tls:" in a for a in argv)

--- a/compute_space/src/compute_space/tests/test_dns.py
+++ b/compute_space/src/compute_space/tests/test_dns.py
@@ -5,6 +5,8 @@ import socket
 import pytest
 
 import compute_space.core.dns as dns_mod
+from compute_space.core.dns import set_txt_records
+from compute_space.core.tls.util import _challenge_record_name
 
 
 class _FakeSocket:
@@ -36,3 +38,27 @@ def test_coredns_bind_ip_falls_back_to_public_ip(monkeypatch: pytest.MonkeyPatch
     monkeypatch.setattr(socket, "socket", raise_os_error)
 
     assert dns_mod._coredns_bind_ip("203.0.113.10") == "203.0.113.10"
+
+
+def test_set_txt_records_multiple_owners(tmp_path):
+    zonefile = tmp_path / "zonefile"
+    zonefile.write_text(
+        "$ORIGIN z.example.\n$TTL 60\n@ IN SOA ns.z.example. admin.z.example. (\n"
+        "    100   ; serial\n    3600 ; refresh\n    600 ; retry\n    86400 ; expire\n    60 ; minimum\n)\n"
+        "@ IN NS ns.z.example.\n@ IN A 127.0.0.1\n"
+    )
+    set_txt_records(zonefile, {"_acme-challenge": ["v1", "v2"], "_acme-challenge.xmpp": ["v3"]})
+    content = zonefile.read_text()
+    assert '_acme-challenge   IN TXT  "v1"' in content
+    assert '_acme-challenge   IN TXT  "v2"' in content
+    assert '_acme-challenge.xmpp   IN TXT  "v3"' in content
+    # Serial bumped to 101.
+    assert "101   ; serial" in content
+
+
+def test_challenge_record_name():
+    zone = "alice.example.com"
+    assert _challenge_record_name(zone, zone) == "_acme-challenge"
+    assert _challenge_record_name(f"*.{zone}", zone) == "_acme-challenge"
+    assert _challenge_record_name(f"xmpp.{zone}", zone) == "_acme-challenge.xmpp"
+    assert _challenge_record_name(f"conference.xmpp.{zone}", zone) == "_acme-challenge.conference.xmpp"

--- a/compute_space/src/compute_space/tests/test_manifest.py
+++ b/compute_space/src/compute_space/tests/test_manifest.py
@@ -725,3 +725,93 @@ class TestShmMb:
         toml = MINIMAL + 'shm_mb = "big"\n'
         with pytest.raises(ValueError, match="shm_mb"):
             parse_manifest_from_string(toml)
+
+
+class TestTlsCerts:
+    """[[tls_certs]] parsing and validation."""
+
+    def test_default_empty(self):
+        manifest = parse_manifest_from_string(MINIMAL)
+        assert manifest.tls_certs == []
+
+    def test_basic_entry(self):
+        toml = MINIMAL + ('\n[[tls_certs]]\nlabel = "xmpp"\ndomains = ["{app}.{zone}", "conference.{app}.{zone}"]\n')
+        manifest = parse_manifest_from_string(toml)
+        assert len(manifest.tls_certs) == 1
+        c = manifest.tls_certs[0]
+        assert c.label == "xmpp"
+        assert c.domains == ["{app}.{zone}", "conference.{app}.{zone}"]
+        # Defaults
+        assert c.cert_path == "certs/{app}.{zone}.crt"
+        assert c.key_path == "certs/{app}.{zone}.key"
+
+    def test_custom_paths(self):
+        toml = MINIMAL + (
+            "\n[[tls_certs]]\n"
+            'label = "main"\n'
+            'domains = ["{app}.{zone}"]\n'
+            'cert_path = "tls/server.pem"\n'
+            'key_path = "tls/server.key"\n'
+        )
+        c = parse_manifest_from_string(toml).tls_certs[0]
+        assert c.cert_path == "tls/server.pem"
+        assert c.key_path == "tls/server.key"
+
+    def test_missing_domains_rejected(self):
+        toml = MINIMAL + '\n[[tls_certs]]\nlabel = "x"\n'
+        with pytest.raises(ValueError, match="domains"):
+            parse_manifest_from_string(toml)
+
+    def test_empty_domains_rejected(self):
+        toml = MINIMAL + '\n[[tls_certs]]\nlabel = "x"\ndomains = []\n'
+        with pytest.raises(ValueError, match="domains"):
+            parse_manifest_from_string(toml)
+
+    def test_missing_label_rejected(self):
+        toml = MINIMAL + '\n[[tls_certs]]\ndomains = ["{app}.{zone}"]\n'
+        with pytest.raises(ValueError, match="label"):
+            parse_manifest_from_string(toml)
+
+    def test_invalid_label_rejected(self):
+        toml = MINIMAL + '\n[[tls_certs]]\nlabel = "Bad Label"\ndomains = ["{app}.{zone}"]\n'
+        with pytest.raises(ValueError, match="label"):
+            parse_manifest_from_string(toml)
+
+    def test_duplicate_label_rejected(self):
+        toml = MINIMAL + (
+            '\n[[tls_certs]]\nlabel = "x"\ndomains = ["{app}.{zone}"]\n'
+            '\n[[tls_certs]]\nlabel = "x"\ndomains = ["a.{app}.{zone}"]\n'
+        )
+        with pytest.raises(ValueError, match="[Dd]uplicate"):
+            parse_manifest_from_string(toml)
+
+    def test_unknown_placeholder_rejected(self):
+        toml = MINIMAL + '\n[[tls_certs]]\nlabel = "x"\ndomains = ["{bogus}.{zone}"]\n'
+        with pytest.raises(ValueError, match="placeholder"):
+            parse_manifest_from_string(toml)
+
+    def test_absolute_cert_path_rejected(self):
+        toml = MINIMAL + ('\n[[tls_certs]]\nlabel = "x"\ndomains = ["{app}.{zone}"]\ncert_path = "/etc/ssl/x.crt"\n')
+        with pytest.raises(ValueError, match="relative path"):
+            parse_manifest_from_string(toml)
+
+    def test_traversal_cert_path_rejected(self):
+        toml = MINIMAL + ('\n[[tls_certs]]\nlabel = "x"\ndomains = ["{app}.{zone}"]\ncert_path = "../escape.crt"\n')
+        with pytest.raises(ValueError, match="relative path"):
+            parse_manifest_from_string(toml)
+
+    def test_too_many_entries_rejected(self):
+        entries = "".join(f'\n[[tls_certs]]\nlabel = "c{i}"\ndomains = ["c{i}.{{app}}.{{zone}}"]\n' for i in range(9))
+        with pytest.raises(ValueError, match="At most"):
+            parse_manifest_from_string(MINIMAL + entries)
+
+    def test_too_many_domains_rejected(self):
+        domains = ", ".join(f'"h{i}.{{app}}.{{zone}}"' for i in range(17))
+        toml = MINIMAL + f'\n[[tls_certs]]\nlabel = "x"\ndomains = [{domains}]\n'
+        with pytest.raises(ValueError, match="too many domains"):
+            parse_manifest_from_string(toml)
+
+    def test_duplicate_domain_rejected(self):
+        toml = MINIMAL + ('\n[[tls_certs]]\nlabel = "x"\ndomains = ["{app}.{zone}", "{app}.{zone}"]\n')
+        with pytest.raises(ValueError, match="duplicate domain"):
+            parse_manifest_from_string(toml)

--- a/compute_space/src/compute_space/tests/test_manifest.py
+++ b/compute_space/src/compute_space/tests/test_manifest.py
@@ -815,3 +815,12 @@ class TestTlsCerts:
         toml = MINIMAL + ('\n[[tls_certs]]\nlabel = "x"\ndomains = ["{app}.{zone}", "{app}.{zone}"]\n')
         with pytest.raises(ValueError, match="duplicate domain"):
             parse_manifest_from_string(toml)
+
+    def test_env_suffix_collision_rejected(self):
+        # "web-a" and "web_a" both normalize to env suffix "WEB_A".
+        toml = MINIMAL + (
+            '\n[[tls_certs]]\nlabel = "web-a"\ndomains = ["a.{app}.{zone}"]\n'
+            '\n[[tls_certs]]\nlabel = "web_a"\ndomains = ["b.{app}.{zone}"]\n'
+        )
+        with pytest.raises(ValueError, match="env-var normalization"):
+            parse_manifest_from_string(toml)

--- a/compute_space/src/compute_space/web/app.py
+++ b/compute_space/src/compute_space/web/app.py
@@ -28,6 +28,7 @@ from compute_space.core.startup import check_app_status
 from compute_space.core.startup import retry_pending_default_apps
 from compute_space.core.storage import start_storage_guard
 from compute_space.core.terminal import cleanup_all as cleanup_terminal
+from compute_space.core.tls.renewal import start_cert_renewal_sweep
 from compute_space.db import provide_db
 from compute_space.web.auth.auth import login_required_redirect
 from compute_space.web.middleware.subdomain_proxy import SubdomainProxyMiddleware
@@ -96,6 +97,7 @@ def _full_app_bootstrap(config: Config) -> None:
     check_app_status(config)
     load_identity_keys(config.persistent_data_dir)
     start_storage_guard(config)
+    start_cert_renewal_sweep(config)
     retry_pending_default_apps(config)
 
 

--- a/docs/src/creating_an_app.md
+++ b/docs/src/creating_an_app.md
@@ -115,6 +115,8 @@ The router injects these environment variables into your app:
 | `OPENHOST_APP_TEMP_DIR` | `/data/app_temp_data/my-app` | Path to the app's temporary data directory. Set when `app_temp_data` or `access_all_app_data` is requested          |
 | `OPENHOST_SQLITE_<NAME>` | `/data/app_data/my-app/sqlite/main.db` (for `sqlite = ["main"]`) | Path to a provisioned SQLite database file. Set once per entry in `sqlite`                                      |
 | `OPENHOST_OWNER_USERNAME` | `alice` | The compute space owner's chosen display name. Use to seed SSO account names. Defaults to `owner` if not explicitly configured. |
+| `OPENHOST_TLS_CERT` / `OPENHOST_TLS_KEY` | `/data/tls/my-app.user.host.imbue.com.crt` | In-container (read-only) paths to the first `[[tls_certs]]` cert/key pair. Set only when `[[tls_certs]]` is declared. `OPENHOST_TLS_DOMAINS` is the comma-separated SAN list. |
+| `OPENHOST_TLS_CERT_<LABEL>` / `OPENHOST_TLS_KEY_<LABEL>` / `OPENHOST_TLS_DOMAINS_<LABEL>` | `/data/tls/...` | Per-cert variants for apps declaring multiple `[[tls_certs]]` entries (`<LABEL>` uppercased, hyphens → underscores). |
 
 ### Data storage
 

--- a/docs/src/manifest_spec.md
+++ b/docs/src/manifest_spec.md
@@ -49,7 +49,7 @@ This exists for apps that need certificates trusted by third parties — for exa
 | `cert_path` | string | no | `certs/{app}.{zone}.crt` | Where the cert PEM lands, relative to `/data/tls`. May use placeholders. Must be a relative path. |
 | `key_path` | string | no | `certs/{app}.{zone}.key` | Where the key PEM lands, relative to `/data/tls`. May use placeholders. Must be a relative path. |
 
-Placeholders: `{app}` expands to the deployed app name, `{zone}` to the zone domain (no port). The router will reuse the zone wildcard cert when it covers every requested SAN (a single-label subdomain like `{app}.{zone}`), and only issue a dedicated certificate when a request needs hostnames the wildcard can't cover (e.g. `conference.{app}.{zone}`). Certificates are renewed automatically by the router (re-issued within 30 days of expiry; the container is restarted to load the new pair).
+Placeholders: `{app}` expands to the deployed app name, `{zone}` to the zone domain (no port). The router always issues a **dedicated** certificate with its own freshly-generated private key, covering exactly the requested SANs. (The zone wildcard cert is never reused: its private key is also valid for the bare zone and every other app's subdomain, so handing it to a container would let the app impersonate the whole zone.) Certificates are renewed automatically by the router (re-issued within 30 days of expiry; the container is restarted to load the new pair).
 
 If the certificate cannot be provisioned yet (e.g. CoreDNS/ACME not configured, or DNS not yet propagated), deployment fails with an error — apps that want to start regardless should also ship a self-signed fallback and only swap to the injected cert when present.
 

--- a/docs/src/manifest_spec.md
+++ b/docs/src/manifest_spec.md
@@ -36,6 +36,29 @@ Rootless podman can bind ports >= 25 only; `host_port` values below 25 are rejec
 | `container_port` | integer | yes | — | Port inside the container |
 | `host_port` | integer | no | `0` | Port on the host (0 = auto-assign) |
 
+### `[[tls_certs]]` — optional, repeatable
+
+Requests a real, ACME-issued TLS certificate (not self-signed) covering one or more hostnames under the app's own subdomain. The router acquires the certificate via the same ACME DNS-01 machinery used for the zone cert, writes it to a router-owned directory, and bind-mounts that directory **read-only** into the container at `/data/tls`. The cert/key paths are also exposed as environment variables.
+
+This exists for apps that need certificates trusted by third parties — for example an XMPP server doing server-to-server federation, where peers reject self-signed certs, and where the zone wildcard `*.{zone}` does not cover second-level component hosts like `conference.xmpp.{zone}`.
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `label` | string | yes | — | Unique identifier for this cert (lowercase, used to disambiguate env vars) |
+| `domains` | string[] | yes | — | SAN hostnames to cover. May use `{app}` and `{zone}` placeholders. Every rendered domain **must** be `{app}.{zone}` or a subdomain of it — apps cannot request certs for the bare zone or other apps' hostnames. |
+| `cert_path` | string | no | `certs/{app}.{zone}.crt` | Where the cert PEM lands, relative to `/data/tls`. May use placeholders. Must be a relative path. |
+| `key_path` | string | no | `certs/{app}.{zone}.key` | Where the key PEM lands, relative to `/data/tls`. May use placeholders. Must be a relative path. |
+
+Placeholders: `{app}` expands to the deployed app name, `{zone}` to the zone domain (no port). The router will reuse the zone wildcard cert when it covers every requested SAN (a single-label subdomain like `{app}.{zone}`), and only issue a dedicated certificate when a request needs hostnames the wildcard can't cover (e.g. `conference.{app}.{zone}`). Certificates are renewed automatically by the router (re-issued within 30 days of expiry; the container is restarted to load the new pair).
+
+If the certificate cannot be provisioned yet (e.g. CoreDNS/ACME not configured, or DNS not yet propagated), deployment fails with an error — apps that want to start regardless should also ship a self-signed fallback and only swap to the injected cert when present.
+
+```toml
+[[tls_certs]]
+label = "xmpp"
+domains = ["{app}.{zone}", "conference.{app}.{zone}", "share.{app}.{zone}"]
+```
+
 ### `[routing]` — optional
 
 | Field | Type | Required | Default | Description |
@@ -91,6 +114,8 @@ The host provisions requested data services and injects connection info as envir
 - `OPENHOST_AUTH_PUBLIC_KEY` — PEM-encoded JWT public key for token verification (only if signing keys are available)
 - `OPENHOST_ROUTER_URL` — URL of the router's HTTP server, reachable from inside the container.
 - `OPENHOST_OWNER_USERNAME` — the compute space owner's chosen display name; use to seed SSO account names. Defaults to `owner` if not explicitly configured.
+- `OPENHOST_TLS_CERT` / `OPENHOST_TLS_KEY` — in-container (read-only) paths to the first `[[tls_certs]]` cert/key pair (only if `[[tls_certs]]` declared). `OPENHOST_TLS_DOMAINS` is the comma-separated SAN list.
+- `OPENHOST_TLS_CERT_<LABEL>` / `OPENHOST_TLS_KEY_<LABEL>` / `OPENHOST_TLS_DOMAINS_<LABEL>` — per-cert variants for apps declaring multiple `[[tls_certs]]` entries (`<LABEL>` is the uppercased label with hyphens replaced by underscores).
 
 ## Examples
 

--- a/tests/test_tls.py
+++ b/tests/test_tls.py
@@ -465,8 +465,6 @@ class TestProvisionAppCerts:
             requests=[req],
             zone=ZONE_DOMAIN,
             openhost_data_path=data_path,
-            wildcard_cert_path=data_path / "nonexistent-cert.pem",
-            wildcard_key_path=data_path / "nonexistent-key.pem",
             acme_account_key_path=acme_account_key["path"],
             coredns_zonefile_path=zonefile_path,
             acme_directory_url=pebble_server["directory_url"],
@@ -483,27 +481,33 @@ class TestProvisionAppCerts:
         assert f"xmpp.{ZONE_DOMAIN}" in dns_names
         assert f"conference.xmpp.{ZONE_DOMAIN}" in dns_names
         assert f"share.xmpp.{ZONE_DOMAIN}" in dns_names
+        # Never a wildcard — the cert is scoped to the app's own SANs only.
+        assert f"*.{ZONE_DOMAIN}" not in dns_names
 
-    def test_wildcard_reuse_no_acme(self, acquired_cert, zonefile_path, tls_tmpdir):
-        """A single-label request reuses the on-disk wildcard cert with no ACME order."""
-        data_path = tls_tmpdir / "openhost_data_reuse"
+    def test_single_label_subdomain_issues_dedicated_cert(
+        self, pebble_server, acme_account_key, zonefile_path, tls_tmpdir
+    ):
+        """Even a single-label request gets its own dedicated cert+key (the zone
+        wildcard key is never handed to an app)."""
+        data_path = tls_tmpdir / "openhost_data_single"
         data_path.mkdir(exist_ok=True)
-        wc_cert = data_path / "wc-cert.pem"
-        wc_key = data_path / "wc-key.pem"
-        wc_cert.write_bytes(acquired_cert["cert_pem"])
-        wc_key.write_bytes(acquired_cert["key_pem"])
-
         req = TlsCertRequest(label="main", domains=["{app}.{zone}"])
         rendered = provision_app_certs(
             app_name="someapp",
             requests=[req],
             zone=ZONE_DOMAIN,
             openhost_data_path=data_path,
-            wildcard_cert_path=wc_cert,
-            wildcard_key_path=wc_key,
-            acme_account_key_path=None,  # must not be needed for reuse
+            acme_account_key_path=acme_account_key["path"],
             coredns_zonefile_path=zonefile_path,
-            coredns_enabled=False,
+            acme_directory_url=pebble_server["directory_url"],
+            coredns_enabled=True,
+            verify_ssl=False,
         )
         cert_dir = data_path / "app_certs" / "someapp"
-        assert (cert_dir / rendered[0].cert_rel_path).read_bytes() == acquired_cert["cert_pem"]
+        cert = x509.load_pem_x509_certificate((cert_dir / rendered[0].cert_rel_path).read_bytes())
+        san = set(
+            cert.extensions.get_extension_for_class(x509.SubjectAlternativeName).value.get_values_for_type(
+                x509.DNSName
+            )
+        )
+        assert san == {f"someapp.{ZONE_DOMAIN}"}

--- a/tests/test_tls.py
+++ b/tests/test_tls.py
@@ -448,9 +448,7 @@ class TestAccountKey:
 class TestProvisionAppCerts:
     """Integration tests for per-app [[tls_certs]] provisioning via DNS-01."""
 
-    def test_dedicated_cert_for_two_level_subdomain(
-        self, pebble_server, acme_account_key, zonefile_path, tls_tmpdir
-    ):
+    def test_dedicated_cert_for_two_level_subdomain(self, pebble_server, acme_account_key, zonefile_path, tls_tmpdir):
         """A request needing conference.<app>.<zone> (not covered by *.<zone>)
         issues a dedicated cert via DNS-01 covering all requested SANs."""
         data_path = tls_tmpdir / "openhost_data_app"

--- a/tests/test_tls.py
+++ b/tests/test_tls.py
@@ -34,7 +34,9 @@ from cryptography.hazmat.primitives.asymmetric import ec
 from cryptography.hazmat.primitives.asymmetric import rsa as rsa_module
 from josepy import JWKRSA
 
+from compute_space.core.manifest import TlsCertRequest
 from compute_space.core.tls.acquire_cert import acquire_tls_cert
+from compute_space.core.tls.app_certs import provision_app_certs
 from compute_space.core.tls.util import _acquire_cert_dns01
 from compute_space.core.tls.util import load_account_key
 from compute_space.tests.utils import kill_tree
@@ -435,3 +437,73 @@ class TestAccountKey:
         original = _generate_acme_account_key(str(key_path))
         loaded = load_account_key(key_path)
         assert original.to_json() == loaded.to_json()
+
+
+# ---------------------------------------------------------------------------
+# Tests — per-app cert provisioning (provision_app_certs)
+# ---------------------------------------------------------------------------
+
+
+@requires_tls
+class TestProvisionAppCerts:
+    """Integration tests for per-app [[tls_certs]] provisioning via DNS-01."""
+
+    def test_dedicated_cert_for_two_level_subdomain(
+        self, pebble_server, acme_account_key, zonefile_path, tls_tmpdir
+    ):
+        """A request needing conference.<app>.<zone> (not covered by *.<zone>)
+        issues a dedicated cert via DNS-01 covering all requested SANs."""
+        data_path = tls_tmpdir / "openhost_data_app"
+        data_path.mkdir(exist_ok=True)
+        # No wildcard cert on disk -> forces dedicated issuance.
+        req = TlsCertRequest(
+            label="xmpp",
+            domains=["{app}.{zone}", "conference.{app}.{zone}", "share.{app}.{zone}"],
+        )
+        rendered = provision_app_certs(
+            app_name="xmpp",
+            requests=[req],
+            zone=ZONE_DOMAIN,
+            openhost_data_path=data_path,
+            wildcard_cert_path=data_path / "nonexistent-cert.pem",
+            wildcard_key_path=data_path / "nonexistent-key.pem",
+            acme_account_key_path=acme_account_key["path"],
+            coredns_zonefile_path=zonefile_path,
+            acme_directory_url=pebble_server["directory_url"],
+            coredns_enabled=True,
+            verify_ssl=False,
+        )
+        assert len(rendered) == 1
+        cert_dir = data_path / "app_certs" / "xmpp"
+        cert_file = cert_dir / rendered[0].cert_rel_path
+        assert cert_file.exists()
+        cert = x509.load_pem_x509_certificate(cert_file.read_bytes())
+        san = cert.extensions.get_extension_for_class(x509.SubjectAlternativeName)
+        dns_names = set(san.value.get_values_for_type(x509.DNSName))
+        assert f"xmpp.{ZONE_DOMAIN}" in dns_names
+        assert f"conference.xmpp.{ZONE_DOMAIN}" in dns_names
+        assert f"share.xmpp.{ZONE_DOMAIN}" in dns_names
+
+    def test_wildcard_reuse_no_acme(self, acquired_cert, zonefile_path, tls_tmpdir):
+        """A single-label request reuses the on-disk wildcard cert with no ACME order."""
+        data_path = tls_tmpdir / "openhost_data_reuse"
+        data_path.mkdir(exist_ok=True)
+        wc_cert = data_path / "wc-cert.pem"
+        wc_key = data_path / "wc-key.pem"
+        wc_cert.write_bytes(acquired_cert["cert_pem"])
+        wc_key.write_bytes(acquired_cert["key_pem"])
+
+        req = TlsCertRequest(label="main", domains=["{app}.{zone}"])
+        rendered = provision_app_certs(
+            app_name="someapp",
+            requests=[req],
+            zone=ZONE_DOMAIN,
+            openhost_data_path=data_path,
+            wildcard_cert_path=wc_cert,
+            wildcard_key_path=wc_key,
+            acme_account_key_path=None,  # must not be needed for reuse
+            coredns_zonefile_path=zonefile_path,
+            coredns_enabled=False,
+        )
+        cert_dir = data_path / "app_certs" / "someapp"
+        assert (cert_dir / rendered[0].cert_rel_path).read_bytes() == acquired_cert["cert_pem"]


### PR DESCRIPTION
Apps can declare a [[tls_certs]] block in their manifest to request real, ACME-issued certificates scoped to their own {app}.{zone} subtree. This is for apps that need third-party-trusted certs rather than self-signed ones, e.g. an XMPP server doing s2s federation (where peers reject self-signed certs and the zone wildcard does not cover second-level component hosts like conference.xmpp.{zone}).

The router provisions a dedicated certificate per request via the existing ACME DNS-01 machinery, with its own freshly-generated private key covering exactly the requested SANs. The zone wildcard cert is never reused: its key is also valid for the bare zone and every other app's subdomain, so handing it to a container would let the app impersonate the whole zone. Certs are written to a router-owned per-app directory bind-mounted read-only at /data/tls, with the paths exposed via OPENHOST_TLS_CERT / OPENHOST_TLS_KEY / OPENHOST_TLS_DOMAINS (plus per-label variants). A daily sweep renews certs within 30 days of expiry and restarts the app to load the new pair.

SAN requests are validated to live under {app}.{zone}; out-of-scope or bare-zone requests are rejected at provision time. Labels that collide after env-var normalization are rejected at parse time.

Also fixes DNS-01 for subdomain identifiers: challenge TXT records are now written at _acme-challenge.<sub> relative to the zone origin instead of always at _acme-challenge.<zone>, which only worked for the zone wildcard.

Tested end-to-end on two fresh Hetzner instances (andrew-4, andrew-5) running this branch: the openhost-xmpp app received real Google Trust Services certs covering xmpp/conference/share subdomains, and bidirectional s2s federation between the two servers succeeded (self-signed would have been rejected). Unit tests and the requires_tls integration suite (incl. dedicated issuance for a two-level subdomain) pass.