### PR TITLE
Recover apps stranded in 'starting' on startup

### DIFF
--- a/compute_space/src/compute_space/core/startup.py
+++ b/compute_space/src/compute_space/core/startup.py
@@ -10,44 +10,56 @@ from compute_space.core.logging import logger
 
 
 def check_app_status(config: Config) -> None:
-    """On startup, verify apps marked 'running' are still alive.
+    """On startup, verify apps that should be up are still alive.
 
-    Apps that need rebuilding are restarted sequentially in a single
-    background thread to avoid concurrent image builds against the same
-    containers-storage instance.
+    Covers 'running' apps plus apps left mid-restart in 'starting'/'building':
+    a reboot kills every container, and if a prior restart sweep was interrupted
+    (e.g. the service restarted mid-rebuild) those apps stay in 'starting'.
+    Looking only at 'running' would strand them forever.
+
+    Apps that need rebuilding are restarted sequentially in a single background
+    thread to avoid concurrent image builds against the same containers-storage
+    instance.
     """
     db = sqlite3.connect(config.db_path)
     db.row_factory = sqlite3.Row
     apps_to_restart: list[str] = []
     try:
-        rows = db.execute("SELECT * FROM apps WHERE status = 'running'").fetchall()
+        rows = db.execute("SELECT * FROM apps WHERE status IN ('running', 'starting', 'building')").fetchall()
         for row in rows:
-            alive = False
-            if row["container_id"]:
-                alive = is_container_running(row["container_id"])
+            alive = bool(row["container_id"]) and is_container_running(row["container_id"])
 
-            if not alive:
-                if row["container_id"]:
-                    repo_path = row["repo_path"]
-                    if not repo_path or not os.path.isdir(repo_path):
-                        db.execute(
-                            "UPDATE apps SET status = 'error', error_message = ? WHERE app_id = ?",
-                            (
-                                f"Cannot restart: repo path missing ({repo_path})",
-                                row["app_id"],
-                            ),
-                        )
-                        continue
+            if alive:
+                # Container survived, or a prior sweep restarted it but the
+                # status never advanced past 'starting'/'building'. Heal it.
+                if row["status"] != "running":
                     db.execute(
-                        "UPDATE apps SET status = 'starting' WHERE app_id = ?",
+                        "UPDATE apps SET status = 'running' WHERE app_id = ?",
                         (row["app_id"],),
                     )
-                    apps_to_restart.append(row["app_id"])
-                else:
+                continue
+
+            if row["container_id"]:
+                repo_path = row["repo_path"]
+                if not repo_path or not os.path.isdir(repo_path):
                     db.execute(
-                        "UPDATE apps SET status = 'stopped' WHERE app_id = ?",
-                        (row["app_id"],),
+                        "UPDATE apps SET status = 'error', error_message = ? WHERE app_id = ?",
+                        (
+                            f"Cannot restart: repo path missing ({repo_path})",
+                            row["app_id"],
+                        ),
                     )
+                    continue
+                db.execute(
+                    "UPDATE apps SET status = 'starting' WHERE app_id = ?",
+                    (row["app_id"],),
+                )
+                apps_to_restart.append(row["app_id"])
+            else:
+                db.execute(
+                    "UPDATE apps SET status = 'stopped' WHERE app_id = ?",
+                    (row["app_id"],),
+                )
         db.commit()
     finally:
         db.close()

--- a/compute_space/src/compute_space/tests/test_check_app_status.py
+++ b/compute_space/src/compute_space/tests/test_check_app_status.py
@@ -1,0 +1,146 @@
+"""Tests for ``check_app_status`` startup recovery.
+
+The key regression: an app left in 'starting' after an interrupted boot-time
+restart sweep must still be recovered. Earlier the sweep only looked at
+'running' apps, so anything stranded in 'starting' stayed down forever.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import threading
+from pathlib import Path
+from typing import Any
+
+import compute_space.core.startup as startup
+from compute_space.core.app_id import new_app_id
+from compute_space.db.connection import init_db
+
+from .conftest import _make_test_config
+
+
+def _seed_app(
+    cfg: Any,
+    *,
+    name: str,
+    status: str,
+    port: int,
+    container_id: str | None,
+    repo_path: str,
+) -> str:
+    app_id = new_app_id()
+    db = sqlite3.connect(cfg.db_path)
+    try:
+        db.execute(
+            """INSERT INTO apps (app_id, name, version, repo_path, local_port, status, container_id)
+               VALUES (?, ?, '1.0', ?, ?, ?, ?)""",
+            (app_id, name, repo_path, port, status, container_id),
+        )
+        db.commit()
+    finally:
+        db.close()
+    return app_id
+
+
+def _status(cfg: Any, app_id: str) -> str:
+    db = sqlite3.connect(cfg.db_path)
+    try:
+        status: str = db.execute("SELECT status FROM apps WHERE app_id = ?", (app_id,)).fetchone()[0]
+        return status
+    finally:
+        db.close()
+
+
+def _capture_restart_sweep(monkeypatch: Any) -> tuple[list[str], threading.Event]:
+    """Replace the background restart sweep with a recorder."""
+    restarted: list[str] = []
+    done = threading.Event()
+
+    def fake_sequential(app_ids: list[str], config: Any) -> None:
+        restarted.extend(app_ids)
+        done.set()
+
+    monkeypatch.setattr(startup, "_restart_apps_sequential", fake_sequential)
+    return restarted, done
+
+
+def test_starting_app_with_dead_container_is_restarted(tmp_path: Path, monkeypatch: Any) -> None:
+    cfg = _make_test_config(tmp_path, port=20200)
+    init_db(cfg.db_path)
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    app_id = _seed_app(cfg, name="stuck", status="starting", port=20210, container_id="deadbeef", repo_path=str(repo))
+
+    monkeypatch.setattr(startup, "is_container_running", lambda cid: False)
+    restarted, done = _capture_restart_sweep(monkeypatch)
+
+    startup.check_app_status(cfg)
+
+    assert done.wait(5), "restart sweep was never scheduled for the stranded 'starting' app"
+    assert app_id in restarted
+
+
+def test_building_app_with_dead_container_is_restarted(tmp_path: Path, monkeypatch: Any) -> None:
+    cfg = _make_test_config(tmp_path, port=20400)
+    init_db(cfg.db_path)
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    app_id = _seed_app(
+        cfg, name="mid-build", status="building", port=20410, container_id="deadbeef", repo_path=str(repo)
+    )
+
+    monkeypatch.setattr(startup, "is_container_running", lambda cid: False)
+    restarted, done = _capture_restart_sweep(monkeypatch)
+
+    startup.check_app_status(cfg)
+
+    assert done.wait(5)
+    assert app_id in restarted
+
+
+def test_starting_app_with_live_container_is_healed_to_running(tmp_path: Path, monkeypatch: Any) -> None:
+    cfg = _make_test_config(tmp_path, port=20300)
+    init_db(cfg.db_path)
+    app_id = _seed_app(
+        cfg, name="live", status="starting", port=20310, container_id="livecontainer", repo_path="/nonexistent"
+    )
+
+    monkeypatch.setattr(startup, "is_container_running", lambda cid: True)
+    _capture_restart_sweep(monkeypatch)
+
+    startup.check_app_status(cfg)
+
+    assert _status(cfg, app_id) == "running"
+
+
+def test_running_app_with_dead_container_is_restarted(tmp_path: Path, monkeypatch: Any) -> None:
+    cfg = _make_test_config(tmp_path, port=20500)
+    init_db(cfg.db_path)
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    app_id = _seed_app(cfg, name="crashed", status="running", port=20510, container_id="deadbeef", repo_path=str(repo))
+
+    monkeypatch.setattr(startup, "is_container_running", lambda cid: False)
+    restarted, done = _capture_restart_sweep(monkeypatch)
+
+    startup.check_app_status(cfg)
+
+    assert done.wait(5)
+    assert app_id in restarted
+
+
+def test_running_app_with_live_container_is_left_alone(tmp_path: Path, monkeypatch: Any) -> None:
+    cfg = _make_test_config(tmp_path, port=20600)
+    init_db(cfg.db_path)
+    app_id = _seed_app(
+        cfg, name="healthy", status="running", port=20610, container_id="livecontainer", repo_path="/nonexistent"
+    )
+
+    monkeypatch.setattr(startup, "is_container_running", lambda cid: True)
+    restarted, done = _capture_restart_sweep(monkeypatch)
+
+    startup.check_app_status(cfg)
+
+    assert not done.is_set()
+    assert restarted == []
+    assert _status(cfg, app_id) == "running"


### PR DESCRIPTION
## Problem

After a server reboot, several apps stayed permanently unavailable (e.g. `backup.host.zackpolizzi.com` → "App is not responding") even though their containers had previously been running fine.

**Root cause** (traced on a live instance): on startup, `check_app_status()` flips every previously-`running` app whose container died to `starting`, then hands the whole list to a *single background thread* (`_restart_apps_sequential`) that rebuilds + restarts them **one at a time**. Sequential image builds are slow. If the `compute_space` service restarts mid-sweep — which it did, via an auto-update SIGTERM right after boot — the daemon thread is killed and every app it hadn't reached yet is left in `starting`.

The next startup then re-ran `check_app_status()`, but its query was:

```python
SELECT * FROM apps WHERE status = 'running'
```

So apps stranded in `starting` were invisible to the recovery sweep and **never retried** — left with no container, their subdomains returning "App is not responding" indefinitely. A plain service restart couldn't fix it either.

On the affected instance this stranded 8 apps (`backup`, `degoog`, `elevate`, `health-dashboard`, `md-notes`, `oauth-provider`, `oura`, `wanderer`), all with `Exited` containers.

## Fix

Widen the startup sweep to `('running', 'starting', 'building')`:

- **Dead container** → rebuild + restart (or mark `error` if the repo path is gone), same as before.
- **Live container but status never advanced** → heal to `running`.

An interrupted restart sweep now self-heals on the next service start instead of stranding apps forever.

## Tests

New `test_check_app_status.py` covering: dead-container `starting`/`building`/`running` apps get queued for restart; a live-container `starting` app is healed to `running`; a healthy `running` app is left untouched. Verified the three new-behavior tests fail on the pre-fix code.

Full lightweight `compute_space` suite passes (614 passed, 32 container/TLS skipped); ruff + mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)