### PR TITLE
Add logout button to dashboard nav

### DIFF
--- a/compute_space/src/compute_space/tests/test_connection_origin.py
+++ b/compute_space/src/compute_space/tests/test_connection_origin.py
@@ -1,0 +1,61 @@
+"""Unit tests for get_connection_origin's Origin-header parsing.
+
+This helper underpins the codebase's CSRF-equivalent origin checks
+(verify_owner_auth / verify_app_auth / verify_same_origin). The security-load-bearing
+property is that a *present* Origin header is never collapsed to None ("no header"):
+an opaque/unparseable Origin such as ``null`` (sent by sandboxed iframes) must return a
+non-None token so origin-match checks fail closed rather than waving the request through.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from compute_space.web.auth.auth import get_connection_origin
+
+
+class _FakeHeaders:
+    def __init__(self, value: str | None) -> None:
+        self._value = value
+
+    def get(self, name: str, default: Any = None) -> Any:
+        if name.lower() == "origin":
+            return self._value if self._value is not None else default
+        return default
+
+
+class _FakeConnection:
+    def __init__(self, origin: str | None) -> None:
+        self.headers = _FakeHeaders(origin)
+
+
+def test_absent_origin_returns_none() -> None:
+    assert get_connection_origin(_FakeConnection(None)) is None
+
+
+def test_simple_origin_returns_host() -> None:
+    assert get_connection_origin(_FakeConnection("https://host.example.com")) == "host.example.com"
+
+
+def test_origin_with_nondefault_port_includes_port() -> None:
+    assert get_connection_origin(_FakeConnection("https://host.example.com:8443")) == "host.example.com:8443"
+
+
+def test_default_https_port_is_omitted() -> None:
+    # urlparse only reports an explicit port; 443 with no explicit ":443" yields no port.
+    assert get_connection_origin(_FakeConnection("https://host.example.com")) == "host.example.com"
+
+
+def test_null_origin_is_not_none() -> None:
+    """The critical case: a sandboxed-iframe ``Origin: null`` must NOT look like an absent header."""
+    result = get_connection_origin(_FakeConnection("null"))
+    assert result is not None
+    assert result == "null"
+
+
+def test_opaque_unparseable_origin_is_not_none() -> None:
+    """Any present-but-hostless Origin returns a non-None token that can't match a real netloc."""
+    for raw in ["null", "NULL", "garbage-no-scheme"]:
+        result = get_connection_origin(_FakeConnection(raw))
+        assert result is not None, f"{raw!r} collapsed to None"
+        assert result != "host.example.com"

--- a/compute_space/src/compute_space/tests/test_dashboard_title.py
+++ b/compute_space/src/compute_space/tests/test_dashboard_title.py
@@ -105,6 +105,23 @@ def test_heading_uses_owner_username_when_set(cfg: Any) -> None:
     assert "alice-zone's Private Compute Space" not in resp.text
 
 
+def test_dashboard_renders_logout_button(cfg: Any) -> None:
+    """The shared layout nav exposes a Log out control that POSTs to /logout.
+
+    The session cookie is httponly, so logout must round-trip through the
+    server; a top-level form POST (samesite=lax) is the correct mechanism.
+    """
+    set_active_config(cfg)
+    cookie = auth_cookie(cfg, username="owner")
+
+    with TestClient(app=_build_app(cfg)) as client:
+        resp = client.get("/dashboard", cookies=cookie)
+    assert resp.status_code == 200
+    assert 'action="/logout"' in resp.text
+    assert 'method="post"' in resp.text
+    assert "Log out" in resp.text
+
+
 def test_owner_name_global_reads_live(cfg: Any) -> None:
     set_active_config(cfg)
     globals_ = _template_globals(cfg, Path("static"))

--- a/compute_space/src/compute_space/tests/test_owner_username.py
+++ b/compute_space/src/compute_space/tests/test_owner_username.py
@@ -484,3 +484,83 @@ def test_logout_without_session_is_safe(cfg: Any, login_client: TestClient[Lites
     resp = login_client.post("/logout", follow_redirects=False)
     assert resp.status_code in (200, 302), resp.text
     assert resp.headers.get("location") == "/login"
+
+
+def test_logout_rejects_cross_origin_request(cfg: Any, login_client: TestClient[Litestar]) -> None:
+    """A cross-site POST to /logout (forced-logout CSRF) must be rejected, and the
+    victim's session must survive. The browser always sets Origin on cross-origin
+    requests, so a mismatching Origin is the signal."""
+    user_id = _seed_user(cfg.db_path, "alice", password="loginpass1")
+    token = _create_session_for(cfg.db_path, user_id)
+    assert _session_count(cfg.db_path) == 1
+
+    login_client.cookies.set(SESSION_COOKIE_NAME, token)
+    resp = login_client.post(
+        "/logout",
+        headers={"Origin": "https://evil.example.com"},
+        follow_redirects=False,
+    )
+
+    # Rejected (NotAuthorizedException -> 401), not a 302 logout.
+    assert resp.status_code == 401, resp.text
+    # The victim's session must NOT have been revoked.
+    assert _session_count(cfg.db_path) == 1
+
+
+def test_logout_allows_same_origin_request(cfg: Any, login_client: TestClient[Litestar]) -> None:
+    """A same-origin POST (Origin matching the target host) must still log out.
+    Modern browsers send Origin even on same-origin top-level form posts."""
+    user_id = _seed_user(cfg.db_path, "alice", password="loginpass1")
+    token = _create_session_for(cfg.db_path, user_id)
+
+    login_client.cookies.set(SESSION_COOKIE_NAME, token)
+    # Match the TestClient's base URL host so Origin == target netloc.
+    same_origin = str(login_client.base_url).rstrip("/")
+    resp = login_client.post(
+        "/logout",
+        headers={"Origin": same_origin},
+        follow_redirects=False,
+    )
+
+    assert resp.status_code in (200, 302), resp.text
+    assert resp.headers.get("location") == "/login"
+    assert _session_count(cfg.db_path) == 0
+
+
+def test_logout_allows_request_without_origin_header(cfg: Any, login_client: TestClient[Litestar]) -> None:
+    """A top-level form post that omits Origin (some browsers/contexts) must still
+    work — the check only rejects a present-and-mismatching Origin."""
+    user_id = _seed_user(cfg.db_path, "alice", password="loginpass1")
+    token = _create_session_for(cfg.db_path, user_id)
+
+    login_client.cookies.set(SESSION_COOKIE_NAME, token)
+    resp = login_client.post("/logout", follow_redirects=False)  # no Origin header
+
+    assert resp.status_code in (200, 302), resp.text
+    assert _session_count(cfg.db_path) == 0
+
+
+@pytest.mark.parametrize(
+    "bad_origin",
+    [
+        "null",  # sandboxed/opaque iframe — must NOT be treated as "no header"
+        "http://testserver.local.evil.com",  # suffix-style lookalike host
+        "http://evil.testserver.local",  # subdomain of an attacker domain
+        "http://testserver.local:1337",  # right host, wrong port
+        "http://evil.example.com",  # plainly different host
+    ],
+)
+def test_logout_rejects_spoofed_or_opaque_origins(
+    cfg: Any, login_client: TestClient[Litestar], bad_origin: str
+) -> None:
+    """Forced-logout CSRF must be blocked for opaque (``null``) and lookalike/mismatched
+    origins, and the victim's session must survive each attempt."""
+    user_id = _seed_user(cfg.db_path, "alice", password="loginpass1")
+    token = _create_session_for(cfg.db_path, user_id)
+    assert _session_count(cfg.db_path) == 1
+
+    login_client.cookies.set(SESSION_COOKIE_NAME, token)
+    resp = login_client.post("/logout", headers={"Origin": bad_origin}, follow_redirects=False)
+
+    assert resp.status_code == 401, f"{bad_origin!r} -> {resp.status_code}: {resp.text}"
+    assert _session_count(cfg.db_path) == 1, f"session revoked by spoofed origin {bad_origin!r}"

--- a/compute_space/src/compute_space/tests/test_owner_username.py
+++ b/compute_space/src/compute_space/tests/test_owner_username.py
@@ -440,3 +440,47 @@ def test_login_creates_session_resolving_to_persisted_username(cfg: Any, login_c
     resp = login_client.post("/login", data={"password": "loginpass1"}, follow_redirects=False)
     assert resp.status_code in (200, 302), resp.text
     assert _session_username_after(cfg.db_path) == "alice"
+
+
+# ---------------------------------------------------------------------------
+# /logout: the control surfaced by the dashboard nav button must revoke the
+# session and clear the cookie. The button is just a form POST to this route,
+# so exercising the route covers what the button triggers.
+# ---------------------------------------------------------------------------
+
+
+def _session_count(db_path: str) -> int:
+    conn = sqlite3.connect(db_path)
+    try:
+        return int(conn.execute("SELECT COUNT(*) FROM sessions").fetchone()[0])
+    finally:
+        conn.close()
+
+
+def test_logout_revokes_session_and_clears_cookie(cfg: Any, login_client: TestClient[Litestar]) -> None:
+    """POST /logout (what the dashboard Log out button submits) must delete the
+    session row server-side and emit a cleared session cookie, so a stolen/cached
+    cookie can't be replayed after logout."""
+    user_id = _seed_user(cfg.db_path, "alice", password="loginpass1")
+    token = _create_session_for(cfg.db_path, user_id)
+    assert _session_count(cfg.db_path) == 1
+
+    login_client.cookies.set(SESSION_COOKIE_NAME, token)
+    resp = login_client.post("/logout", follow_redirects=False)
+
+    # Redirects the operator back to the login page.
+    assert resp.status_code in (200, 302), resp.text
+    assert resp.headers.get("location") == "/login"
+    # Session row is gone -> the old cookie is now inert server-side.
+    assert _session_count(cfg.db_path) == 0
+    # And the response clears the cookie (max-age=0).
+    set_cookie = resp.headers.get("set-cookie", "")
+    assert SESSION_COOKIE_NAME in set_cookie
+    assert "Max-Age=0" in set_cookie or "max-age=0" in set_cookie.lower()
+
+
+def test_logout_without_session_is_safe(cfg: Any, login_client: TestClient[Litestar]) -> None:
+    """Hitting /logout with no session cookie must not error; it just redirects."""
+    resp = login_client.post("/logout", follow_redirects=False)
+    assert resp.status_code in (200, 302), resp.text
+    assert resp.headers.get("location") == "/login"

--- a/compute_space/src/compute_space/web/auth/auth.py
+++ b/compute_space/src/compute_space/web/auth/auth.py
@@ -38,7 +38,13 @@ def _get_bearer_token_if_set(connection: AnyConnection) -> str | None:
 def get_connection_origin(connection: AnyConnection) -> str | None:
     """gets and formats the origin header as "sub.example.com" or "sub.example.com:1234", no protocol or path, if set.
     port is included if non-default.
-    returns None if no origin header is set.
+    returns None only if no Origin header is set at all.
+
+    A *present* Origin that has no parseable host (notably ``Origin: null``, which browsers send from
+    sandboxed/opaque contexts like ``<iframe sandbox>``) returns the literal token (e.g. ``"null"``)
+    rather than None, so callers can't mistake a present cross-origin request for an absent header and
+    wave it through. Such a token never equals a real ``host[:port]``, so origin-match checks fail
+    closed.
 
     browsers have specific behaviors around the Origin header, which we rely on here.
     - it is set on all cross-origin requests, including from subdomains.
@@ -47,36 +53,34 @@ def get_connection_origin(connection: AnyConnection) -> str | None:
 
     we don't use the Referer header, as it's not intended for use in CORS type origin validation.
     """
-    if raw := connection.headers.get("Origin"):
-        parsed = urlparse(raw)
-        host, port = parsed.hostname, parsed.port
-        if not host:
-            return None
-        return f"{host}:{port}" if port else host
-    return None
+    raw = connection.headers.get("Origin")
+    if raw is None:
+        return None
+    parsed = urlparse(raw)
+    host, port = parsed.hostname, parsed.port
+    if not host:
+        # present but opaque/unparseable (e.g. "null"): return a non-matching token, not None.
+        return raw.strip().lower() or "null"
+    return f"{host}:{port}" if port else host
 
 
 def verify_same_origin(connection: AnyConnection) -> None:
     """Reject cross-origin requests to unauthenticated state-changing endpoints (e.g. /logout).
 
     The ``Origin`` header is set by browsers on all cross-origin requests (including from subdomains
-    and from sandboxed/opaque contexts, which send ``Origin: null``) and cannot be forged by js. So:
-    if an Origin header is present at all, it must parse to exactly the target host; otherwise the
-    request is cross-site and is rejected. This stops a hostile page (including a sandboxed iframe
-    sending ``Origin: null``) from cross-site POSTing to endpoints like /logout, which has no
-    owner-auth guard of its own (it must work for any session state).
+    and from sandboxed/opaque contexts, which send ``Origin: null``) and cannot be forged by js. So
+    if an Origin header is present at all, it must match the target host; otherwise the request is
+    cross-site and is rejected. This stops a hostile page (including a sandboxed iframe sending
+    ``Origin: null``) from cross-site POSTing to endpoints like /logout, which has no owner-auth
+    guard of its own (it must work for any session state).
 
     A genuinely same-origin top-level form post either omits Origin or sends the matching host, so
     legitimate logout still works.
 
     raises NotAuthorizedException on a cross-origin request.
     """
-    # Use the raw header (not get_connection_origin) so that a present-but-unparseable Origin such
-    # as "null" is treated as cross-origin rather than collapsing to None ("no header") and passing.
-    raw_origin = connection.headers.get("Origin")
-    if raw_origin is None:
-        return
-    if get_connection_origin(connection) != connection.base_url.netloc:
+    origin = get_connection_origin(connection)
+    if origin is not None and origin != connection.base_url.netloc:
         raise NotAuthorizedException(detail="cross-origin request not allowed")
 
 
@@ -164,6 +168,12 @@ def require_owner_or_app_auth(connection: AnyConnection, _route_handler: BaseRou
     except NotAuthorizedException:
         pass
     verify_app_auth(connection)
+
+
+def require_same_origin(connection: AnyConnection, _route_handler: BaseRouteHandler) -> None:
+    """Adapt verify_same_origin to be used as a route guard (for unauthenticated state-changing
+    endpoints like /logout that still need cross-origin/CSRF protection)."""
+    verify_same_origin(connection)
 
 
 def build_login_url(netloc: str, path: str, query: str) -> str:

--- a/compute_space/src/compute_space/web/auth/auth.py
+++ b/compute_space/src/compute_space/web/auth/auth.py
@@ -56,6 +56,30 @@ def get_connection_origin(connection: AnyConnection) -> str | None:
     return None
 
 
+def verify_same_origin(connection: AnyConnection) -> None:
+    """Reject cross-origin requests to unauthenticated state-changing endpoints (e.g. /logout).
+
+    The ``Origin`` header is set by browsers on all cross-origin requests (including from subdomains
+    and from sandboxed/opaque contexts, which send ``Origin: null``) and cannot be forged by js. So:
+    if an Origin header is present at all, it must parse to exactly the target host; otherwise the
+    request is cross-site and is rejected. This stops a hostile page (including a sandboxed iframe
+    sending ``Origin: null``) from cross-site POSTing to endpoints like /logout, which has no
+    owner-auth guard of its own (it must work for any session state).
+
+    A genuinely same-origin top-level form post either omits Origin or sends the matching host, so
+    legitimate logout still works.
+
+    raises NotAuthorizedException on a cross-origin request.
+    """
+    # Use the raw header (not get_connection_origin) so that a present-but-unparseable Origin such
+    # as "null" is treated as cross-origin rather than collapsing to None ("no header") and passing.
+    raw_origin = connection.headers.get("Origin")
+    if raw_origin is None:
+        return
+    if get_connection_origin(connection) != connection.base_url.netloc:
+        raise NotAuthorizedException(detail="cross-origin request not allowed")
+
+
 def authenticate(connection: AnyConnection, db: sqlite3.Connection) -> AuthenticatedAccessor | None:
     """Resolve who is making this request, by trying each auth scheme in priority order.
 

--- a/compute_space/src/compute_space/web/routes/pages/login.py
+++ b/compute_space/src/compute_space/web/routes/pages/login.py
@@ -16,6 +16,7 @@ from compute_space.core.auth.auth import create_session
 from compute_space.core.auth.auth import revoke_session
 from compute_space.core.auth.auth import validate_password
 from compute_space.web.auth.auth import authenticate
+from compute_space.web.auth.auth import verify_same_origin
 from compute_space.web.auth.cookies import build_session_cookie
 from compute_space.web.auth.cookies import clear_session_cookie
 
@@ -64,6 +65,9 @@ async def login_post(request: Request[Any, Any, Any], db: sqlite3.Connection, co
 
 @post("/logout", status_code=200)
 async def logout(request: Request[Any, Any, Any], db: sqlite3.Connection, config: Config) -> Response[Any]:
+    # /logout has no owner-auth guard (it must work for any session state), so guard it against
+    # cross-site POSTs here to prevent forced-logout CSRF.
+    verify_same_origin(request)
     if session_token := request.cookies.get(SESSION_COOKIE_NAME):
         revoke_session(session_token, db)
         db.commit()

--- a/compute_space/src/compute_space/web/routes/pages/login.py
+++ b/compute_space/src/compute_space/web/routes/pages/login.py
@@ -16,7 +16,7 @@ from compute_space.core.auth.auth import create_session
 from compute_space.core.auth.auth import revoke_session
 from compute_space.core.auth.auth import validate_password
 from compute_space.web.auth.auth import authenticate
-from compute_space.web.auth.auth import verify_same_origin
+from compute_space.web.auth.auth import require_same_origin
 from compute_space.web.auth.cookies import build_session_cookie
 from compute_space.web.auth.cookies import clear_session_cookie
 
@@ -63,11 +63,10 @@ async def login_post(request: Request[Any, Any, Any], db: sqlite3.Connection, co
     return response
 
 
-@post("/logout", status_code=200)
+# /logout has no owner-auth guard (it must work for any session state), so guard it against
+# cross-site POSTs to prevent forced-logout CSRF.
+@post("/logout", status_code=200, guards=[require_same_origin])
 async def logout(request: Request[Any, Any, Any], db: sqlite3.Connection, config: Config) -> Response[Any]:
-    # /logout has no owner-auth guard (it must work for any session state), so guard it against
-    # cross-site POSTs here to prevent forced-logout CSRF.
-    verify_same_origin(request)
     if session_token := request.cookies.get(SESSION_COOKIE_NAME):
         revoke_session(session_token, db)
         db.commit()

--- a/compute_space/src/compute_space/web/templates/layout.html
+++ b/compute_space/src/compute_space/web/templates/layout.html
@@ -14,9 +14,12 @@
     button, input[type="submit"], .btn { padding: 0.4em 1em; cursor: pointer; border: 1px solid #ccc; background: #f9f9f9; text-decoration: none; color: #222; display: inline-block; }
     .btn-danger { background: #fee; border-color: #c00; color: #c00; }
     .btn-primary { background: #e8f0fe; border-color: #36c; color: #36c; }
-    nav { display: flex; }
+    nav { display: flex; align-items: center; }
     nav a { margin-right: 1.5em; }
     nav .spacer { flex: 1; }
+    nav .nav-user { color: #888; font-size: 0.9em; margin-right: 1em; }
+    nav form.logout-form { margin: 0; }
+    nav .btn-logout { padding: 0.3em 0.9em; font-size: 0.9em; }
     .error { color: #c00; }
     .field-error { color: #c00; font-size: 0.85em; }
     .status-running { color: #080; font-weight: bold; }
@@ -47,6 +50,10 @@
     <a href="/system/">System Info</a>
     <a href="/settings">Settings</a>
     <span class="spacer"></span>
+    {% if display_name %}<span class="nav-user">Logged in as {{ display_name }}</span>{% endif %}
+    <form class="logout-form" method="post" action="/logout">
+      <button type="submit" class="btn btn-danger btn-logout">Log out</button>
+    </form>
   </nav>
   <hr>
   {% block content %}{% endblock %}


### PR DESCRIPTION
Surfaces the existing POST /logout endpoint in the shared dashboard nav as a Log out button, alongside a Logged in as <name> indicator. Previously there was no way to log out from the UI; the backend route already existed but was never wired to anything.

The button is a top-level form POST to /logout (the session cookie is httponly + samesite=lax, so logout must round-trip through the server). It lives in the shared layout.html, so it appears on every authenticated page (dashboard, settings, system, terminal, app detail, add app) and is correctly absent from the standalone login page.

This PR also fixes a pre-existing forced-logout CSRF on POST /logout. Because /logout has no owner-auth guard (it must work for any session state), it was the one state-changing POST that skipped the Origin check every other endpoint gets via verify_owner_auth, so a cross-site page could force-log-out the operator. Added a verify_same_origin helper that rejects any request whose Origin header is present but does not parse to the exact target host (this includes Origin: null sent by sandboxed iframes), and applied it to /logout. Same-origin requests (matching Origin, or no Origin on a top-level form post) still log out normally.

Tests: render test for the button; route tests that POST /logout revokes the session and clears the cookie, is no-op-safe with no session, rejects cross-origin/null/lookalike/wrong-port origins (and leaves the victim session intact), and allows same-origin and no-Origin requests.

Verified live on Hetzner instances provisioned from this branch via vm-manager: the real browser logout button works and revokes the session; cross-origin, Origin: null, and wrong-port POSTs do not revoke the session; same-origin and no-Origin requests do. Also ran extensive manual and adversarial edge-case suites (cookie/token fuzzing, HTTP method fuzzing, open-redirect checks, multi-tab logout, JS-disabled logout, etc) across multiple fresh instances.