### PR TITLE
tls: per-instance ACME accounts via EAB-mint (default) + byo fallback

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -38,6 +38,10 @@ jobs:
       AWS_DEFAULT_REGION: us-east-1
       SKIP_APT_UPGRADE: "1"
       OPENHOST_COMMIT: ${{ github.event.pull_request.head.sha || github.sha }}
+      # Deploy with the bring-your-own ACME account key written below rather than
+      # the default "eab_mint" provider, which would mint an EAB from the
+      # cert-api service (not reachable from the e2e instance).
+      CERT_PROVIDER: byo
       # GCP-specific
       GCP_PROJECT: ${{ secrets.GCP_PROJECT_ID }}
       GCP_ZONE: ${{ vars.GCP_ZONE || 'us-central1-a' }}

--- a/ansible/tasks/sync_code.yml
+++ b/ansible/tasks/sync_code.yml
@@ -16,10 +16,13 @@
   register: git_clean_result
   changed_when: git_clean_result.stdout | length > 0
 
-- name: Copy ACME account key
+# Only needed for bring-your-own cert provider. The default (eab_mint) generates
+# a per-instance ACME account key on the box and never ships a shared key.
+- name: Copy ACME account key (bring-your-own only)
   copy:
     src: "{{ playbook_dir }}/secrets/certbot_private_key.json"
     dest: /home/host/openhost/ansible/secrets/certbot_private_key.json
     owner: host
     group: host
     mode: "0600"
+  when: (cert_provider | default('eab_mint')) == 'byo'

--- a/ansible/templates/config.toml.j2
+++ b/ansible/templates/config.toml.j2
@@ -3,10 +3,24 @@ zone_domain = "{{ domain }}"
 host = "127.0.0.1"
 tls_enabled = true
 acquire_tls_cert_if_missing = true
-acme_account_key_path = "/home/host/openhost/ansible/secrets/certbot_private_key.json"
 acme_email = "{{ acme_email | default('openhost@' + domain) }}"
+cert_provider = "{{ cert_provider | default('eab_mint') }}"
+{% if cert_provider | default('eab_mint') == 'byo' %}
+# Bring-your-own: operator supplies their own ACME account key + CA (non-managed domains).
+acme_account_key_path = "{{ acme_account_key_path | default('/home/host/openhost/ansible/secrets/certbot_private_key.json') }}"
 {% if acme_directory_url is defined %}
 acme_directory_url = "{{ acme_directory_url }}"
+{% endif %}
+{% else %}
+# Managed (eab_mint): the instance mints a single-use EAB from the cert-api and
+# creates its own ACME account against Google Trust Services. Override cert_api_url
+# to point at your own minter.
+{% if cert_api_url is defined %}
+cert_api_url = "{{ cert_api_url }}"
+{% endif %}
+{% if cert_api_token is defined %}
+cert_api_token = "{{ cert_api_token }}"
+{% endif %}
 {% endif %}
 coredns_enabled = true
 public_ip = "{{ public_ip | default(inventory_hostname) }}"

--- a/compute_space/src/compute_space/config.py
+++ b/compute_space/src/compute_space/config.py
@@ -9,6 +9,20 @@ import cattrs
 import tomli_w
 import typed_settings
 
+# Cert provider modes (see the `cert_provider` config field).
+# "eab_mint": mint a single-use EAB from the cert-api and create this instance's
+#   own ACME account, then issue from Google Trust Services (the managed default).
+# "byo": operator brings their own acme_account_key_path + acme_directory_url.
+CERT_PROVIDER_EAB_MINT = "eab_mint"
+CERT_PROVIDER_BYO = "byo"
+_VALID_CERT_PROVIDERS = frozenset({CERT_PROVIDER_EAB_MINT, CERT_PROVIDER_BYO})
+
+# Default cert-api EAB minter endpoint (Imbue hosted). Self-hosters running their
+# own minter override this via the `cert_api_url` config field.
+# TODO(cert-api contract): confirm the real hosted endpoint + path with the
+#   ~/openhost-cert-api service once its contract is finalized.
+DEFAULT_CERT_API_URL = "https://cert-api.selfhost.imbue.com"
+
 
 def _lowercase(s: str) -> str:
     # mypy can't handle str.lower apparently
@@ -30,8 +44,18 @@ class Config:
     tls_enabled: bool
     acquire_tls_cert_if_missing: bool
     acme_email: str | None
+    # Operator-supplied ACME account key (used only in "byo" cert_provider mode).
+    # In "eab_mint" mode the instance generates and persists its own account key
+    # at `managed_acme_account_key_path`; this field is ignored.
     acme_account_key_path: str | None
     acme_directory_url: str | None
+
+    # Cert provider mode: "eab_mint" (default) or "byo". See CERT_PROVIDER_* above.
+    cert_provider: str = attr.ib(validator=attr.validators.in_(_VALID_CERT_PROVIDERS))
+    # cert-api EAB minter endpoint (eab_mint mode only). Override to self-host.
+    cert_api_url: str | None
+    # Optional bearer token for authenticating to the cert-api minter (eab_mint mode).
+    cert_api_token: str | None
 
     ## coredns (only really needed if acquiring TLS certs via DNS-01, or if using NS dns records)
     coredns_enabled: bool
@@ -135,6 +159,12 @@ class Config:
         return self.openhost_data_path / "openhost-tls-key.pem"
 
     @property
+    def managed_acme_account_key_path(self) -> Path:
+        # Where "eab_mint" mode persists this instance's own ACME account key so
+        # renewals reuse it.  A lost key means a fresh EAB is minted next boot.
+        return self.openhost_data_path / "acme-account-key.json"
+
+    @property
     def coredns_corefile_path(self) -> Path:
         return self.openhost_data_path / "Corefile"
 
@@ -189,6 +219,13 @@ class DefaultConfig(Config):
     acme_email: str | None = None
     acme_account_key_path: str | None = None
     acme_directory_url: str | None = None
+
+    # Cert provider: default to the managed EAB-mint path (targets GTS).
+    # Re-declare with the validator: a subclass override drops the base attr.ib,
+    # and DefaultConfig is the class actually loaded at runtime.
+    cert_provider: str = attr.ib(default=CERT_PROVIDER_EAB_MINT, validator=attr.validators.in_(_VALID_CERT_PROVIDERS))
+    cert_api_url: str | None = DEFAULT_CERT_API_URL
+    cert_api_token: str | None = None
 
     start_caddy: bool = True
 

--- a/compute_space/src/compute_space/config.py
+++ b/compute_space/src/compute_space/config.py
@@ -17,11 +17,12 @@ CERT_PROVIDER_EAB_MINT = "eab_mint"
 CERT_PROVIDER_BYO = "byo"
 _VALID_CERT_PROVIDERS = frozenset({CERT_PROVIDER_EAB_MINT, CERT_PROVIDER_BYO})
 
-# Default cert-api EAB minter endpoint (Imbue hosted). Self-hosters running their
-# own minter override this via the `cert_api_url` config field.
-# TODO(cert-api contract): confirm the real hosted endpoint + path with the
-#   ~/openhost-cert-api service once its contract is finalized.
-DEFAULT_CERT_API_URL = "https://cert-api.selfhost.imbue.com"
+# Default cert-api EAB minter endpoint (Imbue hosted). The minter is the
+# openhost-cert-api service deployed as an OpenHost app (app name
+# "openhost-cert-api"), so it lives at that subdomain of the managed zone.
+# Self-hosters running their own minter override this via `cert_api_url`.
+# The client appends "/v1/eab" (see core/tls/cert_api_client.py).
+DEFAULT_CERT_API_URL = "https://openhost-cert-api.selfhost.imbue.com"
 
 
 def _lowercase(s: str) -> str:
@@ -54,7 +55,9 @@ class Config:
     cert_provider: str = attr.ib(validator=attr.validators.in_(_VALID_CERT_PROVIDERS))
     # cert-api EAB minter endpoint (eab_mint mode only). Override to self-host.
     cert_api_url: str | None
-    # Optional bearer token for authenticating to the cert-api minter (eab_mint mode).
+    # Per-instance bearer token for the cert-api minter (eab_mint mode). The
+    # operator provisions this; the service requires it under its current auth
+    # scheme (missing/invalid -> the mint call fails loudly with HTTP 401).
     cert_api_token: str | None
 
     ## coredns (only really needed if acquiring TLS certs via DNS-01, or if using NS dns records)

--- a/compute_space/src/compute_space/core/tls/account.py
+++ b/compute_space/src/compute_space/core/tls/account.py
@@ -1,0 +1,120 @@
+import json
+import os
+from pathlib import Path
+
+from acme import client
+from acme import messages
+from cryptography.hazmat.primitives.asymmetric import rsa
+from josepy import JWKRSA  # type: ignore[attr-defined]
+
+from compute_space.config import CERT_PROVIDER_BYO
+from compute_space.config import CERT_PROVIDER_EAB_MINT
+from compute_space.core.logging import logger
+from compute_space.core.tls.cert_api_client import EABCredential
+from compute_space.core.tls.cert_api_client import mint_eab
+from compute_space.core.tls.util import load_account_key
+
+_USER_AGENT = "openhost-router/0.1"
+
+
+def _generate_account_key() -> JWKRSA:
+    """Generate this instance's OWN ACME account key (RSA-2048, certbot JWK format)."""
+    private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    return JWKRSA(key=private_key)
+
+
+def persist_account_key(account_key: JWKRSA, path: Path) -> None:
+    """Persist an ACME account key as a certbot JWK JSON file with 0600 perms.
+
+    Persisting lets renewals reuse the account key without ever calling the
+    cert-api again.  A lost key simply means a fresh EAB is minted next boot.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w") as f:
+        json.dump(account_key.to_json(), f)
+    os.chmod(path, 0o600)
+
+
+def _register_account_with_eab(
+    *,
+    account_key: JWKRSA,
+    directory_url: str,
+    eab_credential: EABCredential,
+    acme_email: str | None,
+    verify_ssl: bool,
+) -> messages.RegistrationResource:
+    """Register a NEW ACME account bound to a single-use EAB credential (RFC 8555 §7.3.4)."""
+    net = client.ClientNetwork(account_key, user_agent=_USER_AGENT, timeout=30, verify_ssl=verify_ssl)
+    directory = messages.Directory.from_json(net.get(directory_url).json())
+    acme_client = client.ClientV2(directory, net)
+
+    eab = messages.ExternalAccountBinding.from_data(
+        account_public_key=account_key.public_key(),
+        kid=eab_credential.kid,
+        hmac_key=eab_credential.hmac_key,
+        directory=directory,
+    )
+    if acme_email:
+        reg = messages.NewRegistration.from_data(
+            email=acme_email, external_account_binding=eab, terms_of_service_agreed=True
+        )
+    else:
+        reg = messages.NewRegistration.from_data(external_account_binding=eab, terms_of_service_agreed=True)
+
+    account = acme_client.new_account(reg)
+    logger.info(f"Created EAB-bound ACME account: {account.uri}")
+    return account
+
+
+def ensure_account_key(
+    *,
+    mode: str,
+    account_key_path: Path,
+    directory_url: str,
+    cert_api_url: str | None,
+    cert_api_token: str | None,
+    zone_domain: str,
+    acme_email: str | None = None,
+    verify_ssl: bool = True,
+) -> JWKRSA:
+    """Return the ACME account key, creating + registering one via EAB when needed.
+
+    This is the only step that differs between cert provider modes; the DNS-01
+    issuance core is shared.  Behaviour:
+
+    - If a key is already persisted at ``account_key_path``: load and return it.
+      This covers BOTH renewals (eab_mint) and bring-your-own — and never
+      contacts the cert-api.
+    - ``byo`` mode with no key: fail loudly (operator must supply one).
+    - ``eab_mint`` mode with no key (first boot): mint a single-use EAB from the
+      cert-api, generate this instance's OWN account key, register a new ACME
+      account bound to that EAB, persist the key, and return it.
+    """
+    if account_key_path.exists():
+        logger.info(f"Using existing ACME account key at {account_key_path}")
+        return load_account_key(account_key_path)
+
+    if mode == CERT_PROVIDER_BYO:
+        raise RuntimeError(
+            f"cert_provider='byo' requires an existing ACME account key at {account_key_path}, but none was found. "
+            f"Generate and register one (see scripts/generate_acme_key.py)."
+        )
+    if mode != CERT_PROVIDER_EAB_MINT:
+        raise RuntimeError(f"Unknown cert_provider mode: {mode!r}")
+
+    if not cert_api_url:
+        raise RuntimeError("cert_provider='eab_mint' requires cert_api_url to be set")
+
+    logger.info("No persisted ACME account key found; minting EAB and registering a new account (eab_mint mode)")
+    eab_credential = mint_eab(cert_api_url, zone_domain, token=cert_api_token, verify_ssl=verify_ssl)
+    account_key = _generate_account_key()
+    _register_account_with_eab(
+        account_key=account_key,
+        directory_url=directory_url,
+        eab_credential=eab_credential,
+        acme_email=acme_email,
+        verify_ssl=verify_ssl,
+    )
+    persist_account_key(account_key, account_key_path)
+    logger.info(f"Registered new EAB-bound ACME account and persisted key to {account_key_path}")
+    return account_key

--- a/compute_space/src/compute_space/core/tls/account.py
+++ b/compute_space/src/compute_space/core/tls/account.py
@@ -2,6 +2,7 @@ import json
 import os
 from pathlib import Path
 
+import attr
 from acme import client
 from acme import messages
 from cryptography.hazmat.primitives.asymmetric import rsa
@@ -15,6 +16,18 @@ from compute_space.core.tls.cert_api_client import mint_eab
 from compute_space.core.tls.util import load_account_key
 
 _USER_AGENT = "openhost-router/0.1"
+
+
+@attr.s(auto_attribs=True, frozen=True)
+class ResolvedAccount:
+    """The account key to issue with, plus the ACME directory it belongs to.
+
+    In eab_mint mode the cert-api dictates the directory (prod vs staging GTS),
+    so issuance must use the same one the account was created against.
+    """
+
+    account_key: JWKRSA
+    directory_url: str
 
 
 def _generate_account_key() -> JWKRSA:
@@ -53,6 +66,7 @@ def _register_account_with_eab(
         kid=eab_credential.kid,
         hmac_key=eab_credential.hmac_key,
         directory=directory,
+        hmac_alg=eab_credential.hmac_alg,
     )
     if acme_email:
         reg = messages.NewRegistration.from_data(
@@ -76,23 +90,26 @@ def ensure_account_key(
     zone_domain: str,
     acme_email: str | None = None,
     verify_ssl: bool = True,
-) -> JWKRSA:
-    """Return the ACME account key, creating + registering one via EAB when needed.
+) -> ResolvedAccount:
+    """Return the ACME account key (+ its directory), minting one via EAB if needed.
 
     This is the only step that differs between cert provider modes; the DNS-01
     issuance core is shared.  Behaviour:
 
-    - If a key is already persisted at ``account_key_path``: load and return it.
-      This covers BOTH renewals (eab_mint) and bring-your-own — and never
-      contacts the cert-api.
+    - If a key is already persisted at ``account_key_path``: load it and pair it
+      with the caller's ``directory_url``.  This covers BOTH renewals (eab_mint)
+      and bring-your-own — and never contacts the cert-api.  (On renewal the
+      directory comes from config; keep ``acme_directory_url`` aligned with what
+      the cert-api used — they match for the prod-GTS default.)
     - ``byo`` mode with no key: fail loudly (operator must supply one).
     - ``eab_mint`` mode with no key (first boot): mint a single-use EAB from the
       cert-api, generate this instance's OWN account key, register a new ACME
-      account bound to that EAB, persist the key, and return it.
+      account bound to that EAB against the directory the cert-api returns,
+      persist the key, and return it paired with that directory.
     """
     if account_key_path.exists():
         logger.info(f"Using existing ACME account key at {account_key_path}")
-        return load_account_key(account_key_path)
+        return ResolvedAccount(account_key=load_account_key(account_key_path), directory_url=directory_url)
 
     if mode == CERT_PROVIDER_BYO:
         raise RuntimeError(
@@ -107,14 +124,16 @@ def ensure_account_key(
 
     logger.info("No persisted ACME account key found; minting EAB and registering a new account (eab_mint mode)")
     eab_credential = mint_eab(cert_api_url, zone_domain, token=cert_api_token, verify_ssl=verify_ssl)
+    # The cert-api is authoritative about which directory the EAB is valid for.
+    effective_directory_url = eab_credential.directory_url
     account_key = _generate_account_key()
     _register_account_with_eab(
         account_key=account_key,
-        directory_url=directory_url,
+        directory_url=effective_directory_url,
         eab_credential=eab_credential,
         acme_email=acme_email,
         verify_ssl=verify_ssl,
     )
     persist_account_key(account_key, account_key_path)
     logger.info(f"Registered new EAB-bound ACME account and persisted key to {account_key_path}")
-    return account_key
+    return ResolvedAccount(account_key=account_key, directory_url=effective_directory_url)

--- a/compute_space/src/compute_space/core/tls/acquire_cert.py
+++ b/compute_space/src/compute_space/core/tls/acquire_cert.py
@@ -2,9 +2,10 @@ import asyncio
 import os
 from pathlib import Path
 
+from compute_space.config import CERT_PROVIDER_BYO
 from compute_space.core.logging import logger
+from compute_space.core.tls.account import ensure_account_key
 from compute_space.core.tls.util import _acquire_cert_dns01
-from compute_space.core.tls.util import load_account_key
 
 GTS_PRODUCTION = "https://dv.acme-v02.api.pki.goog/directory"
 
@@ -16,25 +17,56 @@ def check_if_cert_exists(cert_path: Path, key_path: Path) -> bool:
     return False
 
 
+def _assert_domains_within_zone(domains: list[str], zone_domain: str) -> None:
+    """Defense-in-depth: refuse to request certs for anything outside our own zone.
+
+    The trust boundary is DNS delegation — this instance is authoritative ONLY
+    for its own delegated zone (served by its CoreDNS), so it must only ever
+    order certs for ``zone_domain`` and its subdomains.  This guards against a
+    future change accidentally requesting a domain this instance can't validate.
+    """
+    for d in domains:
+        base = d[2:] if d.startswith("*.") else d
+        if base != zone_domain and not base.endswith(f".{zone_domain}"):
+            raise RuntimeError(f"Refusing to request cert for {d!r}: outside this instance's zone {zone_domain!r}")
+
+
 async def acquire_tls_cert(
     domain: str,
     cert_path: Path,
     key_path: Path,
     acme_account_key_path: Path,
     coredns_zonefile_path: Path,
+    cert_provider: str = CERT_PROVIDER_BYO,
+    cert_api_url: str | None = None,
+    cert_api_token: str | None = None,
     directory_url: str | None = None,
     verify_ssl: bool = True,
     acme_email: str | None = None,
 ) -> None:
 
-    logger.info(f"Acquiring TLS certificate for {domain}...")
-
-    account_key = load_account_key(acme_account_key_path)
-    logger.info(f"Loaded ACME account key from {acme_account_key_path}")
+    logger.info(f"Acquiring TLS certificate for {domain} (cert_provider={cert_provider})...")
 
     if directory_url is None:
         directory_url = GTS_PRODUCTION
+
+    # Resolve the ACME account key.  This is the only step that differs between
+    # provider modes (eab_mint mints+registers a new account; byo/renewal loads
+    # the persisted key); the DNS-01 issuance below is shared.
+    account_key = await asyncio.to_thread(
+        ensure_account_key,
+        mode=cert_provider,
+        account_key_path=acme_account_key_path,
+        directory_url=directory_url,
+        cert_api_url=cert_api_url,
+        cert_api_token=cert_api_token,
+        zone_domain=domain,
+        acme_email=acme_email,
+        verify_ssl=verify_ssl,
+    )
+
     domains = [domain, f"*.{domain}"]
+    _assert_domains_within_zone(domains, domain)
     logger.info(f"Requesting wildcard TLS cert for {domains} from {directory_url} (DNS-01)")
     cert_pem, key_pem = await asyncio.to_thread(
         _acquire_cert_dns01,

--- a/compute_space/src/compute_space/core/tls/acquire_cert.py
+++ b/compute_space/src/compute_space/core/tls/acquire_cert.py
@@ -52,8 +52,10 @@ async def acquire_tls_cert(
 
     # Resolve the ACME account key.  This is the only step that differs between
     # provider modes (eab_mint mints+registers a new account; byo/renewal loads
-    # the persisted key); the DNS-01 issuance below is shared.
-    account_key = await asyncio.to_thread(
+    # the persisted key); the DNS-01 issuance below is shared.  In eab_mint mode
+    # the cert-api also dictates the directory, so issue against the one the
+    # account was created with.
+    resolved = await asyncio.to_thread(
         ensure_account_key,
         mode=cert_provider,
         account_key_path=acme_account_key_path,
@@ -67,13 +69,13 @@ async def acquire_tls_cert(
 
     domains = [domain, f"*.{domain}"]
     _assert_domains_within_zone(domains, domain)
-    logger.info(f"Requesting wildcard TLS cert for {domains} from {directory_url} (DNS-01)")
+    logger.info(f"Requesting wildcard TLS cert for {domains} from {resolved.directory_url} (DNS-01)")
     cert_pem, key_pem = await asyncio.to_thread(
         _acquire_cert_dns01,
         domains=domains,
-        directory_url=directory_url,
+        directory_url=resolved.directory_url,
         coredns_zonefile_path=coredns_zonefile_path,
-        account_key=account_key,
+        account_key=resolved.account_key,
         verify_ssl=verify_ssl,
         acme_email=acme_email,
     )

--- a/compute_space/src/compute_space/core/tls/cert_api_client.py
+++ b/compute_space/src/compute_space/core/tls/cert_api_client.py
@@ -8,55 +8,72 @@ from compute_space.core.logging import logger
 class EABCredential:
     """A single-use External Account Binding credential minted by the cert-api.
 
-    Per RFC 8555 externalAccountBinding: ``kid`` identifies the binding and
-    ``hmac_key`` is the base64url-encoded MAC key used to HMAC-sign the newAccount
-    request.  The credential only enables creating ONE ACME account; it does not
-    grant cert issuance (DNS-01 control still gates that).
+    Maps the cert-api ``POST /v1/eab`` response onto what an ACME client needs:
+    ``kid``/``hmac_key`` (RFC 8555 externalAccountBinding), the ``directory_url``
+    the EAB was minted against (the service is authoritative — prod vs staging
+    GTS), and the HMAC algorithm.  ``hmac_key`` is base64url-encoded, as GTS
+    returns it, and is passed straight through to the ACME library.
     """
 
     kid: str
     hmac_key: str
+    directory_url: str
+    hmac_alg: str = "HS256"
 
 
 def mint_eab(
     cert_api_url: str,
-    zone_domain: str,
+    domain: str,
     *,
     token: str | None = None,
     timeout: float = 30.0,
     verify_ssl: bool = True,
 ) -> EABCredential:
-    """Mint a single-use EAB credential from the cert-api for this instance's zone.
+    """Mint a single-use EAB credential from the cert-api for this instance.
 
-    Called once at bootstrap when no ACME account key is persisted yet.  Renewals
-    reuse the persisted account key and never call here again.
-
-    TODO(cert-api contract): the request/response wire format is owned by the
-    separate ~/openhost-cert-api service and is not yet finalized.  This codes to
-    a clean, documented seam — adjust the endpoint path / field names here once
-    the contract lands:
-
-        POST {cert_api_url}/eab
-          headers: Authorization: Bearer <token>   (only if a token is configured)
-          json:    {"zone_domain": <zone_domain>}
-        -> 200 {"kid": "...", "hmac_key": "<base64url>"}
+    Calls ``POST /v1/eab`` on the openhost-cert-api service (wire contract: that
+    repo's README).  Called once at bootstrap; renewals reuse the persisted
+    account key and never call here again.  ``domain`` is audit-only on the
+    service side (an EAB grants no domain authorization; DNS-01 still gates
+    issuance).  Auth is a per-instance bearer token provisioned by the operator.
     """
-    endpoint = cert_api_url.rstrip("/") + "/eab"
+    endpoint = cert_api_url.rstrip("/") + "/v1/eab"
     headers = {"Authorization": f"Bearer {token}"} if token else {}
-    logger.info(f"Minting single-use EAB credential from cert-api at {endpoint} for zone {zone_domain}")
+    logger.info(f"Minting single-use EAB credential from cert-api at {endpoint}")
 
     response = httpx.post(
         endpoint,
-        json={"zone_domain": zone_domain},
+        json={"domain": domain},
         headers=headers,
         timeout=timeout,
         verify=verify_ssl,
     )
-    response.raise_for_status()
-    payload = response.json()
 
-    # The response is external JSON of a not-yet-pinned shape; pull it into a
-    # typed credential immediately and fail loudly if the fields are missing.
-    if not isinstance(payload, dict) or "kid" not in payload or "hmac_key" not in payload:
-        raise RuntimeError(f"cert-api EAB response missing expected fields (kid, hmac_key): {payload!r}")
-    return EABCredential(kid=payload["kid"], hmac_key=payload["hmac_key"])
+    if response.status_code != 200:
+        raise RuntimeError(f"cert-api EAB mint failed: {_describe_error(response)}")
+
+    payload = response.json()
+    required = ("key_id", "b64_mac_key", "directory_url")
+    if not isinstance(payload, dict) or any(field not in payload for field in required):
+        raise RuntimeError(f"cert-api EAB response missing expected fields {required}: {payload!r}")
+
+    return EABCredential(
+        kid=payload["key_id"],
+        hmac_key=payload["b64_mac_key"],
+        directory_url=payload["directory_url"],
+        hmac_alg=payload.get("key_algorithm", "HS256"),
+    )
+
+
+def _describe_error(response: httpx.Response) -> str:
+    """Best-effort description of a cert-api error envelope ({error, message})."""
+    detail = ""
+    try:
+        body = response.json()
+        if isinstance(body, dict):
+            detail = f" {body.get('error')}: {body.get('message')}"
+    except ValueError:
+        pass
+    retry_after = response.headers.get("Retry-After")
+    suffix = f" (Retry-After={retry_after}s)" if retry_after else ""
+    return f"HTTP {response.status_code}{detail}{suffix}"

--- a/compute_space/src/compute_space/core/tls/cert_api_client.py
+++ b/compute_space/src/compute_space/core/tls/cert_api_client.py
@@ -1,0 +1,62 @@
+import attr
+import httpx
+
+from compute_space.core.logging import logger
+
+
+@attr.s(auto_attribs=True, frozen=True)
+class EABCredential:
+    """A single-use External Account Binding credential minted by the cert-api.
+
+    Per RFC 8555 externalAccountBinding: ``kid`` identifies the binding and
+    ``hmac_key`` is the base64url-encoded MAC key used to HMAC-sign the newAccount
+    request.  The credential only enables creating ONE ACME account; it does not
+    grant cert issuance (DNS-01 control still gates that).
+    """
+
+    kid: str
+    hmac_key: str
+
+
+def mint_eab(
+    cert_api_url: str,
+    zone_domain: str,
+    *,
+    token: str | None = None,
+    timeout: float = 30.0,
+    verify_ssl: bool = True,
+) -> EABCredential:
+    """Mint a single-use EAB credential from the cert-api for this instance's zone.
+
+    Called once at bootstrap when no ACME account key is persisted yet.  Renewals
+    reuse the persisted account key and never call here again.
+
+    TODO(cert-api contract): the request/response wire format is owned by the
+    separate ~/openhost-cert-api service and is not yet finalized.  This codes to
+    a clean, documented seam — adjust the endpoint path / field names here once
+    the contract lands:
+
+        POST {cert_api_url}/eab
+          headers: Authorization: Bearer <token>   (only if a token is configured)
+          json:    {"zone_domain": <zone_domain>}
+        -> 200 {"kid": "...", "hmac_key": "<base64url>"}
+    """
+    endpoint = cert_api_url.rstrip("/") + "/eab"
+    headers = {"Authorization": f"Bearer {token}"} if token else {}
+    logger.info(f"Minting single-use EAB credential from cert-api at {endpoint} for zone {zone_domain}")
+
+    response = httpx.post(
+        endpoint,
+        json={"zone_domain": zone_domain},
+        headers=headers,
+        timeout=timeout,
+        verify=verify_ssl,
+    )
+    response.raise_for_status()
+    payload = response.json()
+
+    # The response is external JSON of a not-yet-pinned shape; pull it into a
+    # typed credential immediately and fail loudly if the fields are missing.
+    if not isinstance(payload, dict) or "kid" not in payload or "hmac_key" not in payload:
+        raise RuntimeError(f"cert-api EAB response missing expected fields (kid, hmac_key): {payload!r}")
+    return EABCredential(kid=payload["kid"], hmac_key=payload["hmac_key"])

--- a/compute_space/src/compute_space/tests/test_tls_account.py
+++ b/compute_space/src/compute_space/tests/test_tls_account.py
@@ -6,6 +6,7 @@ import pytest
 
 from compute_space.config import CERT_PROVIDER_BYO
 from compute_space.config import CERT_PROVIDER_EAB_MINT
+from compute_space.core.tls.account import ResolvedAccount
 from compute_space.core.tls.account import _generate_account_key
 from compute_space.core.tls.account import ensure_account_key
 from compute_space.core.tls.account import persist_account_key
@@ -43,8 +44,11 @@ def test_persisted_key_is_reused_without_minting(tmp_path: Path, monkeypatch: py
 
     monkeypatch.setattr("compute_space.core.tls.account.mint_eab", _boom)
 
-    loaded = _ensure(CERT_PROVIDER_EAB_MINT, key_path)
-    assert loaded.to_json() == original.to_json()
+    resolved = _ensure(CERT_PROVIDER_EAB_MINT, key_path)
+    assert isinstance(resolved, ResolvedAccount)
+    assert resolved.account_key.to_json() == original.to_json()
+    # On the load path the directory comes from the caller's config, unchanged.
+    assert resolved.directory_url == "https://acme.example.test/dir"
 
 
 def test_byo_missing_key_raises(tmp_path: Path) -> None:
@@ -78,14 +82,23 @@ def test_persist_account_key_round_trip_and_perms(tmp_path: Path) -> None:
 
 
 class _FakeResponse:
-    def __init__(self, payload: object) -> None:
+    def __init__(self, payload: object, status_code: int = 200, headers: dict[str, str] | None = None) -> None:
         self._payload = payload
-
-    def raise_for_status(self) -> None:
-        return None
+        self.status_code = status_code
+        self.headers = headers or {}
 
     def json(self) -> object:
         return self._payload
+
+
+# A representative POST /v1/eab success body (see openhost-cert-api README).
+_EAB_OK = {
+    "key_id": "key-123",
+    "b64_mac_key": "bWFjLWtleQ",
+    "directory_url": "https://dv.acme-v02.api.pki.goog/directory",
+    "ca": "google-trust-services",
+    "key_algorithm": "HS256",
+}
 
 
 def test_mint_eab_parses_response_and_sends_auth(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -95,15 +108,20 @@ def test_mint_eab_parses_response_and_sends_auth(monkeypatch: pytest.MonkeyPatch
         captured["url"] = url
         captured["json"] = json
         captured["headers"] = headers
-        return _FakeResponse({"kid": "kid-1", "hmac_key": "bWFjLWtleQ"})
+        return _FakeResponse(_EAB_OK)
 
     monkeypatch.setattr("compute_space.core.tls.cert_api_client.httpx.post", fake_post)
 
     cred = mint_eab("https://cert-api.example.test/", "host.example.com", token="secret-token")
 
-    assert cred == EABCredential(kid="kid-1", hmac_key="bWFjLWtleQ")
-    assert captured["url"] == "https://cert-api.example.test/eab"
-    assert captured["json"] == {"zone_domain": "host.example.com"}
+    assert cred == EABCredential(
+        kid="key-123",
+        hmac_key="bWFjLWtleQ",
+        directory_url="https://dv.acme-v02.api.pki.goog/directory",
+        hmac_alg="HS256",
+    )
+    assert captured["url"] == "https://cert-api.example.test/v1/eab"
+    assert captured["json"] == {"domain": "host.example.com"}
     assert captured["headers"] == {"Authorization": "Bearer secret-token"}
 
 
@@ -112,7 +130,7 @@ def test_mint_eab_omits_auth_header_without_token(monkeypatch: pytest.MonkeyPatc
 
     def fake_post(url: str, *, json: object, headers: dict[str, str], timeout: float, verify: bool) -> _FakeResponse:
         captured["headers"] = headers
-        return _FakeResponse({"kid": "kid-1", "hmac_key": "bWFjLWtleQ"})
+        return _FakeResponse(_EAB_OK)
 
     monkeypatch.setattr("compute_space.core.tls.cert_api_client.httpx.post", fake_post)
 
@@ -123,9 +141,20 @@ def test_mint_eab_omits_auth_header_without_token(monkeypatch: pytest.MonkeyPatc
 def test_mint_eab_missing_fields_raises(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(
         "compute_space.core.tls.cert_api_client.httpx.post",
-        lambda url, **kwargs: _FakeResponse({"kid": "only-kid"}),
+        lambda url, **kwargs: _FakeResponse({"key_id": "only-id"}),
     )
     with pytest.raises(RuntimeError, match="missing expected fields"):
+        mint_eab("https://cert-api.example.test", "host.example.com")
+
+
+def test_mint_eab_non_200_raises_with_error_envelope(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "compute_space.core.tls.cert_api_client.httpx.post",
+        lambda url, **kwargs: _FakeResponse(
+            {"error": "unauthorized", "message": "Missing or invalid bearer token."}, status_code=401
+        ),
+    )
+    with pytest.raises(RuntimeError, match="401.*unauthorized"):
         mint_eab("https://cert-api.example.test", "host.example.com")
 
 

--- a/compute_space/src/compute_space/tests/test_tls_account.py
+++ b/compute_space/src/compute_space/tests/test_tls_account.py
@@ -1,0 +1,145 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from compute_space.config import CERT_PROVIDER_BYO
+from compute_space.config import CERT_PROVIDER_EAB_MINT
+from compute_space.core.tls.account import _generate_account_key
+from compute_space.core.tls.account import ensure_account_key
+from compute_space.core.tls.account import persist_account_key
+from compute_space.core.tls.acquire_cert import _assert_domains_within_zone
+from compute_space.core.tls.cert_api_client import EABCredential
+from compute_space.core.tls.cert_api_client import mint_eab
+from compute_space.core.tls.util import load_account_key
+
+# ---------------------------------------------------------------------------
+# ensure_account_key — provider-mode selection (no network)
+# ---------------------------------------------------------------------------
+
+
+def _ensure(mode: str, account_key_path: Path, **overrides: object) -> object:
+    kwargs: dict[str, object] = {
+        "mode": mode,
+        "account_key_path": account_key_path,
+        "directory_url": "https://acme.example.test/dir",
+        "cert_api_url": "https://cert-api.example.test",
+        "cert_api_token": None,
+        "zone_domain": "host.example.com",
+    }
+    kwargs.update(overrides)
+    return ensure_account_key(**kwargs)  # type: ignore[arg-type]
+
+
+def test_persisted_key_is_reused_without_minting(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A persisted key is loaded directly — the cert-api is never contacted (renewal path)."""
+    key_path = tmp_path / "acme-account-key.json"
+    original = _generate_account_key()
+    persist_account_key(original, key_path)
+
+    def _boom(*args: object, **kwargs: object) -> object:
+        raise AssertionError("mint_eab must not be called when an account key is already persisted")
+
+    monkeypatch.setattr("compute_space.core.tls.account.mint_eab", _boom)
+
+    loaded = _ensure(CERT_PROVIDER_EAB_MINT, key_path)
+    assert loaded.to_json() == original.to_json()
+
+
+def test_byo_missing_key_raises(tmp_path: Path) -> None:
+    with pytest.raises(RuntimeError, match="byo"):
+        _ensure(CERT_PROVIDER_BYO, tmp_path / "missing.json", cert_api_url=None)
+
+
+def test_eab_mint_requires_cert_api_url(tmp_path: Path) -> None:
+    with pytest.raises(RuntimeError, match="cert_api_url"):
+        _ensure(CERT_PROVIDER_EAB_MINT, tmp_path / "missing.json", cert_api_url=None)
+
+
+def test_unknown_mode_raises(tmp_path: Path) -> None:
+    with pytest.raises(RuntimeError, match="Unknown cert_provider"):
+        _ensure("bogus", tmp_path / "missing.json")
+
+
+def test_persist_account_key_round_trip_and_perms(tmp_path: Path) -> None:
+    key_path = tmp_path / "nested" / "acme-account-key.json"
+    original = _generate_account_key()
+    persist_account_key(original, key_path)
+
+    assert key_path.exists()
+    assert oct(key_path.stat().st_mode & 0o777) == "0o600"
+    assert load_account_key(key_path).to_json() == original.to_json()
+
+
+# ---------------------------------------------------------------------------
+# mint_eab — cert-api seam (httpx stubbed)
+# ---------------------------------------------------------------------------
+
+
+class _FakeResponse:
+    def __init__(self, payload: object) -> None:
+        self._payload = payload
+
+    def raise_for_status(self) -> None:
+        return None
+
+    def json(self) -> object:
+        return self._payload
+
+
+def test_mint_eab_parses_response_and_sends_auth(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, object] = {}
+
+    def fake_post(url: str, *, json: object, headers: dict[str, str], timeout: float, verify: bool) -> _FakeResponse:
+        captured["url"] = url
+        captured["json"] = json
+        captured["headers"] = headers
+        return _FakeResponse({"kid": "kid-1", "hmac_key": "bWFjLWtleQ"})
+
+    monkeypatch.setattr("compute_space.core.tls.cert_api_client.httpx.post", fake_post)
+
+    cred = mint_eab("https://cert-api.example.test/", "host.example.com", token="secret-token")
+
+    assert cred == EABCredential(kid="kid-1", hmac_key="bWFjLWtleQ")
+    assert captured["url"] == "https://cert-api.example.test/eab"
+    assert captured["json"] == {"zone_domain": "host.example.com"}
+    assert captured["headers"] == {"Authorization": "Bearer secret-token"}
+
+
+def test_mint_eab_omits_auth_header_without_token(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, object] = {}
+
+    def fake_post(url: str, *, json: object, headers: dict[str, str], timeout: float, verify: bool) -> _FakeResponse:
+        captured["headers"] = headers
+        return _FakeResponse({"kid": "kid-1", "hmac_key": "bWFjLWtleQ"})
+
+    monkeypatch.setattr("compute_space.core.tls.cert_api_client.httpx.post", fake_post)
+
+    mint_eab("https://cert-api.example.test", "host.example.com")
+    assert captured["headers"] == {}
+
+
+def test_mint_eab_missing_fields_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "compute_space.core.tls.cert_api_client.httpx.post",
+        lambda url, **kwargs: _FakeResponse({"kid": "only-kid"}),
+    )
+    with pytest.raises(RuntimeError, match="missing expected fields"):
+        mint_eab("https://cert-api.example.test", "host.example.com")
+
+
+# ---------------------------------------------------------------------------
+# _assert_domains_within_zone — defense-in-depth guard
+# ---------------------------------------------------------------------------
+
+
+def test_zone_guard_allows_own_zone_and_wildcard() -> None:
+    _assert_domains_within_zone(["host.example.com", "*.host.example.com"], "host.example.com")
+    _assert_domains_within_zone(["app.host.example.com"], "host.example.com")
+
+
+@pytest.mark.parametrize("bad", ["evil.com", "*.evil.com", "host.example.com.evil.com", "nothost.example.com"])
+def test_zone_guard_blocks_foreign_domains(bad: str) -> None:
+    with pytest.raises(RuntimeError, match="outside this instance's zone"):
+        _assert_domains_within_zone([bad], "host.example.com")

--- a/compute_space/src/compute_space/web/start.py
+++ b/compute_space/src/compute_space/web/start.py
@@ -11,6 +11,7 @@ from typing import Any
 import hypercorn.asyncio
 import hypercorn.config
 
+from compute_space.config import CERT_PROVIDER_BYO
 from compute_space.config import Config
 from compute_space.config import load_config
 from compute_space.config import set_active_config
@@ -80,17 +81,29 @@ def main() -> None:
         if not check_if_cert_exists(config.tls_cert_path, config.tls_key_path):
             if not config.coredns_enabled:
                 raise RuntimeError("CoreDNS must be enabled to acquire TLS cert via DNS-01 challenge")
-            if not config.acme_account_key_path:
-                raise RuntimeError("ACME account key path must be set in config to acquire TLS cert")
             if not config.acquire_tls_cert_if_missing:
                 raise RuntimeError("TLS cert not found and acquire_tls_cert_if_missing is False")
+
+            # The account key path depends on the provider mode: bring-your-own
+            # uses the operator-supplied key; eab_mint generates and persists the
+            # instance's own key under the managed data dir (so renewals reuse it).
+            if config.cert_provider == CERT_PROVIDER_BYO:
+                if not config.acme_account_key_path:
+                    raise RuntimeError("cert_provider='byo' requires acme_account_key_path to be set in config")
+                account_key_path = Path(config.acme_account_key_path)
+            else:
+                account_key_path = config.managed_acme_account_key_path
+
             asyncio.run(
                 acquire_tls_cert(
                     domain=config.zone_domain,
                     cert_path=config.tls_cert_path,
                     key_path=config.tls_key_path,
-                    acme_account_key_path=Path(config.acme_account_key_path),
+                    acme_account_key_path=account_key_path,
                     coredns_zonefile_path=config.coredns_zonefile_path,
+                    cert_provider=config.cert_provider,
+                    cert_api_url=config.cert_api_url,
+                    cert_api_token=config.cert_api_token,
                     acme_email=config.acme_email,
                     directory_url=config.acme_directory_url,
                 )

--- a/docs/src/routing.md
+++ b/docs/src/routing.md
@@ -27,9 +27,28 @@ certs are acquired via ACME DNS-01 challenge:
 
 the cert and key are stored on disk and reused across restarts. the router only acquires a new cert if none exists.
 
-### "Google Trust Service" certs
+### cert providers
 
-this is like let's encrypt but with higher rate limits tied to your GCP account (but still free).
+the DNS-01 issuance above is shared across both modes. what differs is *how the instance gets its ACME account key*, selected by the `cert_provider` config field:
+
+**`eab_mint` (default, managed).** each instance creates its OWN ACME account:
+- on first boot (no account key on disk yet), the router calls the central **cert-api** (`cert_api_url`, default = Imbue hosted) to mint a single-use [External Account Binding](https://datatracker.ietf.org/doc/html/rfc8555#section-7.3.4) credential.
+- it generates its own ACME account key locally, registers a new account with Google Trust Services using that EAB, and persists the key to disk (`acme-account-key.json` under the openhost data dir).
+- renewals reuse the persisted key and never call the cert-api again. a lost key just means a fresh EAB is minted on the next boot.
+- the EAB only authorizes *creating one account* — it does not grant cert issuance. the instance still has to pass DNS-01, so it can only get certs for domains its own CoreDNS is authoritative for.
+- this is the default for managed domains (e.g. `selfhost.imbue.com` subdomains). self-hosters can point `cert_api_url` at their own minter (see the `openhost-cert-api` repo).
+
+this replaces the old model where every instance shipped a *shared* ACME account key via ansible — now the privileged account key is generated per-instance and never leaves the box.
+
+**`byo` (bring-your-own).** the operator supplies their own ACME account key (`acme_account_key_path`) and CA (`acme_directory_url`). use this for non-managed domains where you bring your own account + CA. fully backward compatible — this is the pre-EAB-mint behavior. see "bring-your-own setup" below for how to create the key.
+
+> **trust boundary.** the only thing stopping an instance from getting a cert for someone else's domain is DNS delegation: an instance is authoritative (via its CoreDNS) ONLY for its own delegated zone, so DNS-01 only succeeds for that zone. the router additionally refuses to *request* certs for anything outside its `zone_domain` (defense-in-depth — see `_assert_domains_within_zone`). follow-up: pin CAA `accounturi` records so the CA only honors orders from each instance's own account.
+
+### bring-your-own setup (Google Trust Services)
+
+the steps below create an ACME account key by hand for `byo` mode. they're also how the central cert-api is bootstrapped against GTS.
+
+GTS is like let's encrypt but with higher rate limits tied to your GCP account (but still free).
 
 https://docs.cloud.google.com/certificate-manager/docs/public-ca-tutorial
 https://docs.cloud.google.com/certificate-manager/docs/quotas
@@ -60,7 +79,7 @@ it does not seem that the email becomes public. sudo is just needed because cert
 
 grab the key from /etc/letsencrypt/accounts/dv.acme-v02.api.pki.goog/directory/[key id?]/private_key.json
 
-put that in certbot_private_key.json in ansible secrets (this is now kept in 1password).
+for `byo` mode, point `acme_account_key_path` at this file (e.g. drop it in ansible secrets, kept in 1password). note this is the legacy *shared-key* path — managed instances use `eab_mint` and don't need it.
 
 to revoke the keys, you have to delete the whole project. to reset rate limits, you can make a new project.
 

--- a/docs/src/routing.md
+++ b/docs/src/routing.md
@@ -32,8 +32,8 @@ the cert and key are stored on disk and reused across restarts. the router only 
 the DNS-01 issuance above is shared across both modes. what differs is *how the instance gets its ACME account key*, selected by the `cert_provider` config field:
 
 **`eab_mint` (default, managed).** each instance creates its OWN ACME account:
-- on first boot (no account key on disk yet), the router calls the central **cert-api** (`cert_api_url`, default = Imbue hosted) to mint a single-use [External Account Binding](https://datatracker.ietf.org/doc/html/rfc8555#section-7.3.4) credential.
-- it generates its own ACME account key locally, registers a new account with Google Trust Services using that EAB, and persists the key to disk (`acme-account-key.json` under the openhost data dir).
+- on first boot (no account key on disk yet), the router calls the central **cert-api** — `POST {cert_api_url}/v1/eab` with a per-instance `Authorization: Bearer` token (`cert_api_token`) — to mint a single-use [External Account Binding](https://datatracker.ietf.org/doc/html/rfc8555#section-7.3.4) credential. `cert_api_url` defaults to the Imbue-hosted minter (the `openhost-cert-api` app); self-hosters override it. The minter is the separate `openhost-cert-api` service.
+- it generates its own ACME account key locally, registers a new account with Google Trust Services using that EAB (against the `directory_url` the cert-api returns), and persists the key to disk (`acme-account-key.json` under the openhost data dir).
 - renewals reuse the persisted key and never call the cert-api again. a lost key just means a fresh EAB is minted on the next boot.
 - the EAB only authorizes *creating one account* — it does not grant cert issuance. the instance still has to pass DNS-01, so it can only get certs for domains its own CoreDNS is authoritative for.
 - this is the default for managed domains (e.g. `selfhost.imbue.com` subdomains). self-hosters can point `cert_api_url` at their own minter (see the `openhost-cert-api` repo).

--- a/scripts/generate_acme_key.py
+++ b/scripts/generate_acme_key.py
@@ -1,6 +1,12 @@
 #!/usr/bin/env python3
 """Generate and register an ACME account key in certbot JWK format.
 
+LEGACY / bring-your-own only. The default cert provider ("eab_mint") makes each
+instance mint a single-use EAB from the cert-api and create its OWN ACME account
+on first boot, so no pre-registered key is needed. This script is for the "byo"
+cert provider mode (non-managed domains): point `acme_account_key_path` at the
+key it produces.
+
 Usage: python3 generate_acme_key.py <output-path> [--email <email>]
 
 Generates an RSA-2048 key, registers it with Let's Encrypt, and saves

--- a/tests/common.sh
+++ b/tests/common.sh
@@ -170,6 +170,14 @@ run_ansible_setup() {
         extra_vars+=(-e "claim_token=$CLAIM_TOKEN")
         echo "  (claim token wired through)"
     fi
+    # The default cert_provider is "eab_mint", which mints an EAB from the
+    # cert-api (openhost-cert-api.<zone>) at startup. That service isn't
+    # reachable from the e2e instance, so deploy with the BYO ACME account key
+    # written by the workflow instead. Override via CERT_PROVIDER if needed.
+    if [ -n "${CERT_PROVIDER:-}" ]; then
+        extra_vars+=(-e "cert_provider=$CERT_PROVIDER")
+        echo "  (cert_provider=$CERT_PROVIDER)"
+    fi
 
     # Run the full setup playbook.
     ANSIBLE_HOST_KEY_CHECKING=false \

--- a/tests/test_tls.py
+++ b/tests/test_tls.py
@@ -15,6 +15,7 @@ Run:
 """
 
 import asyncio
+import base64
 import datetime
 import ipaddress
 import json
@@ -34,7 +35,9 @@ from cryptography.hazmat.primitives.asymmetric import ec
 from cryptography.hazmat.primitives.asymmetric import rsa as rsa_module
 from josepy import JWKRSA
 
+from compute_space.config import CERT_PROVIDER_EAB_MINT
 from compute_space.core.tls.acquire_cert import acquire_tls_cert
+from compute_space.core.tls.cert_api_client import EABCredential
 from compute_space.core.tls.util import _acquire_cert_dns01
 from compute_space.core.tls.util import load_account_key
 from compute_space.tests.utils import kill_tree
@@ -49,6 +52,15 @@ PEBBLE_ACME_PORT = 14000
 PEBBLE_MGMT_PORT = 15000
 COREDNS_PORT = 15353
 ZONE_DOMAIN = "tls-test.localhost"
+
+# A second Pebble instance that REQUIRES External Account Binding, used to test
+# the eab_mint provider end-to-end.  Distinct ACME/management ports so it can run
+# alongside the plain pebble_server; both share the same CoreDNS for DNS-01.
+EAB_PEBBLE_ACME_PORT = 14100
+EAB_PEBBLE_MGMT_PORT = 15100
+EAB_KID = "openhost-test-kid"
+# base64url-encoded HMAC key shared between Pebble's config and the minted EAB.
+EAB_MAC_KEY = base64.urlsafe_b64encode(b"openhost-eab-test-mac-key-32bytes!!").rstrip(b"=").decode()
 
 requires_tls = pytest.mark.requires_tls
 
@@ -435,3 +447,136 @@ class TestAccountKey:
         original = _generate_acme_account_key(str(key_path))
         loaded = load_account_key(key_path)
         assert original.to_json() == loaded.to_json()
+
+
+# ---------------------------------------------------------------------------
+# Fixtures + tests — eab_mint provider (per-instance account via EAB)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def eab_pebble_server(tls_tmpdir, pebble_certs, coredns_server):
+    """Start a Pebble that REQUIRES EAB, with a known kid/MAC key.
+
+    NOTE: the EAB config keys (externalAccountBindingRequired / externalAccountMACKeys)
+    must match the Pebble version in PATH.  base64url MAC keys per RFC 8555.
+    """
+    assert _port_free(EAB_PEBBLE_ACME_PORT), f"Port {EAB_PEBBLE_ACME_PORT} already in use"
+
+    config_path = str(tls_tmpdir / "pebble-eab-config.json")
+    with open(config_path, "w") as f:
+        json.dump(
+            {
+                "pebble": {
+                    "listenAddress": f"0.0.0.0:{EAB_PEBBLE_ACME_PORT}",
+                    "managementListenAddress": f"0.0.0.0:{EAB_PEBBLE_MGMT_PORT}",
+                    "certificate": pebble_certs["cert"],
+                    "privateKey": pebble_certs["key"],
+                    "httpPort": 5002,
+                    "tlsPort": 5001,
+                    "externalAccountBindingRequired": True,
+                    "externalAccountMACKeys": {EAB_KID: EAB_MAC_KEY},
+                }
+            },
+            f,
+        )
+
+    env = os.environ.copy()
+    env["PEBBLE_VA_NOSLEEP"] = "1"
+    env["PEBBLE_WFE_NONCEREJECT"] = "0"
+
+    log_path = tls_tmpdir / "pebble-eab.log"
+    log_file = open(log_path, "w")
+
+    proc = subprocess.Popen(
+        ["pebble", "-config", config_path, "-dnsserver", f"127.0.0.1:{COREDNS_PORT}"],
+        env=env,
+        stdout=log_file,
+        stderr=log_file,
+        start_new_session=True,
+    )
+
+    directory_url = f"https://127.0.0.1:{EAB_PEBBLE_ACME_PORT}/dir"
+    try:
+        poll(
+            lambda: port_connectable("127.0.0.1", EAB_PEBBLE_ACME_PORT),
+            timeout=10,
+            interval=0.3,
+            fail_msg="EAB Pebble did not start",
+        )
+        yield {"proc": proc, "directory_url": directory_url}
+    except Exception as exc:
+        with open(log_path) as f:
+            raise RuntimeError(f"EAB Pebble failed to start:\n{f.read()}") from exc
+    finally:
+        kill_tree(proc)
+        try:
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            kill_tree(proc, signal.SIGKILL)
+            proc.wait(timeout=5)
+        log_file.close()
+
+
+@requires_tls
+class TestEabMintProvider:
+    """End-to-end: mint EAB -> create own account -> persist key -> issue cert."""
+
+    def _acquire(self, *, eab_pebble_server, zonefile_path, account_key_path, cert_path, key_path):
+        asyncio.run(
+            acquire_tls_cert(
+                domain=ZONE_DOMAIN,
+                cert_path=cert_path,
+                key_path=key_path,
+                acme_account_key_path=account_key_path,
+                coredns_zonefile_path=zonefile_path,
+                cert_provider=CERT_PROVIDER_EAB_MINT,
+                cert_api_url="https://cert-api.invalid",
+                directory_url=eab_pebble_server["directory_url"],
+                verify_ssl=False,
+            )
+        )
+
+    def test_eab_mint_registers_persists_and_issues(self, eab_pebble_server, zonefile_path, tls_tmpdir, monkeypatch):
+        account_key_path = tls_tmpdir / "managed-acme-account-key.json"
+        cert_path = tls_tmpdir / "eab-cert.pem"
+        key_path = tls_tmpdir / "eab-key.pem"
+
+        mint_calls = []
+
+        def fake_mint(cert_api_url, zone_domain, *, token=None, timeout=30.0, verify_ssl=True):
+            mint_calls.append(zone_domain)
+            return EABCredential(kid=EAB_KID, hmac_key=EAB_MAC_KEY)
+
+        # account.py imported mint_eab into its own namespace; patch it there.
+        monkeypatch.setattr("compute_space.core.tls.account.mint_eab", fake_mint)
+
+        self._acquire(
+            eab_pebble_server=eab_pebble_server,
+            zonefile_path=zonefile_path,
+            account_key_path=account_key_path,
+            cert_path=cert_path,
+            key_path=key_path,
+        )
+
+        # The instance generated and persisted its OWN account key (0600).
+        assert account_key_path.exists()
+        assert oct(account_key_path.stat().st_mode & 0o777) == "0o600"
+        # EAB minted exactly once, and a wildcard cert was issued.
+        assert mint_calls == [ZONE_DOMAIN]
+        cert = x509.load_pem_x509_certificate(cert_path.read_bytes())
+        dns_names = cert.extensions.get_extension_for_class(x509.SubjectAlternativeName).value.get_values_for_type(
+            x509.DNSName
+        )
+        assert ZONE_DOMAIN in dns_names
+        assert f"*.{ZONE_DOMAIN}" in dns_names
+
+        # A renewal reuses the persisted key and does NOT mint another EAB.
+        self._acquire(
+            eab_pebble_server=eab_pebble_server,
+            zonefile_path=zonefile_path,
+            account_key_path=account_key_path,
+            cert_path=cert_path,
+            key_path=key_path,
+        )
+        assert mint_calls == [ZONE_DOMAIN]

--- a/tests/test_tls.py
+++ b/tests/test_tls.py
@@ -544,9 +544,13 @@ class TestEabMintProvider:
 
         mint_calls = []
 
-        def fake_mint(cert_api_url, zone_domain, *, token=None, timeout=30.0, verify_ssl=True):
-            mint_calls.append(zone_domain)
-            return EABCredential(kid=EAB_KID, hmac_key=EAB_MAC_KEY)
+        def fake_mint(cert_api_url, domain, *, token=None, timeout=30.0, verify_ssl=True):
+            mint_calls.append(domain)
+            return EABCredential(
+                kid=EAB_KID,
+                hmac_key=EAB_MAC_KEY,
+                directory_url=eab_pebble_server["directory_url"],
+            )
 
         # account.py imported mint_eab into its own namespace; patch it there.
         monkeypatch.setattr("compute_space.core.tls.account.mint_eab", fake_mint)


### PR DESCRIPTION
## What & why

Replaces the **shared** ACME account key (shipped to every VM via ansible at `ansible/secrets/certbot_private_key.json`) with a config-selected `cert_provider`. The shared privileged secret spread across all instances is the problem this removes.

### `eab_mint` (new default, managed)
On first boot each instance creates its **own** ACME account:
1. mints a single-use EAB credential from the central **cert-api** (`POST {cert_api_url}/v1/eab`, per-instance bearer token),
2. generates its own ACME account key locally,
3. registers a new account with **Google Trust Services** using that EAB (RFC 8555 `externalAccountBinding`), against the directory the cert-api returns,
4. persists the account key (`acme-account-key.json` under the openhost data dir).

Renewals reuse the persisted key and **never call the cert-api again**; a lost key just means a fresh EAB next boot. The EAB only authorizes *creating one account* — DNS-01 control still gates issuance.

### `byo` (fallback)
Operator-supplied `acme_account_key_path` + `acme_directory_url`, for non-managed domains. **Fully backward compatible** — this is the pre-EAB-mint behavior.

The DNS-01 issuance core is unchanged and **shared** across both modes; only the "how we get the account key" step differs.

## Changes
- `config.py`: `cert_provider` selector (validated), `cert_api_url`, `cert_api_token`, `managed_acme_account_key_path`.
- `core/tls/cert_api_client.py` *(new)*: `EABCredential` + `mint_eab()` — matches the finalized `openhost-cert-api` `POST /v1/eab` contract (`key_id`/`b64_mac_key`/`directory_url`/`key_algorithm`; `{error,message}` envelope on 401/429/502).
- `core/tls/account.py` *(new)*: `ensure_account_key()` → `ResolvedAccount{account_key, directory_url}` — load persisted key (renewal/byo) or mint+generate+register+persist (eab_mint); account creation and issuance share the cert-api-dictated directory.
- `acquire_cert.py` / `start.py`: thread provider config through; require account key only in `byo`; defense-in-depth `_assert_domains_within_zone` guard (trust boundary = DNS delegation).
- `ansible`: `eab_mint` managed default; shared-key copy now `byo`-only.
- `docs/src/routing.md`: documents both modes, trust boundary, CAA `accounturi` follow-up.
- `scripts/generate_acme_key.py`: reframed as legacy/byo.
- tests: unit coverage (provider selection, `mint_eab` contract + error envelope, zone guard — run in CI) + Pebble EAB end-to-end (`--run-tls`, Linux/manual).

## Contract status (resolved)
The `openhost-cert-api` wire contract is now finalized and this client matches it (`/v1/eab`, bearer auth, `key_id`/`b64_mac_key`/`directory_url`). `cert_api_url` defaults to `https://openhost-cert-api.selfhost.imbue.com` (the minter deployed as the `openhost-cert-api` app).

## Remaining (operational, not code-blocking)
- **Token provisioning**: each instance needs a `cert_api_token` set in its config that also exists in the cert-api's `CERT_API_AUTH_TOKENS` `{label: token}` map. Needs an ansible/provisioning step on both sides.
- **Cutover timing**: ansible default flips to `eab_mint`; hold the live flip until cert-api is deployed. Operators can pin `cert_provider=byo` in inventory during the transition.
- **Renewal directory**: renewals use config's `acme_directory_url` (not re-fetched from cert-api). Fine for the prod-GTS default; if pointing cert-api at staging, set `acme_directory_url` to match (or a future enhancement could persist the directory beside the key).
- **CAA `accounturi` pinning**: follow-up so the CA only honors each instance's own account (instance/DNS side, not a cert-api change).
- Pebble EAB test config keys (`externalAccountBindingRequired`/`externalAccountMACKeys`) to confirm against the Pebble version on first `--run-tls`.

## Testing
- 14 unit tests pass locally (and run in CI). pre-commit (ruff + mypy + secrets) clean. Existing settings/dns/docs tests still pass.
- Pebble EAB end-to-end test is Linux/manual (`--run-tls`); CI does not run it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)