### PR TITLE
Broaden host-ownership reclaim to the whole repo, not just .pixi

### DIFF
--- a/ansible/files/openhost-reclaim-pixi
+++ b/ansible/files/openhost-reclaim-pixi
@@ -1,16 +1,18 @@
 #!/bin/sh
-# Reclaim ownership of the host's pixi trees for the host user. Managed by
+# Reclaim ownership of the host's OpenHost trees for the host user. Managed by
 # OpenHost; keep in sync with RECLAIM_SCRIPT in the openhost_system_agent
 # baseline migration (v0002_baseline.py).
 #
-# The openhost service runs as the unprivileged host user via `pixi run`. A
-# pixi operation accidentally run as root leaves root-owned files under the
-# host-owned pixi trees, and the host service's next `pixi run` then fails with
-# EACCES and won't start. Run as root (e.g. from a systemd ExecStartPre with
-# the '+' prefix), this hands those trees back to host so the service
-# self-heals on boot. A standalone script (not an inline ExecStartPre snippet)
-# so no $VAR reaches systemd, which would substitute it before /bin/sh runs.
-# Idempotent; missing paths are skipped.
+# The openhost service runs as the unprivileged host user: it runs `git` and
+# `pixi run` against /home/host/openhost (repo + its .pixi env) and against
+# /home/host/.pixi (pixi binary + caches). The root-run update walk (migrations,
+# git checkout/clean, and in older versions pixi install) can leave root-owned
+# files in those trees, after which the host service's pixi run fails with
+# EACCES and git ops fail on root-owned objects, so it won't start. Run as root
+# (e.g. from a systemd ExecStartPre with the '+' prefix), this hands those trees
+# back to host so the service self-heals on boot. A standalone script (not an
+# inline ExecStartPre snippet) so no $VAR reaches systemd, which would
+# substitute it before /bin/sh runs. Idempotent; missing paths are skipped.
 #
 # Best-effort by design: the whole reclaim is bounded by a single `timeout` and
 # its failure is swallowed (`|| :`). A systemd ExecStartPre with the `-` prefix
@@ -23,7 +25,7 @@
 #
 # shellcheck disable=SC2016  # $dir is expanded by the inner `sh -c`, not here.
 timeout 80 sh -c '
-for dir in /home/host/.pixi /home/host/openhost/.pixi; do
+for dir in /home/host/openhost /home/host/.pixi; do
     if [ -e "$dir" ]; then
         chown -Rh host:host "$dir"
     fi

--- a/openhost_system_agent/src/openhost_system_agent/apply_after_checkout.py
+++ b/openhost_system_agent/src/openhost_system_agent/apply_after_checkout.py
@@ -32,7 +32,7 @@ import sys
 from pathlib import Path
 
 from openhost_system_agent.migrations.runner import apply_system_migrations
-from openhost_system_agent.reclaim import reclaim_pixi_ownership
+from openhost_system_agent.reclaim import reclaim_host_ownership
 
 PIXI_BIN = "/home/host/.pixi/bin/pixi"
 
@@ -158,7 +158,7 @@ def main() -> None:
     # later reclaim — leaving the host bricked. It also precedes the host-user
     # `pixi install` below and heals root-owned residue left by prior updates.
     # Runs as root (this whole apply is root via sudo).
-    reclaim_pixi_ownership()
+    reclaim_host_ownership()
 
     # Migrations run before install so a toolchain upgrade (e.g. pixi) takes
     # effect before deps are installed for this checkout.

--- a/openhost_system_agent/src/openhost_system_agent/migrations/versions/v0002_baseline.py
+++ b/openhost_system_agent/src/openhost_system_agent/migrations/versions/v0002_baseline.py
@@ -21,27 +21,29 @@ OPENHOST_SERVICE_PATH = "/etc/systemd/system/openhost.service"
 # Fixed path for the reclaim script the service runs before ExecStart.
 RECLAIM_SCRIPT_PATH = "/usr/local/bin/openhost-reclaim-pixi"
 
-# The reclaim script: hand the host's pixi trees back to the host user. Run as
-# root (the unit's ExecStartPre uses the `+` prefix) before the host-user
-# `pixi run`, so a pixi op once run as root (old update bugs, stray root
-# self-update) can't brick the service. A standalone script — not an inline
-# ExecStartPre snippet — so no $VAR reaches systemd (which would substitute it
-# from the unit environment before /bin/sh runs). Depends on nothing from the
-# (possibly broken) pixi env. Kept byte-identical with
-# ansible/files/openhost-reclaim-pixi (a test enforces this).
+# The reclaim script: hand the host's OpenHost trees back to the host user. Run
+# as root (the unit's ExecStartPre uses the `+` prefix) before the host-user
+# `git`/`pixi run`, so files a root-run update left behind can't brick the
+# service. A standalone script — not an inline ExecStartPre snippet — so no
+# $VAR reaches systemd (which would substitute it from the unit environment
+# before /bin/sh runs). Depends on nothing from the (possibly broken) pixi env.
+# Kept byte-identical with ansible/files/openhost-reclaim-pixi (a test enforces
+# this).
 RECLAIM_SCRIPT = """#!/bin/sh
-# Reclaim ownership of the host's pixi trees for the host user. Managed by
+# Reclaim ownership of the host's OpenHost trees for the host user. Managed by
 # OpenHost; keep in sync with RECLAIM_SCRIPT in the openhost_system_agent
 # baseline migration (v0002_baseline.py).
 #
-# The openhost service runs as the unprivileged host user via `pixi run`. A
-# pixi operation accidentally run as root leaves root-owned files under the
-# host-owned pixi trees, and the host service's next `pixi run` then fails with
-# EACCES and won't start. Run as root (e.g. from a systemd ExecStartPre with
-# the '+' prefix), this hands those trees back to host so the service
-# self-heals on boot. A standalone script (not an inline ExecStartPre snippet)
-# so no $VAR reaches systemd, which would substitute it before /bin/sh runs.
-# Idempotent; missing paths are skipped.
+# The openhost service runs as the unprivileged host user: it runs `git` and
+# `pixi run` against /home/host/openhost (repo + its .pixi env) and against
+# /home/host/.pixi (pixi binary + caches). The root-run update walk (migrations,
+# git checkout/clean, and in older versions pixi install) can leave root-owned
+# files in those trees, after which the host service's pixi run fails with
+# EACCES and git ops fail on root-owned objects, so it won't start. Run as root
+# (e.g. from a systemd ExecStartPre with the '+' prefix), this hands those trees
+# back to host so the service self-heals on boot. A standalone script (not an
+# inline ExecStartPre snippet) so no $VAR reaches systemd, which would
+# substitute it before /bin/sh runs. Idempotent; missing paths are skipped.
 #
 # Best-effort by design: the whole reclaim is bounded by a single `timeout` and
 # its failure is swallowed (`|| :`). A systemd ExecStartPre with the `-` prefix
@@ -54,7 +56,7 @@ RECLAIM_SCRIPT = """#!/bin/sh
 #
 # shellcheck disable=SC2016  # $dir is expanded by the inner `sh -c`, not here.
 timeout 80 sh -c '
-for dir in /home/host/.pixi /home/host/openhost/.pixi; do
+for dir in /home/host/openhost /home/host/.pixi; do
     if [ -e "$dir" ]; then
         chown -Rh host:host "$dir"
     fi

--- a/openhost_system_agent/src/openhost_system_agent/migrations/versions/v0005_pixi_ownership_failsafe.py
+++ b/openhost_system_agent/src/openhost_system_agent/migrations/versions/v0005_pixi_ownership_failsafe.py
@@ -1,14 +1,16 @@
-"""Reclaim pixi ownership and add the startup failsafe to openhost.service.
+"""Reclaim host ownership and add the startup failsafe to openhost.service.
 
-Older openhost versions ran ``pixi install`` (and ``pixi self-update``) as root
-during ``update apply``, leaving root-owned files under the host-owned pixi
-trees. The host service's ``pixi run`` then fails with EACCES and won't start.
+The root-run update walk (migrations, git checkout/clean, and in older versions
+``pixi install``) can leave root-owned files under the host-owned OpenHost trees
+(``/home/host/openhost`` and ``/home/host/.pixi``). The host service's ``pixi
+run`` then fails with EACCES and its git ops fail on root-owned objects, so it
+won't start.
 
 This migration heals such hosts and prevents recurrence:
-  1. chown the pixi trees back to host now (fixes the current env).
+  1. chown the trees back to host now (fixes the current host).
   2. Rewrite openhost.service to include the ``ExecStartPre=+`` reclaim step,
-     so any future root-owned residue is fixed on every boot before ``pixi
-     run``, even on hosts that can't reach an update.
+     so any future root-owned residue is fixed on every boot before the
+     host-user ExecStart, even on hosts that can't reach an update.
 
 Both steps are idempotent. The rewritten unit is byte-identical to the one the
 baseline migration now produces (both call ``build_openhost_service_unit``).
@@ -24,16 +26,16 @@ from openhost_system_agent.migrations.versions.v0002_baseline import OPENHOST_SE
 from openhost_system_agent.migrations.versions.v0002_baseline import RECLAIM_SCRIPT
 from openhost_system_agent.migrations.versions.v0002_baseline import RECLAIM_SCRIPT_PATH
 from openhost_system_agent.migrations.versions.v0002_baseline import build_openhost_service_unit
-from openhost_system_agent.reclaim import reclaim_pixi_ownership
+from openhost_system_agent.reclaim import reclaim_host_ownership
 
 
 class Migration0005PixiOwnershipFailsafe(SystemMigration):
     version = 5
 
     def up(self) -> None:
-        # Heal the current env up front so this migration's own downstream
+        # Heal the current host up front so this migration's own downstream
         # `pixi install` (run as host by apply_after_checkout) succeeds.
-        reclaim_pixi_ownership()
+        reclaim_host_ownership()
 
         # Install the reclaim script and wire the startup failsafe into the
         # unit so future root-owned residue self-heals on every boot. Existing

--- a/openhost_system_agent/src/openhost_system_agent/reclaim.py
+++ b/openhost_system_agent/src/openhost_system_agent/reclaim.py
@@ -1,16 +1,21 @@
-"""Reclaim ownership of the host's pixi tree.
+"""Reclaim ownership of the host's OpenHost trees.
 
-The openhost service runs as the unprivileged ``host`` user via ``pixi run``,
-and pixi tracks its env and per-user caches under paths owned by ``host``. Any
-pixi (or pip) operation accidentally run as root leaves root-owned files there
-that the host service can't later modify — its next ``pixi run`` fails with
-EACCES ("Failed to update PyPI packages ... Permission denied") and the service
-won't start.
+The openhost service runs as the unprivileged ``host`` user: it invokes ``git``
+and ``pixi run`` against ``/home/host/openhost`` (the repo, including its
+``.pixi`` env) and against ``/home/host/.pixi`` (the pixi binary + per-user
+caches). All of it must stay ``host``-owned.
 
-This module chowns the pixi tree back to ``host`` so such a mistake self-heals
+The update walk runs as root, though: it applies migrations, runs
+``git checkout`` / ``git clean``, and (in older versions) ran ``pixi install``
+as root — all of which can leave root-owned files in these trees. The host
+service then can't modify them: ``pixi run`` fails with EACCES ("Failed to
+update PyPI packages ... Permission denied") and git operations fail on
+root-owned objects/index. Either way the service won't start.
+
+This module chowns those trees back to ``host`` so such a mistake self-heals
 instead of bricking the host. It is a failsafe: the code paths that install
-deps already run as ``host`` (see ``apply_after_checkout``); this reclaims any
-residue left by older buggy versions or by a stray future root-run pixi call.
+deps and update the repo already run as ``host`` where possible; this reclaims
+any residue left by older buggy versions or by a stray root-run command.
 """
 
 from __future__ import annotations
@@ -20,30 +25,30 @@ import subprocess
 
 from openhost_system_agent.pixi import HOST_USER
 
-#: Pixi trees owned by the host user. The first holds the pixi binary itself
-#: (targeted by ``pixi self-update``); the second holds the project's resolved
-#: environment (targeted by ``pixi install``). Both must stay host-owned.
-_PIXI_PATHS = (
+#: Host-owned trees the root-run update walk writes into. ``/home/host/openhost``
+#: is the repo (working tree, ``.git``, and its ``.pixi`` env); ``/home/host/.pixi``
+#: holds the pixi binary (targeted by ``pixi self-update``) and per-user caches.
+_HOST_PATHS = (
+    "/home/host/openhost",
     "/home/host/.pixi",
-    "/home/host/openhost/.pixi",
 )
 
 
-def reclaim_pixi_ownership() -> None:
-    """chown the host's pixi trees back to the host user. Root-only, idempotent.
+def reclaim_host_ownership() -> None:
+    """chown the host's OpenHost trees back to the host user. Root-only, idempotent.
 
     Safe to call repeatedly and cheap when nothing is misowned. Missing paths
-    are skipped (a fresh host may not have the project env yet). Raises if not
-    run as root, since only root can chown files another user owns.
+    are skipped (a fresh host may not have every tree yet). Raises if not run as
+    root, since only root can chown files another user owns.
     """
     if os.geteuid() != 0:
-        raise RuntimeError("reclaim_pixi_ownership must be run as root")
+        raise RuntimeError("reclaim_host_ownership must be run as root")
 
-    for path in _PIXI_PATHS:
+    for path in _HOST_PATHS:
         if not os.path.exists(path):
             continue
         # -R to cover the whole tree; -h so symlinks are chowned in place
-        # rather than followed. check=True: a failure here means the env may
+        # rather than followed. check=True: a failure here means a tree may
         # still be broken, so surface it rather than silently continuing.
         subprocess.run(
             ["chown", "-Rh", f"{HOST_USER}:{HOST_USER}", path],

--- a/openhost_system_agent/src/openhost_system_agent/tests/test_apply_after_checkout.py
+++ b/openhost_system_agent/src/openhost_system_agent/tests/test_apply_after_checkout.py
@@ -233,7 +233,7 @@ def test_ensure_repo_trusted_is_idempotent(tmp_path: Path, monkeypatch: pytest.M
     assert result.stdout.count(str(repo)) == 1
 
 
-def test_main_reclaims_pixi_ownership_before_migrations_and_install() -> None:
+def test_main_reclaims_host_ownership_before_migrations_and_install() -> None:
     # The failsafe must run FIRST: before migrations (a migration can run a
     # host-user pixi op, e.g. v0004's self-update, that would fail on a
     # root-owned tree and abort the update) and before the host-user
@@ -247,7 +247,7 @@ def test_main_reclaims_pixi_ownership_before_migrations_and_install() -> None:
     with (
         patch.object(aac, "_ensure_repo_trusted"),
         patch.object(aac, "apply_system_migrations", side_effect=lambda: order.append("migrations")),
-        patch.object(aac, "reclaim_pixi_ownership", side_effect=lambda: order.append("reclaim")),
+        patch.object(aac, "reclaim_host_ownership", side_effect=lambda: order.append("reclaim")),
         patch("openhost_system_agent.apply_after_checkout.subprocess.run", side_effect=_install) as mock_run,
         patch.object(aac, "_next_step", return_value=None),
     ):

--- a/openhost_system_agent/src/openhost_system_agent/tests/test_reclaim.py
+++ b/openhost_system_agent/src/openhost_system_agent/tests/test_reclaim.py
@@ -7,45 +7,45 @@ import pytest
 from openhost_system_agent import reclaim
 
 
-class TestReclaimPixiOwnership:
+class TestReclaimHostOwnership:
     def test_refuses_when_not_root(self) -> None:
         with patch("os.geteuid", return_value=1000):
             with pytest.raises(RuntimeError, match="must be run as root"):
-                reclaim.reclaim_pixi_ownership()
+                reclaim.reclaim_host_ownership()
 
     def test_chowns_existing_paths_as_root(self) -> None:
-        # Both known pixi paths exist -> both chowned to host:host, recursively,
+        # Both known host trees exist -> both chowned to host:host, recursively,
         # with symlinks handled in place (-h).
         with (
             patch("os.geteuid", return_value=0),
             patch("os.path.exists", return_value=True),
             patch("subprocess.run") as mock_run,
         ):
-            reclaim.reclaim_pixi_ownership()
+            reclaim.reclaim_host_ownership()
 
         called_paths = [call.args[0] for call in mock_run.call_args_list]
         assert called_paths == [
+            ["chown", "-Rh", "host:host", "/home/host/openhost"],
             ["chown", "-Rh", "host:host", "/home/host/.pixi"],
-            ["chown", "-Rh", "host:host", "/home/host/openhost/.pixi"],
         ]
         for call in mock_run.call_args_list:
             assert call.kwargs["check"] is True
 
     def test_skips_missing_paths(self) -> None:
-        # Only the second path exists -> only it is chowned; a fresh host
-        # without the project env yet must not error.
+        # Only the pixi tree exists -> only it is chowned; a fresh host without
+        # the repo yet must not error.
         def fake_exists(path: str) -> bool:
-            return path == "/home/host/openhost/.pixi"
+            return path == "/home/host/.pixi"
 
         with (
             patch("os.geteuid", return_value=0),
             patch("os.path.exists", side_effect=fake_exists),
             patch("subprocess.run") as mock_run,
         ):
-            reclaim.reclaim_pixi_ownership()
+            reclaim.reclaim_host_ownership()
 
         called_paths = [call.args[0] for call in mock_run.call_args_list]
-        assert called_paths == [["chown", "-Rh", "host:host", "/home/host/openhost/.pixi"]]
+        assert called_paths == [["chown", "-Rh", "host:host", "/home/host/.pixi"]]
 
     def test_noop_when_no_paths_exist(self) -> None:
         with (
@@ -53,5 +53,5 @@ class TestReclaimPixiOwnership:
             patch("os.path.exists", return_value=False),
             patch("subprocess.run") as mock_run,
         ):
-            reclaim.reclaim_pixi_ownership()
+            reclaim.reclaim_host_ownership()
         mock_run.assert_not_called()

--- a/openhost_system_agent/src/openhost_system_agent/tests/test_service_unit.py
+++ b/openhost_system_agent/src/openhost_system_agent/tests/test_service_unit.py
@@ -35,10 +35,12 @@ class TestOpenhostServiceUnit:
 
 
 class TestReclaimScript:
-    def test_script_chowns_both_pixi_trees_to_host(self) -> None:
+    def test_script_chowns_host_trees_to_host(self) -> None:
         assert "chown -Rh host:host" in RECLAIM_SCRIPT
+        # The repo tree (covers its .pixi env, .git, working tree) and the
+        # standalone pixi tree (binary + caches).
+        assert "/home/host/openhost" in RECLAIM_SCRIPT
         assert "/home/host/.pixi" in RECLAIM_SCRIPT
-        assert "/home/host/openhost/.pixi" in RECLAIM_SCRIPT
         assert RECLAIM_SCRIPT.startswith("#!/bin/sh")
 
     def test_matches_ansible_copy_byte_for_byte(self) -> None:


### PR DESCRIPTION
Follow-up to #212 (now merged). #213 was auto-closed as merged during a branch reshuffle without landing on main, so this re-opens the same change against main.

The self-heal reclaim in #212 covers /home/host/.pixi and the repo's .pixi env. But the root-run update walk also does git checkout, git clean, and applies migrations directly in /home/host/openhost, which can leave root-owned files in the working tree and .git (objects, index, refs, .pyc). The host user then hits permission errors on git and pixi operations.

This broadens the reclaim to cover the whole /home/host/openhost tree (working tree, .git, and its .pixi env) in addition to the standalone /home/host/.pixi. Renames reclaim_pixi_ownership to reclaim_host_ownership and updates the boot-time script (single timeout wrapper, byte-identical between ansible and the migration constant) accordingly.

Validated end to end on fresh Hetzner instances: root-owned files in the working tree and .git self-heal on boot; an update apply with root-owned env and git files heals both and reaches version 5 with the service active. Vetted clean across many LLM/agentic reviewers.