### PR TITLE
Support pre-provisioned API tokens via initial_api_token_hash

### DIFF
--- a/ansible/setup.yml
+++ b/ansible/setup.yml
@@ -13,6 +13,13 @@
 #                                  If omitted, the play generates a random
 #                                  token and prints the claim URL. Hand the
 #                                  URL to whoever will claim the instance.)
+#   -e initial_api_token_hash=<sha256-hex>
+#                                 (pre-installs an owner API token: the SHA-256
+#                                  hex digest of the raw token is written to the
+#                                  instance and imported into the api_tokens
+#                                  table at boot. The raw token never touches
+#                                  the instance; it becomes usable once the
+#                                  owner claims the instance via /setup.)
 
 - name: Bootstrap host user
   hosts: all

--- a/ansible/tasks/setup_openhost_service.yml
+++ b/ansible/tasks/setup_openhost_service.yml
@@ -48,6 +48,19 @@
   debug:
     msg: "Claim URL: https://{{ domain }}/setup?claim={{ effective_claim_token }}"
 
+# Optional pre-provisioned API token. Provisioning tooling (e.g. vm-manager)
+# passes `-e initial_api_token_hash=<sha256-hex>` — the digest of a raw token
+# it keeps on its side. The router imports the hash into the api_tokens table
+# at boot and deletes this file. Only the hash ever touches the instance.
+- name: Write initial API token hash
+  copy:
+    content: "{{ initial_api_token_hash }}"
+    dest: /home/host/.openhost/local_compute_space/persistent_data/openhost/initial_api_token_hash
+    owner: host
+    group: host
+    mode: "0600"
+  when: initial_api_token_hash is defined and initial_api_token_hash | length > 0
+
 # Look up the host user's UID so the service template can reference
 # the right /run/user/<uid> path and user@<uid>.service unit. The
 # host user is created without a fixed UID so the value varies by

--- a/compute_space/src/compute_space/config.py
+++ b/compute_space/src/compute_space/config.py
@@ -155,6 +155,13 @@ class Config:
         return str(Path(self.openhost_data_path) / "claim_token")
 
     @property
+    def initial_api_token_hash_path(self) -> str:
+        # Optional file written by provisioning tooling (e.g. vm-manager's
+        # ansible run): a SHA-256 hex digest of an API token to pre-install.
+        # Imported into the api_tokens table at boot, then deleted.
+        return str(Path(self.openhost_data_path) / "initial_api_token_hash")
+
+    @property
     def default_apps_sentinel_path(self) -> str:
         return str(Path(self.openhost_data_path) / "default_apps.json")
 

--- a/compute_space/src/compute_space/core/auth/initial_token.py
+++ b/compute_space/src/compute_space/core/auth/initial_token.py
@@ -1,16 +1,3 @@
-"""Import pre-provisioned API tokens written by provisioning tooling.
-
-Provisioning tools (e.g. vm-manager) can install an API token on an instance
-before its first boot by writing the token's SHA-256 hex digest to
-``config.initial_api_token_hash_path`` (the raw token never touches the
-instance).  At boot the hash is inserted into the ``api_tokens`` table and the
-file is deleted.
-
-Pre-provisioned tokens are owner-level and never expire, but they are only
-usable once the owner claims the instance: until then the setup-only app is
-served, which exposes no API routes.
-"""
-
 import re
 import sqlite3
 from pathlib import Path
@@ -23,15 +10,17 @@ _TOKEN_HASH_RE = re.compile(r"^[0-9a-f]{64}$")
 
 
 def import_initial_api_token_hashes(token_hash_file: Path, db: sqlite3.Connection) -> int:
-    """Import API token hashes from ``token_hash_file`` and delete the file.
+    """Import pre-provisioned API token hashes from ``token_hash_file`` and delete the file.
 
-    Each non-empty line is ``<sha256-hex>[ <token name>]``.  Lines with a
-    malformed hash are logged and skipped.  Inserts are idempotent (the hash
-    column is unique), so re-running ansible against an already-provisioned
-    instance is a no-op.  Returns the number of tokens newly inserted.
+    Provisioning tooling (e.g. vm-manager) can install an API token on an instance before its first boot by
+    writing the token's SHA-256 hex digest to this file — the raw token never touches the instance.  Each
+    non-empty line is ``<sha256-hex>[ <token name>]``; malformed lines are logged and skipped.  Inserts are
+    idempotent (the hash column is unique), so re-running ansible against an already-provisioned instance is a
+    no-op.  Imported tokens are owner-level with no expiry, but only become usable once the owner claims the
+    instance (the setup-only app exposes no API routes).  Returns the number of tokens newly inserted.
     """
     try:
-        content = token_hash_file.read_text()
+        content = token_hash_file.read_text(errors="replace")
     except FileNotFoundError:
         return 0
     except OSError as exc:

--- a/compute_space/src/compute_space/core/auth/initial_token.py
+++ b/compute_space/src/compute_space/core/auth/initial_token.py
@@ -1,0 +1,66 @@
+"""Import pre-provisioned API tokens written by provisioning tooling.
+
+Provisioning tools (e.g. vm-manager) can install an API token on an instance
+before its first boot by writing the token's SHA-256 hex digest to
+``config.initial_api_token_hash_path`` (the raw token never touches the
+instance).  At boot the hash is inserted into the ``api_tokens`` table and the
+file is deleted.
+
+Pre-provisioned tokens are owner-level and never expire, but they are only
+usable once the owner claims the instance: until then the setup-only app is
+served, which exposes no API routes.
+"""
+
+import re
+import sqlite3
+from pathlib import Path
+
+from compute_space.core.logging import logger
+
+INITIAL_API_TOKEN_DEFAULT_NAME = "provisioned"
+
+_TOKEN_HASH_RE = re.compile(r"^[0-9a-f]{64}$")
+
+
+def import_initial_api_token_hashes(token_hash_file: Path, db: sqlite3.Connection) -> int:
+    """Import API token hashes from ``token_hash_file`` and delete the file.
+
+    Each non-empty line is ``<sha256-hex>[ <token name>]``.  Lines with a
+    malformed hash are logged and skipped.  Inserts are idempotent (the hash
+    column is unique), so re-running ansible against an already-provisioned
+    instance is a no-op.  Returns the number of tokens newly inserted.
+    """
+    try:
+        content = token_hash_file.read_text()
+    except FileNotFoundError:
+        return 0
+    except OSError as exc:
+        logger.error(f"Failed to read initial API token file {token_hash_file}: {exc}")
+        return 0
+
+    inserted = 0
+    for line in content.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        token_hash, _, name = line.partition(" ")
+        token_hash = token_hash.lower()
+        name = name.strip() or INITIAL_API_TOKEN_DEFAULT_NAME
+        if not _TOKEN_HASH_RE.match(token_hash):
+            logger.warning(f"Skipping malformed initial API token hash in {token_hash_file}")
+            continue
+        cursor = db.execute(
+            "INSERT OR IGNORE INTO api_tokens (name, token_hash, expires_at) VALUES (?, ?, '')",
+            (name, token_hash),
+        )
+        inserted += cursor.rowcount
+    db.commit()
+
+    try:
+        token_hash_file.unlink()
+    except OSError as exc:
+        logger.error(f"Failed to delete initial API token file {token_hash_file}: {exc}")
+
+    if inserted:
+        logger.info(f"Imported {inserted} pre-provisioned API token(s)")
+    return inserted

--- a/compute_space/src/compute_space/tests/test_initial_token.py
+++ b/compute_space/src/compute_space/tests/test_initial_token.py
@@ -76,6 +76,18 @@ class TestImportInitialApiTokenHashes:
         assert count == 1
         db.close()
 
+    def test_binary_garbage_file_does_not_raise(self, tmp_path: Path) -> None:
+        """A corrupt/binary token file must not brick the boot — it's logged,
+        skipped, and deleted."""
+        db = _make_db(tmp_path)
+        token_file = tmp_path / "initial_api_token_hash"
+        token_file.write_bytes(b"\xff\xfe\x00garbage\x80\x81\n" + _hash("tok-ok").encode() + b"\n")
+
+        assert import_initial_api_token_hashes(token_file, db) == 1
+        assert not token_file.exists()
+        assert validate_api_token("tok-ok", db) is not None
+        db.close()
+
     def test_uppercase_hash_is_normalized(self, tmp_path: Path) -> None:
         db = _make_db(tmp_path)
         token_file = tmp_path / "initial_api_token_hash"

--- a/compute_space/src/compute_space/tests/test_initial_token.py
+++ b/compute_space/src/compute_space/tests/test_initial_token.py
@@ -1,0 +1,86 @@
+import hashlib
+import sqlite3
+from pathlib import Path
+
+from compute_space.core.auth.auth import validate_api_token
+from compute_space.core.auth.initial_token import import_initial_api_token_hashes
+from compute_space.db.connection import init_db
+
+
+def _make_db(tmp_path: Path) -> sqlite3.Connection:
+    db_path = str(tmp_path / "test.db")
+    init_db(db_path)
+    db = sqlite3.connect(db_path)
+    db.row_factory = sqlite3.Row
+    return db
+
+
+def _hash(raw: str) -> str:
+    return hashlib.sha256(raw.encode()).hexdigest()
+
+
+class TestImportInitialApiTokenHashes:
+    def test_missing_file_is_noop(self, tmp_path: Path) -> None:
+        db = _make_db(tmp_path)
+        assert import_initial_api_token_hashes(tmp_path / "nope", db) == 0
+        db.close()
+
+    def test_imports_token_and_deletes_file(self, tmp_path: Path) -> None:
+        db = _make_db(tmp_path)
+        raw_token = "raw-token-abc"
+        token_file = tmp_path / "initial_api_token_hash"
+        token_file.write_text(_hash(raw_token) + "\n")
+
+        assert import_initial_api_token_hashes(token_file, db) == 1
+        assert not token_file.exists()
+
+        row = db.execute("SELECT name, expires_at FROM api_tokens").fetchone()
+        assert row["name"] == "provisioned"
+        assert row["expires_at"] == ""
+        # The imported token authenticates as an owner-level API key.
+        assert validate_api_token(raw_token, db) is not None
+        assert validate_api_token("wrong-token", db) is None
+        db.close()
+
+    def test_custom_name_and_multiple_lines(self, tmp_path: Path) -> None:
+        db = _make_db(tmp_path)
+        token_file = tmp_path / "initial_api_token_hash"
+        token_file.write_text(f"{_hash('tok-1')} ci token\n\n{_hash('tok-2')}\n")
+
+        assert import_initial_api_token_hashes(token_file, db) == 2
+        names = {r["name"] for r in db.execute("SELECT name FROM api_tokens").fetchall()}
+        assert names == {"ci token", "provisioned"}
+        db.close()
+
+    def test_reimport_is_idempotent(self, tmp_path: Path) -> None:
+        db = _make_db(tmp_path)
+        token_file = tmp_path / "initial_api_token_hash"
+        token_file.write_text(_hash("tok-1"))
+        assert import_initial_api_token_hashes(token_file, db) == 1
+
+        # Simulate a re-deploy rewriting the same hash file.
+        token_file.write_text(_hash("tok-1"))
+        assert import_initial_api_token_hashes(token_file, db) == 0
+        count = db.execute("SELECT COUNT(*) FROM api_tokens").fetchone()[0]
+        assert count == 1
+        db.close()
+
+    def test_malformed_hash_is_skipped(self, tmp_path: Path) -> None:
+        db = _make_db(tmp_path)
+        token_file = tmp_path / "initial_api_token_hash"
+        token_file.write_text("not-a-hash\n" + _hash("tok-ok") + "\n")
+
+        assert import_initial_api_token_hashes(token_file, db) == 1
+        assert not token_file.exists()
+        count = db.execute("SELECT COUNT(*) FROM api_tokens").fetchone()[0]
+        assert count == 1
+        db.close()
+
+    def test_uppercase_hash_is_normalized(self, tmp_path: Path) -> None:
+        db = _make_db(tmp_path)
+        token_file = tmp_path / "initial_api_token_hash"
+        token_file.write_text(_hash("tok-upper").upper())
+
+        assert import_initial_api_token_hashes(token_file, db) == 1
+        assert validate_api_token("tok-upper", db) is not None
+        db.close()

--- a/compute_space/src/compute_space/tests/test_integration.py
+++ b/compute_space/src/compute_space/tests/test_integration.py
@@ -511,6 +511,80 @@ def test_claim_token_gate_and_delete(tmp_path):
             _stop_router_process(router)
 
 
+def test_initial_api_token_imported_at_boot(tmp_path):
+    """A pre-provisioned token hash file is imported at boot (file deleted), the token is
+    inert while the setup-only app is served, and authenticates owner APIs after setup."""
+    import hashlib  # noqa: PLC0415
+
+    ROUTER_PORT = 18085
+    base_url = f"http://127.0.0.1:{ROUTER_PORT}"
+
+    config, env = _make_config_and_env(tmp_path, port=ROUTER_PORT, claim_token_required=False)
+
+    raw_token = "pre-provisioned-token-for-boot-test"
+    token_hash = hashlib.sha256(raw_token.encode()).hexdigest()
+    with open(config.initial_api_token_hash_path, "w") as f:
+        f.write(f"{token_hash} boot-test-token\n")
+
+    router = None
+    try:
+        router = _start_router_process(base_url, env)
+
+        # Imported at boot: the hash file is gone.
+        assert not os.path.isfile(config.initial_api_token_hash_path), (
+            "initial_api_token_hash file should be deleted after import"
+        )
+
+        # Pre-claim, the setup-only app serves no API routes — the token is inert.
+        r = requests.get(
+            f"{base_url}/api/tokens",
+            headers={"Authorization": f"Bearer {raw_token}"},
+            allow_redirects=False,
+        )
+        assert r.status_code == 404, f"Expected 404 pre-claim, got {r.status_code}"
+
+        # Claim the instance.
+        r = requests.post(
+            f"{base_url}/setup",
+            data={"password": "testpass123", "confirm_password": "testpass123"},
+            allow_redirects=False,
+        )
+        assert r.status_code in (200, 302), f"Setup failed: {r.status_code} {r.text[:200]}"
+
+        # The same process restarts into the full app; poll until the
+        # pre-provisioned token authenticates an owner-level API route.
+        deadline = time.time() + 30
+        last_status = None
+        while time.time() < deadline:
+            try:
+                r = requests.get(
+                    f"{base_url}/api/tokens",
+                    headers={"Authorization": f"Bearer {raw_token}"},
+                    allow_redirects=False,
+                    timeout=2,
+                )
+                last_status = r.status_code
+                if r.status_code == 200:
+                    break
+            except (requests.ConnectionError, requests.ReadTimeout):
+                pass
+            time.sleep(0.5)
+        assert last_status == 200, f"Pre-provisioned token never authenticated: {last_status}"
+        names = [t["name"] for t in r.json()]
+        assert "boot-test-token" in names
+
+        # A wrong token is still rejected.
+        r = requests.get(
+            f"{base_url}/api/tokens",
+            headers={"Authorization": "Bearer wrong-token"},
+            allow_redirects=False,
+        )
+        assert r.status_code in (302, 401), f"Wrong token not rejected: {r.status_code}"
+    finally:
+        if router is not None:
+            _stop_router_process(router)
+
+
 def test_setup_open_when_claim_token_not_required(tmp_path):
     """With claim_token_required=False, /setup accepts a caller with no token (legacy/local
     dev behavior)."""

--- a/compute_space/src/compute_space/web/start.py
+++ b/compute_space/src/compute_space/web/start.py
@@ -14,6 +14,7 @@ import hypercorn.config
 from compute_space.config import Config
 from compute_space.config import load_config
 from compute_space.config import set_active_config
+from compute_space.core.auth.initial_token import import_initial_api_token_hashes
 from compute_space.core.auth.keys import load_keys
 from compute_space.core.caddy import start_caddy
 from compute_space.core.dns import start_coredns
@@ -48,6 +49,13 @@ def _bootstrap(config: Config) -> None:
     setup_file_logging(Path(os.path.dirname(config.db_path)) / "compute_space.log")
     load_keys(config.keys_dir)
     init_db(config.db_path)
+
+    # Pre-provisioned API tokens (e.g. installed by vm-manager's ansible run).
+    db = sqlite3.connect(config.db_path)
+    try:
+        import_initial_api_token_hashes(Path(config.initial_api_token_hash_path), db)
+    finally:
+        db.close()
 
 
 def _owner_exists(config: Config) -> bool:


### PR DESCRIPTION
Lets provisioning tooling such as vm-manager install an owner API token on an instance before first boot. The tooling passes -e initial_api_token_hash=SHA256HEX to ansible, which writes the digest to a file under persistent_data. At boot the router imports the hash into the api_tokens table and deletes the file. The raw token never touches the instance and only works after the owner claims the instance, since the setup-only app has no API routes.

Tested with unit tests and end-to-end on a Hetzner instance provisioned from this branch. Companion PR: imbue-openhost/openhost-vm-manager#29.