### PR TITLE
Fix X-Forwarded-Proto/For not reaching apps correctly behind Caddy

### DIFF
--- a/compute_space/src/compute_space/tests/test_integration.py
+++ b/compute_space/src/compute_space/tests/test_integration.py
@@ -1103,23 +1103,28 @@ class TestContainerE2E:
         assert headers_ci.get("x-custom-test") == "test-value"
         assert "x-forwarded-for" in headers_ci
         assert "x-forwarded-host" in headers_ci
+        assert headers_ci.get("x-forwarded-proto") == "http"  # tls_enabled is False in tests
 
-    def test_proxy_strips_spoofed_forwarded_headers(self, admin_session, config):
-        """Client-supplied X-Forwarded-* headers are overwritten, not forwarded."""
+    def test_proxy_forwarded_headers_trust_model(self, admin_session, config):
+        """X-Forwarded-Proto/Host are derived by the router, never taken from the
+        client.  X-Forwarded-For is trusted only from the loopback front proxy —
+        which the test client is — so its value is passed through to the app."""
         r = admin_session.get(
             f"{_app_url(config, 'test-app')}/echo-headers",
             headers={
-                "X-Forwarded-For": "attacker-ip",
+                "X-Forwarded-For": "203.0.113.7",
                 "X-Forwarded-Proto": "evil",
                 "X-Forwarded-Host": "evil.example.com",
             },
         )
         assert r.status_code == 200
-        headers = r.json()["headers"]
-        # Router must overwrite, not append to, client-supplied values
-        assert "attacker-ip" not in headers.get("X-Forwarded-For", "")
-        assert headers.get("X-Forwarded-Proto") != "evil"
-        assert headers.get("X-Forwarded-Host") != "evil.example.com"
+        headers = {k.lower(): v for k, v in r.json()["headers"].items()}
+        # proto/host come from the router (config + Host), not the client
+        assert headers.get("x-forwarded-proto") == "http"  # tls_enabled is False in tests
+        assert headers.get("x-forwarded-host") != "evil.example.com"
+        # the caller reaches us over loopback, so it's the trusted front proxy:
+        # its X-Forwarded-For (the real client IP) is honored.
+        assert headers.get("x-forwarded-for") == "203.0.113.7"
 
     def test_proxy_strips_zone_auth_cookies(self, admin_session, config):
         """The owner's zone_auth / zone_refresh cookies must not reach the backend app."""

--- a/compute_space/src/compute_space/tests/test_subdomain_proxy.py
+++ b/compute_space/src/compute_space/tests/test_subdomain_proxy.py
@@ -1,0 +1,50 @@
+"""Unit tests for the subdomain proxy middleware's forwarding helpers."""
+
+from typing import Any
+
+from litestar.connection import ASGIConnection
+
+from compute_space.web.middleware.subdomain_proxy import _resolve_forwarded_for
+
+
+def _connection(client_host: str | None, xff: str | None = None) -> ASGIConnection[Any, Any, Any, Any]:
+    headers = [(b"x-forwarded-for", xff.encode())] if xff is not None else []
+    scope = {
+        "type": "http",
+        "method": "GET",
+        "path": "/",
+        "raw_path": b"/",
+        "query_string": b"",
+        "headers": headers,
+        "client": (client_host, 12345) if client_host is not None else None,
+        "server": ("testzone.local", 80),
+        "scheme": "http",
+    }
+    return ASGIConnection(scope)  # type: ignore[arg-type]
+
+
+def test_loopback_peer_trusts_inbound_xff() -> None:
+    """Caddy on loopback set X-Forwarded-For to the real client IP — trust it."""
+    conn = _connection("127.0.0.1", xff="203.0.113.7")
+    assert _resolve_forwarded_for(conn) == "203.0.113.7"
+
+
+def test_loopback_peer_without_inbound_falls_back_to_peer() -> None:
+    conn = _connection("127.0.0.1")
+    assert _resolve_forwarded_for(conn) == "127.0.0.1"
+
+
+def test_non_loopback_peer_ignores_spoofed_xff() -> None:
+    """A container reaching us via the gateway can't spoof the client IP."""
+    conn = _connection("10.200.0.5", xff="203.0.113.7")
+    assert _resolve_forwarded_for(conn) == "10.200.0.5"
+
+
+def test_ipv6_loopback_peer_trusts_inbound_xff() -> None:
+    conn = _connection("::1", xff="203.0.113.7")
+    assert _resolve_forwarded_for(conn) == "203.0.113.7"
+
+
+def test_no_client_returns_none() -> None:
+    conn = _connection(None)
+    assert _resolve_forwarded_for(conn) is None

--- a/compute_space/src/compute_space/web/middleware/subdomain_proxy.py
+++ b/compute_space/src/compute_space/web/middleware/subdomain_proxy.py
@@ -25,6 +25,28 @@ from compute_space.web.helpers.proxy import proxy_websocket_request
 
 IS_OWNER_HEADER = ("X-OpenHost-Is-Owner", "true")
 
+# Caddy (our front proxy) reaches hypercorn over loopback and, by default,
+# strips client-spoofed X-Forwarded-* before forwarding.  So we trust the
+# X-Forwarded-For it sets; any other peer (e.g. a container reaching us via the
+# 10.200.0.1 gateway) is untrusted and can't dictate the chain.
+_LOOPBACK_HOSTS = frozenset({"127.0.0.1", "::1"})
+
+
+def _resolve_forwarded_for(connection: ASGIConnection[Any, Any, Any, Any]) -> str | None:
+    """The X-Forwarded-For value to pass to the backend app.
+
+    When the peer is the loopback front proxy (Caddy), forward the
+    X-Forwarded-For it set — it carries the real client IP.  For any other peer,
+    use the peer's own address so an untrusted source can't spoof the chain.
+    """
+    if connection.client is None:
+        return None
+    if connection.client.host in _LOOPBACK_HOSTS:
+        # the real client IP, as recorded by Caddy. port should not be included.
+        if inbound := connection.headers.get("x-forwarded-for"):
+            return inbound
+    return connection.client.host
+
 
 async def _send_bad_request(scope: Scope, send: Send) -> None:
     """Best-effort 400/close for malformed requests where Litestar's response
@@ -130,13 +152,21 @@ class SubdomainProxyMiddleware:
 
         # TODO: maybe behave differently for apps that are not in running state. not sure
 
-        # add forwarding headers for the openhost app, so it can tell where the request came from.
-        # these are annoying but unavoidable - we can't spoof the IP or proto in the forwarded request.
-        # X-Forwarded-Host preserves the original Host so apps that build absolute URLs don't use the proxy's internal hostname
-        extra_headers = [("X-Forwarded-Host", netloc)]
-        if connection.client:
-            # client IP; for some reason this is allowed to be None in ASGI. port should not be included.
-            extra_headers.append(("X-Forwarded-For", f"{connection.client.host}"))
+        # Forwarding headers so the app can tell where the request originated.
+        # Caddy terminates TLS and speaks plain HTTP to us on loopback, so we
+        # can't read the client's real proto or IP off this hop:
+        #  - proto: scope["scheme"] is always "http"; derive it from config
+        #    instead (the :80->:443 redirect means nothing is proxied in the
+        #    clear when TLS is on), matching build_login_url.
+        #  - client IP: connection.client is always Caddy; recover the real one
+        #    from the X-Forwarded-For Caddy set (see _resolve_forwarded_for).
+        # X-Forwarded-Host preserves the original Host so apps that build absolute URLs don't use the proxy's internal hostname.
+        extra_headers = [
+            ("X-Forwarded-Host", netloc),
+            ("X-Forwarded-Proto", "https" if get_config().tls_enabled else "http"),
+        ]
+        if forwarded_for := _resolve_forwarded_for(connection):
+            extra_headers.append(("X-Forwarded-For", forwarded_for))
 
         try:
             verify_owner_auth(connection)
@@ -159,7 +189,6 @@ class SubdomainProxyMiddleware:
                 return
 
         if scope["type"] == ScopeType.HTTP:
-            extra_headers.append(("X-Forwarded-Proto", scope["scheme"]))
             proxied = await proxy_http_request(
                 Request(scope, receive, send),
                 target_port=app.local_port,

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -229,9 +229,11 @@ class TestSelfHost:
         # X-Forwarded-* are set by the proxy
         assert "x-forwarded-for" in headers
         assert "x-forwarded-host" in headers
-        # Spoofed values are overwritten
+        # The client connected over HTTPS (Caddy terminates TLS); the app must
+        # see that, even though the router talks plain HTTP to Caddy internally.
+        assert headers.get("x-forwarded-proto") == "https"
+        # Spoofed values are overwritten (Caddy drops them before the router).
         assert "attacker-ip" not in headers.get("x-forwarded-for", "")
-        assert headers.get("x-forwarded-proto") != "evil"
         assert headers.get("x-forwarded-host") != "evil.example.com"
 
     def test_07e_subdomain_unauth_rejected(self, domain):


### PR DESCRIPTION
## Problem

Caddy terminates TLS and proxies to hypercorn over plain HTTP on loopback. The subdomain proxy stripped the inbound `X-Forwarded-*` headers and rebuilt them from that internal hop, discarding the authentic values Caddy had set:

- **`X-Forwarded-Proto`** was set from `scope["scheme"]`, which is *always* `"http"` behind Caddy. So **every app behind TLS saw `X-Forwarded-Proto: http`** — breaking secure-cookie flags, absolute-URL/redirect building, OAuth `redirect_uri`, HSTS, and framework "am I on HTTPS?" checks. (The codebase already worked around this exact issue in `build_login_url`.)
- **`X-Forwarded-For`** was set from `connection.client.host`, which behind Caddy is *always* `127.0.0.1`. Apps never saw the real client IP (rate-limiting, geo, audit logs).
- The **WebSocket** path set no `X-Forwarded-Proto` at all.

Caddy's documented default (no `trusted_proxies` is configured) is to strip client-spoofed `X-Forwarded-*` and set authentic values — so the values reaching hypercorn from Caddy are trustworthy, and the proxy was throwing them away.

## Fix (`subdomain_proxy.py`)

- **`X-Forwarded-Proto`** → derived from `config.tls_enabled` (`https`/`http`), now set for both HTTP and WebSocket. Not spoofable; correct because the `:80→:443` redirect means nothing is ever proxied in the clear when TLS is on.
- **`X-Forwarded-For`** → new `_resolve_forwarded_for()`: trusts the inbound XFF **only when the peer is loopback** (Caddy), otherwise falls back to the peer address — so a container on the `10.200.0.x` gateway can't spoof it.
- **`X-Forwarded-Host`** → unchanged (already used the original Host).

## Tests

- New `tests/test_subdomain_proxy.py` unit tests for `_resolve_forwarded_for` (loopback trusts inbound, IPv6 loopback, **non-loopback ignores spoof**, fallback, no-client) — runs in the default suite.
- Updated the integration anti-spoof test to the trust-front-proxy model and fixed it to normalize header case (the old assertions were silently vacuous).
- Strengthened the e2e test to assert `x-forwarded-proto == "https"` end-to-end through real Caddy.

`609 passed, 32 skipped` (container/TLS skips on macOS) + 5 new unit tests. `mypy`/`ruff` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)