### PR TITLE
Rename cpu_millicores to cpu_cores with unit conversion

### DIFF
--- a/apps/file_browser/openhost.toml
+++ b/apps/file_browser/openhost.toml
@@ -10,7 +10,7 @@ command = "/data -A"
 
 [resources]
 memory_mb = 64
-cpu_millicores = 100
+cpu_cores = 0.1
 
 [data]
 access_all_data = true

--- a/apps/oauth_demo/openhost.toml
+++ b/apps/oauth_demo/openhost.toml
@@ -9,7 +9,7 @@ port = 8080
 
 [resources]
 memory_mb = 256
-cpu_millicores = 500
+cpu_cores = 0.5
 
 [[services.v2.consumes]]
 service = "github.com/imbue-openhost/openhost/services/oauth"

--- a/apps/oauth_provider/openhost.toml
+++ b/apps/oauth_provider/openhost.toml
@@ -12,7 +12,7 @@ public_paths = ["/callback", "/device", "/grant"]
 
 [resources]
 memory_mb = 256
-cpu_millicores = 1000
+cpu_cores = 1.0
 
 [data]
 sqlite = ["main"]

--- a/apps/test_app/openhost.toml
+++ b/apps/test_app/openhost.toml
@@ -19,4 +19,4 @@ grants = [{ key = "TEST_SECRET" }]
 
 [resources]
 memory_mb = 64
-cpu_millicores = 100
+cpu_cores = 0.1

--- a/compute_space/src/compute_space/core/apps.py
+++ b/compute_space/src/compute_space/core/apps.py
@@ -125,7 +125,7 @@ class App:
     status: str
     error_message: str | None
     memory_mb: int
-    cpu_millicores: int
+    cpu_cores: float
     gpu: int
     public_paths: list[str]
     links: list[AppLink]
@@ -393,7 +393,7 @@ def insert_and_deploy(
     db.execute(
         """INSERT INTO apps
            (app_id, name, manifest_name, version, description, runtime_type, repo_path, repo_url,
-            health_check, local_port, container_port, memory_mb, cpu_millicores,
+            health_check, local_port, container_port, memory_mb, cpu_cores,
             gpu, public_paths, links, manifest_raw, status, installed_by)
            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
         (
@@ -409,7 +409,7 @@ def insert_and_deploy(
             local_port,
             manifest.container_port,
             manifest.memory_mb,
-            manifest.cpu_millicores,
+            manifest.cpu_cores,
             int(manifest.gpu),
             json.dumps(manifest.public_paths),
             _serialize_links(manifest.links),

--- a/compute_space/src/compute_space/core/containers.py
+++ b/compute_space/src/compute_space/core/containers.py
@@ -251,7 +251,7 @@ def run_container(
     cmd.extend(
         [
             f"--memory={manifest.memory_mb}m",
-            f"--cpus={manifest.cpu_millicores / 1000.0}",
+            f"--cpus={manifest.cpu_cores}",
             "--restart=unless-stopped",
             "--cap-drop=ALL",
             "--security-opt=no-new-privileges=true",

--- a/compute_space/src/compute_space/core/manifest.py
+++ b/compute_space/src/compute_space/core/manifest.py
@@ -163,7 +163,7 @@ class AppManifest:
 
     # [resources]
     memory_mb: int = 128
-    cpu_millicores: int = 100
+    cpu_cores: float = 0.1
     gpu: bool = False
 
     # [data]
@@ -298,6 +298,24 @@ def _parse_links(links_list: Any) -> list[AppLink]:
     return result
 
 
+def _parse_cpu_cores(resources: dict[str, Any], app_name: str) -> float:
+    """Read [resources].cpu_cores, falling back to the deprecated cpu_millicores key.
+
+    cpu_millicores (1000 = 1 core) was the old unit; cpu_cores expresses the
+    same allocation as fractional cores. When only the old key is present we
+    convert it (millicores / 1000) and warn.
+    """
+    if "cpu_cores" in resources:
+        return float(resources["cpu_cores"])
+    if "cpu_millicores" in resources:
+        logger.warning(
+            "App '%s' uses deprecated 'cpu_millicores' in [resources]. Use 'cpu_cores' (fractional cores) instead.",
+            app_name,
+        )
+        return float(resources["cpu_millicores"]) / 1000.0
+    return 0.1
+
+
 def _structure_list(data: list[Any], cls: type[Any], label: str) -> list[Any]:
     try:
         return [cattrs.structure(entry, cls) for entry in data]
@@ -411,7 +429,7 @@ def parse_manifest_from_string(raw_text: str) -> AppManifest:
         public_paths=routing.get("public_paths", []),
         links=_parse_links(data.get("links", [])),
         memory_mb=resources.get("memory_mb", 128),
-        cpu_millicores=resources.get("cpu_millicores", 100),
+        cpu_cores=_parse_cpu_cores(resources, app_name),
         gpu=resources.get("gpu", False),
         sqlite_dbs=data_section.get("sqlite", []),
         app_data=data_section.get("app_data", True),

--- a/compute_space/src/compute_space/db/schema.sql
+++ b/compute_space/src/compute_space/db/schema.sql
@@ -17,7 +17,7 @@ CREATE TABLE IF NOT EXISTS apps (
     status TEXT NOT NULL DEFAULT 'stopped' CHECK(status IN ('building', 'starting', 'running', 'stopped', 'error', 'removing')),
     error_message TEXT,
     memory_mb INTEGER NOT NULL DEFAULT 128,
-    cpu_millicores INTEGER NOT NULL DEFAULT 100,
+    cpu_cores REAL NOT NULL DEFAULT 0.1,
     gpu INTEGER NOT NULL DEFAULT 0,
     public_paths TEXT NOT NULL DEFAULT '[]',
     links TEXT NOT NULL DEFAULT '[]',

--- a/compute_space/src/compute_space/db/versioned/migrations/v0011_cpu_cores.py
+++ b/compute_space/src/compute_space/db/versioned/migrations/v0011_cpu_cores.py
@@ -1,0 +1,10 @@
+"""v11: rename ``apps.cpu_millicores`` -> ``apps.cpu_cores``.  Body in v0011_cpu_cores.sql."""
+
+from __future__ import annotations
+
+from compute_space.db.versioned.base import SqlFileMigration
+
+
+class Migration0011CpuCores(SqlFileMigration):
+    version = 11
+    sql_file = "v0011_cpu_cores.sql"

--- a/compute_space/src/compute_space/db/versioned/migrations/v0011_cpu_cores.sql
+++ b/compute_space/src/compute_space/db/versioned/migrations/v0011_cpu_cores.sql
@@ -1,0 +1,11 @@
+-- v11: rename apps.cpu_millicores -> apps.cpu_cores and switch the unit
+-- from millicores (integer, 1000 = 1 core) to fractional CPU cores (real).
+--
+-- Existing integer millicore values are divided by 1000 so the effective
+-- allocation is preserved (e.g. 100 -> 0.1, 500 -> 0.5, 1000 -> 1.0).
+-- SQLite can't change a column's type in place, so we add the new REAL
+-- column, copy the converted values across, then drop the old one.
+
+ALTER TABLE apps ADD COLUMN cpu_cores REAL NOT NULL DEFAULT 0.1;
+UPDATE apps SET cpu_cores = cpu_millicores / 1000.0;
+ALTER TABLE apps DROP COLUMN cpu_millicores;

--- a/compute_space/src/compute_space/db/versioned/registry.py
+++ b/compute_space/src/compute_space/db/versioned/registry.py
@@ -17,6 +17,7 @@ from compute_space.db.versioned.migrations.v0007_app_ids import Migration0007App
 from compute_space.db.versioned.migrations.v0008_drop_v1_service_tables import Migration0008DropV1ServiceTables
 from compute_space.db.versioned.migrations.v0009_session_auth import Migration0009SessionAuth
 from compute_space.db.versioned.migrations.v0010_app_links import Migration0010AppLinks
+from compute_space.db.versioned.migrations.v0011_cpu_cores import Migration0011CpuCores
 
 # Numbered migrations in apply order. Versions MUST start at 2 and be
 # contiguous. v0 (legacy) and v1 (baseline produced by the existing
@@ -31,4 +32,5 @@ REGISTRY: list[Migration] = [
     Migration0008DropV1ServiceTables(),
     Migration0009SessionAuth(),
     Migration0010AppLinks(),
+    Migration0011CpuCores(),
 ]

--- a/compute_space/src/compute_space/tests/fixtures/test_app/openhost.toml
+++ b/compute_space/src/compute_space/tests/fixtures/test_app/openhost.toml
@@ -12,4 +12,4 @@ health_check = "/health"
 
 [resources]
 memory_mb = 64
-cpu_millicores = 100
+cpu_cores = 0.1

--- a/compute_space/src/compute_space/tests/snapshots/empty/v0011.sql
+++ b/compute_space/src/compute_space/tests/snapshots/empty/v0011.sql
@@ -6,8 +6,6 @@ CREATE TABLE api_tokens (
     expires_at TEXT NOT NULL,
     created_at TEXT NOT NULL DEFAULT (datetime('now'))
 );
-INSERT INTO "api_tokens" VALUES(1,'ci-deploy','api-hash-ci','2099-01-01T00:00:00','2024-01-01T00:00:00');
-INSERT INTO "api_tokens" VALUES(2,'monitoring','api-hash-mon','2099-12-31T00:00:00','2024-03-01T00:00:00');
 CREATE TABLE "app_databases" (
                 id INTEGER PRIMARY KEY AUTOINCREMENT,
                 app_id TEXT NOT NULL,
@@ -16,8 +14,6 @@ CREATE TABLE "app_databases" (
                 FOREIGN KEY (app_id) REFERENCES apps(app_id) ON DELETE CASCADE,
                 UNIQUE(app_id, db_name)
             );
-INSERT INTO "app_databases" VALUES(1,'111111111112','orders_db','/data/orders/orders.db');
-INSERT INTO "app_databases" VALUES(2,'111111111113','billing_db','/data/billing/billing.db');
 CREATE TABLE "app_port_mappings" (
                 id INTEGER PRIMARY KEY AUTOINCREMENT,
                 app_id TEXT NOT NULL,
@@ -27,16 +23,11 @@ CREATE TABLE "app_port_mappings" (
                 FOREIGN KEY (app_id) REFERENCES apps(app_id) ON DELETE CASCADE,
                 UNIQUE(app_id, label)
             );
-INSERT INTO "app_port_mappings" VALUES(1,'111111111112','grpc',8000,19500);
-INSERT INTO "app_port_mappings" VALUES(2,'111111111112','health',8080,19501);
-INSERT INTO "app_port_mappings" VALUES(3,'111111111113','http',8000,19502);
 CREATE TABLE "app_tokens" (
                 app_id TEXT PRIMARY KEY,
                 token_hash TEXT NOT NULL UNIQUE,
                 FOREIGN KEY (app_id) REFERENCES apps(app_id) ON DELETE CASCADE
             );
-INSERT INTO "app_tokens" VALUES('111111111112','app-hash-orders');
-INSERT INTO "app_tokens" VALUES('111111111113','app-hash-billing');
 CREATE TABLE "apps" (
                 id INTEGER PRIMARY KEY AUTOINCREMENT,
                 app_id TEXT NOT NULL UNIQUE,
@@ -54,16 +45,13 @@ CREATE TABLE "apps" (
                 status TEXT NOT NULL DEFAULT 'stopped' CHECK(status IN ('building', 'starting', 'running', 'stopped', 'error', 'removing')),
                 error_message TEXT,
                 memory_mb INTEGER NOT NULL DEFAULT 128,
-                cpu_millicores INTEGER NOT NULL DEFAULT 100,
                 gpu INTEGER NOT NULL DEFAULT 0,
                 public_paths TEXT NOT NULL DEFAULT '[]',
                 manifest_raw TEXT,
                 installed_by TEXT,
                 created_at TEXT NOT NULL DEFAULT (datetime('now')),
                 updated_at TEXT NOT NULL DEFAULT (datetime('now'))
-            , links TEXT NOT NULL DEFAULT '[]');
-INSERT INTO "apps" VALUES(1,'111111111112','orders','orders','1.0.0','Order service','serverfull','/repo/orders',NULL,NULL,19100,NULL,NULL,'stopped',NULL,256,500,0,'[]',NULL,NULL,'2024-01-01T00:00:00','2024-01-01T00:00:00','[]');
-INSERT INTO "apps" VALUES(2,'111111111113','billing','billing','2.1.0','Billing service','serverfull','/repo/billing','https://git.example/billing',NULL,19101,NULL,NULL,'running',NULL,512,1000,0,'["/invoices"]',NULL,NULL,'2024-02-15T10:00:00','2024-02-15T10:00:00','[]');
+            , links TEXT NOT NULL DEFAULT '[]', cpu_cores REAL NOT NULL DEFAULT 0.1);
 CREATE TABLE archive_backend (
     id INTEGER PRIMARY KEY CHECK (id = 1),
     backend TEXT NOT NULL DEFAULT 'disabled' CHECK(backend IN ('disabled', 's3')),
@@ -91,7 +79,7 @@ CREATE TABLE schema_version (
     id INTEGER PRIMARY KEY CHECK (id = 1),
     version INTEGER NOT NULL
 );
-INSERT INTO "schema_version" VALUES(1,10);
+INSERT INTO "schema_version" VALUES(1,11);
 CREATE TABLE "service_defaults" (
                 service_url TEXT PRIMARY KEY,
                 app_id TEXT NOT NULL,
@@ -116,7 +104,6 @@ CREATE TABLE users (
     password_hash TEXT NOT NULL,
     created_at TEXT NOT NULL DEFAULT (datetime('now'))
 );
-INSERT INTO "users" VALUES(1,'admin','argon2-stub-owner-hash','2024-01-01T00:00:00');
 CREATE INDEX idx_apps_status ON apps(status);
 CREATE UNIQUE INDEX idx_apps_app_id ON apps(app_id);
 CREATE UNIQUE INDEX idx_port_mappings_host_port ON app_port_mappings(host_port);

--- a/compute_space/src/compute_space/tests/snapshots/owner_null_password/v0011.sql
+++ b/compute_space/src/compute_space/tests/snapshots/owner_null_password/v0011.sql
@@ -45,14 +45,13 @@ CREATE TABLE "apps" (
                 status TEXT NOT NULL DEFAULT 'stopped' CHECK(status IN ('building', 'starting', 'running', 'stopped', 'error', 'removing')),
                 error_message TEXT,
                 memory_mb INTEGER NOT NULL DEFAULT 128,
-                cpu_millicores INTEGER NOT NULL DEFAULT 100,
                 gpu INTEGER NOT NULL DEFAULT 0,
                 public_paths TEXT NOT NULL DEFAULT '[]',
                 manifest_raw TEXT,
                 installed_by TEXT,
                 created_at TEXT NOT NULL DEFAULT (datetime('now')),
                 updated_at TEXT NOT NULL DEFAULT (datetime('now'))
-            , links TEXT NOT NULL DEFAULT '[]');
+            , links TEXT NOT NULL DEFAULT '[]', cpu_cores REAL NOT NULL DEFAULT 0.1);
 CREATE TABLE archive_backend (
     id INTEGER PRIMARY KEY CHECK (id = 1),
     backend TEXT NOT NULL DEFAULT 'disabled' CHECK(backend IN ('disabled', 's3')),
@@ -80,7 +79,7 @@ CREATE TABLE schema_version (
     id INTEGER PRIMARY KEY CHECK (id = 1),
     version INTEGER NOT NULL
 );
-INSERT INTO "schema_version" VALUES(1,10);
+INSERT INTO "schema_version" VALUES(1,11);
 CREATE TABLE "service_defaults" (
                 service_url TEXT PRIMARY KEY,
                 app_id TEXT NOT NULL,

--- a/compute_space/src/compute_space/tests/snapshots/service_with_ports/v0011.sql
+++ b/compute_space/src/compute_space/tests/snapshots/service_with_ports/v0011.sql
@@ -6,6 +6,8 @@ CREATE TABLE api_tokens (
     expires_at TEXT NOT NULL,
     created_at TEXT NOT NULL DEFAULT (datetime('now'))
 );
+INSERT INTO "api_tokens" VALUES(1,'ci-deploy','api-hash-ci','2099-01-01T00:00:00','2024-01-01T00:00:00');
+INSERT INTO "api_tokens" VALUES(2,'monitoring','api-hash-mon','2099-12-31T00:00:00','2024-03-01T00:00:00');
 CREATE TABLE "app_databases" (
                 id INTEGER PRIMARY KEY AUTOINCREMENT,
                 app_id TEXT NOT NULL,
@@ -14,6 +16,8 @@ CREATE TABLE "app_databases" (
                 FOREIGN KEY (app_id) REFERENCES apps(app_id) ON DELETE CASCADE,
                 UNIQUE(app_id, db_name)
             );
+INSERT INTO "app_databases" VALUES(1,'111111111112','orders_db','/data/orders/orders.db');
+INSERT INTO "app_databases" VALUES(2,'111111111113','billing_db','/data/billing/billing.db');
 CREATE TABLE "app_port_mappings" (
                 id INTEGER PRIMARY KEY AUTOINCREMENT,
                 app_id TEXT NOT NULL,
@@ -23,11 +27,16 @@ CREATE TABLE "app_port_mappings" (
                 FOREIGN KEY (app_id) REFERENCES apps(app_id) ON DELETE CASCADE,
                 UNIQUE(app_id, label)
             );
+INSERT INTO "app_port_mappings" VALUES(1,'111111111112','grpc',8000,19500);
+INSERT INTO "app_port_mappings" VALUES(2,'111111111112','health',8080,19501);
+INSERT INTO "app_port_mappings" VALUES(3,'111111111113','http',8000,19502);
 CREATE TABLE "app_tokens" (
                 app_id TEXT PRIMARY KEY,
                 token_hash TEXT NOT NULL UNIQUE,
                 FOREIGN KEY (app_id) REFERENCES apps(app_id) ON DELETE CASCADE
             );
+INSERT INTO "app_tokens" VALUES('111111111112','app-hash-orders');
+INSERT INTO "app_tokens" VALUES('111111111113','app-hash-billing');
 CREATE TABLE "apps" (
                 id INTEGER PRIMARY KEY AUTOINCREMENT,
                 app_id TEXT NOT NULL UNIQUE,
@@ -45,14 +54,15 @@ CREATE TABLE "apps" (
                 status TEXT NOT NULL DEFAULT 'stopped' CHECK(status IN ('building', 'starting', 'running', 'stopped', 'error', 'removing')),
                 error_message TEXT,
                 memory_mb INTEGER NOT NULL DEFAULT 128,
-                cpu_millicores INTEGER NOT NULL DEFAULT 100,
                 gpu INTEGER NOT NULL DEFAULT 0,
                 public_paths TEXT NOT NULL DEFAULT '[]',
                 manifest_raw TEXT,
                 installed_by TEXT,
                 created_at TEXT NOT NULL DEFAULT (datetime('now')),
                 updated_at TEXT NOT NULL DEFAULT (datetime('now'))
-            , links TEXT NOT NULL DEFAULT '[]');
+            , links TEXT NOT NULL DEFAULT '[]', cpu_cores REAL NOT NULL DEFAULT 0.1);
+INSERT INTO "apps" VALUES(1,'111111111112','orders','orders','1.0.0','Order service','serverfull','/repo/orders',NULL,NULL,19100,NULL,NULL,'stopped',NULL,256,0,'[]',NULL,NULL,'2024-01-01T00:00:00','2024-01-01T00:00:00','[]',0.5);
+INSERT INTO "apps" VALUES(2,'111111111113','billing','billing','2.1.0','Billing service','serverfull','/repo/billing','https://git.example/billing',NULL,19101,NULL,NULL,'running',NULL,512,0,'["/invoices"]',NULL,NULL,'2024-02-15T10:00:00','2024-02-15T10:00:00','[]',1.0);
 CREATE TABLE archive_backend (
     id INTEGER PRIMARY KEY CHECK (id = 1),
     backend TEXT NOT NULL DEFAULT 'disabled' CHECK(backend IN ('disabled', 's3')),
@@ -80,7 +90,7 @@ CREATE TABLE schema_version (
     id INTEGER PRIMARY KEY CHECK (id = 1),
     version INTEGER NOT NULL
 );
-INSERT INTO "schema_version" VALUES(1,10);
+INSERT INTO "schema_version" VALUES(1,11);
 CREATE TABLE "service_defaults" (
                 service_url TEXT PRIMARY KEY,
                 app_id TEXT NOT NULL,
@@ -105,6 +115,7 @@ CREATE TABLE users (
     password_hash TEXT NOT NULL,
     created_at TEXT NOT NULL DEFAULT (datetime('now'))
 );
+INSERT INTO "users" VALUES(1,'admin','argon2-stub-owner-hash','2024-01-01T00:00:00');
 CREATE INDEX idx_apps_status ON apps(status);
 CREATE UNIQUE INDEX idx_apps_app_id ON apps(app_id);
 CREATE UNIQUE INDEX idx_port_mappings_host_port ON app_port_mappings(host_port);

--- a/compute_space/src/compute_space/tests/test_api_archive_backend.py
+++ b/compute_space/src/compute_space/tests/test_api_archive_backend.py
@@ -324,7 +324,7 @@ def _archive_manifest(name: str, *, app_archive: bool, access_all_archive: bool 
         container_port=8080,
         container_command=None,
         memory_mb=128,
-        cpu_millicores=100,
+        cpu_cores=0.1,
         gpu=False,
         app_data=True,
         app_archive=app_archive,

--- a/compute_space/src/compute_space/tests/test_app_archive.py
+++ b/compute_space/src/compute_space/tests/test_app_archive.py
@@ -29,7 +29,7 @@ def _manifest(**kwargs) -> AppManifest:  # type: ignore[no-untyped-def]
         container_image="Dockerfile",
         container_port=8080,
         memory_mb=128,
-        cpu_millicores=100,
+        cpu_cores=0.1,
     )
     base.update(kwargs)
     return AppManifest(**base)  # type: ignore[arg-type]

--- a/compute_space/src/compute_space/tests/test_containers.py
+++ b/compute_space/src/compute_space/tests/test_containers.py
@@ -286,7 +286,7 @@ def _basic_manifest(**overrides) -> AppManifest:  # type: ignore[no-untyped-def]
         container_image="Dockerfile",
         container_port=8080,
         memory_mb=256,
-        cpu_millicores=500,
+        cpu_cores=0.5,
     )
     kwargs.update(overrides)
     return AppManifest(**kwargs)  # type: ignore[arg-type]

--- a/compute_space/src/compute_space/tests/test_manifest.py
+++ b/compute_space/src/compute_space/tests/test_manifest.py
@@ -24,10 +24,10 @@ port = 8080
 class TestDefaults:
     """Verify default values match the documented manifest spec."""
 
-    def test_cpu_millicores_default_is_100(self):
-        """cpu_millicores should default to 100 when omitted (manifest_spec.md)."""
+    def test_cpu_cores_default_is_point_one(self):
+        """cpu_cores should default to 0.1 when omitted (manifest_spec.md)."""
         manifest = parse_manifest_from_string(MINIMAL)
-        assert manifest.cpu_millicores == 100
+        assert manifest.cpu_cores == 0.1
 
     def test_memory_mb_default_is_128(self):
         manifest = parse_manifest_from_string(MINIMAL)
@@ -86,10 +86,16 @@ port = 8080
 class TestExplicitValues:
     """Verify that explicitly set values override defaults."""
 
-    def test_cpu_millicores_explicit(self):
+    def test_cpu_cores_explicit(self):
+        toml = MINIMAL + "\n[resources]\ncpu_cores = 0.5\n"
+        manifest = parse_manifest_from_string(toml)
+        assert manifest.cpu_cores == 0.5
+
+    def test_cpu_millicores_deprecated_alias_converts_to_cores(self):
+        """The old cpu_millicores key is still accepted and divided by 1000."""
         toml = MINIMAL + "\n[resources]\ncpu_millicores = 500\n"
         manifest = parse_manifest_from_string(toml)
-        assert manifest.cpu_millicores == 500
+        assert manifest.cpu_cores == 0.5
 
     def test_memory_mb_explicit(self):
         toml = MINIMAL + "\n[resources]\nmemory_mb = 256\n"

--- a/compute_space/src/compute_space/tests/test_owner_username.py
+++ b/compute_space/src/compute_space/tests/test_owner_username.py
@@ -100,7 +100,7 @@ def _bare_manifest() -> AppManifest:
         container_image="Dockerfile",
         container_port=8080,
         memory_mb=128,
-        cpu_millicores=100,
+        cpu_cores=0.1,
         app_data=True,
     )
 

--- a/compute_space/src/compute_space/web/templates/add_app.html
+++ b/compute_space/src/compute_space/web/templates/add_app.html
@@ -161,7 +161,7 @@ function renderManifest(m, url) {
 
   section('Resources', '#e8f0fe');
   row('Memory', m.memory_mb + ' MB');
-  row('CPU', m.cpu_millicores + ' millicores');
+  row('CPU', m.cpu_cores + ' cores');
   if (m.gpu) row('GPU', 'Yes');
 
   if (m.sqlite_dbs.length) {

--- a/compute_space/src/compute_space/web/templates/app_detail.html
+++ b/compute_space/src/compute_space/web/templates/app_detail.html
@@ -27,7 +27,7 @@
   <tr><th>Local Port</th><td>{{ app.local_port }}</td></tr>
   <tr><th>Health Check</th><td>{{ app.health_check or "---" }}</td></tr>
   <tr><th>Memory</th><td>{{ app.memory_mb }} MB</td></tr>
-  <tr><th>CPU</th><td>{{ app.cpu_millicores }} millicores</td></tr>
+  <tr><th>CPU</th><td>{{ app.cpu_cores }} cores</td></tr>
   {% if app.repo_url %}
   <tr><th>Git URL</th><td>
     <span id="remote-display">

--- a/docs/src/creating_an_app.md
+++ b/docs/src/creating_an_app.md
@@ -53,7 +53,7 @@ public_paths = ["/webhook"]   # routes accessible without auth
 
 [resources]
 memory_mb = 128
-cpu_millicores = 100
+cpu_cores = 0.1
 
 [data]
 sqlite = ["main"]

--- a/docs/src/manifest_spec.md
+++ b/docs/src/manifest_spec.md
@@ -57,7 +57,7 @@ User-facing links the app advertises for paths on its own URL that aren't the ba
 | Field | Type | Required | Default | Description |
 |-------|------|----------|---------|-------------|
 | `memory_mb` | integer | no | 128 | Max memory in MB |
-| `cpu_millicores` | integer | no | 100 | CPU allocation (1000 = 1 core) |
+| `cpu_cores` | float | no | 0.1 | CPU allocation in cores (1.0 = 1 core) |
 | `gpu` | boolean | no | false | Whether GPU access is needed |
 
 ### `[data]` — optional
@@ -121,7 +121,7 @@ health_check = "/health"
 
 [resources]
 memory_mb = 128
-cpu_millicores = 100
+cpu_cores = 0.1
 
 [data]
 sqlite = ["main"]
@@ -144,7 +144,7 @@ public_paths = ["/tunnel"]
 
 [resources]
 memory_mb = 128
-cpu_millicores = 100
+cpu_cores = 0.1
 ```
 
 ### App with extra port mappings

--- a/openhost_app_test_harness/src/openhost_test_harness/consumer_app.py
+++ b/openhost_app_test_harness/src/openhost_test_harness/consumer_app.py
@@ -39,7 +39,7 @@ def write_consumer_app_dir(
         },
         "runtime": {"container": {"image": "Dockerfile", "port": 5000}},
         "routing": {"health_check": "/health"},
-        "resources": {"memory_mb": 64, "cpu_millicores": 100},
+        "resources": {"memory_mb": 64, "cpu_cores": 0.1},
         "services": {
             "v2": {
                 "consumes": [

--- a/openhost_app_test_harness/src/openhost_test_harness/tests/provider_app/openhost.toml
+++ b/openhost_app_test_harness/src/openhost_test_harness/tests/provider_app/openhost.toml
@@ -13,7 +13,7 @@ health_check = "/health"
 
 [resources]
 memory_mb = 64
-cpu_millicores = 100
+cpu_cores = 0.1
 
 [[services.v2.provides]]
 service = "github.com/example/echo"


### PR DESCRIPTION
## Summary

- Replaces the integer `cpu_millicores` field (1000 = 1 core) with a float `cpu_cores` field (0.1 = 100 millicores) across the manifest, DB schema, App dataclass, podman flags, UI templates, docs, and all tests.
- Adds DB migration v0011 that adds the `cpu_cores REAL` column, converts existing millicore values (÷1000), and drops the old column.
- The old `cpu_millicores` TOML key is still accepted as a deprecated alias — values are converted automatically with a log warning.

## Test plan

- [x] Full lightweight test suite passes (743 passed, 42 skipped)
- [x] Migration snapshot suite regenerated and verified (value conversion: 500→0.5, 1000→1.0)
- [x] ruff + mypy clean
- [x] Deprecated alias test added (`cpu_millicores = 500` parses as `cpu_cores = 0.5`)
- [ ] Verify on a real deployment that the v0011 migration upgrades existing DBs correctly


🤖 Generated with [Claude Code](https://claude.com/claude-code)