### PR TITLE
Centralize cert_api config validation + DNS/TOML cleanups

### DIFF
--- a/compute_space/src/compute_space/config.py
+++ b/compute_space/src/compute_space/config.py
@@ -121,13 +121,16 @@ class Config:
     def evolve(self, **kwargs: Any) -> Self:
         return attr.evolve(self, **kwargs)
 
+    def _to_toml_dict(self) -> dict[str, dict[str, Any]]:
+        return {"openhost": {k: v for k, v in attr.asdict(self).items() if v is not None}}
+
     def to_toml_str(self) -> str:
-        return tomli_w.dumps({"openhost": {k: v for k, v in attr.asdict(self).items() if v is not None}})
+        return tomli_w.dumps(self._to_toml_dict())
 
     def to_toml(self, path: str) -> None:
         os.makedirs(os.path.dirname(path), exist_ok=True)
         with open(path, "wb") as f:
-            tomli_w.dump({"openhost": {k: v for k, v in attr.asdict(self).items() if v is not None}}, f)
+            tomli_w.dump(self._to_toml_dict(), f)
 
     @classmethod
     def from_toml(cls, path: str) -> Self:

--- a/compute_space/src/compute_space/config.py
+++ b/compute_space/src/compute_space/config.py
@@ -93,6 +93,27 @@ class Config:
     # /api/add_app and do not need to be present on disk ahead of time.
     default_apps: list[str]
 
+    def __attrs_post_init__(self) -> None:
+        # Validate cert provider selection up front so any Config object can be
+        # trusted as valid by the rest of the system (rather than discovering a
+        # misconfiguration only at cert-acquisition time).
+        if self.cert_provider not in (CERT_PROVIDER_ACME, CERT_PROVIDER_CERT_API):
+            raise ValueError(
+                f"Unknown cert_provider {self.cert_provider!r} (expected "
+                f"{CERT_PROVIDER_ACME!r} or {CERT_PROVIDER_CERT_API!r})"
+            )
+        if self.cert_provider == CERT_PROVIDER_CERT_API:
+            # The cert_api broker path needs the broker URL plus the per-instance
+            # Keycloak client-credentials; none have a usable default.
+            for name in (
+                "cert_api_base_url",
+                "cert_api_keycloak_issuer_url",
+                "cert_api_keycloak_client_id",
+                "cert_api_keycloak_client_secret",
+            ):
+                if not getattr(self, name):
+                    raise ValueError(f"{name} must be set in config to use the cert_api provider")
+
     @property
     def zone_domain_no_port(self) -> str:
         return self.zone_domain.split(":")[0]

--- a/compute_space/src/compute_space/core/dns.py
+++ b/compute_space/src/compute_space/core/dns.py
@@ -4,8 +4,9 @@ The VM runs CoreDNS authoritative for its zone domain (e.g. alice.host.imbue.com
 This module writes and updates the zone file. CoreDNS watches for SOA serial
 changes and auto-reloads.
 
-For DNS-01 ACME challenges, the router calls set_txt() to add a TXT record,
-waits for CoreDNS to pick it up, then calls clear_txt() after the cert is issued.
+For DNS-01 ACME challenges, the router calls append_txt_records() to add TXT
+records, waits for CoreDNS to pick them up, then calls clear_txt() after the cert
+is issued.
 """
 
 from __future__ import annotations
@@ -101,54 +102,36 @@ def _bump_serial(content: str) -> str:
     return _SERIAL_RE.sub(f"{m.group(1)}{new_serial}{m.group(3)}", content, count=1)
 
 
-def set_txt(
-    zone_file_path: Path,
-    name: str,
-    values: str | list[str],
-) -> None:
-    """Append TXT record(s) to the zone file and bump the SOA serial.
-
-    For ACME DNS-01 challenges, name is typically '_acme-challenge'.
-    values can be a single string or a list of strings (for multiple
-    authorizations, e.g. base domain + wildcard).
-    """
-    if isinstance(values, str):
-        values = [values]
-    with open(zone_file_path) as f:
-        content = f.read()
-    content = _bump_serial(content)
-    for v in values:
-        content += f'{name}   IN TXT  "{v}"\n'
-    with open(zone_file_path, "w") as f:
-        f.write(content)
-    logger.info(f"Set {len(values)} TXT record(s) {name}")
-
-
 @attr.s(auto_attribs=True, frozen=True)
 class TxtRecord:
-    """A TXT record to publish, addressed by its fully-qualified name."""
+    """A TXT record to publish.
+
+    ``record_name`` is written into the zone file verbatim, so the caller chooses
+    the addressing: a name relative to the zone's $ORIGIN (e.g. '_acme-challenge')
+    has CoreDNS append the origin, while an absolute FQDN ending in '.' is honored
+    as-is.
+    """
 
     record_name: str
     record_value: str
 
 
-def set_txt_records(zone_file_path: Path, records: list[TxtRecord]) -> None:
-    """Append TXT record(s) addressed by fully-qualified name and bump the SOA serial.
+def append_txt_records(zone_file_path: Path, records: list[TxtRecord]) -> None:
+    """Append TXT record(s) to the zone file and bump the SOA serial.
 
-    Unlike set_txt (which takes a name relative to $ORIGIN), this writes each
-    record_name as an absolute FQDN — appending a trailing dot if missing — so
-    CoreDNS does not re-append $ORIGIN.  Used for openhost-cert-api broker
-    challenges, whose record_name values are full FQDNs to honor verbatim.
+    Each record's ``record_name`` is written verbatim (see TxtRecord), so this
+    serves both local DNS-01 challenges (relative '_acme-challenge' names) and
+    openhost-cert-api broker challenges (absolute FQDNs). Bumping the SOA serial
+    triggers a CoreDNS reload.
     """
     with open(zone_file_path) as f:
         content = f.read()
     content = _bump_serial(content)
     for record in records:
-        name = record.record_name if record.record_name.endswith(".") else f"{record.record_name}."
-        content += f'{name}   IN TXT  "{record.record_value}"\n'
+        content += f'{record.record_name}   IN TXT  "{record.record_value}"\n'
     with open(zone_file_path, "w") as f:
         f.write(content)
-    logger.info(f"Set {len(records)} absolute TXT record(s)")
+    logger.info(f"Appended {len(records)} TXT record(s)")
 
 
 def clear_txt(zone_file_path: Path) -> None:

--- a/compute_space/src/compute_space/core/tls/acquire_cert.py
+++ b/compute_space/src/compute_space/core/tls/acquire_cert.py
@@ -24,9 +24,11 @@ def write_cert_and_key(cert_path: Path, key_path: Path, cert_pem: bytes, key_pem
     """
     with open(cert_path, "wb") as f:
         f.write(cert_pem)
-    with open(key_path, "wb") as f:
+    # Create the key with 0o600 from the start so the private key is never
+    # briefly readable by other users between write and chmod.
+    fd = os.open(key_path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    with os.fdopen(fd, "wb") as f:
         f.write(key_pem)
-    os.chmod(key_path, 0o600)
 
 
 async def acquire_tls_cert(

--- a/compute_space/src/compute_space/core/tls/acquire_cert_broker.py
+++ b/compute_space/src/compute_space/core/tls/acquire_cert_broker.py
@@ -40,6 +40,11 @@ from compute_space.core.tls.util import tls_private_key_to_pem
 _COREDNS_RELOAD_SECONDS = 3.0
 
 
+def _as_fqdn(name: str) -> str:
+    """Return ``name`` as an absolute FQDN, appending a trailing dot if missing."""
+    return name if name.endswith(".") else f"{name}."
+
+
 class CertAcquisitionTimeoutError(RuntimeError):
     """The broker did not issue the certificate before the overall timeout."""
 
@@ -101,8 +106,10 @@ def acquire_tls_cert_via_broker(
     order = client.create_order(csr_pem)
     logger.info(f"Broker order {order.order_id} created with {len(order.challenges)} challenge(s)")
 
-    records = [TxtRecord(record_name=c.record_name, record_value=c.record_value) for c in order.challenges]
-    dns_module.set_txt_records(coredns_zonefile_path, records)
+    # Broker challenge names are full FQDNs; write them absolute (trailing dot) so
+    # CoreDNS does not re-append $ORIGIN.
+    records = [TxtRecord(record_name=_as_fqdn(c.record_name), record_value=c.record_value) for c in order.challenges]
+    dns_module.append_txt_records(coredns_zonefile_path, records)
     try:
         # Don't poll finalize until the records are actually live: the broker drives
         # CA validation during finalize, so a not-yet-visible record fails the order.

--- a/compute_space/src/compute_space/core/tls/acquire_cert_broker.py
+++ b/compute_space/src/compute_space/core/tls/acquire_cert_broker.py
@@ -141,7 +141,7 @@ def _poll_until_issued(
     """
     deadline = clock.monotonic() + poll_timeout_seconds
     interval = poll_interval_seconds
-    while True:
+    while clock.monotonic() < deadline:
         result = client.finalize_order(order_id)
         if result.status == FINALIZE_STATUS_VALID:
             if not result.certificate:
@@ -149,11 +149,11 @@ def _poll_until_issued(
             logger.info(f"Broker issued certificate for order {order_id}")
             return result.certificate
 
-        remaining = deadline - clock.monotonic()
-        if remaining <= 0:
-            raise CertAcquisitionTimeoutError(
-                f"Broker did not issue cert for order {order_id} within {poll_timeout_seconds}s"
-            )
-        logger.info(f"Broker order {order_id} still pending; retrying in {min(interval, remaining):.0f}s")
-        clock.sleep(min(interval, remaining))
+        sleep_for = min(interval, deadline - clock.monotonic())
+        if sleep_for <= 0:
+            break
+        logger.info(f"Broker order {order_id} still pending; retrying in {sleep_for:.0f}s")
+        clock.sleep(sleep_for)
         interval = min(interval * poll_backoff_factor, poll_max_interval_seconds)
+
+    raise CertAcquisitionTimeoutError(f"Broker did not issue cert for order {order_id} within {poll_timeout_seconds}s")

--- a/compute_space/src/compute_space/core/tls/util.py
+++ b/compute_space/src/compute_space/core/tls/util.py
@@ -166,7 +166,10 @@ def _acquire_cert_dns01(
             if pending_challenges:
                 # Write all TXT records to the zone file at once
                 logger.info(f"Setting {len(validation_values)} DNS-01 challenge TXT record(s)")
-                dns_module.set_txt(coredns_zonefile_path, "_acme-challenge", validation_values)
+                dns_module.append_txt_records(
+                    coredns_zonefile_path,
+                    [dns_module.TxtRecord(record_name="_acme-challenge", record_value=v) for v in validation_values],
+                )
 
                 # Wait for CoreDNS to pick up the zone file change (reload interval = 2s)
                 time.sleep(3)

--- a/compute_space/src/compute_space/tests/test_api_archive_backend.py
+++ b/compute_space/src/compute_space/tests/test_api_archive_backend.py
@@ -18,12 +18,11 @@ from compute_space.core import archive_backend
 from compute_space.core.app_id import new_app_id
 from compute_space.core.manifest import AppManifest
 from compute_space.db.connection import init_db
+from compute_space.tests._litestar_helpers import auth_cookie
+from compute_space.tests._litestar_helpers import make_test_app
+from compute_space.tests.conftest import _make_test_config
 from compute_space.web.routes.api.apps import api_apps_routes
 from compute_space.web.routes.api.archive_backend import api_archive_backend_routes
-
-from ._litestar_helpers import auth_cookie
-from ._litestar_helpers import make_test_app
-from .conftest import _make_test_config
 
 
 @pytest.fixture

--- a/compute_space/src/compute_space/tests/test_app_status.py
+++ b/compute_space/src/compute_space/tests/test_app_status.py
@@ -22,11 +22,10 @@ from compute_space.config import get_config
 from compute_space.core.app_id import new_app_id
 from compute_space.core.containers import BUILD_CACHE_CORRUPT_MARKER
 from compute_space.db.connection import init_db
+from compute_space.tests._litestar_helpers import auth_cookie
+from compute_space.tests._litestar_helpers import make_test_app
+from compute_space.tests.conftest import _make_test_config
 from compute_space.web.routes.api.apps import api_apps_routes
-
-from ._litestar_helpers import auth_cookie
-from ._litestar_helpers import make_test_app
-from .conftest import _make_test_config
 
 
 @pytest.fixture

--- a/compute_space/src/compute_space/tests/test_archive_backend.py
+++ b/compute_space/src/compute_space/tests/test_archive_backend.py
@@ -18,8 +18,7 @@ from compute_space.core.archive_backend import configure_backend
 from compute_space.core.archive_backend import juicefs_mount_dir
 from compute_space.core.archive_backend import read_state
 from compute_space.db.connection import init_db
-
-from .conftest import _make_test_config
+from compute_space.tests.conftest import _make_test_config
 
 
 @pytest.fixture

--- a/compute_space/src/compute_space/tests/test_build_cache.py
+++ b/compute_space/src/compute_space/tests/test_build_cache.py
@@ -17,12 +17,11 @@ from litestar.testing import TestClient
 
 from compute_space.core.containers import drop_docker_build_cache
 from compute_space.db.connection import init_db
+from compute_space.tests._litestar_helpers import auth_cookie
+from compute_space.tests._litestar_helpers import make_test_app
+from compute_space.tests.conftest import _make_test_config
 from compute_space.web.routes.api import system as system_routes
 from compute_space.web.routes.api.system import system_routes as system_router
-
-from ._litestar_helpers import auth_cookie
-from ._litestar_helpers import make_test_app
-from .conftest import _make_test_config
 
 
 @pytest.fixture

--- a/compute_space/src/compute_space/tests/test_cert_provider_config.py
+++ b/compute_space/src/compute_space/tests/test_cert_provider_config.py
@@ -8,11 +8,22 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
 import typed_settings
 
 from compute_space.config import CERT_PROVIDER_ACME
 from compute_space.config import CERT_PROVIDER_CERT_API
 from compute_space.config import DefaultConfig
+
+
+def _full_cert_api_kwargs() -> dict[str, str]:
+    return dict(
+        cert_provider=CERT_PROVIDER_CERT_API,
+        cert_api_base_url="https://cert-api.example.com",
+        cert_api_keycloak_issuer_url="https://keycloak.example.com/realms/openhost-customers",
+        cert_api_keycloak_client_id="instance-alice",
+        cert_api_keycloak_client_secret="s3cr3t",
+    )
 
 
 def test_default_provider_is_acme() -> None:
@@ -81,3 +92,36 @@ def test_cert_provider_round_trips_through_toml() -> None:
     assert 'cert_api_keycloak_issuer_url = "https://keycloak.example.com/realms/openhost-customers"' in rendered
     assert 'cert_api_keycloak_client_id = "instance-alice"' in rendered
     assert 'cert_api_keycloak_client_secret = "s3cr3t"' in rendered
+
+
+def test_unknown_cert_provider_is_rejected() -> None:
+    with pytest.raises(ValueError, match="Unknown cert_provider"):
+        DefaultConfig(zone_domain="alice.host.example.com", cert_provider="bogus")
+
+
+def test_complete_cert_api_config_is_valid() -> None:
+    cfg = DefaultConfig(zone_domain="alice.host.example.com", **_full_cert_api_kwargs())
+    assert cfg.cert_provider == CERT_PROVIDER_CERT_API
+
+
+@pytest.mark.parametrize(
+    "missing_field",
+    [
+        "cert_api_base_url",
+        "cert_api_keycloak_issuer_url",
+        "cert_api_keycloak_client_id",
+        "cert_api_keycloak_client_secret",
+    ],
+)
+def test_cert_api_provider_requires_all_settings(missing_field: str) -> None:
+    kwargs = _full_cert_api_kwargs()
+    kwargs[missing_field] = None  # type: ignore[assignment]
+    with pytest.raises(ValueError, match=f"{missing_field} must be set"):
+        DefaultConfig(zone_domain="alice.host.example.com", **kwargs)
+
+
+def test_acme_provider_ignores_cert_api_settings() -> None:
+    # The default acme path must not require any cert_api settings, even though
+    # cert_api_keycloak_* default to None.
+    cfg = DefaultConfig(zone_domain="alice.host.example.com")
+    assert cfg.cert_provider == CERT_PROVIDER_ACME

--- a/compute_space/src/compute_space/tests/test_cors_preflight.py
+++ b/compute_space/src/compute_space/tests/test_cors_preflight.py
@@ -16,9 +16,8 @@ from compute_space.config import provide_config
 from compute_space.core.app_id import new_app_id
 from compute_space.db import provide_db
 from compute_space.db.connection import init_db
+from compute_space.tests.conftest import _make_test_config
 from compute_space.web.routes.services_v2 import services_v2_routes
-
-from .conftest import _make_test_config
 
 APP_NAME = "test-cors-app"
 CALL_URL = f"/api/services/v2/call/{APP_NAME}/some-endpoint"

--- a/compute_space/src/compute_space/tests/test_dns.py
+++ b/compute_space/src/compute_space/tests/test_dns.py
@@ -7,8 +7,8 @@ import pytest
 
 import compute_space.core.dns as dns_mod
 from compute_space.core.dns import TxtRecord
+from compute_space.core.dns import append_txt_records
 from compute_space.core.dns import clear_txt
-from compute_space.core.dns import set_txt_records
 
 
 def _write_zonefile(path: Path, serial: int = 100) -> None:
@@ -58,45 +58,47 @@ def test_coredns_bind_ip_falls_back_to_public_ip(monkeypatch: pytest.MonkeyPatch
     assert dns_mod._coredns_bind_ip("203.0.113.10") == "203.0.113.10"
 
 
-def test_set_txt_records_writes_absolute_fqdn_names(tmp_path: Path) -> None:
+def test_append_txt_records_writes_relative_names_verbatim(tmp_path: Path) -> None:
     zonefile = tmp_path / "zonefile"
     _write_zonefile(zonefile, serial=100)
 
-    # Two challenges sharing one record_name (base + wildcard) plus a distinct one.
-    set_txt_records(
+    # Local DNS-01 path: several values share one relative name, left for CoreDNS
+    # to resolve against $ORIGIN.
+    append_txt_records(
         zonefile,
         [
-            TxtRecord(record_name="_acme-challenge.app.example.com", record_value="base-value"),
-            TxtRecord(record_name="_acme-challenge.app.example.com", record_value="wildcard-value"),
+            TxtRecord(record_name="_acme-challenge", record_value="base-value"),
+            TxtRecord(record_name="_acme-challenge", record_value="wildcard-value"),
         ],
     )
 
     content = zonefile.read_text()
-    # Names are written as absolute FQDNs (trailing dot) so CoreDNS does not
-    # re-append $ORIGIN.
-    assert '_acme-challenge.app.example.com.   IN TXT  "base-value"' in content
-    assert '_acme-challenge.app.example.com.   IN TXT  "wildcard-value"' in content
-    # Not doubled up into _acme-challenge.app.example.com.app.example.com.
-    assert "app.example.com.app.example.com" not in content
+    assert '_acme-challenge   IN TXT  "base-value"' in content
+    assert '_acme-challenge   IN TXT  "wildcard-value"' in content
+    # Relative name is not turned into an absolute FQDN.
+    assert "_acme-challenge.   IN TXT" not in content
     # Serial bumped so CoreDNS reloads.
     assert "101   ; serial" in content
 
 
-def test_set_txt_records_preserves_existing_trailing_dot(tmp_path: Path) -> None:
+def test_append_txt_records_writes_absolute_fqdn_names_verbatim(tmp_path: Path) -> None:
     zonefile = tmp_path / "zonefile"
     _write_zonefile(zonefile)
 
-    set_txt_records(zonefile, [TxtRecord(record_name="_acme-challenge.app.example.com.", record_value="v")])
+    # Broker path: names arrive as absolute FQDNs (trailing dot) so CoreDNS does
+    # not re-append $ORIGIN.
+    append_txt_records(zonefile, [TxtRecord(record_name="_acme-challenge.app.example.com.", record_value="v")])
 
     content = zonefile.read_text()
     assert '_acme-challenge.app.example.com.   IN TXT  "v"' in content
-    assert "app.example.com..   IN TXT" not in content
+    # Not doubled up into _acme-challenge.app.example.com.app.example.com.
+    assert "app.example.com.app.example.com" not in content
 
 
-def test_clear_txt_removes_broker_records(tmp_path: Path) -> None:
+def test_clear_txt_removes_records(tmp_path: Path) -> None:
     zonefile = tmp_path / "zonefile"
     _write_zonefile(zonefile)
-    set_txt_records(zonefile, [TxtRecord(record_name="_acme-challenge.app.example.com", record_value="v")])
+    append_txt_records(zonefile, [TxtRecord(record_name="_acme-challenge.app.example.com.", record_value="v")])
 
     clear_txt(zonefile)
 

--- a/compute_space/src/compute_space/tests/test_docs.py
+++ b/compute_space/src/compute_space/tests/test_docs.py
@@ -40,9 +40,8 @@ from litestar.testing import TestClient
 import compute_space.web.routes.docs as docs_routes
 from compute_space.config import set_active_config
 from compute_space.core.apps import RESERVED_PATHS
+from compute_space.tests._litestar_helpers import make_test_app
 from compute_space.web.routes.docs import docs_routes as docs_router
-
-from ._litestar_helpers import make_test_app
 
 
 class _FakeCfg:

--- a/compute_space/src/compute_space/tests/test_installer_route.py
+++ b/compute_space/src/compute_space/tests/test_installer_route.py
@@ -30,9 +30,8 @@ from compute_space.core.installer import InstallError
 from compute_space.core.installer import InstallResult
 from compute_space.db import provide_db
 from compute_space.db.connection import init_db
+from compute_space.tests.conftest import _make_test_config
 from compute_space.web.routes.services_v2 import services_v2_routes
-
-from .conftest import _make_test_config
 
 CALLER_APP = "openhost-catalog"
 CALLER_TOKEN = "test-installer-caller-token"

--- a/compute_space/src/compute_space/tests/test_integration.py
+++ b/compute_space/src/compute_space/tests/test_integration.py
@@ -24,14 +24,13 @@ from compute_space import OPENHOST_PROJECT_DIR
 from compute_space.core.caddy import generate_caddyfile
 from compute_space.core.data import provision_data
 from compute_space.core.manifest import AppManifest
+from compute_space.tests.conftest import _make_config_and_env
+from compute_space.tests.conftest import _start_router_process
+from compute_space.tests.conftest import _stop_router_process
+from compute_space.tests.container import container_cleanup
 from compute_space.tests.utils import app_id_for
 from compute_space.tests.utils import wait_app_removed
 from compute_space.tests.utils import wait_app_running
-
-from .conftest import _make_config_and_env
-from .conftest import _start_router_process
-from .conftest import _stop_router_process
-from .container import container_cleanup
 
 _APPS_DIR = str(OPENHOST_PROJECT_DIR / "apps")
 

--- a/compute_space/src/compute_space/tests/test_owner_username.py
+++ b/compute_space/src/compute_space/tests/test_owner_username.py
@@ -39,11 +39,10 @@ from compute_space.core.data import provision_data
 from compute_space.core.manifest import AppManifest
 from compute_space.db import provide_db
 from compute_space.db.connection import init_db
+from compute_space.tests.conftest import _make_test_config
 from compute_space.web.routes.api.settings import api_settings_routes
 from compute_space.web.routes.pages.login import pages_login_routes
 from compute_space.web.setup_app import create_setup_app
-
-from .conftest import _make_test_config
 
 # ---------------------------------------------------------------------------
 # Shared helpers

--- a/compute_space/src/compute_space/tests/test_provider_selection.py
+++ b/compute_space/src/compute_space/tests/test_provider_selection.py
@@ -18,10 +18,9 @@ from compute_space.config import provide_config
 from compute_space.core.app_id import new_app_id
 from compute_space.db import provide_db
 from compute_space.db.connection import init_db
+from compute_space.tests.conftest import _make_test_config
 from compute_space.web.routes.api.services_v2 import api_services_v2_routes
 from compute_space.web.routes.services_v2 import services_v2_routes
-
-from .conftest import _make_test_config
 
 SVC_DATA = "github.com/org/repo/services/data"
 

--- a/compute_space/src/compute_space/tests/test_remove_app_background.py
+++ b/compute_space/src/compute_space/tests/test_remove_app_background.py
@@ -9,8 +9,7 @@ from unittest.mock import patch
 from compute_space.core.app_id import new_app_id
 from compute_space.core.apps import remove_app_background
 from compute_space.db.connection import init_db
-
-from .conftest import _make_test_config
+from compute_space.tests.conftest import _make_test_config
 
 
 def _seed_app_with_children(db_path: str, app_name: str = "myapp") -> str:

--- a/compute_space/src/compute_space/tests/test_remove_app_route.py
+++ b/compute_space/src/compute_space/tests/test_remove_app_route.py
@@ -15,11 +15,10 @@ from litestar.testing import TestClient
 
 from compute_space.core.app_id import new_app_id
 from compute_space.db.connection import init_db
+from compute_space.tests._litestar_helpers import auth_cookie
+from compute_space.tests._litestar_helpers import make_test_app
+from compute_space.tests.conftest import _make_test_config
 from compute_space.web.routes.api.apps import api_apps_routes
-
-from ._litestar_helpers import auth_cookie
-from ._litestar_helpers import make_test_app
-from .conftest import _make_test_config
 
 
 @pytest.fixture

--- a/compute_space/src/compute_space/tests/test_rename_app.py
+++ b/compute_space/src/compute_space/tests/test_rename_app.py
@@ -15,11 +15,10 @@ from litestar.testing import TestClient
 import compute_space.web.routes.api.apps as apps_routes
 from compute_space.core.app_id import new_app_id
 from compute_space.db.connection import init_db
+from compute_space.tests._litestar_helpers import auth_cookie
+from compute_space.tests._litestar_helpers import make_test_app
+from compute_space.tests.conftest import _make_test_config
 from compute_space.web.routes.api.apps import api_apps_routes
-
-from ._litestar_helpers import auth_cookie
-from ._litestar_helpers import make_test_app
-from .conftest import _make_test_config
 
 
 @pytest.fixture

--- a/compute_space/src/compute_space/web/start.py
+++ b/compute_space/src/compute_space/web/start.py
@@ -12,7 +12,6 @@ import hypercorn.asyncio
 import hypercorn.config
 
 from compute_space.config import CERT_PROVIDER_ACME
-from compute_space.config import CERT_PROVIDER_CERT_API
 from compute_space.config import Config
 from compute_space.config import load_config
 from compute_space.config import set_active_config
@@ -64,19 +63,16 @@ def _owner_exists(config: Config) -> bool:
         db.close()
 
 
-def _require_cert_api_setting(value: str | None, name: str) -> str:
-    """Return a required cert_api config value, failing loudly if unset."""
-    if not value:
-        raise RuntimeError(f"{name} must be set in config to use the cert_api provider")
-    return value
-
-
 def _acquire_missing_tls_cert(config: Config) -> None:
     """Acquire a missing TLS cert using the configured provider.
 
     Caller has already verified the cert is missing, CoreDNS is enabled, and
     acquire_tls_cert_if_missing is set.  The default "acme" provider is the
     unchanged BYO-ACME path; "cert_api" fetches from the openhost-cert-api broker.
+
+    The cert_provider value and its required settings are validated when the
+    Config is constructed (Config.__attrs_post_init__), so here we only narrow
+    the optional fields for the type checker.
     """
     if config.cert_provider == CERT_PROVIDER_ACME:
         if not config.acme_account_key_path:
@@ -92,19 +88,22 @@ def _acquire_missing_tls_cert(config: Config) -> None:
                 directory_url=config.acme_directory_url,
             )
         )
-    elif config.cert_provider == CERT_PROVIDER_CERT_API:
-        base_url = _require_cert_api_setting(config.cert_api_base_url, "cert_api_base_url")
+    else:
+        # cert_provider is guaranteed to be CERT_PROVIDER_CERT_API with all of
+        # the cert_api settings populated (validated in Config.__attrs_post_init__).
+        assert config.cert_api_base_url is not None
+        assert config.cert_api_keycloak_issuer_url is not None
+        assert config.cert_api_keycloak_client_id is not None
+        assert config.cert_api_keycloak_client_secret is not None
         credentials = KeycloakClientCredentials(
-            issuer_url=_require_cert_api_setting(config.cert_api_keycloak_issuer_url, "cert_api_keycloak_issuer_url"),
-            client_id=_require_cert_api_setting(config.cert_api_keycloak_client_id, "cert_api_keycloak_client_id"),
-            client_secret=_require_cert_api_setting(
-                config.cert_api_keycloak_client_secret, "cert_api_keycloak_client_secret"
-            ),
+            issuer_url=config.cert_api_keycloak_issuer_url,
+            client_id=config.cert_api_keycloak_client_id,
+            client_secret=config.cert_api_keycloak_client_secret,
         )
         # The token provider fetches a bearer from Keycloak (client-credentials) and
         # refreshes it transparently across the broker's finalize-poll loop.
         with KeycloakTokenProvider.create(credentials) as token_provider:
-            with CertApiClient.create(base_url, token_provider) as client:
+            with CertApiClient.create(config.cert_api_base_url, token_provider) as client:
                 acquire_tls_cert_via_broker(
                     domain=config.zone_domain,
                     cert_path=config.tls_cert_path,
@@ -112,11 +111,6 @@ def _acquire_missing_tls_cert(config: Config) -> None:
                     coredns_zonefile_path=config.coredns_zonefile_path,
                     client=client,
                 )
-    else:
-        raise RuntimeError(
-            f"Unknown cert_provider {config.cert_provider!r} (expected "
-            f"{CERT_PROVIDER_ACME!r} or {CERT_PROVIDER_CERT_API!r})"
-        )
 
 
 def main() -> None:


### PR DESCRIPTION
## Summary

A series of cert_api / DNS / config cleanups on top of centralizing cert_api config validation.

- **Centralize cert_api config validation** in `Config.__attrs_post_init__` so invalid cert_api configuration is caught at construction time.
- **Use absolute imports** instead of relative in the compute_space tests.
- **cert_api: harden key file perms and bound the finalize poll loop** — create the TLS private key with `0o600` from the start (`os.open`) so it is never briefly world-readable between write and chmod; restructure `_poll_until_issued` to loop while within the deadline so the timeout is a single, clear exit condition.
- **dns: collapse `set_txt`/`set_txt_records` into one `append_txt_records`** — the two functions shared ~90% of their body and differed only in name addressing (relative-to-`$ORIGIN` vs absolute FQDN). The unified function writes each `TxtRecord.record_name` verbatim and lets the caller choose addressing; the broker path normalizes its FQDNs via a new `_as_fqdn` helper.
- **config: share TOML dict-building between `to_toml` and `to_toml_str`** — extract `_to_toml_dict` so both writers share one source of truth.

## Testing

- `pixi run -e dev pytest -x compute_space/src/compute_space/tests/test_dns.py compute_space/src/compute_space/tests/test_acquire_cert_broker.py` — 9 passed
- `pixi run -e dev pytest -x compute_space/src/compute_space/tests/ -k "toml or config"` — 22 passed
- pre-commit (ruff + mypy) clean on all commits

🤖 Generated with [Claude Code](https://claude.com/claude-code)