### PR TITLE
harness: add a pre_deploy hook to OpenhostStack

### DIFF
--- a/openhost_app_test_harness/readme.md
+++ b/openhost_app_test_harness/readme.md
@@ -54,6 +54,10 @@ def test_index(stack):
     assert r.status_code == 200
 ```
 
+The app under test deploys from a snapshot of your git working tree (tracked +
+untracked files, minus gitignored ones), so uncommitted changes are what runs — the
+router would otherwise clone the repo at HEAD and silently test stale code.
+
 - `stack.url` — your app through the router (subdomain routing, real auth)
 - `stack.owner_session` — a `requests.Session` authenticated as the zone owner; its cookie
   is scoped to the zone domain so it works on `stack.url` and every other app URL.

--- a/openhost_app_test_harness/readme.md
+++ b/openhost_app_test_harness/readme.md
@@ -80,6 +80,22 @@ def test_my_app_reads_secrets(stack):
 app's `[[services.v2.consumes]]` are approved at install; pass `False` to test the
 permission-denied flow.
 
+If your app needs a provider at **startup** (e.g. it reads config from the secrets service
+before binding its port), deploy and seed that provider via the `pre_deploy` hook, which runs
+after the router is up but before the app under test deploys — like an owner preparing the
+server before installing the app:
+
+```python
+def _seed(s: OpenhostStack) -> None:
+    s.deploy_app("https://github.com/imbue-openhost/secrets")
+    s.owner_session.post(f"{s.url_for('secrets')}/api/secrets", json={"key": "DB_URL", "value": "..."})
+
+@pytest.fixture(scope="session")
+def stack():
+    with OpenhostStack(pre_deploy=_seed) as s:
+        yield s
+```
+
 ### Your app provides a service
 
 Use a synthetic consumer to call your service through the real proxy:

--- a/openhost_app_test_harness/src/openhost_test_harness/stack.py
+++ b/openhost_app_test_harness/src/openhost_test_harness/stack.py
@@ -28,6 +28,7 @@ import logging
 import shutil
 import socket
 import sqlite3
+import subprocess
 import sys
 import tempfile
 from collections.abc import Callable
@@ -87,6 +88,33 @@ def _data_base_dir() -> Path:
 
 def _normalize_service_url(url: str) -> str:
     return url.removeprefix("https://").removeprefix("http://").rstrip("/")
+
+
+def _snapshot_working_tree(app_dir: Path, dest: Path) -> None:
+    """Copy ``app_dir``'s git working tree to ``dest``: tracked + untracked files,
+    minus gitignored ones and ``.git`` itself.
+
+    The router clones git repos at HEAD, which would silently deploy stale code while
+    you iterate; deploying a snapshot makes the app under test reflect uncommitted
+    changes, while gitignored build artefacts (.venv, node_modules, ...) stay out of
+    the build context.
+    """
+    listing = subprocess.run(
+        ["git", "ls-files", "--cached", "--others", "--exclude-standard", "-z"],
+        cwd=app_dir,
+        capture_output=True,
+        check=True,
+    )
+    for raw in listing.stdout.split(b"\0"):
+        if not raw:
+            continue
+        rel = raw.decode()
+        src = app_dir / rel
+        if not src.is_file():  # staged deletions still appear in ls-files
+            continue
+        target = dest / rel
+        target.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(src, target)
 
 
 def _warn_if_linux_gateway_missing() -> None:
@@ -187,8 +215,12 @@ class OpenhostStack:
             self._owner = complete_setup(self._local_stack)
             if self.pre_deploy is not None:
                 self.pre_deploy(self)
+            deploy_src = self.app_dir
+            if (self.app_dir / ".git").exists():
+                deploy_src = self._data_dir / "app-under-test"
+                _snapshot_working_tree(self.app_dir, deploy_src)
             self._app_id = self.deploy_app(
-                f"file://{self.app_dir}",
+                f"file://{deploy_src}",
                 app_name=self.app_name,
                 grant_manifest_permissions=self.grant_manifest_permissions,
             )

--- a/openhost_app_test_harness/src/openhost_test_harness/stack.py
+++ b/openhost_app_test_harness/src/openhost_test_harness/stack.py
@@ -30,6 +30,7 @@ import socket
 import sqlite3
 import sys
 import tempfile
+from collections.abc import Callable
 from pathlib import Path
 from types import TracebackType
 from typing import Any
@@ -155,6 +156,11 @@ class OpenhostStack:
     """Deploy under this name; defaults to the openhost.toml [app].name."""
     grant_manifest_permissions: bool = True
     """Auto-grant the grants declared in the app's [[services.v2.consumes]] at install."""
+    pre_deploy: Callable[["OpenhostStack"], None] | None = None
+    """Called once the router is up and the owner session exists, before the app under test
+    deploys.  Use it to deploy provider apps and seed config the app needs at startup (e.g.
+    a secrets provider plus its values) — mirroring an owner preparing a server before
+    installing the app.  ``stack.url``/``stack.app_id`` are not available yet inside the hook."""
     zone_name: str = "harness"
     deploy_timeout: float = 300.0
 
@@ -179,6 +185,8 @@ class OpenhostStack:
         try:
             self._exit_stack.enter_context(managed_router(config))
             self._owner = complete_setup(self._local_stack)
+            if self.pre_deploy is not None:
+                self.pre_deploy(self)
             self._app_id = self.deploy_app(
                 f"file://{self.app_dir}",
                 app_name=self.app_name,


### PR DESCRIPTION
## Why

Two gaps surfaced while porting imbue-hosted-spaces (the first real consumer) onto the harness:

1. **Startup config ordering.** `OpenhostStack.__enter__` deploys the app under test immediately after router setup. Apps that read their startup config from a provider over the v2 service interface — e.g. hosted-spaces pulls its Stripe/OIDC config from the secrets service before binding its port — can't come healthy until that provider is deployed and seeded, so the install (`wait_for_ready`) fails before the test gets a chance to deploy anything. On a real server the owner installs and configures the secrets app first; the harness had no way to express that ordering.
2. **Stale code.** The router clones `file://` git repos at HEAD, so the harness silently deployed the last *commit* of the app under test — uncommitted changes were never exercised by the tests.

## What

**`OpenhostStack(pre_deploy=...)`**: a hook called once the router is up and the owner session exists, before the app under test deploys. Inside it, `stack.deploy_app(...)`, `stack.owner_session`, `stack.url_for(...)`, and `stack.grant(...)` all work; `stack.url`/`stack.app_id` (the app under test) do not exist yet.

```python
def _seed(s: OpenhostStack) -> None:
    s.deploy_app("https://github.com/imbue-openhost/secrets")
    s.owner_session.post(f"{s.url_for('secrets')}/api/secrets", json={"key": "DB_URL", "value": "..."})

@pytest.fixture(scope="session")
def stack():
    with OpenhostStack(pre_deploy=_seed) as s:
        yield s
```

An exception in the hook aborts `__enter__` through the existing rollback path (router torn down, containers removed, data dir deleted).

**Working-tree deploys**: when the app dir is a git repo, the harness now deploys a snapshot of the working tree — `git ls-files --cached --others --exclude-standard`, i.e. tracked + untracked files minus gitignored ones — so uncommitted changes are what runs, and build artefacts (`.venv`, `node_modules`) stay out of the build context.

First consumer: imbue-hosted-spaces, which uses `pre_deploy` to deploy + seed the secrets app and openhost-vm-manager before its own install.

🤖 Generated with [Claude Code](https://claude.com/claude-code)