### PR TITLE
Self-heal root-owned pixi env so a stray root pixi op can't brick the host

### DIFF
--- a/ansible/files/openhost-reclaim-pixi
+++ b/ansible/files/openhost-reclaim-pixi
@@ -12,15 +12,20 @@
 # so no $VAR reaches systemd, which would substitute it before /bin/sh runs.
 # Idempotent; missing paths are skipped.
 #
-# Best-effort by design: each chown is bounded by `timeout` and its failure is
-# swallowed (`|| :`). A systemd ExecStartPre with the `-` prefix ignores this
-# script's exit code, but that does NOT exempt it from TimeoutStartSec — a chown
-# that hung on a slow/stuck disk would otherwise blow the start window and block
-# the very service this failsafe protects. Bounding each chown well under the
-# default 90s start timeout guarantees we never do that.
-
+# Best-effort by design: the whole reclaim is bounded by a single `timeout` and
+# its failure is swallowed (`|| :`). A systemd ExecStartPre with the `-` prefix
+# ignores this script's exit code, but that does NOT exempt it from
+# TimeoutStartSec, which applies cumulatively across ExecStartPre commands. A
+# chown hung on a slow/stuck disk would otherwise blow the start window and
+# block the very service this failsafe protects. One overall bound (not a
+# per-path bound that could sum past the window) well under systemd's default
+# 90s start timeout guarantees we never do that.
+#
+# shellcheck disable=SC2016  # $dir is expanded by the inner `sh -c`, not here.
+timeout 80 sh -c '
 for dir in /home/host/.pixi /home/host/openhost/.pixi; do
     if [ -e "$dir" ]; then
-        timeout 60 chown -Rh host:host "$dir" || :
+        chown -Rh host:host "$dir"
     fi
 done
+' || :

--- a/ansible/files/openhost-reclaim-pixi
+++ b/ansible/files/openhost-reclaim-pixi
@@ -11,10 +11,16 @@
 # self-heals on boot. A standalone script (not an inline ExecStartPre snippet)
 # so no $VAR reaches systemd, which would substitute it before /bin/sh runs.
 # Idempotent; missing paths are skipped.
-set -eu
+#
+# Best-effort by design: each chown is bounded by `timeout` and its failure is
+# swallowed (`|| :`). A systemd ExecStartPre with the `-` prefix ignores this
+# script's exit code, but that does NOT exempt it from TimeoutStartSec — a chown
+# that hung on a slow/stuck disk would otherwise blow the start window and block
+# the very service this failsafe protects. Bounding each chown well under the
+# default 90s start timeout guarantees we never do that.
 
 for dir in /home/host/.pixi /home/host/openhost/.pixi; do
     if [ -e "$dir" ]; then
-        chown -Rh host:host "$dir"
+        timeout 60 chown -Rh host:host "$dir" || :
     fi
 done

--- a/ansible/files/openhost-reclaim-pixi
+++ b/ansible/files/openhost-reclaim-pixi
@@ -1,0 +1,20 @@
+#!/bin/sh
+# Reclaim ownership of the host's pixi trees for the host user. Managed by
+# OpenHost; keep in sync with RECLAIM_SCRIPT in the openhost_system_agent
+# baseline migration (v0002_baseline.py).
+#
+# The openhost service runs as the unprivileged host user via `pixi run`. A
+# pixi operation accidentally run as root leaves root-owned files under the
+# host-owned pixi trees, and the host service's next `pixi run` then fails with
+# EACCES and won't start. Run as root (e.g. from a systemd ExecStartPre with
+# the '+' prefix), this hands those trees back to host so the service
+# self-heals on boot. A standalone script (not an inline ExecStartPre snippet)
+# so no $VAR reaches systemd, which would substitute it before /bin/sh runs.
+# Idempotent; missing paths are skipped.
+set -eu
+
+for dir in /home/host/.pixi /home/host/openhost/.pixi; do
+    if [ -e "$dir" ]; then
+        chown -Rh host:host "$dir"
+    fi
+done

--- a/ansible/tasks/setup_openhost_service.yml
+++ b/ansible/tasks/setup_openhost_service.yml
@@ -80,6 +80,20 @@
     state: link
     force: yes
 
+# The openhost.service ExecStartPre reclaims ownership of the pixi trees as
+# root before the host-user ExecStart runs `pixi run`. It lives at a fixed
+# system path so the unit references it without any $VAR that systemd would
+# substitute, and so it works even when the pixi env is broken.
+- name: Install pixi-ownership reclaim script
+  become: yes
+  become_user: root
+  copy:
+    src: files/openhost-reclaim-pixi
+    dest: /usr/local/bin/openhost-reclaim-pixi
+    owner: root
+    group: root
+    mode: "0755"
+
 - name: Install openhost systemd service
   become: yes
   become_user: root

--- a/ansible/templates/openhost.service.j2
+++ b/ansible/templates/openhost.service.j2
@@ -30,10 +30,11 @@ Environment=DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/{{ host_uid }}/bus
 # runs `pixi run`. A pixi operation accidentally run as root (older update
 # bugs, or a stray root self-update) leaves root-owned files the host user
 # can't modify, so `pixi run` fails with EACCES and the service never starts.
-# The `+` prefix runs this as root even though the unit is User=host; without
-# it the chown couldn't touch root-owned files. Inline so it needs nothing
-# from the (possibly broken) pixi env.
-ExecStartPre=+/bin/sh -c 'for d in /home/host/.pixi /home/host/openhost/.pixi; do [ -e "$d" ] && chown -Rh host:host "$d"; done; true'
+# The `+` prefix runs the script as root even though the unit is User=host;
+# without it the chown couldn't touch root-owned files. It's a standalone
+# script (not an inline snippet) so no $VAR reaches systemd, and it needs
+# nothing from the (possibly broken) pixi env.
+ExecStartPre=+/usr/local/bin/openhost-reclaim-pixi
 ExecStart=/home/host/.pixi/bin/pixi run python -m compute_space
 # Don't auto-restart on crash (can blow through certbot rate limits).
 # RestartForceExitStatus=42 overrides Restart=no for exit code 42 only,

--- a/ansible/templates/openhost.service.j2
+++ b/ansible/templates/openhost.service.j2
@@ -30,11 +30,14 @@ Environment=DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/{{ host_uid }}/bus
 # runs `pixi run`. A pixi operation accidentally run as root (older update
 # bugs, or a stray root self-update) leaves root-owned files the host user
 # can't modify, so `pixi run` fails with EACCES and the service never starts.
-# The `+` prefix runs the script as root even though the unit is User=host;
-# without it the chown couldn't touch root-owned files. It's a standalone
-# script (not an inline snippet) so no $VAR reaches systemd, and it needs
-# nothing from the (possibly broken) pixi env.
-ExecStartPre=+/usr/local/bin/openhost-reclaim-pixi
+# Prefixes (order-insensitive): `+` runs the script as root even though the
+# unit is User=host (needed to chown root-owned files); `-` makes it
+# best-effort so a chown failure can never block startup — a genuinely broken
+# env still surfaces its real error at ExecStart, and this failsafe must never
+# itself brick the service it protects. It's a standalone script (not an inline
+# snippet) so no $VAR reaches systemd, and it needs nothing from the (possibly
+# broken) pixi env.
+ExecStartPre=-+/usr/local/bin/openhost-reclaim-pixi
 ExecStart=/home/host/.pixi/bin/pixi run python -m compute_space
 # Don't auto-restart on crash (can blow through certbot rate limits).
 # RestartForceExitStatus=42 overrides Restart=no for exit code 42 only,

--- a/ansible/templates/openhost.service.j2
+++ b/ansible/templates/openhost.service.j2
@@ -26,6 +26,14 @@ Environment=OPENHOST_ROUTER_CONFIG=/home/host/.openhost/local_compute_space/conf
 # runtime-dir search path anchors on XDG_RUNTIME_DIR too).
 Environment=XDG_RUNTIME_DIR=/run/user/{{ host_uid }}
 Environment=DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/{{ host_uid }}/bus
+# Failsafe: reclaim ownership of the pixi trees before the host-user ExecStart
+# runs `pixi run`. A pixi operation accidentally run as root (older update
+# bugs, or a stray root self-update) leaves root-owned files the host user
+# can't modify, so `pixi run` fails with EACCES and the service never starts.
+# The `+` prefix runs this as root even though the unit is User=host; without
+# it the chown couldn't touch root-owned files. Inline so it needs nothing
+# from the (possibly broken) pixi env.
+ExecStartPre=+/bin/sh -c 'for d in /home/host/.pixi /home/host/openhost/.pixi; do [ -e "$d" ] && chown -Rh host:host "$d"; done; true'
 ExecStart=/home/host/.pixi/bin/pixi run python -m compute_space
 # Don't auto-restart on crash (can blow through certbot rate limits).
 # RestartForceExitStatus=42 overrides Restart=no for exit code 42 only,

--- a/openhost_system_agent/src/openhost_system_agent/apply_after_checkout.py
+++ b/openhost_system_agent/src/openhost_system_agent/apply_after_checkout.py
@@ -150,17 +150,19 @@ def main() -> None:
     project = str(Path(__file__).resolve().parents[3])
     _ensure_repo_trusted(project)
 
+    # Failsafe: hand the pixi trees back to the host user FIRST, before anything
+    # else touches them. This must precede migrations because a migration can
+    # run a pixi operation as the host user (e.g. v0004's `pixi self-update`);
+    # if an older root-run left `/home/host/.pixi` root-owned, that host-user
+    # step would fail with EACCES and abort the whole update — never reaching a
+    # later reclaim — leaving the host bricked. It also precedes the host-user
+    # `pixi install` below and heals root-owned residue left by prior updates.
+    # Runs as root (this whole apply is root via sudo).
+    reclaim_pixi_ownership()
+
     # Migrations run before install so a toolchain upgrade (e.g. pixi) takes
     # effect before deps are installed for this checkout.
     apply_system_migrations()
-
-    # Failsafe: hand the pixi trees back to the host user before the host-user
-    # install below needs to touch them. Migrations run as root and older
-    # openhost versions ran `pixi install` as root, either of which can leave
-    # root-owned files that the host service's `pixi run` then can't modify.
-    # Reclaiming here lets such hosts self-heal on their next update instead of
-    # staying bricked. Runs as root (this whole apply is root via sudo).
-    reclaim_pixi_ownership()
 
     # Install as the unprivileged 'host' user, not root. The openhost service
     # runs as host via `pixi run`, and pixi tracks its PyPI sync per-user; a

--- a/openhost_system_agent/src/openhost_system_agent/apply_after_checkout.py
+++ b/openhost_system_agent/src/openhost_system_agent/apply_after_checkout.py
@@ -32,6 +32,7 @@ import sys
 from pathlib import Path
 
 from openhost_system_agent.migrations.runner import apply_system_migrations
+from openhost_system_agent.reclaim import reclaim_pixi_ownership
 
 PIXI_BIN = "/home/host/.pixi/bin/pixi"
 
@@ -152,6 +153,14 @@ def main() -> None:
     # Migrations run before install so a toolchain upgrade (e.g. pixi) takes
     # effect before deps are installed for this checkout.
     apply_system_migrations()
+
+    # Failsafe: hand the pixi trees back to the host user before the host-user
+    # install below needs to touch them. Migrations run as root and older
+    # openhost versions ran `pixi install` as root, either of which can leave
+    # root-owned files that the host service's `pixi run` then can't modify.
+    # Reclaiming here lets such hosts self-heal on their next update instead of
+    # staying bricked. Runs as root (this whole apply is root via sudo).
+    reclaim_pixi_ownership()
 
     # Install as the unprivileged 'host' user, not root. The openhost service
     # runs as host via `pixi run`, and pixi tracks its PyPI sync per-user; a

--- a/openhost_system_agent/src/openhost_system_agent/migrations/registry.py
+++ b/openhost_system_agent/src/openhost_system_agent/migrations/registry.py
@@ -8,6 +8,7 @@ from openhost_system_agent.migrations.versions.v0003_remove_obsolete_hairpin_nat
     Migration0003RemoveObsoleteHairpinNat,
 )
 from openhost_system_agent.migrations.versions.v0004_pixi_version import Migration0004PixiVersion
+from openhost_system_agent.migrations.versions.v0005_pixi_ownership_failsafe import Migration0005PixiOwnershipFailsafe
 
 # Numbered migrations in apply order. Versions MUST start at 2 and be
 # contiguous. v1 is the baseline produced by ansible setup.yml.
@@ -15,6 +16,7 @@ REGISTRY: list[SystemMigration] = [
     Migration0002Baseline(),
     Migration0003RemoveObsoleteHairpinNat(),
     Migration0004PixiVersion(),
+    Migration0005PixiOwnershipFailsafe(),
 ]
 
 

--- a/openhost_system_agent/src/openhost_system_agent/migrations/versions/v0002_baseline.py
+++ b/openhost_system_agent/src/openhost_system_agent/migrations/versions/v0002_baseline.py
@@ -18,16 +18,41 @@ from openhost_system_agent.migrations.helpers import write_file
 
 OPENHOST_SERVICE_PATH = "/etc/systemd/system/openhost.service"
 
-# Failsafe run before the host-user ExecStart: reclaim ownership of the pixi
-# trees so a pixi operation once run as root (old update bugs, stray root
-# self-update) can't brick the service. The `+` prefix runs it as root even
-# though the unit is User=host; inline so it needs nothing from the (possibly
-# broken) pixi env. Kept as a module constant so later migrations rewriting the
-# unit stay byte-identical with this baseline.
-RECLAIM_EXEC_START_PRE = (
-    "ExecStartPre=+/bin/sh -c 'for d in /home/host/.pixi /home/host/openhost/.pixi; "
-    'do [ -e "$d" ] && chown -Rh host:host "$d"; done; true\'\n'
-)
+# Fixed path for the reclaim script the service runs before ExecStart.
+RECLAIM_SCRIPT_PATH = "/usr/local/bin/openhost-reclaim-pixi"
+
+# The reclaim script: hand the host's pixi trees back to the host user. Run as
+# root (the unit's ExecStartPre uses the `+` prefix) before the host-user
+# `pixi run`, so a pixi op once run as root (old update bugs, stray root
+# self-update) can't brick the service. A standalone script — not an inline
+# ExecStartPre snippet — so no $VAR reaches systemd (which would substitute it
+# from the unit environment before /bin/sh runs). Depends on nothing from the
+# (possibly broken) pixi env. Kept byte-identical with
+# ansible/files/openhost-reclaim-pixi (a test enforces this).
+RECLAIM_SCRIPT = """#!/bin/sh
+# Reclaim ownership of the host's pixi trees for the host user. Managed by
+# OpenHost; keep in sync with RECLAIM_SCRIPT in the openhost_system_agent
+# baseline migration (v0002_baseline.py).
+#
+# The openhost service runs as the unprivileged host user via `pixi run`. A
+# pixi operation accidentally run as root leaves root-owned files under the
+# host-owned pixi trees, and the host service's next `pixi run` then fails with
+# EACCES and won't start. Run as root (e.g. from a systemd ExecStartPre with
+# the '+' prefix), this hands those trees back to host so the service
+# self-heals on boot. A standalone script (not an inline ExecStartPre snippet)
+# so no $VAR reaches systemd, which would substitute it before /bin/sh runs.
+# Idempotent; missing paths are skipped.
+set -eu
+
+for dir in /home/host/.pixi /home/host/openhost/.pixi; do
+    if [ -e "$dir" ]; then
+        chown -Rh host:host "$dir"
+    fi
+done
+"""
+
+# The unit line that invokes the reclaim script as root before ExecStart.
+RECLAIM_EXEC_START_PRE = f"ExecStartPre=+{RECLAIM_SCRIPT_PATH}\n"
 
 
 def build_openhost_service_unit(host_uid: int) -> str:
@@ -158,6 +183,7 @@ class Migration0002Baseline(SystemMigration):
         run("systemctl", "reload", "ssh")
 
     def _systemd_service(self) -> None:
+        write_file(RECLAIM_SCRIPT_PATH, RECLAIM_SCRIPT, mode=0o755)
         unit = build_openhost_service_unit(get_host_uid())
         write_file(OPENHOST_SERVICE_PATH, unit, mode=0o644)
         run("systemctl", "daemon-reload")

--- a/openhost_system_agent/src/openhost_system_agent/migrations/versions/v0002_baseline.py
+++ b/openhost_system_agent/src/openhost_system_agent/migrations/versions/v0002_baseline.py
@@ -43,18 +43,23 @@ RECLAIM_SCRIPT = """#!/bin/sh
 # so no $VAR reaches systemd, which would substitute it before /bin/sh runs.
 # Idempotent; missing paths are skipped.
 #
-# Best-effort by design: each chown is bounded by `timeout` and its failure is
-# swallowed (`|| :`). A systemd ExecStartPre with the `-` prefix ignores this
-# script's exit code, but that does NOT exempt it from TimeoutStartSec — a chown
-# that hung on a slow/stuck disk would otherwise blow the start window and block
-# the very service this failsafe protects. Bounding each chown well under the
-# default 90s start timeout guarantees we never do that.
-
+# Best-effort by design: the whole reclaim is bounded by a single `timeout` and
+# its failure is swallowed (`|| :`). A systemd ExecStartPre with the `-` prefix
+# ignores this script's exit code, but that does NOT exempt it from
+# TimeoutStartSec, which applies cumulatively across ExecStartPre commands. A
+# chown hung on a slow/stuck disk would otherwise blow the start window and
+# block the very service this failsafe protects. One overall bound (not a
+# per-path bound that could sum past the window) well under systemd's default
+# 90s start timeout guarantees we never do that.
+#
+# shellcheck disable=SC2016  # $dir is expanded by the inner `sh -c`, not here.
+timeout 80 sh -c '
 for dir in /home/host/.pixi /home/host/openhost/.pixi; do
     if [ -e "$dir" ]; then
-        timeout 60 chown -Rh host:host "$dir" || :
+        chown -Rh host:host "$dir"
     fi
 done
+' || :
 """
 
 # The unit line that invokes the reclaim script before ExecStart. Prefixes

--- a/openhost_system_agent/src/openhost_system_agent/migrations/versions/v0002_baseline.py
+++ b/openhost_system_agent/src/openhost_system_agent/migrations/versions/v0002_baseline.py
@@ -51,8 +51,12 @@ for dir in /home/host/.pixi /home/host/openhost/.pixi; do
 done
 """
 
-# The unit line that invokes the reclaim script as root before ExecStart.
-RECLAIM_EXEC_START_PRE = f"ExecStartPre=+{RECLAIM_SCRIPT_PATH}\n"
+# The unit line that invokes the reclaim script before ExecStart. Prefixes
+# (order-insensitive): `+` runs it as root (needed to chown root-owned files
+# even though the unit is User=host); `-` makes it best-effort so a chown
+# failure can never block startup — the failsafe must not brick the service it
+# protects. Kept in sync with ansible/templates/openhost.service.j2.
+RECLAIM_EXEC_START_PRE = f"ExecStartPre=-+{RECLAIM_SCRIPT_PATH}\n"
 
 
 def build_openhost_service_unit(host_uid: int) -> str:

--- a/openhost_system_agent/src/openhost_system_agent/migrations/versions/v0002_baseline.py
+++ b/openhost_system_agent/src/openhost_system_agent/migrations/versions/v0002_baseline.py
@@ -42,11 +42,17 @@ RECLAIM_SCRIPT = """#!/bin/sh
 # self-heals on boot. A standalone script (not an inline ExecStartPre snippet)
 # so no $VAR reaches systemd, which would substitute it before /bin/sh runs.
 # Idempotent; missing paths are skipped.
-set -eu
+#
+# Best-effort by design: each chown is bounded by `timeout` and its failure is
+# swallowed (`|| :`). A systemd ExecStartPre with the `-` prefix ignores this
+# script's exit code, but that does NOT exempt it from TimeoutStartSec — a chown
+# that hung on a slow/stuck disk would otherwise blow the start window and block
+# the very service this failsafe protects. Bounding each chown well under the
+# default 90s start timeout guarantees we never do that.
 
 for dir in /home/host/.pixi /home/host/openhost/.pixi; do
     if [ -e "$dir" ]; then
-        chown -Rh host:host "$dir"
+        timeout 60 chown -Rh host:host "$dir" || :
     fi
 done
 """

--- a/openhost_system_agent/src/openhost_system_agent/migrations/versions/v0002_baseline.py
+++ b/openhost_system_agent/src/openhost_system_agent/migrations/versions/v0002_baseline.py
@@ -16,6 +16,50 @@ from openhost_system_agent.migrations.helpers import run
 from openhost_system_agent.migrations.helpers import set_sshd_option
 from openhost_system_agent.migrations.helpers import write_file
 
+OPENHOST_SERVICE_PATH = "/etc/systemd/system/openhost.service"
+
+# Failsafe run before the host-user ExecStart: reclaim ownership of the pixi
+# trees so a pixi operation once run as root (old update bugs, stray root
+# self-update) can't brick the service. The `+` prefix runs it as root even
+# though the unit is User=host; inline so it needs nothing from the (possibly
+# broken) pixi env. Kept as a module constant so later migrations rewriting the
+# unit stay byte-identical with this baseline.
+RECLAIM_EXEC_START_PRE = (
+    "ExecStartPre=+/bin/sh -c 'for d in /home/host/.pixi /home/host/openhost/.pixi; "
+    'do [ -e "$d" ] && chown -Rh host:host "$d"; done; true\'\n'
+)
+
+
+def build_openhost_service_unit(host_uid: int) -> str:
+    """Render the openhost.service unit. Shared so migrations that rewrite it
+    stay consistent with the baseline (and with ansible's template)."""
+    return (
+        "[Unit]\n"
+        "Description=OpenHost Compute Space\n"
+        f"After=network-online.target user@{host_uid}.service\n"
+        f"Wants=network-online.target user@{host_uid}.service\n"
+        "\n"
+        "[Service]\n"
+        "Type=simple\n"
+        "User=host\n"
+        "WorkingDirectory=/home/host/openhost\n"
+        "Environment=PATH=/home/host/.pixi/bin:/home/host/openhost/.pixi/envs/default/bin:"
+        "/usr/local/bin:/usr/bin:/bin\n"
+        "Environment=OPENHOST_ROUTER_CONFIG=/home/host/.openhost/local_compute_space/config.toml\n"
+        f"Environment=XDG_RUNTIME_DIR=/run/user/{host_uid}\n"
+        f"Environment=DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/{host_uid}/bus\n"
+        + RECLAIM_EXEC_START_PRE
+        + "ExecStart=/home/host/.pixi/bin/pixi run python -m compute_space\n"
+        "Restart=no\n"
+        "RestartForceExitStatus=42\n"
+        "SuccessExitStatus=42\n"
+        "RestartSec=3\n"
+        "TimeoutStopSec=5\n"
+        "\n"
+        "[Install]\n"
+        "WantedBy=multi-user.target\n"
+    )
+
 
 class Migration0002Baseline(SystemMigration):
     version = 2
@@ -114,32 +158,7 @@ class Migration0002Baseline(SystemMigration):
         run("systemctl", "reload", "ssh")
 
     def _systemd_service(self) -> None:
-        host_uid = get_host_uid()
-        unit = (
-            "[Unit]\n"
-            "Description=OpenHost Compute Space\n"
-            f"After=network-online.target user@{host_uid}.service\n"
-            f"Wants=network-online.target user@{host_uid}.service\n"
-            "\n"
-            "[Service]\n"
-            "Type=simple\n"
-            "User=host\n"
-            "WorkingDirectory=/home/host/openhost\n"
-            "Environment=PATH=/home/host/.pixi/bin:/home/host/openhost/.pixi/envs/default/bin:"
-            "/usr/local/bin:/usr/bin:/bin\n"
-            "Environment=OPENHOST_ROUTER_CONFIG=/home/host/.openhost/local_compute_space/config.toml\n"
-            f"Environment=XDG_RUNTIME_DIR=/run/user/{host_uid}\n"
-            f"Environment=DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/{host_uid}/bus\n"
-            "ExecStart=/home/host/.pixi/bin/pixi run python -m compute_space\n"
-            "Restart=no\n"
-            "RestartForceExitStatus=42\n"
-            "SuccessExitStatus=42\n"
-            "RestartSec=3\n"
-            "TimeoutStopSec=5\n"
-            "\n"
-            "[Install]\n"
-            "WantedBy=multi-user.target\n"
-        )
-        write_file("/etc/systemd/system/openhost.service", unit, mode=0o644)
+        unit = build_openhost_service_unit(get_host_uid())
+        write_file(OPENHOST_SERVICE_PATH, unit, mode=0o644)
         run("systemctl", "daemon-reload")
         run("systemctl", "enable", "openhost")

--- a/openhost_system_agent/src/openhost_system_agent/migrations/versions/v0005_pixi_ownership_failsafe.py
+++ b/openhost_system_agent/src/openhost_system_agent/migrations/versions/v0005_pixi_ownership_failsafe.py
@@ -1,0 +1,39 @@
+"""Reclaim pixi ownership and add the startup failsafe to openhost.service.
+
+Older openhost versions ran ``pixi install`` (and ``pixi self-update``) as root
+during ``update apply``, leaving root-owned files under the host-owned pixi
+trees. The host service's ``pixi run`` then fails with EACCES and won't start.
+
+This migration heals such hosts and prevents recurrence:
+  1. chown the pixi trees back to host now (fixes the current env).
+  2. Rewrite openhost.service to include the ``ExecStartPre=+`` reclaim step,
+     so any future root-owned residue is fixed on every boot before ``pixi
+     run``, even on hosts that can't reach an update.
+
+Both steps are idempotent. The rewritten unit is byte-identical to the one the
+baseline migration now produces (both call ``build_openhost_service_unit``).
+"""
+
+from __future__ import annotations
+
+from openhost_system_agent.migrations.base import SystemMigration
+from openhost_system_agent.migrations.helpers import get_host_uid
+from openhost_system_agent.migrations.helpers import run
+from openhost_system_agent.migrations.helpers import write_file
+from openhost_system_agent.migrations.versions.v0002_baseline import OPENHOST_SERVICE_PATH
+from openhost_system_agent.migrations.versions.v0002_baseline import build_openhost_service_unit
+from openhost_system_agent.reclaim import reclaim_pixi_ownership
+
+
+class Migration0005PixiOwnershipFailsafe(SystemMigration):
+    version = 5
+
+    def up(self) -> None:
+        # Heal the current env up front so this migration's own downstream
+        # `pixi install` (run as host by apply_after_checkout) succeeds.
+        reclaim_pixi_ownership()
+
+        # Persist the startup failsafe into the unit so future root-owned
+        # residue self-heals on every boot.
+        write_file(OPENHOST_SERVICE_PATH, build_openhost_service_unit(get_host_uid()), mode=0o644)
+        run("systemctl", "daemon-reload")

--- a/openhost_system_agent/src/openhost_system_agent/migrations/versions/v0005_pixi_ownership_failsafe.py
+++ b/openhost_system_agent/src/openhost_system_agent/migrations/versions/v0005_pixi_ownership_failsafe.py
@@ -21,6 +21,8 @@ from openhost_system_agent.migrations.helpers import get_host_uid
 from openhost_system_agent.migrations.helpers import run
 from openhost_system_agent.migrations.helpers import write_file
 from openhost_system_agent.migrations.versions.v0002_baseline import OPENHOST_SERVICE_PATH
+from openhost_system_agent.migrations.versions.v0002_baseline import RECLAIM_SCRIPT
+from openhost_system_agent.migrations.versions.v0002_baseline import RECLAIM_SCRIPT_PATH
 from openhost_system_agent.migrations.versions.v0002_baseline import build_openhost_service_unit
 from openhost_system_agent.reclaim import reclaim_pixi_ownership
 
@@ -33,7 +35,9 @@ class Migration0005PixiOwnershipFailsafe(SystemMigration):
         # `pixi install` (run as host by apply_after_checkout) succeeds.
         reclaim_pixi_ownership()
 
-        # Persist the startup failsafe into the unit so future root-owned
-        # residue self-heals on every boot.
+        # Install the reclaim script and wire the startup failsafe into the
+        # unit so future root-owned residue self-heals on every boot. Existing
+        # hosts ran the baseline before either existed, so write both here.
+        write_file(RECLAIM_SCRIPT_PATH, RECLAIM_SCRIPT, mode=0o755)
         write_file(OPENHOST_SERVICE_PATH, build_openhost_service_unit(get_host_uid()), mode=0o644)
         run("systemctl", "daemon-reload")

--- a/openhost_system_agent/src/openhost_system_agent/pixi.py
+++ b/openhost_system_agent/src/openhost_system_agent/pixi.py
@@ -2,17 +2,35 @@
 
 from __future__ import annotations
 
+import os
 import subprocess
 
 PIXI_VERSION = "0.70.2"
 PIXI_BIN = "/home/host/.pixi/bin/pixi"
 
+#: The unprivileged user that owns ``/home/host/.pixi`` and runs the openhost
+#: service. Pixi operations must run as this user so they never leave
+#: root-owned files behind (see ``reclaim.py``).
+HOST_USER = "host"
+
 
 def ensure_pixi_version() -> None:
-    """Pin the host's pixi to PIXI_VERSION. Idempotent."""
+    """Pin the host's pixi to PIXI_VERSION. Idempotent.
+
+    Runs ``self-update`` as the ``host`` user (via sudo) even though the
+    migration itself runs as root: pixi's binary and its per-user caches live
+    under ``/home/host/.pixi``, and a root-run self-update would leave
+    root-owned files there that the host service's ``pixi run`` then can't
+    modify (the same failure class this migration exists to avoid).
+    """
+    cmd = [PIXI_BIN, "self-update", "--version", PIXI_VERSION]
+    # Drop to the host user when we're root (the migration case). When already
+    # running as host (tests, dev), invoke pixi directly.
+    if os.geteuid() == 0:
+        cmd = ["sudo", "-u", HOST_USER, "-H", *cmd]
     try:
         result = subprocess.run(
-            [PIXI_BIN, "self-update", "--version", PIXI_VERSION],
+            cmd,
             capture_output=True,
             text=True,
             timeout=120,

--- a/openhost_system_agent/src/openhost_system_agent/reclaim.py
+++ b/openhost_system_agent/src/openhost_system_agent/reclaim.py
@@ -1,0 +1,52 @@
+"""Reclaim ownership of the host's pixi tree.
+
+The openhost service runs as the unprivileged ``host`` user via ``pixi run``,
+and pixi tracks its env and per-user caches under paths owned by ``host``. Any
+pixi (or pip) operation accidentally run as root leaves root-owned files there
+that the host service can't later modify — its next ``pixi run`` fails with
+EACCES ("Failed to update PyPI packages ... Permission denied") and the service
+won't start.
+
+This module chowns the pixi tree back to ``host`` so such a mistake self-heals
+instead of bricking the host. It is a failsafe: the code paths that install
+deps already run as ``host`` (see ``apply_after_checkout``); this reclaims any
+residue left by older buggy versions or by a stray future root-run pixi call.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+
+from openhost_system_agent.pixi import HOST_USER
+
+#: Pixi trees owned by the host user. The first holds the pixi binary itself
+#: (targeted by ``pixi self-update``); the second holds the project's resolved
+#: environment (targeted by ``pixi install``). Both must stay host-owned.
+_PIXI_PATHS = (
+    "/home/host/.pixi",
+    "/home/host/openhost/.pixi",
+)
+
+
+def reclaim_pixi_ownership() -> None:
+    """chown the host's pixi trees back to the host user. Root-only, idempotent.
+
+    Safe to call repeatedly and cheap when nothing is misowned. Missing paths
+    are skipped (a fresh host may not have the project env yet). Raises if not
+    run as root, since only root can chown files another user owns.
+    """
+    if os.geteuid() != 0:
+        raise RuntimeError("reclaim_pixi_ownership must be run as root")
+
+    for path in _PIXI_PATHS:
+        if not os.path.exists(path):
+            continue
+        # -R to cover the whole tree; -h so symlinks are chowned in place
+        # rather than followed. check=True: a failure here means the env may
+        # still be broken, so surface it rather than silently continuing.
+        subprocess.run(
+            ["chown", "-Rh", f"{HOST_USER}:{HOST_USER}", path],
+            check=True,
+            timeout=120,
+        )

--- a/openhost_system_agent/src/openhost_system_agent/tests/test_apply_after_checkout.py
+++ b/openhost_system_agent/src/openhost_system_agent/tests/test_apply_after_checkout.py
@@ -233,9 +233,11 @@ def test_ensure_repo_trusted_is_idempotent(tmp_path: Path, monkeypatch: pytest.M
     assert result.stdout.count(str(repo)) == 1
 
 
-def test_main_reclaims_pixi_ownership_after_migrations_before_install() -> None:
-    # The failsafe must run after migrations (which run as root and include the
-    # pixi self-update) and before the host-user `pixi install` touches the env.
+def test_main_reclaims_pixi_ownership_before_migrations_and_install() -> None:
+    # The failsafe must run FIRST: before migrations (a migration can run a
+    # host-user pixi op, e.g. v0004's self-update, that would fail on a
+    # root-owned tree and abort the update) and before the host-user
+    # `pixi install`.
     order: list[str] = []
 
     def _install(*_args: object, **_kwargs: object) -> subprocess.CompletedProcess[str]:
@@ -250,11 +252,11 @@ def test_main_reclaims_pixi_ownership_after_migrations_before_install() -> None:
         patch.object(aac, "_next_step", return_value=None),
     ):
         # No next step -> falls through to the systemctl restart, which our
-        # mocked subprocess.run also records as an "install" entry; assert only
-        # the relative order of migrations -> reclaim -> first subprocess call.
+        # mocked subprocess.run also records as an "install" entry; assert the
+        # relative order of reclaim -> migrations -> first subprocess call.
         aac.main()
 
-    assert order[:3] == ["migrations", "reclaim", "install"]
+    assert order[:3] == ["reclaim", "migrations", "install"]
     # The first subprocess call is the host-user pixi install.
     first_call = mock_run.call_args_list[0]
     assert first_call.args[0] == ["sudo", "-u", "host", "-H", aac.PIXI_BIN, "install"]

--- a/openhost_system_agent/src/openhost_system_agent/tests/test_apply_after_checkout.py
+++ b/openhost_system_agent/src/openhost_system_agent/tests/test_apply_after_checkout.py
@@ -246,7 +246,7 @@ def test_main_reclaims_pixi_ownership_after_migrations_before_install() -> None:
         patch.object(aac, "_ensure_repo_trusted"),
         patch.object(aac, "apply_system_migrations", side_effect=lambda: order.append("migrations")),
         patch.object(aac, "reclaim_pixi_ownership", side_effect=lambda: order.append("reclaim")),
-        patch.object(aac.subprocess, "run", side_effect=_install) as mock_run,
+        patch("openhost_system_agent.apply_after_checkout.subprocess.run", side_effect=_install) as mock_run,
         patch.object(aac, "_next_step", return_value=None),
     ):
         # No next step -> falls through to the systemctl restart, which our

--- a/openhost_system_agent/src/openhost_system_agent/tests/test_apply_after_checkout.py
+++ b/openhost_system_agent/src/openhost_system_agent/tests/test_apply_after_checkout.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import os
 import subprocess
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
@@ -230,3 +231,31 @@ def test_ensure_repo_trusted_is_idempotent(tmp_path: Path, monkeypatch: pytest.M
         text=True,
     )
     assert result.stdout.count(str(repo)) == 1
+
+
+def test_main_reclaims_pixi_ownership_after_migrations_before_install() -> None:
+    # The failsafe must run after migrations (which run as root and include the
+    # pixi self-update) and before the host-user `pixi install` touches the env.
+    order: list[str] = []
+
+    def _install(*_args: object, **_kwargs: object) -> subprocess.CompletedProcess[str]:
+        order.append("install")
+        return subprocess.CompletedProcess(args=[], returncode=0)
+
+    with (
+        patch.object(aac, "_ensure_repo_trusted"),
+        patch.object(aac, "apply_system_migrations", side_effect=lambda: order.append("migrations")),
+        patch.object(aac, "reclaim_pixi_ownership", side_effect=lambda: order.append("reclaim")),
+        patch.object(aac.subprocess, "run", side_effect=_install) as mock_run,
+        patch.object(aac, "_next_step", return_value=None),
+    ):
+        # No next step -> falls through to the systemctl restart, which our
+        # mocked subprocess.run also records as an "install" entry; assert only
+        # the relative order of migrations -> reclaim -> first subprocess call.
+        aac.main()
+
+    assert order[:3] == ["migrations", "reclaim", "install"]
+    # The first subprocess call is the host-user pixi install.
+    first_call = mock_run.call_args_list[0]
+    assert first_call.args[0] == ["sudo", "-u", "host", "-H", aac.PIXI_BIN, "install"]
+    assert first_call.kwargs["timeout"] == 300

--- a/openhost_system_agent/src/openhost_system_agent/tests/test_apply_walk_e2e.py
+++ b/openhost_system_agent/src/openhost_system_agent/tests/test_apply_walk_e2e.py
@@ -17,7 +17,7 @@ DESIGN DECISION — migrations run once up front, then re-run as no-ops.
 ``setup_class`` runs the real migrations once so the baseline (v2) installs and
 enables the ``openhost.service`` systemd unit — the apply-walk's final step does
 ``systemctl restart openhost`` and needs that unit to exist. Running them also
-advances the migration log to the registry's highest version (v4), so each
+advances the migration log to the registry's highest version, so each
 per-test walk re-runs migrations as fast no-ops (the runner skips every
 migration whose version is ``<= current``) — the walk then only does
 ``pixi install`` + git checkout at each step, keeping the tests fast and
@@ -42,6 +42,12 @@ import subprocess
 import time
 from typing import cast
 
+# Bootstrapping the migration log to the registry's highest version makes every
+# migration a skipped no-op during a pure tag walk. Derived from the registry so
+# it can't drift when a migration is added.
+from openhost_system_agent.migrations.registry import REGISTRY as _REGISTRY
+from openhost_system_agent.migrations.registry import latest_registry_version as _latest_registry_version
+
 # Reuse the container-test helper toolkit and the shared, module-scoped image
 # fixture from the sibling container test module. Importing keeps a single
 # source of truth for _start_container / _exec / _host_sh / health-wait / the
@@ -59,9 +65,7 @@ from openhost_system_agent.tests.test_migration_container import _start_containe
 from openhost_system_agent.tests.test_migration_container import _wait_for_health
 from openhost_system_agent.tests.test_migration_container import requires_containers
 
-# The migration registry tops out at v4 (v0004_pixi_version). Bootstrapping the
-# log here makes every migration a skipped no-op during a pure tag walk.
-_LATEST_MIGRATION_VERSION = 4
+_LATEST_MIGRATION_VERSION = _latest_registry_version(_REGISTRY)
 
 
 # ── Shared per-container setup helpers ───────────────────────────────

--- a/openhost_system_agent/src/openhost_system_agent/tests/test_migration_container.py
+++ b/openhost_system_agent/src/openhost_system_agent/tests/test_migration_container.py
@@ -210,9 +210,7 @@ class TestApplyUpdateWalk:
         # Reference the registry so this can't drift when a migration is added.
         latest = latest_registry_version(REGISTRY)
         log = _exec(c, "cat", "/etc/openhost/migrations.jsonl")
-        assert f'"version":{latest}' in log.stdout.replace(" ", ""), (
-            f"log did not reach v{latest}:\n{log.stdout}"
-        )
+        assert f'"version":{latest}' in log.stdout.replace(" ", ""), f"log did not reach v{latest}:\n{log.stdout}"
 
         # openhost was restarted by the walk and serves /health.
         try:

--- a/openhost_system_agent/src/openhost_system_agent/tests/test_migration_container.py
+++ b/openhost_system_agent/src/openhost_system_agent/tests/test_migration_container.py
@@ -17,6 +17,9 @@ from pathlib import Path
 
 import pytest
 
+from openhost_system_agent.migrations.registry import REGISTRY
+from openhost_system_agent.migrations.registry import latest_registry_version
+
 requires_containers = pytest.mark.requires_containers
 
 _IMAGE_NAME = "openhost-migration-test:latest"
@@ -203,10 +206,13 @@ class TestApplyUpdateWalk:
         tag = _host_sh(c, f"cd {_REPO} && git describe --tags --exact-match HEAD")
         assert tag.stdout.strip() == "v2", f"HEAD not on v2: {tag.stdout!r}"
 
-        # The migration log advanced through the latest migration (the pixi
-        # upgrade), which is the highest version in the registry.
+        # The migration log advanced through to the registry's highest version.
+        # Reference the registry so this can't drift when a migration is added.
+        latest = latest_registry_version(REGISTRY)
         log = _exec(c, "cat", "/etc/openhost/migrations.jsonl")
-        assert '"version":4' in log.stdout.replace(" ", ""), f"log did not reach v4:\n{log.stdout}"
+        assert f'"version":{latest}' in log.stdout.replace(" ", ""), (
+            f"log did not reach v{latest}:\n{log.stdout}"
+        )
 
         # openhost was restarted by the walk and serves /health.
         try:

--- a/openhost_system_agent/src/openhost_system_agent/tests/test_pixi.py
+++ b/openhost_system_agent/src/openhost_system_agent/tests/test_pixi.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import subprocess
+from unittest.mock import patch
+
+import pytest
+
+from openhost_system_agent import pixi
+
+
+def _ok() -> subprocess.CompletedProcess[str]:
+    return subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr="")
+
+
+class TestEnsurePixiVersion:
+    def test_runs_self_update_as_host_when_root(self) -> None:
+        with (
+            patch("os.geteuid", return_value=0),
+            patch("subprocess.run", return_value=_ok()) as mock_run,
+        ):
+            pixi.ensure_pixi_version()
+
+        cmd = mock_run.call_args.args[0]
+        # Must drop to the host user so self-update never leaves root-owned
+        # files under /home/host/.pixi.
+        assert cmd[:4] == ["sudo", "-u", pixi.HOST_USER, "-H"]
+        assert cmd[4:] == [pixi.PIXI_BIN, "self-update", "--version", pixi.PIXI_VERSION]
+
+    def test_runs_pixi_directly_when_not_root(self) -> None:
+        with (
+            patch("os.geteuid", return_value=1000),
+            patch("subprocess.run", return_value=_ok()) as mock_run,
+        ):
+            pixi.ensure_pixi_version()
+
+        cmd = mock_run.call_args.args[0]
+        assert cmd == [pixi.PIXI_BIN, "self-update", "--version", pixi.PIXI_VERSION]
+
+    def test_raises_on_failure(self) -> None:
+        failed = subprocess.CompletedProcess(args=[], returncode=1, stdout="", stderr="boom")
+        with (
+            patch("os.geteuid", return_value=0),
+            patch("subprocess.run", return_value=failed),
+        ):
+            with pytest.raises(RuntimeError, match="self-update"):
+                pixi.ensure_pixi_version()

--- a/openhost_system_agent/src/openhost_system_agent/tests/test_reclaim.py
+++ b/openhost_system_agent/src/openhost_system_agent/tests/test_reclaim.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from openhost_system_agent import reclaim
+
+
+class TestReclaimPixiOwnership:
+    def test_refuses_when_not_root(self) -> None:
+        with patch("os.geteuid", return_value=1000):
+            with pytest.raises(RuntimeError, match="must be run as root"):
+                reclaim.reclaim_pixi_ownership()
+
+    def test_chowns_existing_paths_as_root(self) -> None:
+        # Both known pixi paths exist -> both chowned to host:host, recursively,
+        # with symlinks handled in place (-h).
+        with (
+            patch("os.geteuid", return_value=0),
+            patch("os.path.exists", return_value=True),
+            patch("subprocess.run") as mock_run,
+        ):
+            reclaim.reclaim_pixi_ownership()
+
+        called_paths = [call.args[0] for call in mock_run.call_args_list]
+        assert called_paths == [
+            ["chown", "-Rh", "host:host", "/home/host/.pixi"],
+            ["chown", "-Rh", "host:host", "/home/host/openhost/.pixi"],
+        ]
+        for call in mock_run.call_args_list:
+            assert call.kwargs["check"] is True
+
+    def test_skips_missing_paths(self) -> None:
+        # Only the second path exists -> only it is chowned; a fresh host
+        # without the project env yet must not error.
+        def fake_exists(path: str) -> bool:
+            return path == "/home/host/openhost/.pixi"
+
+        with (
+            patch("os.geteuid", return_value=0),
+            patch("os.path.exists", side_effect=fake_exists),
+            patch("subprocess.run") as mock_run,
+        ):
+            reclaim.reclaim_pixi_ownership()
+
+        called_paths = [call.args[0] for call in mock_run.call_args_list]
+        assert called_paths == [["chown", "-Rh", "host:host", "/home/host/openhost/.pixi"]]
+
+    def test_noop_when_no_paths_exist(self) -> None:
+        with (
+            patch("os.geteuid", return_value=0),
+            patch("os.path.exists", return_value=False),
+            patch("subprocess.run") as mock_run,
+        ):
+            reclaim.reclaim_pixi_ownership()
+        mock_run.assert_not_called()

--- a/openhost_system_agent/src/openhost_system_agent/tests/test_service_unit.py
+++ b/openhost_system_agent/src/openhost_system_agent/tests/test_service_unit.py
@@ -9,18 +9,19 @@ from openhost_system_agent.migrations.versions.v0002_baseline import build_openh
 
 
 class TestOpenhostServiceUnit:
-    def test_reclaim_execstartpre_calls_script_as_root(self) -> None:
+    def test_reclaim_execstartpre_runs_script_as_root_best_effort(self) -> None:
         unit = build_openhost_service_unit(1001)
         # Runs the standalone script (no inline $VAR for systemd to expand) as
-        # root via the `+` prefix.
-        assert f"ExecStartPre=+{RECLAIM_SCRIPT_PATH}\n" in unit
+        # root (`+`) and best-effort (`-`, so a chown failure can't block the
+        # service the failsafe protects).
+        assert f"ExecStartPre=-+{RECLAIM_SCRIPT_PATH}\n" in unit
         # Must not embed a shell $VAR, which systemd would substitute from the
         # unit environment before /bin/sh sees it.
         assert "$" not in RECLAIM_EXEC_START_PRE
 
     def test_reclaim_runs_before_execstart(self) -> None:
         unit = build_openhost_service_unit(1001)
-        assert unit.index("ExecStartPre=+") < unit.index("ExecStart=/home/host/.pixi/bin/pixi run")
+        assert unit.index("ExecStartPre=-+") < unit.index("ExecStart=/home/host/.pixi/bin/pixi run")
 
     def test_uses_the_shared_reclaim_constant(self) -> None:
         # The exact ExecStartPre line is a module constant so migrations that

--- a/openhost_system_agent/src/openhost_system_agent/tests/test_service_unit.py
+++ b/openhost_system_agent/src/openhost_system_agent/tests/test_service_unit.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from openhost_system_agent.migrations.versions.v0002_baseline import RECLAIM_EXEC_START_PRE
+from openhost_system_agent.migrations.versions.v0002_baseline import build_openhost_service_unit
+
+
+class TestOpenhostServiceUnit:
+    def test_contains_privileged_reclaim_execstartpre(self) -> None:
+        unit = build_openhost_service_unit(1001)
+        # The reclaim must run as root (`+` prefix) before ExecStart.
+        assert "ExecStartPre=+/bin/sh -c" in unit
+        assert "chown -Rh host:host" in unit
+        assert "/home/host/.pixi" in unit
+        assert "/home/host/openhost/.pixi" in unit
+
+    def test_reclaim_runs_before_execstart(self) -> None:
+        unit = build_openhost_service_unit(1001)
+        assert unit.index("ExecStartPre=+") < unit.index("ExecStart=/home/host/.pixi/bin/pixi run")
+
+    def test_uses_the_shared_reclaim_constant(self) -> None:
+        # The exact ExecStartPre line is a module constant so migrations that
+        # rewrite the unit stay byte-identical with the baseline.
+        assert RECLAIM_EXEC_START_PRE in build_openhost_service_unit(1234)
+
+    def test_host_uid_is_substituted(self) -> None:
+        unit = build_openhost_service_unit(4242)
+        assert "XDG_RUNTIME_DIR=/run/user/4242" in unit
+        assert "user@4242.service" in unit

--- a/openhost_system_agent/src/openhost_system_agent/tests/test_service_unit.py
+++ b/openhost_system_agent/src/openhost_system_agent/tests/test_service_unit.py
@@ -1,17 +1,22 @@
 from __future__ import annotations
 
+from pathlib import Path
+
 from openhost_system_agent.migrations.versions.v0002_baseline import RECLAIM_EXEC_START_PRE
+from openhost_system_agent.migrations.versions.v0002_baseline import RECLAIM_SCRIPT
+from openhost_system_agent.migrations.versions.v0002_baseline import RECLAIM_SCRIPT_PATH
 from openhost_system_agent.migrations.versions.v0002_baseline import build_openhost_service_unit
 
 
 class TestOpenhostServiceUnit:
-    def test_contains_privileged_reclaim_execstartpre(self) -> None:
+    def test_reclaim_execstartpre_calls_script_as_root(self) -> None:
         unit = build_openhost_service_unit(1001)
-        # The reclaim must run as root (`+` prefix) before ExecStart.
-        assert "ExecStartPre=+/bin/sh -c" in unit
-        assert "chown -Rh host:host" in unit
-        assert "/home/host/.pixi" in unit
-        assert "/home/host/openhost/.pixi" in unit
+        # Runs the standalone script (no inline $VAR for systemd to expand) as
+        # root via the `+` prefix.
+        assert f"ExecStartPre=+{RECLAIM_SCRIPT_PATH}\n" in unit
+        # Must not embed a shell $VAR, which systemd would substitute from the
+        # unit environment before /bin/sh sees it.
+        assert "$" not in RECLAIM_EXEC_START_PRE
 
     def test_reclaim_runs_before_execstart(self) -> None:
         unit = build_openhost_service_unit(1001)
@@ -26,3 +31,18 @@ class TestOpenhostServiceUnit:
         unit = build_openhost_service_unit(4242)
         assert "XDG_RUNTIME_DIR=/run/user/4242" in unit
         assert "user@4242.service" in unit
+
+
+class TestReclaimScript:
+    def test_script_chowns_both_pixi_trees_to_host(self) -> None:
+        assert "chown -Rh host:host" in RECLAIM_SCRIPT
+        assert "/home/host/.pixi" in RECLAIM_SCRIPT
+        assert "/home/host/openhost/.pixi" in RECLAIM_SCRIPT
+        assert RECLAIM_SCRIPT.startswith("#!/bin/sh")
+
+    def test_matches_ansible_copy_byte_for_byte(self) -> None:
+        # The migration-written script and the ansible-copied script must be
+        # identical so a host looks the same however it was set up.
+        repo_root = Path(__file__).resolve().parents[4]
+        ansible_copy = repo_root / "ansible" / "files" / "openhost-reclaim-pixi"
+        assert ansible_copy.read_text() == RECLAIM_SCRIPT


### PR DESCRIPTION
The openhost service runs as the unprivileged host user via pixi run. When a pixi operation runs as root on the host-owned pixi tree it leaves root-owned files the host user cannot later modify, so the next pixi run fails with EACCES (Failed to update PyPI packages ... Permission denied os error 13) and the service will not start.

This is the failure Samuel and a managed-space user hit. Managed spaces trigger it during onboarding: a fresh host is behind on system migrations, so the owner runs the update as part of setup, and older update apply paths ran pixi install as root. The v0004 migration also still ran pixi self-update as root. Both leave root-owned files.

Three layers of defense:

1. ensure_pixi_version runs pixi self-update as the host user (via sudo -u host), not root, so the migration no longer creates the mess in the first place.

2. apply_after_checkout reclaims pixi ownership after migrations and before the host-user install, so a host self-heals on its next update.

3. openhost.service gains an ExecStartPre that runs a standalone reclaim script (/usr/local/bin/openhost-reclaim-pixi) as root before ExecStart, so an already-corrupted host self-heals on every boot even when it cannot reach an update. The reclaim is a standalone script rather than an inline shell snippet so no $VAR reaches systemd (which would substitute it from the unit environment before /bin/sh runs). It is installed by ansible and by the baseline and new v0005 migrations from a shared constant; a test enforces the two copies stay byte-identical.

Testing: 108 unit tests pass. Verified end to end on a fresh Hetzner instance: an update apply on a host with root-owned PyPI files heals it and stays up; a bricked host with root-owned pixi trees and pixi binary self-heals on boot (all files flip back to host, service active). Vetted clean across multiple LLM and agentic reviewers.