### PR TITLE
Disable setup submit button to prevent double-submit

### DIFF
--- a/compute_space/src/compute_space/tests/test_owner_username.py
+++ b/compute_space/src/compute_space/tests/test_owner_username.py
@@ -416,6 +416,18 @@ def test_setup_invalid_username_re_renders_form(cfg: Any, setup_client: TestClie
         conn.close()
 
 
+def test_setup_get_disables_submit_button_to_prevent_double_submit(setup_client: TestClient[Litestar]) -> None:
+    """Owner provisioning is a one-time, non-idempotent POST, so a double-click
+    must not be able to fire a second /setup request. The rendered form wires a
+    submit handler that disables the submit button on first submit."""
+    resp = setup_client.get("/setup")
+    assert resp.status_code == 200, resp.text
+    body = resp.text
+    assert 'id="setup-form"' in body
+    assert "addEventListener('submit'" in body
+    assert "btn.disabled = true" in body
+
+
 # ---------------------------------------------------------------------------
 # /login: session resolves to persisted username (mirror invariant of /setup)
 # ---------------------------------------------------------------------------

--- a/compute_space/src/compute_space/web/templates/setup.html
+++ b/compute_space/src/compute_space/web/templates/setup.html
@@ -31,5 +31,18 @@
     <input type="password" name="confirm_password" required>
     <input type="submit" id="submit-btn" value="Set Password">
   </form>
+  <script>
+    // Guard against double-submit: provisioning the owner is a one-time,
+    // non-idempotent POST, so a double-click would fire a second /setup
+    // request that races the first. Disable the button once the form is
+    // actually submitting. Using the 'submit' event (not 'click') means a
+    // failed HTML5 validation pass never disables the button, and because
+    // the button has no 'name' it's never part of the posted form data.
+    document.getElementById('setup-form').addEventListener('submit', function () {
+      var btn = document.getElementById('submit-btn');
+      btn.disabled = true;
+      btn.value = 'Setting up\u2026';
+    });
+  </script>
 </body>
 </html>


### PR DESCRIPTION
## Problem

The first-boot `/setup` form lets the operator set the owner password. The
"Set Password" submit button could be clicked twice, firing two `POST /setup`
requests. Owner provisioning is one-time and **non-idempotent**: the second
request races the first (the second `INSERT` into `users` hits a constraint,
and it collides with the post-setup restart trigger), which can leave the
setup flow in a confusing/broken state.

## Fix

Disable the submit button as soon as the form actually submits, in
`setup.html`:

- Hooks the form's `submit` event (not the button's `click`), so a failed
  HTML5 validation pass never disables the button.
- The submit button has no `name`, so disabling it doesn't drop any posted
  form data.
- Updates the label to "Setting up…" for feedback.

This is a minimal, client-side guard against double submission.

## Tests

Added `test_setup_get_disables_submit_button_to_prevent_double_submit`, which
asserts the rendered `/setup` page wires the disable-on-submit guard.

## Vetting

- `ruff check` + `ruff format --check`: clean
- `mypy` (strict): `Success: no issues found in 142 source files`
- `pytest compute_space/.../test_owner_username.py`: 37 passed
- Full default suite: 696 passed, 43 skipped (the one unrelated failure,
  `test_pixi_check`, is an environment artifact — `pixi` isn't installed in
  the sandbox).
