### PR TITLE
Add OpenhostStack.playwright_login() for browser tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,8 @@ jobs:
           sudo ip link set openhost0 up
           mkdir -p ~/.config/containers
           printf '[containers]\nhost_containers_internal_ip = "10.200.0.1"\n' >> ~/.config/containers/containers.conf
+      - name: Install playwright browsers
+        run: pixi run -e dev playwright install --with-deps chromium
       - name: Run all tests, including containerized tests
         run: |
           pixi run -e dev pytest --run-containers -v

--- a/openhost_app_test_harness/readme.md
+++ b/openhost_app_test_harness/readme.md
@@ -67,6 +67,29 @@ router would otherwise clone the repo at HEAD and silently test stale code.
 - `stack.url_for(app_name)` — any other deployed app, through the router
 - `stack.router_url` — the router itself (dashboard, owner APIs)
 
+### Testing owner routes in a browser (playwright)
+
+`stack.url` goes through the real router, so an unauthenticated `page.goto(stack.url)`
+redirects to `/login`. `stack.playwright_login(page)` drives the real login form (navigates
+to `/login`, submits the owner password, waits for the redirect) and returns the page
+logged in, so it can then reach owner-only pages. Playwright and pytest-playwright come
+with the `test-harness` extra; pass pytest-playwright's `page` fixture:
+
+```python
+# tests/test_pages.py
+from playwright.sync_api import expect
+from openhost_test_harness import OpenhostStack
+
+def test_dashboard_renders(stack: OpenhostStack, page) -> None:
+    stack.playwright_login(page)
+    page.goto(stack.url)                             # authenticated, no /login redirect
+    expect(page.get_by_role("heading", name="My App")).to_be_visible()
+```
+
+To test the unauthenticated experience instead, use pytest-playwright's plain `page`
+fixture (no cookies) and assert the `/login` redirect, or hit `stack.app_url` to bypass
+the router entirely.
+
 ## Testing the service interface
 
 ### Your app consumes a service

--- a/openhost_app_test_harness/src/openhost_test_harness/stack.py
+++ b/openhost_app_test_harness/src/openhost_test_harness/stack.py
@@ -39,6 +39,7 @@ from typing import Self
 
 import attr
 import requests
+from playwright.sync_api import Page
 
 from compute_space.core.auth.permissions_v2 import Grant
 from compute_space.core.manifest import parse_manifest
@@ -254,6 +255,24 @@ class OpenhostStack:
         """Session authenticated as the zone owner (cookie valid for all app subdomains)."""
         assert self._owner is not None, "OpenhostStack must be entered first"
         return self._owner
+
+    def playwright_login(self, page: Page) -> Page:
+        """Log ``page`` in as the zone owner through the real /login form, and return it.
+
+        Drives the actual login flow — navigate to the router's login page, submit the
+        owner password, wait for the post-login redirect — so the session cookie lands on
+        the page's context and the page (and any others in that context) can then reach
+        owner-only routes::
+
+            def test_dashboard(stack, page):
+                stack.playwright_login(page)
+                page.goto(stack.url)
+        """
+        page.goto(f"{self.router_url}/login")
+        page.fill("input[name=password]", self.local_stack.owner_password)
+        page.click("input[type=submit]")
+        page.wait_for_url(lambda url: "/login" not in url)
+        return page
 
     @property
     def app_id(self) -> str:

--- a/openhost_app_test_harness/src/openhost_test_harness/tests/test_harness_e2e.py
+++ b/openhost_app_test_harness/src/openhost_test_harness/tests/test_harness_e2e.py
@@ -4,11 +4,14 @@ Run:
     pixi run -e dev pytest openhost_app_test_harness -x --run-containers --timeout=900
 """
 
+import re
 from collections.abc import Iterator
 from pathlib import Path
 
 import pytest
 import requests
+from playwright.sync_api import Page
+from playwright.sync_api import expect
 
 from openhost_test_harness import OpenhostStack
 from openhost_test_harness import ServiceConsumer
@@ -41,6 +44,16 @@ class TestHarness:
         r = requests.get(f"{stack.url}/", allow_redirects=False, timeout=10)
         assert r.status_code == 302
         assert "/login" in r.headers["Location"]
+
+    def test_playwright_login(self, stack: OpenhostStack, page: Page) -> None:
+        """playwright_login drives the real /login form so browser tests reach owner routes."""
+        page.goto(stack.url)
+        expect(page).to_have_url(re.compile(r"/login"))  # gated before login
+
+        stack.playwright_login(page)
+        page.goto(stack.url)
+        expect(page).not_to_have_url(re.compile(r"/login"))
+        assert "echo-provider" in page.content()
 
     def test_app_url_bypasses_router(self, stack: OpenhostStack) -> None:
         """Direct container access, e.g. for provider tests that forge identity headers."""

--- a/pixi.lock
+++ b/pixi.lock
@@ -372,6 +372,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/93/35/850277d1b17b206bd10874c8a9a3f52e059452fb49bb0d22cbb908f6038b/hypercorn-0.18.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/93/8c/2e650f2afeb7ee576912636c23ddb621c91ac6a98e66dc8d29c3c69446e1/werkzeug-3.1.8-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/94/84/d9273cd09688070a6523c4aee4663a8538721b2b755c4962aafae0011e72/identify-2.6.19-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/98/1c/b00940ab9eb8ede7897443b771987f2f4a76f06be02f1b3f01eb7567e24a/pytest_base_url-2.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/9d/76/f789f7a86709c6b087c5a2f52f911838cad707cc613162401badc665acfe/setuptools-82.0.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/9e/c9/b2622292ea83fbb4ec318f5b9ab867d0a28ab43c5717bb85b0a5f6b3b0a4/networkx-3.6.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a0/32/615eb5911859e43d054941b0d0a7d06cfa2870eba86529cf385b052b111c/mypy-2.1.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
@@ -379,8 +380,10 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/a0/c4/b4d4827c93ef43c01f599ef31453ccc1c132b353284fc6c87d535c233129/pyee-13.0.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a3/5e/ecf12fdb62546d64385c158514e9b2b671f7832108ef2ecd2020ce0af2d1/pyjwt-2.13.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a4/62/02da182e544a51a5c3ccf4b03ab79df279f9c60c5e82d5e8bec7ca26ac11/python_slugify-8.0.4-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a4/f5/10b68b7b1544245097b2a1b8238f66f2fc6dcaeb24ba5d917f52bd2eed4f/wsproto-1.3.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a5/69/6da5581c6a7fede7dc261bf4e67d6adca4196f176b43288b55b3db395b6e/mdit_py_plugins-0.6.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a6/a5/c0b6468d3824fe3fde30dbb5e1f687b291608f9473681bbf7dabbf5a87d7/text_unidecode-1.3-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a9/4e/0463faa15aa5c618691f8c959bb0c40b215f5883175e3daa0f15f3b3e5a9/diskimage_builder-3.42.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ab/a1/7e35f2e16774b88df66427990ff6438e660115e6ebb6fc2374dd4cc87ca3/jsonschema_rs-0.46.5-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/b0/24/bbf7175ffc47cb3d3e1eb523ddb23272968359dfcf2e1294707a2bf12fc4/flake8-6.1.0-py2.py3-none-any.whl
@@ -414,6 +417,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/f5/ac/19f9941c74add59d17694930ec8105d5eddeee4ce56dd8632b765ca16d6c/stevedore-5.8.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f8/b2/b5caed897fbb1cc286c62c01feca977e08d99a17230ff3055b9a98eccf1d/josepy-2.2.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fa/b6/3127540ecdf1464a00e5a01ee60a1b09175f6913f0644ac748494d9c4b21/pytest_timeout-2.4.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/fe/71/1c545fac6a9054b52b3771238fb2dc6e8f1d0ccec116e1c7786ec191887c/pytest_playwright-0.8.0-py3-none-any.whl
       osx-arm64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-types-0.7.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/anyio-4.13.0-pyhcf101f3_0.conda
@@ -510,6 +514,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/93/35/850277d1b17b206bd10874c8a9a3f52e059452fb49bb0d22cbb908f6038b/hypercorn-0.18.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/93/8c/2e650f2afeb7ee576912636c23ddb621c91ac6a98e66dc8d29c3c69446e1/werkzeug-3.1.8-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/94/84/d9273cd09688070a6523c4aee4663a8538721b2b755c4962aafae0011e72/identify-2.6.19-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/98/1c/b00940ab9eb8ede7897443b771987f2f4a76f06be02f1b3f01eb7567e24a/pytest_base_url-2.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/9a/81/7e4e08678a1f98521201c3079f77db69fb552acd56067661f8c2f534a718/markupsafe-3.0.3-cp312-cp312-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/9d/76/f789f7a86709c6b087c5a2f52f911838cad707cc613162401badc665acfe/setuptools-82.0.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/9e/c9/b2622292ea83fbb4ec318f5b9ab867d0a28ab43c5717bb85b0a5f6b3b0a4/networkx-3.6.1-py3-none-any.whl
@@ -518,8 +523,10 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a3/43/35e3f136343aef451e545ce8c38d36c2f93c0ed88703db8b64ba2b205c68/rpds_py-2026.5.1-cp312-cp312-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/a3/5e/ecf12fdb62546d64385c158514e9b2b671f7832108ef2ecd2020ce0af2d1/pyjwt-2.13.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a4/62/02da182e544a51a5c3ccf4b03ab79df279f9c60c5e82d5e8bec7ca26ac11/python_slugify-8.0.4-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a4/f5/10b68b7b1544245097b2a1b8238f66f2fc6dcaeb24ba5d917f52bd2eed4f/wsproto-1.3.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a5/69/6da5581c6a7fede7dc261bf4e67d6adca4196f176b43288b55b3db395b6e/mdit_py_plugins-0.6.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a6/a5/c0b6468d3824fe3fde30dbb5e1f687b291608f9473681bbf7dabbf5a87d7/text_unidecode-1.3-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a9/4e/0463faa15aa5c618691f8c959bb0c40b215f5883175e3daa0f15f3b3e5a9/diskimage_builder-3.42.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b0/24/bbf7175ffc47cb3d3e1eb523ddb23272968359dfcf2e1294707a2bf12fc4/flake8-6.1.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b1/90/a998c550d0ddd07e38605bb5c455d00fcc177a800ff9cc3dafdcb3dd7b56/pycodestyle-2.11.1-py2.py3-none-any.whl
@@ -551,6 +558,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/f5/ac/19f9941c74add59d17694930ec8105d5eddeee4ce56dd8632b765ca16d6c/stevedore-5.8.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f8/b2/b5caed897fbb1cc286c62c01feca977e08d99a17230ff3055b9a98eccf1d/josepy-2.2.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fa/b6/3127540ecdf1464a00e5a01ee60a1b09175f6913f0644ac748494d9c4b21/pytest_timeout-2.4.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/fe/71/1c545fac6a9054b52b3771238fb2dc6e8f1d0ccec116e1c7786ec191887c/pytest_playwright-0.8.0-py3-none-any.whl
 packages:
 - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
   build_number: 20
@@ -1936,6 +1944,8 @@ packages:
   - websockets
   - pytest>=8.0 ; extra == 'test-harness'
   - requests>=2.31 ; extra == 'test-harness'
+  - playwright>=1.40 ; extra == 'test-harness'
+  - pytest-playwright>=0.5 ; extra == 'test-harness'
   requires_python: '>=3.12'
 - pypi: https://files.pythonhosted.org/packages/00/15/b92b4e1d88d02c6eff9733c9eea21846ab435cc4d813d84ccc5d335955df/graphql_core-3.2.11-py3-none-any.whl
   name: graphql-core
@@ -2476,6 +2486,19 @@ packages:
   requires_dist:
   - ukkonen ; extra == 'license'
   requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/98/1c/b00940ab9eb8ede7897443b771987f2f4a76f06be02f1b3f01eb7567e24a/pytest_base_url-2.1.0-py3-none-any.whl
+  name: pytest-base-url
+  version: 2.1.0
+  sha256: 3ad15611778764d451927b2a53240c1a7a591b521ea44cebfe45849d2d2812e6
+  requires_dist:
+  - pytest>=7.0.0
+  - requests>=2.9
+  - black>=22.1.0 ; extra == 'test'
+  - flake8>=4.0.1 ; extra == 'test'
+  - pre-commit>=2.17.0 ; extra == 'test'
+  - pytest-localserver>=0.7.1 ; extra == 'test'
+  - tox>=3.24.5 ; extra == 'test'
+  requires_python: '>=3.8'
 - pypi: https://files.pythonhosted.org/packages/9a/81/7e4e08678a1f98521201c3079f77db69fb552acd56067661f8c2f534a718/markupsafe-3.0.3-cp312-cp312-macosx_11_0_arm64.whl
   name: markupsafe
   version: 3.0.3
@@ -2659,6 +2682,14 @@ packages:
   - typing-extensions>=4.0 ; python_full_version < '3.11'
   - cryptography>=3.4.0 ; extra == 'crypto'
   requires_python: '>=3.9'
+- pypi: https://files.pythonhosted.org/packages/a4/62/02da182e544a51a5c3ccf4b03ab79df279f9c60c5e82d5e8bec7ca26ac11/python_slugify-8.0.4-py2.py3-none-any.whl
+  name: python-slugify
+  version: 8.0.4
+  sha256: 276540b79961052b66b7d116620b36518847f52d5fd9e3a70164fc8c50faa6b8
+  requires_dist:
+  - text-unidecode>=1.3
+  - unidecode>=1.1.1 ; extra == 'unidecode'
+  requires_python: '>=3.7'
 - pypi: https://files.pythonhosted.org/packages/a4/f5/10b68b7b1544245097b2a1b8238f66f2fc6dcaeb24ba5d917f52bd2eed4f/wsproto-1.3.2-py3-none-any.whl
   name: wsproto
   version: 1.3.2
@@ -2681,6 +2712,10 @@ packages:
   - pytest-regressions ; extra == 'testing'
   - pytest-timeout ; extra == 'testing'
   requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/a6/a5/c0b6468d3824fe3fde30dbb5e1f687b291608f9473681bbf7dabbf5a87d7/text_unidecode-1.3-py2.py3-none-any.whl
+  name: text-unidecode
+  version: '1.3'
+  sha256: 1311f10e8b895935241623731c2ba64f4c455287888b18189350b67134a822e8
 - pypi: https://files.pythonhosted.org/packages/a9/4e/0463faa15aa5c618691f8c959bb0c40b215f5883175e3daa0f15f3b3e5a9/diskimage_builder-3.42.0-py3-none-any.whl
   name: diskimage-builder
   version: 3.42.0
@@ -3098,3 +3133,13 @@ packages:
   requires_dist:
   - pytest>=7.0.0
   requires_python: '>=3.7'
+- pypi: https://files.pythonhosted.org/packages/fe/71/1c545fac6a9054b52b3771238fb2dc6e8f1d0ccec116e1c7786ec191887c/pytest_playwright-0.8.0-py3-none-any.whl
+  name: pytest-playwright
+  version: 0.8.0
+  sha256: 856aae6efd4bc055f2ef229c647768760bcaad5cd3a5983c314ac260a974a933
+  requires_dist:
+  - playwright>=1.18
+  - pytest>=6.2.4,<10.0.0
+  - pytest-base-url>=1.0.0,<3.0.0
+  - python-slugify>=6.0.0,<9.0.0
+  requires_python: '>=3.10'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,8 @@ dependencies = [
 test-harness = [
     "pytest>=8.0",
     "requests>=2.31",
+    "playwright>=1.40",
+    "pytest-playwright>=0.5",
 ]
 
 [project.scripts]
@@ -152,6 +154,7 @@ pytest = ">=8.0"
 requests = ">=2.31"
 pytest-timeout = ">=2.2"
 playwright = "*"
+pytest-playwright = "*"
 pytest-asyncio = "*"
 ruff = "==0.15.5"
 mypy = "*"


### PR DESCRIPTION
## What

Adds **`OpenhostStack.playwright_login(page)`** — logs a playwright page in as the zone owner by driving the real `/login` form — plus a self-test that exercises it, and makes playwright a real test-harness dependency.

## Why

The harness fronts apps with the **real** router, so an unauthenticated `page.goto(stack.url)` redirects to `/login`. `playwright_login` navigates to `/login`, submits the owner password, waits for the post-login redirect, and returns the page logged in, so browser tests can reach owner-only routes:

```python
def test_dashboard_renders(stack, page):
    stack.playwright_login(page)
    page.goto(stack.url)            # authenticated, no /login redirect
    expect(page.get_by_role("heading", name="My App")).to_be_visible()
```

This drives the actual login flow rather than injecting cookies, so it also covers that the login form itself works.

## Changes

- `stack.py`: `playwright_login(page)` method.
- `pyproject.toml`: `playwright` + `pytest-playwright` added to the `test-harness` extra (so `openhost[test-harness]` ships them) and to the dev env; `pixi.lock` updated.
- `tests/test_harness_e2e.py`: `test_playwright_login` (`requires_containers`) — asserts `stack.url` redirects to `/login` before login and reaches the app after.
- `.github/workflows/ci.yml`: installs chromium before the `--run-containers` run so the self-test executes in CI.
- Readme example updated.

## Verification

- `test_playwright_login` passes end-to-end against a real container locally (`pytest --run-containers`).
- Project-wide strict `mypy` (142 files) and `ruff` clean; pre-commit passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)