### PR TITLE
enable ssh into app container via oh

### DIFF
--- a/compute_space/src/compute_space/web/routes/api/apps.py
+++ b/compute_space/src/compute_space/web/routes/api/apps.py
@@ -136,6 +136,7 @@ class AppStatusResponse:
     git_branch: str | None = None
     git_sha: str | None = None
     git_dirty: bool | None = None
+    container_id: str | None = None
 
 
 @attr.s(auto_attribs=True, frozen=True)
@@ -434,7 +435,7 @@ async def _read_app_git_info(repo_path: str | None) -> tuple[str | None, str | N
 async def app_status(app_id: str, db: sqlite3.Connection) -> Response[AppStatusResponse] | Response[ErrorResponse]:
     if not is_valid_app_id(app_id):
         return Response(content=ErrorResponse(error="Invalid app_id"), status_code=400)
-    app_row = db.execute("SELECT status, error_message, repo_path FROM apps WHERE app_id = ?", (app_id,)).fetchone()
+    app_row = db.execute("SELECT status, error_message, repo_path, container_id FROM apps WHERE app_id = ?", (app_id,)).fetchone()
     if not app_row:
         return Response(content=ErrorResponse(error="not found"), status_code=404)
     error_msg = app_row["error_message"]
@@ -454,6 +455,7 @@ async def app_status(app_id: str, db: sqlite3.Connection) -> Response[AppStatusR
             git_branch=git_branch,
             git_sha=git_sha,
             git_dirty=git_dirty,
+            container_id=app_row["container_id"],
         ),
         status_code=200,
         media_type=MediaType.JSON,

--- a/compute_space_cli/src/compute_space_cli/main.py
+++ b/compute_space_cli/src/compute_space_cli/main.py
@@ -238,9 +238,12 @@ class AppCmd:
         self,
         app_name: Annotated[str, cappa.Arg(help="App name")],
         cfg: Annotated[config.Instance, Dep(resolve_instance)],
-        shell: Annotated[str, cappa.Arg(long=True, help="Shell to invoke inside container")] = "/bin/sh",
+        shell: Annotated[str, cappa.Arg(long=True, help="Shell to invoke inside container")] = "bash",
     ) -> None:
         """Open an interactive shell inside an app's container."""
+        _SHELL_SHORTHANDS = {"bash": "/usr/bin/bash", "sh": "/bin/sh"}
+        shell = _SHELL_SHORTHANDS.get(shell, shell)
+
         ssh_bin = shutil.which("ssh")
         if not ssh_bin:
             print("ssh not found on PATH", file=sys.stderr)

--- a/compute_space_cli/src/compute_space_cli/main.py
+++ b/compute_space_cli/src/compute_space_cli/main.py
@@ -233,6 +233,33 @@ class AppCmd:
         ).json()
         print(f"Renamed {app_name} → {result.get('name', new_name)}")
 
+    @cappa.command(name="ssh")
+    def ssh(
+        self,
+        app_name: Annotated[str, cappa.Arg(help="App name")],
+        cfg: Annotated[config.Instance, Dep(resolve_instance)],
+        shell: Annotated[str, cappa.Arg(long=True, help="Shell to invoke inside container")] = "/bin/sh",
+    ) -> None:
+        """Open an interactive shell inside an app's container."""
+        ssh_bin = shutil.which("ssh")
+        if not ssh_bin:
+            print("ssh not found on PATH", file=sys.stderr)
+            raise SystemExit(1)
+
+        app_id = resolve_app_id_by_name(cfg.url, cfg.token, app_name)
+        status = make_api_request(cfg.url, cfg.token, "GET", f"/api/app_status/{app_id}").json()
+        container_id = status.get("container_id")
+        if not container_id:
+            print(f"No running container for {app_name} (status: {status.get('status')})", file=sys.stderr)
+            raise SystemExit(1)
+
+        remote_cmd = f"cd ~/openhost && /home/host/.pixi/bin/pixi run -e dev podman exec -it {container_id} {shell}"
+        cmd = [ssh_bin, "-t"]
+        if cfg.ssh_key:
+            cmd += ["-i", cfg.ssh_key]
+        cmd += [f"host@{cfg.hostname}", remote_cmd]
+        raise SystemExit(subprocess.call(cmd))
+
     @cappa.command(name="list")
     def list_apps(
         self,

--- a/compute_space_cli/src/compute_space_cli/main.py
+++ b/compute_space_cli/src/compute_space_cli/main.py
@@ -238,7 +238,7 @@ class AppCmd:
         self,
         app_name: Annotated[str, cappa.Arg(help="App name")],
         cfg: Annotated[config.Instance, Dep(resolve_instance)],
-        shell: Annotated[str, cappa.Arg(long=True, help="Shell to invoke inside container")] = "bash",
+        shell: Annotated[str, cappa.Arg(long=True, help="Shell to invoke inside container")] = "sh",
     ) -> None:
         """Open an interactive shell inside an app's container."""
         _SHELL_SHORTHANDS = {"bash": "/usr/bin/bash", "sh": "/bin/sh"}


### PR DESCRIPTION
able to ssh into app container using `oh app ssh cool-app`. 
required adding container id to api endpoint: /api/app_status/id returns one more field called "container_id". 