### PR TITLE
settings: show restart status under Updates

### DIFF
--- a/compute_space/src/compute_space/web/templates/settings.html
+++ b/compute_space/src/compute_space/web/templates/settings.html
@@ -36,6 +36,9 @@
 <div id="update-status">
   <p>Checking for updates&hellip;</p>
 </div>
+<div id="restart-overlay" style="display:none;">
+  <p id="restart-status"><strong>Waiting for shutdown&hellip;</strong></p>
+</div>
 
 <h3>Change Password</h3>
 <div>
@@ -44,10 +47,6 @@
   <input type="password" id="confirm-pw" placeholder="Confirm new password" style="margin-bottom:0.3em;">
   <button onclick="changePassword()" class="btn btn-primary">Change Password</button>
   <p id="pw-msg" style="display:none; margin-top:0.3em;"></p>
-</div>
-
-<div id="restart-overlay" style="display:none;">
-  <p id="restart-status"><strong>Waiting for shutdown&hellip;</strong></p>
 </div>
 
 <h2>Archive Backend</h2>


### PR DESCRIPTION
## What

Fixes the placement of the "Service stopped, waiting for restart…" message on the Settings page. It was rendering under **Change Password**; it now appears under **Updates**, where the update/restart flow that triggers it lives.

## Why

The `#restart-overlay` div was positioned in the DOM after the Change Password section. `showRestartOverlay()` hides the Updates content and reveals the overlay, but since the overlay sat further down the page, the status text appeared in the wrong spot.

## How

Moved the `#restart-overlay` div to sit directly beneath the Updates section (`#update-status`). Template-only change; no behavior/JS changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)