### PR TITLE
Fix factual inaccuracies in docs

### DIFF
--- a/docs/src/creating_an_app.md
+++ b/docs/src/creating_an_app.md
@@ -114,6 +114,7 @@ The router injects these environment variables into your app:
 | `OPENHOST_MY_REDIRECT_DOMAIN` | `my.selfhost.imbue.com` | The shared `my.*` OAuth redirect domain. This hosts a browser-local page that redirects the user to their zone. |
 | `OPENHOST_APP_DATA_DIR` | `/data/app_data/my-app` | Path to the app's persistent data directory. Set when `app_data` (default on), `sqlite`, or `access_all_app_data` is requested   |
 | `OPENHOST_APP_TEMP_DIR` | `/data/app_temp_data/my-app` | Path to the app's temporary data directory. Set when `app_temp_data` or `access_all_app_data` is requested          |
+| `OPENHOST_APP_ARCHIVE_DIR` | `/data/app_archive/my-app` | Path to the app's elastic archive directory. Set when `app_archive` or `access_all_archive` is requested |
 | `OPENHOST_SQLITE_<NAME>` | `/data/app_data/my-app/sqlite/main.db` (for `sqlite = ["main"]`) | Path to a provisioned SQLite database file. Set once per entry in `sqlite`                                      |
 | `OPENHOST_OWNER_USERNAME` | `alice` | The compute space owner's chosen display name. Use to seed SSO account names. Defaults to `owner` if not explicitly configured. |
 
@@ -157,7 +158,7 @@ In general, the debugging flow is something like:
 6. Retest and repeat
 
 We find AI tools work best when they can directly reference openhost code+docs. So we'd suggest:
-```cd some_dir && git clone https://github.com/imbue-ai/openhost.git```
+```cd some_dir && git clone https://github.com/imbue-openhost/openhost.git```
 then point them at that checkout and tell them to read this doc.
 
 ## CLI
@@ -172,7 +173,7 @@ this will automatically get updates if you pull new changes from the openhost re
 
 or if not,
 ```bash
-uv tool install "oh @ git+https://github.com/imbue-ai/openhost.git#subdirectory=compute_space_cli"
+uv tool install "oh @ git+https://github.com/imbue-openhost/openhost.git#subdirectory=compute_space_cli"
 ```
 Run `oh instance login` to login to your compute space.
 

--- a/docs/src/cross_app_services.md
+++ b/docs/src/cross_app_services.md
@@ -61,7 +61,7 @@ This endpoint is app-specific - the router loads the consumer's manifest, finds 
 
 The router identifies and authenticates the calling app two ways:
 - **Server-side calls:** must include `Authorization: Bearer $OPENHOST_APP_TOKEN`. Each app gets a unique `OPENHOST_APP_TOKEN` injected as an env var at deploy time.
-- **Browser calls:** the request's `Origin` is matched against the app's subdomain, with the JWT cookie authenticating the user. No bearer token is needed for these — the browser provides the cookie automatically.
+- **Browser calls:** the request's `Origin` is matched against the app's subdomain, with the owner session cookie authenticating the user. No bearer token is needed for these — the browser provides the cookie automatically.
 
 Service calls should be API-only - the user's browser should never be redirected to a service endpoint, with the exception of permission grant pages.
 
@@ -139,7 +139,7 @@ HTTP 403
   "error": "permission_required",
   "required_grant": {
     "grant": { ... },
-    "scope": "global"
+    "scope": "app"
   },
   "grant_url": GRANT_URL
 }
@@ -161,10 +161,10 @@ Note for `scope: "app"`, the provider must include its own `grant_url`.
    Authorization: Bearer $OPENHOST_APP_TOKEN
    Content-Type: application/json
 
-   {"consumer_app": "<name>", "service_url": "<url>", "grant": <grant>}
+   {"consumer_app_id": "<consumer_app_id>", "service_url": "<url>", "grant": <grant>}
    ```
 
-   The router takes `provider_app` from the bearer token, so the provider can only grant permissions *for itself* — it can't create grants attributed to another provider. The grant body is the same shape the provider will later see in `X-OpenHost-Permissions`. str or json can be used.
+   The consumer's app ID is the value the provider received in the `X-OpenHost-Consumer-Id` header. The router takes the provider's own app ID from the bearer token, so the provider can only grant permissions *for itself* — it can't create grants attributed to another provider. The grant body is the same shape the provider will later see in `X-OpenHost-Permissions`. str or json can be used.
 
 4. **Provider sends the user back.** After the grant call succeeds, the provider should redirect the user's browser to the consumer-supplied `return_to`. The consumer can then retry the original service call, which will now succeed. If the user declines, the provider should also redirect to `return_to` (without creating a grant) so the consumer can show its own "permission denied" UI rather than leaving the user stranded on the provider's page.
 
@@ -175,10 +175,10 @@ These endpoints back the owner-facing UI and are authenticated by the owner logi
 
 **Permissions**
 
-- `GET /api/permissions/v2[?app=<name>]` — list grants, optionally filtered to one consumer app. Returns an array of `{consumer_app, service_url, grant, scope, provider_app}`.
-- `POST /api/permissions/v2/grant_global_scoped` — grant a global-scoped permission. Body: `{app, service_url, grant}`.
-- `POST /api/permissions/v2/grant_app_scoped` — grant an app-scoped permission. **Authenticated with the calling provider's app token** (not the owner cookie); the `provider_app` is taken from the token. Body: `{consumer_app, service_url, grant}`. Used by provider apps after running their own user-facing approval flow (e.g. an OAuth dance).
-- `POST /api/permissions/v2/revoke` — revoke a permission. Body: `{app, service_url, grant, scope?, provider_app?}`. `scope` defaults to `"global"`. 404 if no matching row.
+- `GET /api/permissions/v2[?app_id=<consumer_app_id>]` — list grants, optionally filtered to one consumer app. Returns an array of `{consumer_app_id, service_url, grant, scope, provider_app_id}`.
+- `POST /api/permissions/v2/grant_global_scoped` — grant a global-scoped permission. Body: `{app_id, service_url, grant}`.
+- `POST /api/permissions/v2/grant_app_scoped` — grant an app-scoped permission. **Authenticated with the calling provider's app token** (not the owner cookie); the provider's app ID is taken from the token. Body: `{consumer_app_id, service_url, grant}`. Used by provider apps after running their own user-facing approval flow (e.g. an OAuth dance).
+- `POST /api/permissions/v2/revoke` — revoke a permission. Body: `{app_id, service_url, grant, scope?, provider_app_id?}`. `scope` defaults to `"global"`. 404 if no matching row.
 
 The `grant` field on these endpoints is whatever shape the service defines — passed through the router verbatim.
 
@@ -186,9 +186,9 @@ The `grant` field on these endpoints is whatever shape the service defines — p
 
 Each service URL has at most one default provider (set automatically to the first app to register; the owner can change it). Calls without an explicit provider use this default.
 
-- `GET /api/services/v2/defaults` — list all `(service_url, app_name)` defaults.
+- `GET /api/services/v2/defaults` — list all defaults; each entry includes `service_url`, `app_id`, and `app_name`.
 - `GET /api/services/v2/providers?service=<url>` — list every registered provider for a service, with `is_default`, `service_version`, `endpoint`, and app `status`. Accepts both owner auth and app bearer tokens, so consumer apps can discover providers at runtime.
-- `POST /api/services/v2/defaults` — set the default. Body: `{service_url, app_name}`. 404 if `app_name` doesn't actually provide that service.
+- `POST /api/services/v2/defaults` — set the default. Body: `{service_url, app_id}`. 404 if that app doesn't actually provide the service.
 - `DELETE /api/services/v2/defaults` — clear the default. Body: `{service_url}`. After this, calls to the service return 503 until a new default is set (or another provider is installed).
 
 ### Retrofitting existing apps

--- a/docs/src/data.md
+++ b/docs/src/data.md
@@ -13,7 +13,7 @@
         - examples: source jpegs / RAWs in a photo library, original video files, attachment uploads, large model weights.
     - **temporary data (`app_temp_data`)** — local disk scratch, not backed up, recreatable on demand.
         - examples: low-res thumbnails generated from source photos, transcoding work files, in-flight upload chunks.
-- there’s also a folder for router-level data, eg the sqlite database used by the router.
+- there’s also VM-level / router data (eg the sqlite database used by the router). apps see this in-container as `/data/vm_data/` (only with the `access_vm_data` permission); on the host the router db lives at `persistent_data/openhost/router.db`.
 - where do app build artifacts go? probably in app temp data?
 - folder structure (as seen inside containers, mounted at `/data/`)
     - /data/
@@ -23,8 +23,7 @@
             - app_name/
         - app_archive/
             - app_name/
-        - router_data/
-            - router.db
+        - vm_data/          # VM-level / router shared data (only with access_vm_data)
 - regardless of permissions, apps should see the same folder structure, just only with folders they have access to. that way the structure doesn't change if the permissions change. without any special permissions, apps will just have basically `/data/app_data/APP_NAME` and `/data/app_temp_data/APP_NAME` (and `/data/app_archive/APP_NAME` if requested).
 
 ### Why three tiers, not two

--- a/docs/src/manifest_spec.md
+++ b/docs/src/manifest_spec.md
@@ -9,7 +9,7 @@ Apps declare how they should be deployed on OpenHost by placing an `openhost.tom
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
 | `name` | string | yes | Unique app identifier (lowercase, hyphens ok) |
-| `version` | string | yes | Semver version string |
+| `version` | string | yes | Version string. Conventionally semver, but only checked for non-emptiness (not validated as semver). |
 | `description` | string | no | Short description |
 | `authors` | string[] | no | List of author names |
 
@@ -28,7 +28,7 @@ Apps declare how they should be deployed on OpenHost by placing an `openhost.tom
 
 Declares additional port mappings for the container. Each entry binds a container port to a host port (TCP+UDP on 0.0.0.0). Set `host_port = 0` for auto-assignment from the 9000-9999 range.
 
-Rootless podman can bind ports >= 25 only; `host_port` values below 25 are rejected at parse time. Ports `80` and `443` are claimed by the built-in Caddy front-door and will fail to bind if an app requests them. For public HTTP/HTTPS, route through the router proxy (apps live under `https://{app_name}.{zone_domain}/`); for other protocols (e.g. SMTP on `25`), pick `host_port = 25` or any port in the 9000-9999 auto-assign range.
+Rootless podman can bind ports >= 25 only; `host_port` values below 25 are rejected at parse time. Ports `80` and `443` are not rejected by the manifest parser, but they are claimed at runtime by the built-in Caddy front-door, so an app that requests them will fail to bind. For public HTTP/HTTPS, route through the router proxy (apps live under `https://{app_name}.{zone_domain}/`); for other protocols (e.g. SMTP on `25`), pick `host_port = 25` or any port in the 9000-9999 auto-assign range.
 
 | Field | Type | Required | Default | Description |
 |-------|------|----------|---------|-------------|
@@ -97,9 +97,10 @@ The host provisions requested data services and injects connection info as envir
 - `OPENHOST_APP_DATA_DIR` — `/data/app_data/{app_name}` (only if app_data access granted)
 - `OPENHOST_APP_TEMP_DIR` — `/data/app_temp_data/{app_name}` (only if app_temp_data access granted)
 - `OPENHOST_APP_ARCHIVE_DIR` — `/data/app_archive/{app_name}` (only if app_archive access granted)
-- `OPENHOST_AUTH_PUBLIC_KEY` — PEM-encoded JWT public key for token verification (only if signing keys are available)
 - `OPENHOST_ROUTER_URL` — URL of the router's HTTP server, reachable from inside the container.
 - `OPENHOST_OWNER_USERNAME` — the compute space owner's chosen display name; use to seed SSO account names. Defaults to `owner` if not explicitly configured.
+
+The host also injects identity/routing variables (`OPENHOST_APP_NAME`, `OPENHOST_APP_ID`, `OPENHOST_APP_TOKEN`, `OPENHOST_ZONE_DOMAIN`, `OPENHOST_MY_REDIRECT_DOMAIN`); see the full table in [Creating an App](creating_an_app.md). The zone's identity public key is **not** injected as an environment variable — it is served over HTTP at `/.well-known/jwks.json` (JWKS) and `/.well-known/openhost-identity` (PEM).
 
 ## Examples
 

--- a/docs/src/oauth.md
+++ b/docs/src/oauth.md
@@ -1,12 +1,14 @@
 # OAuth Token Service
 
-The secrets app provides OAuth tokens to other apps via the cross-app service system. Apps request tokens by provider and scopes, and the secrets app handles the OAuth flow — either authorization code (Google) or device flow (GitHub), depending on the provider. Multiple accounts per provider are supported.
+The OAuth provider app (`oauth-provider`, in `apps/oauth_provider/`) provides OAuth tokens to other apps via the cross-app service system. Apps request tokens by provider and scopes, and the OAuth provider handles the OAuth flow — either authorization code (Google) or device flow (GitHub), depending on the provider. Multiple accounts per provider are supported.
+
+(Note: this is distinct from the `secrets` key-value service. The OAuth provider app *consumes* the secrets service to fetch its own Google client credentials, but the OAuth functionality described here is provided by the `oauth-provider` app, not a "secrets app".)
 
 ## How it works
 
 ### Requesting a token
 
-1. **App requests a token:** `POST /api/services/v2/call/<shortname>/oauth/token` with `{"provider": "google", "scopes": ["https://www.googleapis.com/auth/gmail.readonly"], "return_to": "//app.zone.domain/callback", "account": "user@gmail.com"}` (where `<shortname>` is the alias declared in the app's `[[services.v2.consumes]]` block)
+1. **App requests a token:** `POST /api/services/v2/call/<shortname>/token` with `{"provider": "google", "scopes": ["https://www.googleapis.com/auth/gmail.readonly"], "return_to": "//app.zone.domain/callback", "account": "user@gmail.com"}` (where `<shortname>` is the alias declared in the app's `[[services.v2.consumes]]` block; the router proxies `token` onto the provider's `/oauth_service/` endpoint)
 
 2. **Token cached?** Returns it immediately. Tokens that don't expire (GitHub) are returned as-is. Expiring tokens (Google) are checked with a 60s buffer.
 
@@ -18,25 +20,25 @@ The secrets app provides OAuth tokens to other apps via the cross-app service sy
 
 Tokens are stored with an `account` label, keyed by `(provider, scopes, account)`. The account name is resolved automatically after OAuth — for Google it's the email address, for GitHub it's the username.
 
-- **Connecting a new account:** Request a token with `"account": "new"`. After OAuth, the secrets app resolves the identity (e.g. `user@gmail.com`) and stores the token under that name.
+- **Connecting a new account:** Request a token with `"account": "NEW"`. After OAuth, the OAuth provider resolves the identity (e.g. `user@gmail.com`) and stores the token under that name.
 - **Using a specific account:** Request with `"account": "user@gmail.com"` to get that account's token.
-- **Default fallback:** Request with `"account": "default"` (or omit it). If there's exactly one token for that provider+scopes, it's returned regardless of account name.
-- **Listing accounts:** `POST /api/services/v2/call/<shortname>/oauth/accounts` with `{"provider": "google", "scopes": [...]}` returns `{"accounts": ["user1@gmail.com", "user2@gmail.com"]}`.
+- **Default fallback:** Request with `"account": "default"` (or omit it — the request body defaults to `"default"`). If there's exactly one token for that provider+scopes, it's returned regardless of account name.
+- **Listing accounts:** `POST /api/services/v2/call/<shortname>/accounts` with `{"provider": "google", "scopes": [...]}` returns `{"accounts": ["user1@gmail.com", "user2@gmail.com"]}`.
 
 ### Authorization code flow (Google)
 
 The `authorize_url` points directly to Google's consent page. After the user authorizes:
 
-1. Google redirects to `https://my.<base_domain>/secrets/oauth/callback?code=...&state=...`
-2. The `my.` provider redirect sends the user to `<zone_domain>/secrets/oauth/callback?code=...&state=...`
-3. The router has an explicit route for `/secrets/oauth/callback` that proxies to the secrets app
-4. Secrets app exchanges the code for tokens, fetches the user's identity (email), stores the token under that account name, and redirects to `return_to`
+1. Google redirects to `https://my.<base_domain>/api/services/v2/oauth_callback?code=...&state=...`
+2. The `my.` provider redirect sends the user to `<zone_domain>/api/services/v2/oauth_callback?code=...&state=...`
+3. The router has an explicit route for `/api/services/v2/oauth_callback` that proxies to the OAuth provider app
+4. The OAuth provider exchanges the code for tokens, fetches the user's identity (email), stores the token under that account name, and redirects to `return_to`
 
 Google tokens always request `email` and `openid` scopes in addition to the requested scopes, so the identity can be resolved. The callback also verifies that all requested scopes were granted (Google's granular consent lets users uncheck scopes).
 
 ### Device flow (GitHub)
 
-The `authorize_url` points to `secrets.<zone_domain>/oauth/device?...` — a page on the secrets app that:
+The `authorize_url` points to `oauth-provider.<zone_domain>/device?...` — a page on the OAuth provider app that:
 
 1. Starts the device flow with GitHub, getting a user code and verification URL
 2. Shows the user the code + a link to GitHub's verification page + a copy button
@@ -70,17 +72,17 @@ Permissions approved by the owner on the deploy page are granted at install time
 The `/api/services/v2/call/` endpoints accept two forms of authentication:
 
 - **Server-to-server:** `Authorization: Bearer <app_token>` header
-- **Browser:** JWT auth cookie + `Origin` header. The router derives the app identity from the Origin's subdomain (e.g. `oauth-demo.zone.domain` → app `oauth-demo`).
+- **Browser:** owner session cookie + `Origin` header. The router derives the app identity from the Origin's subdomain (e.g. `oauth-demo.zone.domain` → app `oauth-demo`).
 
 For browser requests, the router adds CORS headers allowing the app's subdomain origin with credentials. This lets client-side JavaScript call service endpoints on the zone domain directly.
 
 ### Token storage
 
-Tokens are stored in SQLite, keyed by `(provider, scopes, account)` where scopes is a sorted space-separated string. Different scope sets or accounts = different tokens.
+Tokens are stored in SQLite, keyed by `(provider, scopes, account)` where scopes is a sorted comma-separated string. Different scope sets or accounts = different tokens.
 
 ### Token revocation
 
-On deletion via the secrets dashboard:
+On deletion via the OAuth provider's dashboard:
 - **Google:** revokes the refresh token via `https://oauth2.googleapis.com/revoke` (invalidates both access and refresh tokens)
 - **GitHub:** revokes via `DELETE https://api.github.com/applications/{client_id}/token` with basic auth
 
@@ -91,20 +93,20 @@ On deletion via the secrets dashboard:
 The app server requests the token. If auth is needed, it redirects the user's browser to the `authorize_url`. After OAuth, the user is redirected back to the original page (via `return_to`), which retries and gets the token.
 
 ```python
-from oauth import get_oauth_token, OAuthAuthRequired
+from oauth import get_oauth_token, AuthRedirectRequired
 
 try:
     token = await get_oauth_token("google", [GMAIL_SCOPE], account,
                                    return_to="//app.zone.domain/unread")
-except OAuthAuthRequired as e:
-    return redirect(e.authorize_url)
+except AuthRedirectRequired as e:
+    return redirect(e.url)
 
 # use token to call Google API server-side
 ```
 
 ### Client-side (popups)
 
-JavaScript calls `/_services/` directly from the browser. If auth is needed, opens the `authorize_url` in a popup. The popup ends at `/oauth-complete` which sends `postMessage` back to the opener.
+JavaScript calls the service endpoint (`/api/services/v2/call/<shortname>/...`) directly from the browser. If auth is needed, it opens the `authorize_url` in a popup. The popup ends at the app's `/client/oauth-complete` page, which sends a `postMessage` back to the opener.
 
 ```javascript
 var oauth = new OAuthClient({
@@ -123,7 +125,7 @@ await oauth.connect('google');
 var accounts = await oauth.getAccounts('google');
 ```
 
-The `oauth.js` library handles the popup lifecycle, postMessage communication, and token retry. The `/oauth-complete` page sends `postMessage({ type: 'oauth_complete' })` to `window.opener` and closes itself.
+The `oauth.js` library handles the popup lifecycle, postMessage communication, and token retry. The `/client/oauth-complete` page sends `postMessage({ type: 'auth_complete' })` to `window.opener` and closes itself.
 
 ## Providers
 
@@ -131,7 +133,7 @@ The `oauth.js` library handles the popup lifecycle, postMessage communication, a
 
 - OAuth client type: **Web application**
 - Created at https://console.cloud.google.com/apis/credentials
-- Redirect URIs: `https://my.<base_domain>/secrets/oauth/callback`
+- Redirect URIs: `https://my.<base_domain>/api/services/v2/oauth_callback`
 - Enable needed APIs at https://console.cloud.google.com/apis/library
 - No authorized JavaScript origins needed (server-side flow)
 - Tokens expire (~1 hour) but have refresh tokens for automatic renewal
@@ -172,7 +174,7 @@ Add an entry to the providers configuration in the OAuth provider app with eithe
 },
 ```
 
-For auth code providers, register the redirect URI: `https://my.<base_domain>/secrets/oauth/callback`
+For auth code providers, register the redirect URI: `https://my.<base_domain>/api/services/v2/oauth_callback`
 
 For device flow providers, no redirect URI is needed.
 
@@ -184,12 +186,14 @@ If the provider has a non-standard revocation API (like GitHub), add a case in t
 
 - `apps/oauth_provider/src/oauth_provider/` — OAuth provider app (v2 service interface)
   - `core/permissions.py` — v2 grant parsing, permission checking, app-scoped grant helper
-  - `core/oauth.py` — provider configs, auth URL builder, code exchange, device flow, token refresh, revocation
+  - `core/providers.py` — provider configs, auth URL builder, code exchange, device flow, token revocation, `fetch_account_identity()`, `revoke_token()`
+  - `core/tokens.py` — token storage, caching, expiry checks, and refresh
+  - `core/credentials.py` — fetches the provider's own client credentials from the `secrets` service
 - `compute_space/src/compute_space/web/routes/services_v2.py` — v2 service proxy with shortname routing, permission header injection, CORS, OAuth callback proxy
 - `compute_space/src/compute_space/web/routes/api/permissions_v2.py` — permission management API (grant, revoke, pending requests)
 - `compute_space/src/compute_space/core/auth/permissions_v2.py` — core permission DB operations
-- `apps/oauth_demo/` — example app with two demo modes:
+- `apps/oauth_demo/src/oauth_demo/` — example app with two demo modes:
   - `server_demo.py` — server-side OAuth with full-page redirects
   - `client_demo.py` — client-side SPA using `static/oauth.js` and popups
-  - `oauth.py` — shared Python OAuth helpers (`get_oauth_token`, `get_accounts`)
+  - `oauth.py` — shared Python OAuth helpers (`get_oauth_token`, `get_accounts`, `AuthRedirectRequired`)
   - `static/oauth.js` — client-side OAuth library (`OAuthClient` class)

--- a/docs/src/routing.md
+++ b/docs/src/routing.md
@@ -75,18 +75,15 @@ when TLS is enabled:
 when TLS is not enabled (e.g. Cloudflare Tunnel setups):
 - **:80** — reverse proxies to the router on `:8080`
 
-in dev mode (`openhost up --dev`), Caddy does not run at all — the router serves HTTP directly on `:8080`.
+in a local setup (`openhost up` without `--domain`), Caddy does not run at all — the router serves HTTP directly on `:8080`. (TLS + Caddy are opted into by passing `--domain`; there is no `--dev` flag.)
 
-the Caddyfile is generated dynamically by `compute_space/compute_space/core/caddy.py`. no static Caddyfile is checked in.
+the Caddyfile is generated dynamically by `compute_space/src/compute_space/core/caddy.py`. no static Caddyfile is checked in.
 
 ## app routing
 
-the router (Hypercorn on :8080) handles all app routing. two mechanisms:
+the router (Hypercorn on :8080) handles all app routing via **subdomain routing**: `my-app.host.imbue.com` — the router extracts `my-app` from the Host header and proxies to the app's container port.
 
-1. **subdomain routing**: `my-app.host.imbue.com` — the router extracts `my-app` from the Host header and proxies to the app's container port.
-2. **path prefix routing**: `host.imbue.com/my-app/...` — fallback when subdomains aren't available. the router strips the prefix before proxying.
-
-both HTTP and WebSocket requests are proxied. auth (JWT cookie) is checked before proxying to non-public paths.
+both HTTP and WebSocket requests are proxied. auth (an opaque, DB-backed `session_token` cookie — not a JWT) is checked before proxying to non-public paths.
 
 ## latency
 
@@ -100,4 +97,4 @@ for a single server setup, there's some optimizations you can do:
 - TLS session resumption: after the first TLS handshake, the client and server can cache the session parameters. then on subsequent connections, they can do a shorter handshake that just references the cached session, which saves roundtrips. this is tricky because it is only properly secure on GET requests.
 - TLS 1.3 has less roundtrips
 - HTTP/3 has less roundtrips
-- use fast ECDSA P-256 keys (we do this — see `compute_space/compute_space/core/tls/util.py`)
+- use fast ECDSA P-256 keys (we do this — see `compute_space/src/compute_space/core/tls/util.py`)


### PR DESCRIPTION
Went through every doc in docs/src/ and verified each claim against the actual source code, then fixed the errors found.

oauth.md: The OAuth functionality is provided by the oauth-provider app, not a secrets app (the doc repeatedly conflated the two; the oauth-provider only consumes the separate secrets service for its client credentials). Corrected the service endpoint (/oauth_service/), the call paths (call/<shortname>/token and /accounts, not /oauth/token), the OAuth callback (/api/services/v2/oauth_callback, not /secrets/oauth/callback), the device-flow URL, the default account value, the scope separator (comma), the postMessage type (auth_complete) and /client/oauth-complete page, the server-side Python example (AuthRedirectRequired/.url), and the Files section (core/oauth.py does not exist).

cross_app_services.md: Management API request/response field names are app_id, consumer_app_id, provider_app_id (not app, consumer_app, provider_app), and POST defaults takes app_id (not app_name). Fixed a scope global->app copy-paste error in the app-scoped 403 example. Corrected the browser-auth cookie description.

manifest_spec.md: Removed OPENHOST_AUTH_PUBLIC_KEY which is not injected as an env var (the identity public key is served at /.well-known/jwks.json and /.well-known/openhost-identity). Clarified that version is not validated as semver and that ports 80/443 fail at runtime bind, not parse time.

creating_an_app.md: Repo org imbue-ai -> imbue-openhost in the clone and CLI-install commands. Added OPENHOST_APP_ARCHIVE_DIR to the env var table.

routing.md: Fixed source paths (compute_space/compute_space -> compute_space/src/compute_space). Removed the nonexistent openhost up --dev flag and the unimplemented path-prefix routing mechanism. Corrected JWT cookie to the opaque DB-backed session_token cookie.

data.md: router_data/ directory does not exist; corrected to vm_data with the actual router.db host path.

mdbook build passes; all chapters render.