### PR TITLE
Deploy oauth-provider app by default

### DIFF
--- a/compute_space/src/compute_space/config.py
+++ b/compute_space/src/compute_space/config.py
@@ -276,6 +276,7 @@ class DefaultConfig(Config):
         lambda: [
             "https://github.com/imbue-openhost/secrets",
             "file_browser",
+            "oauth_provider",
             "https://github.com/imbue-openhost/openhost-catalog",
         ]
     )

--- a/compute_space/src/compute_space/tests/test_default_apps.py
+++ b/compute_space/src/compute_space/tests/test_default_apps.py
@@ -296,6 +296,25 @@ def test_catalog_in_default_factory():
     assert catalog_entries, f"openhost-catalog not in default_apps: {cfg.default_apps}"
 
 
+def test_oauth_provider_in_default_factory():
+    """The vendored oauth_provider app must be in the shipped
+    DefaultConfig.default_apps so every new instance auto-installs the OAuth
+    cross-app service provider at /setup completion.
+
+    Regression guard against accidental removal during config refactors.
+    """
+    cfg = DefaultConfig(
+        host="127.0.0.1",
+        data_root_dir="/tmp/fake",
+        zone_domain="test.local",
+        tls_enabled=False,
+        start_caddy=False,
+    )
+    assert "oauth_provider" in cfg.default_apps, (
+        f"oauth_provider not in default_apps: {cfg.default_apps}"
+    )
+
+
 def test_mixed_local_and_remote_entries(cfg_with_apps, monkeypatch):
     """A single deploy can contain both vendored and remote entries."""
     _patch_insert_and_deploy(monkeypatch)

--- a/compute_space/src/compute_space/tests/test_default_apps.py
+++ b/compute_space/src/compute_space/tests/test_default_apps.py
@@ -310,9 +310,7 @@ def test_oauth_provider_in_default_factory():
         tls_enabled=False,
         start_caddy=False,
     )
-    assert "oauth_provider" in cfg.default_apps, (
-        f"oauth_provider not in default_apps: {cfg.default_apps}"
-    )
+    assert "oauth_provider" in cfg.default_apps, f"oauth_provider not in default_apps: {cfg.default_apps}"
 
 
 def test_mixed_local_and_remote_entries(cfg_with_apps, monkeypatch):

--- a/docs/src/oauth.md
+++ b/docs/src/oauth.md
@@ -4,6 +4,13 @@ The OAuth provider app (`oauth-provider`, in `apps/oauth_provider/`) provides OA
 
 (Note: this is distinct from the `secrets` key-value service. The OAuth provider app *consumes* the secrets service to fetch its own Google client credentials, but the OAuth functionality described here is provided by the `oauth-provider` app, not a "secrets app".)
 
+## Deployment
+
+The OAuth provider ships as a **default app**: every new instance auto-installs it at `/setup` completion (it is listed in `Config.default_apps` alongside `secrets`, `file_browser`, and `openhost-catalog`). No manual install is required — consumer apps can request OAuth tokens as soon as the zone is set up.
+
+- **GitHub** works out of the box (it uses the device flow with bundled client credentials).
+- **Google** requires the zone owner to store `GOOGLE_OAUTH_CLIENT_ID` and `GOOGLE_OAUTH_CLIENT_SECRET` in the `secrets` app; the provider fetches them lazily, so its container starts cleanly even before those secrets exist.
+
 ## How it works
 
 ### Requesting a token


### PR DESCRIPTION
Adds the vendored oauth_provider app to DefaultConfig.default_apps so every new instance auto-installs the OAuth cross-app service provider at /setup completion, alongside secrets, file_browser, and openhost-catalog.

The app starts cleanly without Google credentials configured (they are fetched lazily from the secrets service); GitHub device flow works out of the box. Added a regression-guard test mirroring the existing catalog guard, and a deployment note in docs/src/oauth.md.

Verified end-to-end on a fresh Hetzner instance provisioned from this branch: after /setup the dashboard lists secrets, file-browser, oauth-provider, and catalog, all running; the oauth-provider dashboard serves and its public /device path is reachable. Unit tests for default_apps pass and vet runs are clean.