### PR TITLE
Make system agent robust to detached HEAD

### DIFF
--- a/compute_space/src/compute_space/tests/test_settings_host_prep.py
+++ b/compute_space/src/compute_space/tests/test_settings_host_prep.py
@@ -73,6 +73,26 @@ async def test_check_for_updates_migration_behind_is_update_available(monkeypatc
 
 
 @pytest.mark.asyncio
+async def test_check_for_updates_detached_head_is_update_available_with_notice(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def fake_fetch() -> FetchResult:
+        return FetchResult(state="DETACHED_HEAD")
+
+    async def fake_status() -> MigrationStatus:
+        return MigrationStatus(ok=True, reason="", message="ok", current_host_version=1, expected_version=1)
+
+    monkeypatch.setattr(settings_mod, "system_agent_fetch", fake_fetch)
+    monkeypatch.setattr(settings_mod, "system_agent_status", fake_status)
+
+    result = await settings_mod.check_for_updates.fn()
+
+    assert result.state == "UPDATE_AVAILABLE"
+    assert result.error is not None
+    assert "detached HEAD" in result.error
+
+
+@pytest.mark.asyncio
 async def test_check_for_updates_migration_missing_is_error(monkeypatch: pytest.MonkeyPatch) -> None:
     async def fake_fetch() -> FetchResult:
         return FetchResult(state="UP_TO_DATE")

--- a/compute_space/src/compute_space/web/routes/api/settings.py
+++ b/compute_space/src/compute_space/web/routes/api/settings.py
@@ -38,6 +38,18 @@ _GIT_STATE_TO_UPDATE_STATE = {
     "BEHIND_REMOTE": UpdateState.UPDATE_AVAILABLE,
     "AHEAD_OF_REMOTE": UpdateState.UPDATE_AVAILABLE,
     "DIRTY": UpdateState.UPDATE_AVAILABLE,
+    # Detached HEAD is recoverable: `update apply` checks the host back onto its
+    # tracking branch before updating. Offer the update rather than erroring.
+    "DETACHED_HEAD": UpdateState.UPDATE_AVAILABLE,
+}
+
+# Explanatory text shown to the owner for git states that need a heads-up
+# beyond the generic "Updates available." message.
+_GIT_STATE_NOTICE = {
+    "DETACHED_HEAD": (
+        "This host's code checkout is in a detached HEAD state (not on a branch). "
+        "Applying the update will move it back onto its tracking branch and update normally."
+    ),
 }
 
 
@@ -103,7 +115,7 @@ async def check_for_updates() -> CheckUpdatesResponse:
     if state is None:
         return CheckUpdatesResponse(state=UpdateState.ERROR, error=f"Unknown git state: {fetch_result.state}")
 
-    return CheckUpdatesResponse(state=state)
+    return CheckUpdatesResponse(state=state, error=_GIT_STATE_NOTICE.get(fetch_result.state))
 
 
 @post("/api/settings/update", status_code=204, guards=[require_owner_auth])

--- a/compute_space/src/compute_space/web/templates/settings.html
+++ b/compute_space/src/compute_space/web/templates/settings.html
@@ -109,7 +109,9 @@ async function checkForUpdates() {
     if (data.state === 'UP_TO_DATE') {
       el.innerHTML = '<p style="color:#080;">Up to date.</p>' + checkAgainBtn;
     } else if (data.state === 'UPDATE_AVAILABLE') {
+      const notice = data.error ? '<p class="error">' + esc(data.error) + '</p>' : '';
       el.innerHTML = '<p>Updates available.</p>'
+        + notice
         + '<button onclick="applyUpdate()" class="btn btn-primary">Update &amp; restart</button> '
         + checkAgainBtn;
     } else if (data.state === 'ERROR') {

--- a/openhost_system_agent/README.md
+++ b/openhost_system_agent/README.md
@@ -22,8 +22,21 @@ sudo openhost-system-agent <command>
 Key subcommands:
 
 - `update fetch` — fetch latest code from remote
-- `update apply` — apply pending system migrations and restart services
-- `update status` — show current version and pending migrations
+- `update apply` — apply pending update: checkout, install deps, run system migrations
+- `status` — show current system version and whether migrations are pending
+
+### Detached HEAD recovery
+
+The host checkout can occasionally end up in a detached HEAD state (HEAD points
+at a commit rather than a branch). In that state there is no tracking branch to
+reason about, so:
+
+- `update fetch` reports `{"state": "DETACHED_HEAD"}` rather than pretending the
+  host is up to date.
+- `update apply` recovers automatically: it resolves the remote's default branch
+  (via `origin/HEAD`, falling back to `main`), checks it out as a local tracking
+  branch, and then performs the normal update. If the configured remote uses a
+  non-default branch, pin it explicitly with `update set_remote <url>@<branch>`.
 
 ## Adding a New Migration
 

--- a/openhost_system_agent/src/openhost_system_agent/tests/test_update.py
+++ b/openhost_system_agent/src/openhost_system_agent/tests/test_update.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+from pathlib import Path
+
+import git
 import pytest
 
 import openhost_system_agent.update as update_mod
@@ -11,6 +14,7 @@ class _Commit:
 
 class _Head:
     commit = _Commit()
+    is_detached = False
 
 
 class _Branch:
@@ -48,3 +52,110 @@ def test_apply_update_reports_up_to_date_when_no_migrations_run(monkeypatch: pyt
     assert result.ref == "aaaaaaaa"
     assert result.system_migrations_applied == []
     assert result.already_up_to_date is True
+
+
+# --- detached HEAD recovery (real git repos) --------------------------------
+
+
+def _make_clone_with_remote(tmp_path: Path) -> git.Repo:
+    """Create a bare 'remote' with two commits on main and a working clone of it."""
+    remote_path = tmp_path / "remote.git"
+    git.Repo.init(remote_path, bare=True, initial_branch="main")
+
+    work_path = tmp_path / "work"
+    repo = git.Repo.clone_from(remote_path, work_path)
+    repo.config_writer().set_value("user", "name", "t").release()
+    repo.config_writer().set_value("user", "email", "t@example.com").release()
+
+    (work_path / "f.txt").write_text("v1\n")
+    repo.index.add(["f.txt"])
+    repo.index.commit("c1")
+    repo.git.branch("-M", "main")
+    repo.git.push("origin", "main")
+
+    (work_path / "f.txt").write_text("v2\n")
+    repo.index.add(["f.txt"])
+    repo.index.commit("c2")
+    repo.git.push("origin", "main")
+
+    # Point origin/HEAD at main so the recovery default-branch lookup resolves.
+    repo.git.remote("set-head", "origin", "main")
+    return repo
+
+
+def test_fetch_reports_detached_head(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    repo = _make_clone_with_remote(tmp_path)
+    first_sha = repo.git.rev_list("--max-parents=0", "HEAD").strip()
+    repo.git.checkout(first_sha)
+    assert repo.head.is_detached
+
+    monkeypatch.setattr(update_mod, "_repo", lambda: repo)
+
+    result = update_mod.fetch_updates()
+
+    assert result.state == "DETACHED_HEAD"
+
+
+def test_apply_recovers_from_detached_head(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    repo = _make_clone_with_remote(tmp_path)
+    latest_sha = repo.head.commit.hexsha
+    first_sha = repo.git.rev_list("--max-parents=0", "HEAD").strip()
+    repo.git.checkout(first_sha)
+    assert repo.head.is_detached
+
+    pixi_calls = {"n": 0}
+    monkeypatch.setattr(update_mod, "_repo", lambda: repo)
+    monkeypatch.setattr(update_mod, "_run_pixi_install", lambda: pixi_calls.__setitem__("n", pixi_calls["n"] + 1))
+    monkeypatch.setattr(update_mod, "_run_migrations_reexec", lambda: [2])
+
+    result = update_mod.apply_update()
+
+    # HEAD is back on a real branch, tracking origin/main, at the latest commit.
+    assert not repo.head.is_detached
+    assert repo.active_branch.name == "main"
+    assert repo.active_branch.tracking_branch().name == "origin/main"
+    assert repo.head.commit.hexsha == latest_sha
+    assert result.ref == latest_sha[:8]
+    assert result.system_migrations_applied == [2]
+    assert result.already_up_to_date is False
+    # Recovering from an OLD detached commit changes the code, so deps must be
+    # reinstalled (regression guard: the pre-recovery sha must drive this).
+    assert pixi_calls["n"] == 1
+
+
+def test_apply_recovers_from_detached_head_at_tip_skips_pixi(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    repo = _make_clone_with_remote(tmp_path)
+    latest_sha = repo.head.commit.hexsha
+    # Detach at the tip of main — same commit as origin/main.
+    repo.git.checkout(latest_sha)
+    assert repo.head.is_detached
+
+    pixi_calls = {"n": 0}
+    monkeypatch.setattr(update_mod, "_repo", lambda: repo)
+    monkeypatch.setattr(update_mod, "_run_pixi_install", lambda: pixi_calls.__setitem__("n", pixi_calls["n"] + 1))
+    monkeypatch.setattr(update_mod, "_run_migrations_reexec", list)
+
+    result = update_mod.apply_update()
+
+    assert not repo.head.is_detached
+    assert repo.active_branch.name == "main"
+    assert repo.head.commit.hexsha == latest_sha
+    # No code change → no pixi install, just migrations.
+    assert pixi_calls["n"] == 0
+    assert result.already_up_to_date is True
+
+
+def test_apply_detached_head_errors_clearly_without_remote_branch(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo = _make_clone_with_remote(tmp_path)
+    first_sha = repo.git.rev_list("--max-parents=0", "HEAD").strip()
+    repo.git.checkout(first_sha)
+    # Drop the remote-tracking refs so there is nothing to recover onto.
+    repo.git.update_ref("-d", "refs/remotes/origin/HEAD")
+    repo.git.update_ref("-d", "refs/remotes/origin/main")
+
+    monkeypatch.setattr(update_mod, "_repo", lambda: repo)
+
+    with pytest.raises(RuntimeError, match="HEAD is detached"):
+        update_mod.apply_update()

--- a/openhost_system_agent/src/openhost_system_agent/tests/test_update.py
+++ b/openhost_system_agent/src/openhost_system_agent/tests/test_update.py
@@ -159,3 +159,29 @@ def test_apply_detached_head_errors_clearly_without_remote_branch(
 
     with pytest.raises(RuntimeError, match="HEAD is detached"):
         update_mod.apply_update()
+
+
+def test_apply_recovers_when_origin_head_is_stale(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A stale origin/HEAD (pointing at a branch with no remote ref) must not
+    block recovery: the default-branch lookup falls back to a branch that
+    actually exists (main) instead of trusting the dangling symref."""
+    repo = _make_clone_with_remote(tmp_path)
+    latest_sha = repo.head.commit.hexsha
+    first_sha = repo.git.rev_list("--max-parents=0", "HEAD").strip()
+    repo.git.checkout(first_sha)
+    # Point origin/HEAD at a branch that has no origin/<branch> ref (e.g. the
+    # remote's default branch was renamed/deleted after this host cloned).
+    repo.git.symbolic_ref("refs/remotes/origin/HEAD", "refs/remotes/origin/gone")
+    assert repo.head.is_detached
+
+    monkeypatch.setattr(update_mod, "_repo", lambda: repo)
+    monkeypatch.setattr(update_mod, "_run_pixi_install", lambda: None)
+    monkeypatch.setattr(update_mod, "_run_migrations_reexec", lambda: [])
+
+    result = update_mod.apply_update()
+
+    assert not repo.head.is_detached
+    assert repo.active_branch.name == "main"
+    assert repo.active_branch.tracking_branch().name == "origin/main"
+    assert repo.head.commit.hexsha == latest_sha
+    assert result.ref == latest_sha[:8]

--- a/openhost_system_agent/src/openhost_system_agent/update.py
+++ b/openhost_system_agent/src/openhost_system_agent/update.py
@@ -37,6 +37,63 @@ def _branch_name(repo: git.Repo) -> str:
         return repo.head.commit.hexsha[:8]
 
 
+def _is_detached(repo: git.Repo) -> bool:
+    """Return True when HEAD points at a commit rather than a branch."""
+    return repo.head.is_detached
+
+
+_DEFAULT_BRANCH = "main"
+
+
+def _remote_default_branch(repo: git.Repo) -> str:
+    """Best-effort guess of the branch the host should be tracking.
+
+    Prefers the remote's published default branch (origin/HEAD -> origin/<name>),
+    then a local branch named `main`, then any local branch, and finally falls
+    back to the literal "main". This is used to recover from a detached HEAD,
+    where there is no active branch to derive a tracking ref from.
+    """
+    # origin/HEAD is a symbolic ref pointing at the remote's default branch.
+    try:
+        symref = str(repo.git.symbolic_ref("refs/remotes/origin/HEAD")).strip()
+        # e.g. "refs/remotes/origin/main" -> "main"
+        prefix = "refs/remotes/origin/"
+        if symref.startswith(prefix):
+            return symref[len(prefix) :]
+    except git.GitCommandError:
+        pass
+
+    if _DEFAULT_BRANCH in [h.name for h in repo.heads]:
+        return _DEFAULT_BRANCH
+    if repo.heads:
+        return repo.heads[0].name
+    return _DEFAULT_BRANCH
+
+
+def _recover_detached_head(repo: git.Repo) -> str:
+    """Move a detached HEAD back onto a real, tracking branch.
+
+    Resolves a target branch (see `_remote_default_branch`) and checks it out
+    with the remote ref as its upstream so subsequent fetch/apply logic has a
+    tracking branch to reason about. Returns the branch name.
+    """
+    branch = _remote_default_branch(repo)
+    remote_ref = f"origin/{branch}"
+    try:
+        repo.refs[remote_ref]
+    except IndexError as e:
+        raise RuntimeError(
+            f"HEAD is detached and no remote branch '{remote_ref}' exists to recover onto. "
+            f"Run 'update fetch' first, or set an explicit branch with "
+            f"'update set_remote <url>@<branch>'."
+        ) from e
+
+    logger.info(f"HEAD is detached; recovering onto {branch} (tracking {remote_ref})...")
+    repo.git.checkout("-fB", branch, remote_ref)
+    repo.heads[branch].set_tracking_branch(repo.refs[remote_ref])
+    return branch
+
+
 _KNOWN_SCHEMES = {"http", "https", "ssh", "git", "file"}
 
 
@@ -58,11 +115,13 @@ def fetch_updates() -> FetchResult:
     if repo.is_dirty(untracked_files=True):
         return FetchResult(state="DIRTY")
 
-    try:
-        branch = repo.active_branch
-    except TypeError:
-        return FetchResult(state="UP_TO_DATE")
+    # A detached HEAD has no branch (and so no tracking branch) to compare
+    # against. Surface it explicitly instead of pretending we're up to date —
+    # `update apply` knows how to recover from this state.
+    if _is_detached(repo):
+        return FetchResult(state="DETACHED_HEAD")
 
+    branch = repo.active_branch
     tracking = branch.tracking_branch()
     if tracking is None:
         raise RuntimeError(f"Branch {branch.name} has no tracking branch set")
@@ -79,7 +138,9 @@ def fetch_updates() -> FetchResult:
 
 def show_diff() -> DiffResult:
     repo = _repo()
-    branch = _branch_name(repo)
+    # In detached HEAD there is no branch to derive `origin/<branch>` from, so
+    # diff against the branch we would recover onto during `update apply`.
+    branch = _remote_default_branch(repo) if _is_detached(repo) else _branch_name(repo)
     remote_ref = f"origin/{branch}"
 
     try:
@@ -108,7 +169,15 @@ def apply_update() -> ApplyResult:
     if repo.is_dirty(untracked_files=True):
         raise RuntimeError("Working tree has uncommitted changes. Stash or commit first.")
 
-    branch = _branch_name(repo)
+    # Capture the checked-out commit *before* any detached-HEAD recovery moves
+    # HEAD, so the up-to-date comparison below reflects whether the working tree
+    # actually changed (and therefore whether `pixi install` needs to run).
+    local_sha = repo.head.commit.hexsha
+
+    if _is_detached(repo):
+        branch = _recover_detached_head(repo)
+    else:
+        branch = _branch_name(repo)
     remote_ref = f"origin/{branch}"
 
     try:
@@ -116,7 +185,6 @@ def apply_update() -> ApplyResult:
     except IndexError as e:
         raise RuntimeError(f"No remote ref {remote_ref} found. Run 'update fetch' first.") from e
 
-    local_sha = repo.head.commit.hexsha
     remote_sha = repo.refs[remote_ref].commit.hexsha
 
     if local_sha == remote_sha:

--- a/openhost_system_agent/src/openhost_system_agent/update.py
+++ b/openhost_system_agent/src/openhost_system_agent/update.py
@@ -54,12 +54,22 @@ def _remote_default_branch(repo: git.Repo) -> str:
     where there is no active branch to derive a tracking ref from.
     """
     # origin/HEAD is a symbolic ref pointing at the remote's default branch.
+    # Only trust it when the branch it names actually exists as a remote ref;
+    # a stale origin/HEAD (e.g. the remote's default branch was renamed or
+    # deleted after this host cloned) would otherwise name a branch that no
+    # longer exists, and recovery would fail even though a usable branch like
+    # `main` is right there. Fall through to the local fallbacks in that case.
     try:
         symref = str(repo.git.symbolic_ref("refs/remotes/origin/HEAD")).strip()
         # e.g. "refs/remotes/origin/main" -> "main"
         prefix = "refs/remotes/origin/"
         if symref.startswith(prefix):
-            return symref[len(prefix) :]
+            candidate = symref[len(prefix) :]
+            try:
+                repo.refs[f"origin/{candidate}"]
+                return candidate
+            except IndexError:
+                pass
     except git.GitCommandError:
         pass
 


### PR DESCRIPTION
The system agent assumed the host checkout was always on a branch. In a detached HEAD state, update fetch falsely reported UP_TO_DATE and update apply failed with a cryptic error like "No remote ref origin/3141ae62 found" (the short commit sha treated as a branch name), leaving the host stuck and unable to apply pending migrations.

Changes:
- fetch_updates now reports a DETACHED_HEAD state instead of pretending the host is up to date.
- apply_update recovers automatically from detached HEAD: it resolves the remote default branch (origin/HEAD, falling back to main, then any local branch), checks it out as a local tracking branch, and proceeds with the normal update. If no recovery branch exists it raises a clear, actionable error pointing at update fetch / set_remote.
- The pre-recovery HEAD sha is captured before recovery so the up-to-date comparison is correct and pixi install still runs when recovery moves the host across a real code change.
- show_diff diffs against the recovery target branch when detached.
- compute_space settings: DETACHED_HEAD maps to UPDATE_AVAILABLE with an explanatory notice surfaced in the owner settings UI, so the update is offered rather than shown as an error.
- README documents the detached HEAD behavior for developers and fixes the stale update status reference.

Testing:
- Added real-git-repo unit tests covering fetch reporting DETACHED_HEAD, apply recovering onto the tracking branch at the latest commit, the pixi-install regression guard, the at-tip no-op case, and the clear error when no remote branch exists.
- Added a settings API test for the DETACHED_HEAD -> UPDATE_AVAILABLE mapping with notice.
- Reproduced the original failure against a real git repo and confirmed recovery.
- Full openhost_system_agent and settings test suites pass; ruff clean.
- Provisioned a Hetzner VM from this branch and confirmed it deploys and runs healthy on a real host.