### PR TITLE
e2e: deploy the merge commit so test code and deployed code match

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -37,7 +37,12 @@ jobs:
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       AWS_DEFAULT_REGION: us-east-1
       SKIP_APT_UPGRADE: "1"
-      OPENHOST_COMMIT: ${{ github.event.pull_request.head.sha || github.sha }}
+      # Deploy the same commit the test code is checked out from (github.sha):
+      # the PR merge commit on pull_request, the pushed commit otherwise. The
+      # merge commit only lives on refs/pull/N/merge, so pass that as a refspec
+      # for the VM's clone to fetch it.
+      OPENHOST_COMMIT: ${{ github.sha }}
+      OPENHOST_REFSPEC: ${{ github.event.pull_request.number && format('refs/pull/{0}/merge', github.event.pull_request.number) || '' }}
       # GCP-specific
       GCP_PROJECT: ${{ secrets.GCP_PROJECT_ID }}
       GCP_ZONE: ${{ vars.GCP_ZONE || 'us-central1-a' }}

--- a/ansible/tasks/sync_code.yml
+++ b/ansible/tasks/sync_code.yml
@@ -1,12 +1,15 @@
 ---
 # Clone repo from GitHub and optionally checkout a specific commit.
 # Pass -e openhost_commit=<sha> to pin a specific version.
+# Pass -e openhost_refspec=<ref> to also fetch a ref that the commit lives on
+# (e.g. refs/pull/N/merge), for commits not reachable from any branch.
 
 - name: Clone or update openhost repo
   ansible.builtin.git:
     repo: https://github.com/imbue-openhost/openhost.git
     dest: /home/host/openhost
     version: "{{ openhost_commit | default('main') }}"
+    refspec: "{{ openhost_refspec | default(omit) }}"
     force: true
 
 - name: Remove untracked files from openhost repo

--- a/tests/common.sh
+++ b/tests/common.sh
@@ -145,6 +145,8 @@ EOF
 # Environment:
 #   SKIP_APT_UPGRADE=1    — skip apt dist-upgrade (speeds up ephemeral CI instances)
 #   OPENHOST_COMMIT=<sha> — deploy a specific git commit (defaults to main)
+#   OPENHOST_REFSPEC=<ref> — extra refspec to fetch so OPENHOST_COMMIT is reachable
+#                            (e.g. refs/pull/N/merge for a PR merge commit)
 run_ansible_setup() {
     local ip="$1" ssh_key="$2" domain="$3" ssh_user="${4:-ubuntu}"
     local repo_dir
@@ -165,6 +167,10 @@ run_ansible_setup() {
     if [ -n "${OPENHOST_COMMIT:-}" ]; then
         extra_vars+=(-e "openhost_commit=$OPENHOST_COMMIT")
         echo "  (deploying commit $OPENHOST_COMMIT)"
+    fi
+    if [ -n "${OPENHOST_REFSPEC:-}" ]; then
+        extra_vars+=(-e "openhost_refspec=$OPENHOST_REFSPEC")
+        echo "  (fetching refspec $OPENHOST_REFSPEC)"
     fi
     if [ -n "${CLAIM_TOKEN:-}" ]; then
         extra_vars+=(-e "claim_token=$CLAIM_TOKEN")


### PR DESCRIPTION
## Problem

The `e2e` job tested **different code than it deployed** on `pull_request` events:

- **Test code** came from `actions/checkout`'s default ref → the PR **merge** commit (`github.sha`).
- **Deployed code** came from `OPENHOST_COMMIT: github.event.pull_request.head.sha` → the **unmerged** branch tip, cloned onto the VM by `ansible/tasks/sync_code.yml`.

So new test assertions could run against old deployed code (or vice versa), producing failures unrelated to the PR's own diff. Concretely: a PR branched before #179 (X-Forwarded-Proto fix) deployed the old proxy (emits `http`) while running the post-#179 test (`assert x-forwarded-proto == "https"`) → red, even though the PR's diff was unrelated. (`push` events were already consistent — `OPENHOST_COMMIT` fell through to `github.sha`.)

## Fix

Deploy `github.sha` — the *same* commit the test code is checked out from (the PR merge commit on `pull_request`, the pushed commit otherwise). That merge commit only lives on `refs/pull/N/merge` and isn't reachable from any branch, so pass it as a refspec for the VM's `git` clone to fetch.

- `.github/workflows/e2e.yml`: `OPENHOST_COMMIT: ${{ github.sha }}` + `OPENHOST_REFSPEC` = `refs/pull/N/merge` on PRs (empty otherwise).
- `tests/common.sh`: thread `OPENHOST_REFSPEC` through as the `openhost_refspec` ansible var.
- `ansible/tasks/sync_code.yml`: `refspec: "{{ openhost_refspec | default(omit) }}"` — **omitted when unset, so production deploys are unchanged.**

Result: deployed code == test code == the PR merged into `main`, for `pull_request`, `push`, and `workflow_dispatch`.

## Notes / caveats

- Relies on the repo being **public** (the VM fetches `refs/pull/N/merge` unauthenticated — verified it resolves).
- If a PR has merge conflicts with `main`, GitHub doesn't produce a fresh merge ref; that PR can't be merged anyway, so a red e2e is acceptable.
- Verified locally: YAML parses, `common.sh` passes `bash -n`. The real proof is this PR's own e2e run going green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)