### PR TITLE
apps: reject SSH git URLs with a clear error

### DIFF
--- a/compute_space/src/compute_space/core/apps.py
+++ b/compute_space/src/compute_space/core/apps.py
@@ -33,6 +33,7 @@ from compute_space.core.data import deprovision_temp_data
 from compute_space.core.data import provision_data
 from compute_space.core.data import rmtree_with_sudo_fallback
 from compute_space.core.git_ops import UnsupportedRepoUrlError
+from compute_space.core.git_ops import is_github_repo_url
 from compute_space.core.git_ops import is_ssh_url
 from compute_space.core.git_ops import parse_repo_url
 from compute_space.core.logging import logger
@@ -283,7 +284,7 @@ async def clone_with_github_fallback(
     # An SSH URL never clones over HTTPS-authenticated OAuth, so don't bounce
     # the owner through the GitHub authorize flow only to fail again — the
     # error from clone_and_read_manifest already explains to use HTTPS.
-    if error and "github.com" in repo_url and not is_ssh_url(repo_url):
+    if error and is_github_repo_url(repo_url) and not is_ssh_url(repo_url):
         clone_error = error
         try:
             token = await get_oauth_token("github", ["repo"], return_to=return_to)

--- a/compute_space/src/compute_space/core/apps.py
+++ b/compute_space/src/compute_space/core/apps.py
@@ -32,6 +32,8 @@ from compute_space.core.data import deprovision_data
 from compute_space.core.data import deprovision_temp_data
 from compute_space.core.data import provision_data
 from compute_space.core.data import rmtree_with_sudo_fallback
+from compute_space.core.git_ops import UnsupportedRepoUrlError
+from compute_space.core.git_ops import is_ssh_url
 from compute_space.core.git_ops import parse_repo_url
 from compute_space.core.logging import logger
 from compute_space.core.manifest import AppLink
@@ -188,7 +190,10 @@ async def clone_and_read_manifest(
 
     Returns (manifest, clone_dir, error). On success error is None.
     """
-    base_url, ref = parse_repo_url(repo_url)
+    try:
+        base_url, ref = parse_repo_url(repo_url)
+    except UnsupportedRepoUrlError as e:
+        return None, None, str(e)
     clone_url = base_url
 
     # For file:// URLs, copy the directory if it's not a git repo
@@ -275,7 +280,10 @@ async def clone_with_github_fallback(
     """
     manifest, tmp_dir, error = await clone_and_read_manifest(repo_url)
 
-    if error and "github.com" in repo_url:
+    # An SSH URL never clones over HTTPS-authenticated OAuth, so don't bounce
+    # the owner through the GitHub authorize flow only to fail again — the
+    # error from clone_and_read_manifest already explains to use HTTPS.
+    if error and "github.com" in repo_url and not is_ssh_url(repo_url):
         clone_error = error
         try:
             token = await get_oauth_token("github", ["repo"], return_to=return_to)
@@ -759,7 +767,11 @@ def git_pull(
     # happened to be checked out.
     ref: str | None = None
     if repo_url:
-        base_url, ref = parse_repo_url(repo_url)
+        try:
+            base_url, ref = parse_repo_url(repo_url)
+        except UnsupportedRepoUrlError as e:
+            _log(str(e))
+            return False, str(e)
         try:
             subprocess.run(
                 ["git", "remote", "set-url", "origin", base_url],

--- a/compute_space/src/compute_space/core/git_ops.py
+++ b/compute_space/src/compute_space/core/git_ops.py
@@ -1,3 +1,4 @@
+import re
 import urllib.parse
 from pathlib import Path
 
@@ -14,14 +15,57 @@ class NoRemoteBranchForLocalBranch(Exception):
     pass
 
 
+class UnsupportedRepoUrlError(ValueError):
+    """A repo URL whose transport we recognise but deliberately don't support.
+
+    Currently only SSH (``ssh://`` and SCP-style ``git@host:path``) — clones
+    over SSH would need a deploy key, known_hosts, and an SSH agent that the
+    compute_space process doesn't have, so we reject them up front with a clear
+    message rather than letting ``git clone`` fail cryptically.
+    """
+
+
 _KNOWN_SCHEMES = {"http", "https", "ssh", "git", "file"}
+
+# SCP-style SSH shorthand: ``[user@]host:path`` with no URL scheme, e.g.
+# ``git@github.com:user/repo.git``. We require a ``user@`` and a ``host:``
+# before the first slash so we don't misfire on credential URLs like
+# ``oauth2:TOKEN@host/path`` (where the ``@`` follows the colon).
+_SCP_STYLE_SSH_RE = re.compile(r"^[^/@]+@[^/:]+:")
+
+_SSH_URL_ERROR = (
+    "SSH git URLs are not supported (e.g. 'git@github.com:user/repo.git' or "
+    "'ssh://git@github.com/user/repo.git'). Please use the HTTPS clone URL "
+    "instead, e.g. 'https://github.com/user/repo.git'."
+)
+
+
+def is_ssh_url(repo_url: str) -> bool:
+    """True if ``repo_url`` uses the SSH transport.
+
+    Matches both the ``ssh://`` scheme and git's SCP-style shorthand
+    (``git@host:path``). Credential-bearing HTTPS-ish URLs such as
+    ``oauth2:TOKEN@host/path`` are not SSH and return False.
+    """
+    if urllib.parse.urlparse(repo_url).scheme == "ssh":
+        return True
+    return bool(_SCP_STYLE_SSH_RE.match(repo_url))
 
 
 def parse_repo_url(repo_url: str) -> tuple[str, str | None]:
     """Parse a repo URL with optional @ref suffix (pip-style).
 
     Returns (base_url, ref) where ref is a branch, tag, or commit hash, or None.
+
+    Raises:
+        UnsupportedRepoUrlError: if the URL uses the SSH transport.
     """
+    # Reject SSH URLs before the bare-hostname fallback below: an SCP-style
+    # URL like "git@github.com:user/repo.git" has no scheme, so it would
+    # otherwise be rewritten to a malformed "https://git@github.com:user/..."
+    # (git reads "user" as a port) and fail cryptically.
+    if is_ssh_url(repo_url):
+        raise UnsupportedRepoUrlError(_SSH_URL_ERROR)
     # Allow bare hostnames like "github.com/user/repo" without a scheme.
     # urlparse misidentifies credentials (e.g. "oauth2:TOKEN@host") as a scheme,
     # so we only trust schemes we actually recognise.

--- a/compute_space/src/compute_space/core/git_ops.py
+++ b/compute_space/src/compute_space/core/git_ops.py
@@ -52,6 +52,28 @@ def is_ssh_url(repo_url: str) -> bool:
     return bool(_SCP_STYLE_SSH_RE.match(repo_url))
 
 
+def _repo_url_hostname(repo_url: str) -> str:
+    """Lowercased hostname of ``repo_url``, applying the same bare-hostname
+    normalisation as :func:`parse_repo_url` (a scheme-less URL is treated as
+    https). Returns "" when no host can be parsed."""
+    parsed = urllib.parse.urlparse(repo_url)
+    if parsed.scheme not in _KNOWN_SCHEMES:
+        parsed = urllib.parse.urlparse("https://" + repo_url)
+    return (parsed.hostname or "").lower()
+
+
+def is_github_repo_url(repo_url: str) -> bool:
+    """True if ``repo_url``'s host is github.com (or a subdomain of it).
+
+    Matches on the parsed hostname rather than a substring so a look-alike
+    host like ``github.com.evil.example`` or ``notgithub.com`` doesn't gate
+    the GitHub OAuth clone fallback (which would otherwise attach a GitHub
+    token to a request bound for the wrong host).
+    """
+    host = _repo_url_hostname(repo_url)
+    return host == "github.com" or host.endswith(".github.com")
+
+
 def parse_repo_url(repo_url: str) -> tuple[str, str | None]:
     """Parse a repo URL with optional @ref suffix (pip-style).
 

--- a/compute_space/src/compute_space/tests/test_parse_repo_url.py
+++ b/compute_space/src/compute_space/tests/test_parse_repo_url.py
@@ -9,6 +9,7 @@ import pytest
 
 from compute_space.core.apps import parse_repo_url
 from compute_space.core.git_ops import UnsupportedRepoUrlError
+from compute_space.core.git_ops import is_github_repo_url
 from compute_space.core.git_ops import is_ssh_url
 
 
@@ -113,6 +114,38 @@ class TestIsSshUrl:
     )
     def test_not_ssh(self, url):
         assert is_ssh_url(url) is False
+
+
+class TestIsGithubRepoUrl:
+    """is_github_repo_url matches on the parsed host, not a substring, so
+    look-alike hosts don't gate the GitHub OAuth fallback."""
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "https://github.com/user/repo.git",
+            "https://github.com/user/repo.git@main",
+            "http://github.com/user/repo",
+            "https://x-access-token:TOKEN@github.com/user/repo.git",
+            "github.com/user/repo.git",  # bare host normalised to https
+            "https://api.github.com/repos/user/repo",  # subdomain
+        ],
+    )
+    def test_github(self, url):
+        assert is_github_repo_url(url) is True
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "https://github.com.evil.example/user/repo.git",
+            "https://notgithub.com/user/repo.git",
+            "https://github.community/user/repo.git",
+            "https://gitlab.com/user/repo.git",
+            "https://evil.example/?github.com",
+        ],
+    )
+    def test_not_github(self, url):
+        assert is_github_repo_url(url) is False
 
 
 class TestParseRepoUrlBareHostname:

--- a/compute_space/src/compute_space/tests/test_parse_repo_url.py
+++ b/compute_space/src/compute_space/tests/test_parse_repo_url.py
@@ -5,7 +5,11 @@ parse_repo_url must correctly handle URLs with embedded credentials
 is not a real URL scheme and prepending https://.
 """
 
+import pytest
+
 from compute_space.core.apps import parse_repo_url
+from compute_space.core.git_ops import UnsupportedRepoUrlError
+from compute_space.core.git_ops import is_ssh_url
 
 
 class TestParseRepoUrlCredentialUrls:
@@ -31,7 +35,7 @@ class TestParseRepoUrlCredentialUrls:
 
 
 class TestParseRepoUrlKnownSchemes:
-    """Known schemes (http, https, ssh, git, file) should be preserved."""
+    """Supported schemes (http, https, git, file) should be preserved."""
 
     def test_https_url(self):
         url, ref = parse_repo_url("https://github.com/user/repo.git")
@@ -43,11 +47,6 @@ class TestParseRepoUrlKnownSchemes:
         assert url == "http://github.com/user/repo.git"
         assert ref is None
 
-    def test_ssh_url(self):
-        url, ref = parse_repo_url("ssh://git@github.com/user/repo.git")
-        assert url == "ssh://git@github.com/user/repo.git"
-        assert ref is None
-
     def test_git_url(self):
         url, ref = parse_repo_url("git://github.com/user/repo.git")
         assert url == "git://github.com/user/repo.git"
@@ -57,6 +56,63 @@ class TestParseRepoUrlKnownSchemes:
         url, ref = parse_repo_url("file:///home/user/repo")
         assert url == "file:///home/user/repo"
         assert ref is None
+
+
+class TestParseRepoUrlSshRejected:
+    """SSH URLs are unsupported; parse_repo_url rejects them with a clear error."""
+
+    @pytest.mark.parametrize(
+        "ssh_url",
+        [
+            "git@github.com:user/repo.git",
+            "git@github.com:user/repo.git@main",
+            "git@gitlab.com:group/subgroup/repo.git",
+            "ssh://git@github.com/user/repo.git",
+            "ssh://git@github.com:22/user/repo.git",
+        ],
+    )
+    def test_ssh_urls_raise(self, ssh_url):
+        with pytest.raises(UnsupportedRepoUrlError):
+            parse_repo_url(ssh_url)
+
+    def test_error_message_points_to_https(self):
+        with pytest.raises(UnsupportedRepoUrlError) as excinfo:
+            parse_repo_url("git@github.com:user/repo.git")
+        assert "HTTPS" in str(excinfo.value)
+
+
+class TestIsSshUrl:
+    """is_ssh_url distinguishes SSH transport from HTTPS/credential URLs."""
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "git@github.com:user/repo.git",
+            "git@github.com:user/repo.git@main",
+            "git@gitlab.com:group/subgroup/repo.git",
+            "ssh://git@github.com/user/repo.git",
+            "ssh://git@github.com:22/user/repo.git",
+        ],
+    )
+    def test_ssh(self, url):
+        assert is_ssh_url(url) is True
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "https://github.com/user/repo.git",
+            "http://github.com/user/repo.git",
+            "https://git@github.com/user/repo.git",
+            "git://github.com/user/repo.git",
+            "file:///home/user/repo",
+            "github.com/user/repo.git",
+            # Credential-bearing URLs: the '@' follows the colon, not an scp host.
+            "oauth2:glpat-xxxx@gitlab.com/user/repo.git",
+            "user:pass@github.com/user/repo.git",
+        ],
+    )
+    def test_not_ssh(self, url):
+        assert is_ssh_url(url) is False
 
 
 class TestParseRepoUrlBareHostname:

--- a/compute_space/src/compute_space/tests/test_set_app_remote.py
+++ b/compute_space/src/compute_space/tests/test_set_app_remote.py
@@ -111,6 +111,53 @@ def test_set_app_remote_rejects_builtin_without_git(cfg: Any, tmp_path: Path) ->
     assert "no git repository" in resp.json()["error"].lower()
 
 
+@pytest.mark.parametrize(
+    "ssh_url",
+    ["git@github.com:user/repo.git", "ssh://git@github.com/user/repo.git"],
+)
+def test_set_app_remote_rejects_ssh_url(cfg: Any, tmp_path: Path, ssh_url: str) -> None:
+    """The remote-update box rejects SSH URLs with an HTTPS-pointing error and
+    leaves the stored upstream unchanged."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init")
+    app_id = _seed_git_app(cfg, "myapp", str(repo), repo_url="https://github.com/old/repo")
+    cookies = auth_cookie(cfg)
+    with TestClient(app=make_test_app(api_apps_routes)) as client:
+        resp = client.post(f"/set_app_remote/{app_id}", json={"repo_url": ssh_url}, cookies=cookies)
+    assert resp.status_code == 400, resp.text
+    assert "HTTPS" in resp.json()["error"]
+
+    db = sqlite3.connect(cfg.db_path)
+    try:
+        stored = db.execute("SELECT repo_url FROM apps WHERE app_id = ?", (app_id,)).fetchone()[0]
+    finally:
+        db.close()
+    assert stored == "https://github.com/old/repo"
+
+
+@pytest.mark.parametrize(
+    "ssh_url",
+    ["git@github.com:user/repo.git", "ssh://git@github.com/user/repo.git"],
+)
+def test_clone_and_get_app_info_rejects_ssh_url(cfg: Any, ssh_url: str) -> None:
+    """The deploy page (clone-and-inspect) rejects SSH URLs up front with a
+    clear error — no clone attempt, no GitHub OAuth bounce."""
+    cookies = auth_cookie(cfg)
+    with TestClient(app=make_test_app(api_apps_routes)) as client:
+        resp = client.post("/api/clone_and_get_app_info", json={"repo_url": ssh_url}, cookies=cookies)
+    assert resp.status_code == 400, resp.text
+    assert "HTTPS" in resp.json()["error"]
+
+
+def test_git_pull_rejects_ssh_url(tmp_path: Path) -> None:
+    """git_pull (the Update & Reload path) fails cleanly on an SSH upstream
+    rather than mangling it into a broken HTTPS URL."""
+    ok, err = git_pull(str(tmp_path), "myapp", repo_url="git@github.com:user/repo.git")
+    assert ok is False
+    assert err is not None and "HTTPS" in err
+
+
 def test_set_app_remote_rejects_empty(cfg: Any, tmp_path: Path) -> None:
     repo = tmp_path / "repo"
     repo.mkdir()

--- a/compute_space/src/compute_space/web/routes/api/apps.py
+++ b/compute_space/src/compute_space/web/routes/api/apps.py
@@ -36,6 +36,7 @@ from compute_space.core.containers import BUILD_CACHE_CORRUPT_MARKER
 from compute_space.core.containers import get_docker_logs
 from compute_space.core.containers import stop_app_process
 from compute_space.core.containers import stop_container
+from compute_space.core.git_ops import UnsupportedRepoUrlError
 from compute_space.core.git_ops import get_branch_name
 from compute_space.core.git_ops import get_head_sha
 from compute_space.core.git_ops import is_dirty
@@ -221,7 +222,12 @@ async def _pin_refless_to_landed_branch(repo_url: str | None, repo_path: str) ->
     """
     if not repo_url:
         return None
-    base_url, ref = parse_repo_url(repo_url)
+    try:
+        base_url, ref = parse_repo_url(repo_url)
+    except UnsupportedRepoUrlError:
+        # A stored SSH upstream can't be pinned (and shouldn't exist after the
+        # set_app_remote guard); leave it untouched rather than crashing.
+        return None
     if ref or not os.path.isdir(os.path.join(repo_path, ".git")):
         return None
     landed = await get_branch_name(Path(repo_path))
@@ -928,7 +934,10 @@ async def set_app_remote(
 
     # Normalise via parse_repo_url so a bare hostname gets an https:// scheme
     # and the stored value matches what git_pull will re-point origin to.
-    base_url, ref = parse_repo_url(repo_url)
+    try:
+        base_url, ref = parse_repo_url(repo_url)
+    except UnsupportedRepoUrlError as e:
+        return Response(content=ErrorResponse(error=str(e)), status_code=400)
     normalized = f"{base_url}@{ref}" if ref else base_url
 
     db.execute("UPDATE apps SET repo_url = ? WHERE app_id = ?", (normalized, app_id))

--- a/compute_space/src/compute_space/web/routes/api/apps.py
+++ b/compute_space/src/compute_space/web/routes/api/apps.py
@@ -40,6 +40,7 @@ from compute_space.core.git_ops import UnsupportedRepoUrlError
 from compute_space.core.git_ops import get_branch_name
 from compute_space.core.git_ops import get_head_sha
 from compute_space.core.git_ops import is_dirty
+from compute_space.core.git_ops import is_github_repo_url
 from compute_space.core.git_ops import parse_repo_url
 from compute_space.core.logging import logger
 from compute_space.core.manifest import parse_manifest
@@ -557,7 +558,7 @@ async def _reload_app_impl(
                     repo_url=repo_url,
                 )
 
-            if not pull_ok and "github.com" in repo_url:
+            if not pull_ok and is_github_repo_url(repo_url):
                 lf.write("Attempting git pull with github oauth\n")
                 lf.flush()
                 return_to = f"//{config.zone_domain}/reload_app/{app_id}?continue_oauth_update=1"

--- a/compute_space/src/compute_space/web/routes/pages/apps.py
+++ b/compute_space/src/compute_space/web/routes/pages/apps.py
@@ -14,6 +14,7 @@ from compute_space.core.apps import deserialize_links
 from compute_space.core.apps import list_builtin_apps
 from compute_space.core.auth.permissions_v2 import get_all_permissions_v2
 from compute_space.core.containers import get_docker_logs
+from compute_space.core.git_ops import UnsupportedRepoUrlError
 from compute_space.core.git_ops import get_head_sha
 from compute_space.core.git_ops import get_remote_url
 from compute_space.core.git_ops import parse_repo_url
@@ -131,7 +132,12 @@ async def _resolve_edit_app(
             return None
         repo_url = openhost_remote
         repo_path = str(config.openhost_repo_path)
-    base_url, ref_from_url = parse_repo_url(repo_url)
+    try:
+        base_url, ref_from_url = parse_repo_url(repo_url)
+    except UnsupportedRepoUrlError:
+        # Legacy SSH upstream (set_app_remote rejects these now): fall back to a
+        # plain link to the raw URL rather than failing the detail page render.
+        return {"mode": "repo", "href": repo_url}
     repo_link_fallback = {"mode": "repo", "href": base_url}
     ref = ref_from_url
     if not ref:


### PR DESCRIPTION
## What

Pasting an SSH git URL (e.g. `git@github.com:piuccio/cowsay.git`) into the **app deploy page** or the **remote-update box** never worked — and failed misleadingly.

`parse_repo_url` saw an SCP-style URL had no scheme, prepended `https://`, and produced a malformed `https://git@github.com:piuccio/...` where git reads `piuccio` as a port:

```
fatal: unable to access 'https://github.com:piuccio/cowsay.git/':
URL rejected: Port number was not a decimal number between 0 and 65535
```

Worse, because the string contains `github.com`, it then bounced the owner through a pointless GitHub OAuth authorize flow that still failed.

## Change

We only support HTTPS clones, so this **recognizes SSH URLs and rejects them up front** with a message pointing at the HTTPS clone URL — rather than mangling them.

- `git_ops.py`: new `is_ssh_url()` (matches `ssh://` and SCP-style `git@host:path`); `parse_repo_url()` raises `UnsupportedRepoUrlError` for SSH before the bare-hostname `https://`-prepend. The SCP regex deliberately does **not** misfire on credential URLs like `oauth2:TOKEN@host/path`.
- Wired into all three surfaces with friendly errors: deploy page (`/api/clone_and_get_app_info`), remote-update box (`/set_app_remote`), and Update & Reload (`git_pull`).
- Skips the GitHub OAuth fallback for SSH URLs (it would just fail again).
- Defensive catches in the detail-page render and refless-branch pinning so any legacy stored `ssh://` upstream degrades to a plain link instead of 500-ing.

`git://` is left untouched (only SSH was in scope).

## Tests

- `test_parse_repo_url.py`: flipped the old "ssh:// passes through" expectation to rejection; added SSH-rejection cases and full `is_ssh_url` coverage (incl. credential-URL non-SSH cases).
- `test_set_app_remote.py`: SSH rejection across `/set_app_remote`, `/api/clone_and_get_app_info`, and `git_pull`.
- Full compute_space suite: `592 passed, 32 skipped`. ruff + mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)