### PR TITLE
app_detail: make all buttons uniform, dedupe inline styles

### DIFF
--- a/compute_space/src/compute_space/web/templates/app_detail.html
+++ b/compute_space/src/compute_space/web/templates/app_detail.html
@@ -15,13 +15,13 @@
   <tr><th>URL</th><td>
     <span id="name-display">
       <a href="{{ app_url(app.name) }}">{{ app_url(app.name) }}</a>
-      <button class="btn" onclick="editName()" style="margin-left:0.5em;padding:0.1em 0.5em;font-size:0.85em;">Edit</button>
+      <button class="btn" onclick="editName()" style="margin-left:0.5em;">Edit</button>
     </span>
     <span id="name-edit" style="display:none;">
       <input type="text" id="name-input" value="{{ app.name }}" style="font-family:monospace;width:15em;">
-      <button class="btn btn-primary" onclick="saveName()" style="padding:0.1em 0.5em;font-size:0.85em;">Save</button>
-      <button class="btn" onclick="cancelName()" style="padding:0.1em 0.5em;font-size:0.85em;">Cancel</button>
-      <span id="name-error" style="color:#c00;font-size:0.85em;"></span>
+      <button class="btn btn-primary" onclick="saveName()">Save</button>
+      <button class="btn" onclick="cancelName()">Cancel</button>
+      <span id="name-error" class="field-error"></span>
     </span>
   </td></tr>
   <tr><th>Local Port</th><td>{{ app.local_port }}</td></tr>
@@ -32,14 +32,14 @@
   <tr><th>Git URL</th><td>
     <span id="remote-display">
       <code>{{ app.repo_url }}</code>
-      <button class="btn" onclick="editRemote()" style="margin-left:0.5em;padding:0.1em 0.5em;font-size:0.85em;">Edit</button>
+      <button class="btn" onclick="editRemote()" style="margin-left:0.5em;">Edit</button>
     </span>
     <span id="remote-edit" style="display:none;">
       <input type="text" id="remote-input" value="{{ app.repo_url }}" style="font-family:monospace;width:28em;" placeholder="https://github.com/owner/repo@branch">
-      <button class="btn btn-primary" onclick="saveRemote()" style="padding:0.1em 0.5em;font-size:0.85em;">Save &amp; update</button>
-      <button class="btn" onclick="cancelRemote()" style="padding:0.1em 0.5em;font-size:0.85em;">Cancel</button>
-      <div style="color:#666;font-size:0.8em;margin-top:0.25em;">Append <code>@branch</code> (or a tag/commit) to change the ref. Saving re-points the upstream and pulls the latest code.</div>
-      <span id="remote-error" style="color:#c00;font-size:0.85em;"></span>
+      <button class="btn btn-primary" onclick="saveRemote()">Save &amp; update</button>
+      <button class="btn" onclick="cancelRemote()">Cancel</button>
+      <div class="hint" style="margin-top:0.25em;">Append <code>@branch</code> (or a tag/commit) to change the ref. Saving re-points the upstream and pulls the latest code.</div>
+      <span id="remote-error" class="field-error"></span>
     </span>
   </td></tr>
   {% endif %}
@@ -126,7 +126,7 @@
   <tr>
     <td><code>{{ p.service_url }}</code></td>
     <td><code>{{ p.grant | tojson }}</code></td>
-    <td><button class="btn btn-primary" style="padding:0.1em 0.5em;font-size:0.85em;"
+    <td><button class="btn btn-primary"
       data-perm-idx="{{ loop.index0 }}"
       onclick="grantPermission(this)">Grant</button></td>
   </tr>

--- a/compute_space/src/compute_space/web/templates/layout.html
+++ b/compute_space/src/compute_space/web/templates/layout.html
@@ -15,6 +15,7 @@
     nav a { margin-right: 1.5em; }
     nav .spacer { flex: 1; }
     .error { color: #c00; }
+    .field-error { color: #c00; font-size: 0.85em; }
     .status-running { color: #080; font-weight: bold; }
     .status-error { color: #c00; font-weight: bold; }
     .status-stopped { color: #888; }


### PR DESCRIPTION
## Summary
On the app detail page, several buttons (the two **Edit** buttons, **Save**/**Cancel** in the inline editors, and **Grant**) carried inline `padding:0.1em 0.5em;font-size:0.85em;` overrides that made them visibly smaller than the standard `.btn` buttons in the action bar.

- Drop those inline overrides so every button uses the shared `.btn` / `.btn-primary` styling — all buttons now look the same.
- Consolidate the repeated inline error-span style into a new `.field-error` class in the layout stylesheet.
- Reuse the existing `.hint` class for the Git-URL helper text instead of an inline style.

## Test plan
- [ ] Load an app detail page; confirm Edit / Save / Cancel / Grant buttons match the action-bar buttons in size and font.
- [ ] Trigger a name/remote save error; confirm the inline error text still renders red and small via `.field-error`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-authored-by: Sculptor <sculptor@imbue.com>