### PR TITLE
Publish docs to GitHub Pages via mdBook

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,51 @@
+name: docs
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "docs/**"
+      - ".github/workflows/docs.yml"
+  workflow_dispatch:
+
+# Allow only one concurrent deployment, skipping runs queued between the run
+# in-progress and latest queued. Do not cancel in-progress runs so deploys finish.
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+env:
+  MDBOOK_VERSION: "0.4.40"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install mdBook
+        run: |
+          mkdir -p "$HOME/.local/bin"
+          curl -sSL "https://github.com/rust-lang/mdBook/releases/download/v${MDBOOK_VERSION}/mdbook-v${MDBOOK_VERSION}-x86_64-unknown-linux-gnu.tar.gz" \
+            | tar -xz -C "$HOME/.local/bin"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+      - name: Build docs
+        run: mdbook build docs
+      - uses: actions/configure-pages@v5
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs/book
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ specs/
 # Beads (local only — not shared via git)
 .beads/
 
+# mdBook build output
+docs/book/
+

--- a/docs/book.toml
+++ b/docs/book.toml
@@ -1,0 +1,14 @@
+[book]
+title = "OpenHost Manual"
+authors = ["Imbue"]
+description = "Documentation for the OpenHost platform, for operators and app authors."
+src = "src"
+language = "en"
+
+[output.html]
+git-repository-url = "https://github.com/imbue-openhost/openhost"
+edit-url-template = "https://github.com/imbue-openhost/openhost/edit/main/docs/{path}"
+default-theme = "rust"
+
+[output.html.search]
+enable = true


### PR DESCRIPTION
Adds an mdBook config and a GitHub Pages deploy workflow so the existing docs/src markdown is published to GitHub Pages.

docs/book.toml configures the book (title, search, edit links).
.github/workflows/docs.yml installs a pinned mdBook, builds docs, and deploys to Pages on push to main (paths-filtered to docs changes) and via manual dispatch.
Build output (docs/book) is gitignored.

The existing in-zone server-side doc rendering is unchanged; this only adds a public hosted copy. After merge, enable Pages in repo settings with source set to GitHub Actions.

Tested: mdbook build succeeds, all chapters render, edit links resolve to docs/src/<file>.md.