### PR TITLE
Dashboard heading: prefer owner username over zone name

### DIFF
--- a/compute_space/src/compute_space/tests/test_dashboard_title.py
+++ b/compute_space/src/compute_space/tests/test_dashboard_title.py
@@ -1,0 +1,121 @@
+"""Tests for the dashboard/layout heading name.
+
+The top-of-page ``<h1>`` (and ``<title>``) prefers the owner's configured
+username over the zone subdomain, falling back to the zone name (and then to
+"OpenHost") when no username is set. The name is exposed to templates via the
+``owner_name`` callable installed in ``_template_globals``.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Any
+
+import pytest
+from litestar import Litestar
+from litestar.contrib.jinja import JinjaTemplateEngine
+from litestar.di import Provide
+from litestar.template.config import TemplateConfig
+from litestar.testing import TestClient
+
+from compute_space.config import provide_config
+from compute_space.config import set_active_config
+from compute_space.core.auth.auth import update_owner_username
+from compute_space.db import provide_db
+from compute_space.db.connection import init_db
+from compute_space.web.app import _template_globals
+from compute_space.web.routes.pages.apps import dashboard
+
+from ._litestar_helpers import auth_cookie
+from ._litestar_helpers import seed_user
+from .conftest import _make_test_config
+
+
+def _seed_username(db_path: str, username: str) -> None:
+    conn = sqlite3.connect(db_path)
+    try:
+        conn.row_factory = sqlite3.Row
+        update_owner_username(conn, username)
+        conn.commit()
+    finally:
+        conn.close()
+
+
+@pytest.fixture
+def cfg(tmp_path: Path) -> Iterator[Any]:
+    config = _make_test_config(tmp_path, zone_domain="alice-zone.example.com")
+    init_db(config.db_path)
+    yield config
+
+
+def _build_app(cfg: Any) -> Litestar:
+    """A minimal app with the real dashboard route + Jinja globals installed."""
+    web_dir = Path(__file__).resolve().parents[1] / "web"
+    template_config: TemplateConfig[JinjaTemplateEngine] = TemplateConfig(
+        directory=web_dir / "templates",
+        engine=JinjaTemplateEngine,
+    )
+
+    def _install_globals(app: Litestar) -> None:
+        engine = app.template_engine
+        if isinstance(engine, JinjaTemplateEngine):
+            engine.engine.globals.update(_template_globals(cfg, web_dir / "static"))
+
+    app = Litestar(
+        route_handlers=[dashboard],
+        template_config=template_config,
+        dependencies={
+            "config": Provide(provide_config, sync_to_thread=False),
+            "db": Provide(provide_db),
+        },
+        on_startup=[_install_globals],
+        openapi_config=None,
+    )
+    # The dashboard route is guarded by require_owner_auth; tests below provide a
+    # real session cookie, so no guard override is needed.
+    return app
+
+
+def test_heading_uses_zone_name_when_no_username(cfg: Any) -> None:
+    set_active_config(cfg)
+    # auth_cookie seeds a user named "owner" (the default), so to exercise the
+    # *fallback* we clear the username to empty after seeding.
+    cookie = auth_cookie(cfg, username="owner")
+    _seed_username(cfg.db_path, "")  # simulate "no username set"
+
+    with TestClient(app=_build_app(cfg)) as client:
+        resp = client.get("/dashboard", cookies=cookie)
+    assert resp.status_code == 200
+    assert "alice-zone's Private Compute Space" in resp.text
+    assert "owner's Private Compute Space" not in resp.text
+
+
+def test_heading_uses_owner_username_when_set(cfg: Any) -> None:
+    set_active_config(cfg)
+    cookie = auth_cookie(cfg, username="owner")
+    _seed_username(cfg.db_path, "alice")
+
+    with TestClient(app=_build_app(cfg)) as client:
+        resp = client.get("/dashboard", cookies=cookie)
+    assert resp.status_code == 200
+    assert "alice's Private Compute Space" in resp.text
+    # The zone subdomain must no longer drive the heading.
+    assert "alice-zone's Private Compute Space" not in resp.text
+
+
+def test_owner_name_global_reads_live(cfg: Any) -> None:
+    set_active_config(cfg)
+    globals_ = _template_globals(cfg, Path("static"))
+    owner_name = globals_["owner_name"]
+
+    # Pre-setup (no user row) -> None so the heading falls back to zone_name.
+    assert owner_name() is None
+
+    seed_user(cfg.db_path, username="bob")
+    assert owner_name() == "bob"
+
+    # Changing the username is reflected immediately (read live, not cached).
+    _seed_username(cfg.db_path, "carol")
+    assert owner_name() == "carol"

--- a/compute_space/src/compute_space/web/app.py
+++ b/compute_space/src/compute_space/web/app.py
@@ -22,12 +22,14 @@ from compute_space.config import Config
 from compute_space.config import get_config
 from compute_space.config import provide_config
 from compute_space.core import archive_backend
+from compute_space.core.auth.auth import read_owner_username
 from compute_space.core.auth.identity import load_identity_keys
 from compute_space.core.logging import logger
 from compute_space.core.startup import check_app_status
 from compute_space.core.startup import retry_pending_default_apps
 from compute_space.core.storage import start_storage_guard
 from compute_space.core.terminal import cleanup_all as cleanup_terminal
+from compute_space.db import get_db
 from compute_space.db import provide_db
 from compute_space.web.auth.auth import login_required_redirect
 from compute_space.web.middleware.subdomain_proxy import SubdomainProxyMiddleware
@@ -74,10 +76,29 @@ def _template_globals(config: Config, static_dir: Path) -> dict[str, Any]:
         proto = "https" if config.tls_enabled else "http"
         return f"{proto}://{app_name}.{zone_domain}/"
 
+    def owner_name() -> str | None:
+        """The owner's configured username, or None if unset / pre-setup.
+
+        Read live (not cached) because the owner can change it from Settings at
+        any time. Exposed as a callable template global so templates can prefer
+        it over ``zone_name`` for headings.
+        """
+        try:
+            db = get_db()
+            try:
+                return read_owner_username(db)
+            finally:
+                db.close()
+        except Exception:
+            # Never let a heading lookup break page rendering (e.g. pre-init DB).
+            logger.exception("failed to read owner username for template")
+            return None
+
     return {
         "zone_name": zone_name,
         "zone_domain": zone_domain,
         "app_url": app_url,
+        "owner_name": owner_name,
         "static_url": _make_static_url(static_dir),
     }
 

--- a/compute_space/src/compute_space/web/templates/layout.html
+++ b/compute_space/src/compute_space/web/templates/layout.html
@@ -1,7 +1,10 @@
+{#- Owner username (if set) takes precedence over the zone subdomain for the
+   instance name shown in the title + heading. Computed once and reused below. -#}
+{%- set display_name = owner_name() or zone_name -%}
 <!DOCTYPE html>
 <html>
 <head>
-  <title>{% if zone_name %}{{ zone_name }}'s Private Compute Space{% else %}OpenHost{% endif %}{% block title_suffix %}{% endblock %}</title>
+  <title>{% if display_name %}{{ display_name }}'s Private Compute Space{% else %}OpenHost{% endif %}{% block title_suffix %}{% endblock %}</title>
   <style>
     body { font-family: -apple-system, system-ui, sans-serif; max-width: 960px; margin: 2em auto; padding: 0 1em; color: #222; }
     table { border-collapse: collapse; width: 100%; margin: 1em 0; }
@@ -35,7 +38,7 @@
   </style>
 </head>
 <body>
-  <h1>{% if zone_name %}{{ zone_name }}'s Private Compute Space{% else %}OpenHost{% endif %}</h1>
+  <h1>{% if display_name %}{{ display_name }}'s Private Compute Space{% else %}OpenHost{% endif %}</h1>
   <nav>
     <a href="/dashboard">Dashboard</a>
     <a href="/docs/" target="_blank" rel="noopener">Docs</a>


### PR DESCRIPTION
The instance name at the top of the dashboard (the layout h1 and title) showed {zone_name}'s Private Compute Space, where zone_name is the zone subdomain. This changes it to prefer the owner's configured username when set, falling back to the zone name (and then OpenHost) when not.

Implementation: adds an owner_name() template global in _template_globals that reads the username from the users table live, so it reflects Settings changes immediately without restart. layout.html computes the display name once (single DB read per render) and reuses it for both the title and heading; the lookup is wrapped so a DB error can never break page rendering.

Tests: adds test_dashboard_title.py covering the username case, the zone-name fallback, and the live-read behavior of the owner_name() global. Existing owner-username and page tests still pass; ruff and mypy clean.