### PR TITLE
Stop web update UI from telling owners to SSH in when host is behind

### DIFF
--- a/compute_space/src/compute_space/tests/test_settings_host_prep.py
+++ b/compute_space/src/compute_space/tests/test_settings_host_prep.py
@@ -69,8 +69,11 @@ async def test_check_for_updates_migration_behind_is_update_available(monkeypatc
 
     result = await settings_mod.check_for_updates.fn()
 
+    # A "behind" host is applied by the Update button, so we must not surface the
+    # CLI-oriented status message (which tells the owner to SSH in and run
+    # `sudo openhost_system_agent update apply`) as a scary error in the UI.
     assert result.state == "UPDATE_AVAILABLE"
-    assert result.error == "run system migrations"
+    assert result.error is None
 
 
 @pytest.mark.asyncio

--- a/compute_space/src/compute_space/web/routes/api/settings.py
+++ b/compute_space/src/compute_space/web/routes/api/settings.py
@@ -98,7 +98,12 @@ async def check_for_updates() -> CheckUpdatesResponse:
         return CheckUpdatesResponse(state=UpdateState.ERROR, error=str(e))
 
     if not migration_status.ok and migration_status.reason == "behind":
-        return CheckUpdatesResponse(state=UpdateState.UPDATE_AVAILABLE, error=migration_status.message)
+        # A "behind" host just needs pending system migrations applied, which the
+        # Update button does (it runs the same `openhost_system_agent update apply`
+        # the CLI status message suggests). Surfacing that CLI-oriented message here
+        # would wrongly tell the owner to SSH in, so we treat this like any other
+        # available update and let the button handle it.
+        return CheckUpdatesResponse(state=UpdateState.UPDATE_AVAILABLE)
 
     if not migration_status.ok:
         return CheckUpdatesResponse(state=UpdateState.ERROR, error=migration_status.message)


### PR DESCRIPTION
The Update settings page rendered the system agent's CLI-oriented migration-behind message as a red error above the Update button. That message tells the owner to run sudo openhost_system_agent update apply in a terminal, but the Update button already runs exactly that command (compute_space calls it and the host user has passwordless sudo). So the notice wrongly told owners to SSH in for something the button handles.

The behind-version message is generated by get_migration_status in openhost_system_agent, which is shared by the CLI status command (where the SSH instruction is appropriate) and the web check_for_updates endpoint (where it is not). This change stops check_for_updates from passing that message through for the behind case and treats a behind host as an ordinary available update, letting the button apply it. The CLI message is unchanged.

Tested on a fresh Hetzner OpenHost instance provisioned from this branch. After provisioning the host was at system version 1 while the code expected version 4 (behind). Confirmed the web check_for_updates returned UPDATE_AVAILABLE with no error message, then applied the update via the same code path the button uses. The host migrated v1 to v4, all migrations succeeded, openhost restarted healthy, and the check then reported UP_TO_DATE.

Updated the corresponding unit test to assert the behind message is no longer surfaced to the web UI.