### PR TITLE
Fix meta-dump listing to use JuiceFS volume-name prefix

### DIFF
--- a/compute_space/src/compute_space/core/archive_backend.py
+++ b/compute_space/src/compute_space/core/archive_backend.py
@@ -502,11 +502,16 @@ def list_meta_dumps(
     s3_endpoint: str | None,
     s3_access_key_id: str,
     s3_secret_access_key: str,
-    s3_prefix: str | None,
+    juicefs_volume_name: str,
 ) -> MetaDumpSummary | None:
-    """Summarise JuiceFS meta-dump objects.  None on error.  Caps at 1000 dumps."""
-    prefix = (s3_prefix or "").strip("/")
-    list_prefix = f"{prefix}/meta/" if prefix else "meta/"
+    """Summarise JuiceFS meta-dump objects.  None on error.  Caps at 1000 dumps.
+
+    JuiceFS prefixes every object it writes with the volume name, so dumps land
+    at ``<volume>/meta/`` — not under ``s3_prefix`` (which only ever *feeds* the
+    volume name, and is null whenever the operator didn't set one).
+    """
+    volume = (juicefs_volume_name or "").strip("/")
+    list_prefix = f"{volume}/meta/" if volume else "meta/"
     try:
         client = _s3_client(s3_region, s3_endpoint, s3_access_key_id, s3_secret_access_key)
         resp = client.list_objects_v2(Bucket=s3_bucket, Prefix=list_prefix, MaxKeys=1000)

--- a/compute_space/src/compute_space/tests/test_api_archive_backend.py
+++ b/compute_space/src/compute_space/tests/test_api_archive_backend.py
@@ -133,6 +133,25 @@ def test_get_meta_dumps_null_on_s3_list_failure(
     assert body["meta_dumps"] is None
 
 
+def test_get_meta_dumps_lists_by_volume_name(cfg: Any, client: TestClient[Litestar], cookies: dict[str, str]) -> None:
+    """Regression: dumps live under ``<volume>/meta/``, so the route must pass
+    the JuiceFS volume name (not the often-null s3_prefix) to ``list_meta_dumps``."""
+    db = sqlite3.connect(cfg.db_path)
+    try:
+        db.execute(
+            "UPDATE archive_backend SET backend='s3', s3_bucket='b', s3_prefix=NULL, "
+            "juicefs_volume_name='openhost', s3_access_key_id='AKIA', s3_secret_access_key='hunter2'"
+        )
+        db.commit()
+    finally:
+        db.close()
+    spy = mock.MagicMock(return_value=archive_backend.MetaDumpSummary(count=0, latest_at=None, latest_key=None))
+    with mock.patch.object(archive_backend, "list_meta_dumps", spy):
+        client.get("/api/storage/archive_backend", cookies=cookies)
+    # last positional arg is the object prefix JuiceFS actually writes under
+    assert spy.call_args.args[-1] == "openhost"
+
+
 # --- configure route ------------------------------------------------------
 
 

--- a/compute_space/src/compute_space/tests/test_archive_backend.py
+++ b/compute_space/src/compute_space/tests/test_archive_backend.py
@@ -250,8 +250,9 @@ def test_list_meta_dumps_returns_none_on_s3_failure():
         assert archive_backend.list_meta_dumps("b", "us-east-1", None, "ak", "sk", "p") is None
 
 
-def test_list_meta_dumps_handles_no_prefix():
-    """Empty prefix lists at meta/ (no leading slash, no double /)."""
+def test_list_meta_dumps_lists_under_volume_name():
+    """Regression: JuiceFS writes dumps to ``<volume>/meta/``, so the listing
+    must use the volume name — not s3_prefix, which is null on most installs."""
     captured = {}
 
     def fake_list(*, Bucket, Prefix, MaxKeys):
@@ -263,7 +264,24 @@ def test_list_meta_dumps_handles_no_prefix():
         "_s3_client",
         return_value=mock.MagicMock(list_objects_v2=fake_list),
     ):
-        archive_backend.list_meta_dumps("b", "us-east-1", None, "ak", "sk", None)
+        archive_backend.list_meta_dumps("b", "us-east-1", None, "ak", "sk", "openhost")
+    assert captured["prefix"] == "openhost/meta/"
+
+
+def test_list_meta_dumps_handles_empty_volume_name():
+    """Defensive: a blank volume name lists at meta/ (no leading slash, no double /)."""
+    captured = {}
+
+    def fake_list(*, Bucket, Prefix, MaxKeys):
+        captured["prefix"] = Prefix
+        return {"Contents": []}
+
+    with mock.patch.object(
+        archive_backend,
+        "_s3_client",
+        return_value=mock.MagicMock(list_objects_v2=fake_list),
+    ):
+        archive_backend.list_meta_dumps("b", "us-east-1", None, "ak", "sk", "")
     assert captured["prefix"] == "meta/"
 
 

--- a/compute_space/src/compute_space/web/routes/api/archive_backend.py
+++ b/compute_space/src/compute_space/web/routes/api/archive_backend.py
@@ -139,7 +139,7 @@ async def get_archive_backend(db: sqlite3.Connection, config: Config) -> Backend
             state.s3_endpoint,
             state.s3_access_key_id,
             state.s3_secret_access_key,
-            state.s3_prefix,
+            state.juicefs_volume_name,
         )
         if summary is not None:
             meta_dumps = MetaDumpsSummary(

--- a/compute_space/src/compute_space/web/templates/settings.html
+++ b/compute_space/src/compute_space/web/templates/settings.html
@@ -476,7 +476,7 @@ function renderArchiveBackend(state) {
       dumpLine = '<span class="error">No metadata dumps in bucket yet.</span> <span class="hint">JuiceFS writes one within an hour of mount.</span>';
     } else {
       dumpLine = '<span class="hint">unavailable; could not list <code>'
-        + escSettingsHtml((state.s3_prefix ? state.s3_prefix + '/' : '') + 'meta/')
+        + escSettingsHtml((state.juicefs_volume_name ? state.juicefs_volume_name + '/' : '') + 'meta/')
         + '</code></span>';
     }
     rows += '<tr><th>Latest meta dump</th><td>' + dumpLine + '</td></tr>';


### PR DESCRIPTION
## Problem

The settings page shows **"No metadata dumps in bucket yet. JuiceFS writes one within an hour of mount."** indefinitely on instances that have been up for weeks — even though JuiceFS *is* writing metadata dumps hourly.

Diagnosed on the `personal` instance (read-only):
- JuiceFS is healthy and writing dumps every hour, e.g.
  `…/openhost-personal-juicefs/openhost/meta/dump-2026-06-18-214613.json.gz`
- The API returns `meta_dumps.count == 0` with **no error** — the S3 list succeeded but looked in the wrong place.

## Root cause

`list_meta_dumps` built its listing prefix from `s3_prefix`, but JuiceFS prefixes **every** object it writes with the *volume name*, so dumps land at `<volume>/meta/`. The two only coincide when the operator explicitly set `s3_prefix` (which then feeds the volume name via `volume = juicefs_volume_name or s3_prefix or "openhost"`).

When `s3_prefix` is null (the common case), the volume defaults to `"openhost"`:
- JuiceFS writes to `openhost/meta/dump-*.json.gz`
- the listing looked at `meta/` → finds nothing → "no dumps yet", forever.

## Fix

- List by `juicefs_volume_name` (the actual object prefix JuiceFS uses) instead of `s3_prefix` — in both `list_meta_dumps` and the route that calls it.
- Update the `settings.html` "unavailable; could not list …" hint to reference the volume name.

## Tests

- Reworked `list_meta_dumps` prefix tests to assert the volume-name contract (`openhost/meta/`), plus a defensive blank-volume case.
- Added a route-level regression test asserting the API passes `juicefs_volume_name` (not the null `s3_prefix`) to `list_meta_dumps`.
- Full lightweight suite green: 739 passed, 42 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)