### PR TITLE
Add platform and per-app diagnostics

### DIFF
--- a/compute_space/src/compute_space/core/diagnostics.py
+++ b/compute_space/src/compute_space/core/diagnostics.py
@@ -746,10 +746,16 @@ async def collect_platform_diagnostics(db: sqlite3.Connection, config: Config) -
             "manifest_raw, local_port, health_check, container_id, cpu_cores, memory_mb "
             "FROM apps ORDER BY name"
         ).fetchall()
-        for row in rows:
-            apps.append(await _collect_app_summary(row))
     except Exception:
-        logger.opt(exception=True).warning("Failed to collect per-app diagnostics summary")
+        logger.opt(exception=True).warning("Failed to query apps for diagnostics summary")
+        rows = []
+    for row in rows:
+        # Collect each app independently so one malformed row can't drop the
+        # rest of the fleet from the bundle.
+        try:
+            apps.append(await _collect_app_summary(row))
+        except Exception:
+            logger.opt(exception=True).warning("Failed to collect diagnostics for one app; skipping it")
 
     reachability = await _collect_reachability(config)
 

--- a/compute_space/src/compute_space/core/diagnostics.py
+++ b/compute_space/src/compute_space/core/diagnostics.py
@@ -37,6 +37,7 @@ import httpx
 
 from compute_space import OPENHOST_PROJECT_DIR
 from compute_space.config import Config
+from compute_space.core.containers import is_container_running
 from compute_space.core.git_ops import get_branch_name
 from compute_space.core.git_ops import get_head_sha
 from compute_space.core.git_ops import get_remote_url
@@ -521,6 +522,14 @@ def _collect_app_resources(
         return base
     if shutil.which("podman") is None:
         return attr.evolve(base, error="podman not found on PATH")
+    # Determine "running" authoritatively from the container's actual state
+    # rather than from whether ``podman stats`` returned data: on current podman
+    # ``stats --no-stream`` exits 0 and emits a zero-valued entry even for an
+    # *exited* container, which would otherwise be reported as running=True with
+    # 0% CPU / 0 B memory — misleading in a report whose job is to debug a down
+    # app (e.g. a container that crashed while the DB row still says "running").
+    if not is_container_running(container_id):
+        return base
     try:
         proc = subprocess.run(
             ["podman", "stats", "--no-stream", "--format", "json", container_id],

--- a/compute_space/src/compute_space/core/diagnostics.py
+++ b/compute_space/src/compute_space/core/diagnostics.py
@@ -255,9 +255,7 @@ def _collect_container_runtime() -> ContainerRuntimeInfo:
     assert the rootless flag) so the two agree on what "healthy" looks like.
     """
     if shutil.which("podman") is None:
-        return ContainerRuntimeInfo(
-            available=False, version=None, rootless=None, error="podman not found on PATH"
-        )
+        return ContainerRuntimeInfo(available=False, version=None, rootless=None, error="podman not found on PATH")
     try:
         info_proc = subprocess.run(
             ["podman", "info", "--format", "json"],
@@ -278,7 +276,10 @@ def _collect_container_runtime() -> ContainerRuntimeInfo:
     try:
         info = json.loads(info_proc.stdout)
         host = info.get("host", {})
-        version = host.get("serverVersion")
+        # podman reports its own version under the top-level ``version`` table
+        # (``version.Version``); ``host.serverVersion`` is not populated in
+        # current releases, so read the former and fall back to the latter.
+        version = info.get("version", {}).get("Version") or host.get("serverVersion")
         rootless_val = host.get("security", {}).get("rootless")
         rootless = rootless_val if isinstance(rootless_val, bool) else None
     except (json.JSONDecodeError, AttributeError):

--- a/compute_space/src/compute_space/core/diagnostics.py
+++ b/compute_space/src/compute_space/core/diagnostics.py
@@ -42,8 +42,9 @@ from compute_space.core.logging import logger
 from compute_space.core.manifest import parse_manifest_from_string
 from compute_space.core.storage import storage_status
 
-# The schema version of the diagnostics payload.  Bump when the shape changes so
-# consumers (support tooling, the CLI) can detect an incompatible bundle.
+# The schema version of the diagnostics payload.  Bump when the shape changes
+# so consumers (support tooling, the CLI, the dashboard) can detect an
+# incompatible bundle.  Present on both the platform and per-app bundles.
 DIAGNOSTICS_SCHEMA_VERSION = 1
 
 # Distribution names whose versions are worth surfacing in a bug report.  These

--- a/compute_space/src/compute_space/core/diagnostics.py
+++ b/compute_space/src/compute_space/core/diagnostics.py
@@ -1,0 +1,399 @@
+"""Collect diagnostic information for debugging OpenHost instances and apps.
+
+Two public entry points:
+
+  - :func:`collect_platform_diagnostics` — a snapshot of the whole instance:
+    OpenHost git checkout (branch/SHA/dirty), host OS/kernel, Python and
+    installed dependency versions, container runtime (podman) info, disk usage,
+    and a summary of every installed app.  Owner-only; intended to be copied or
+    downloaded and pasted into a bug report.
+
+  - :func:`collect_app_diagnostics` — a per-app snapshot: the app's declared
+    version + manifest git checkout, container status, plus a slim slice of the
+    same host/system info so an app report is self-contained.
+
+Every collector is defensive: a failure gathering one field degrades that field
+to ``None``/an error string rather than failing the whole report, because a
+diagnostics bundle is most valuable precisely when the instance is unhealthy.
+"""
+
+from __future__ import annotations
+
+import importlib.metadata
+import json
+import os
+import platform
+import shutil
+import sqlite3
+import subprocess
+from datetime import UTC
+from datetime import datetime
+from pathlib import Path
+
+import attr
+
+from compute_space import OPENHOST_PROJECT_DIR
+from compute_space.config import Config
+from compute_space.core.git_ops import get_branch_name
+from compute_space.core.git_ops import get_head_sha
+from compute_space.core.git_ops import get_remote_url
+from compute_space.core.git_ops import is_dirty
+from compute_space.core.logging import logger
+from compute_space.core.manifest import parse_manifest_from_string
+from compute_space.core.storage import storage_status
+
+# The schema version of the diagnostics payload.  Bump when the shape changes so
+# consumers (support tooling, the CLI) can detect an incompatible bundle.
+DIAGNOSTICS_SCHEMA_VERSION = 1
+
+# Distribution names whose versions are worth surfacing in a bug report.  These
+# are the packages most likely to explain a runtime bug; the full environment is
+# large and noisy, so we curate rather than dump everything.
+_KEY_DEPENDENCIES = (
+    "litestar",
+    "hypercorn",
+    "GitPython",
+    "attrs",
+    "cattrs",
+    "typed-settings",
+    "httpx",
+    "bcrypt",
+    "jinja2",
+    "tomli-w",
+    "cappa",
+)
+
+_SUBPROCESS_TIMEOUT_S = 10
+
+
+# ─── attrs models ────────────────────────────────────────────────────────────
+
+
+@attr.s(auto_attribs=True, frozen=True)
+class GitInfo:
+    """Git checkout state for a repository on disk.
+
+    ``sha`` is empty and ``branch`` is None when the path isn't a git checkout
+    (e.g. builtin apps or tarball deploys). ``branch`` is None when HEAD is
+    detached even if ``sha`` is populated.
+    """
+
+    branch: str | None
+    sha: str
+    short_sha: str
+    dirty: bool
+    remote_url: str | None
+
+
+@attr.s(auto_attribs=True, frozen=True)
+class SystemInfo:
+    """Host OS / Python / process facts."""
+
+    hostname: str
+    platform: str
+    system: str
+    release: str
+    machine: str
+    processor: str
+    python_version: str
+    python_implementation: str
+    cpu_count: int | None
+    boot_time: str | None
+
+
+@attr.s(auto_attribs=True, frozen=True)
+class ContainerRuntimeInfo:
+    """Facts about the container runtime (podman)."""
+
+    available: bool
+    version: str | None
+    rootless: bool | None
+    error: str | None = None
+
+
+@attr.s(auto_attribs=True, frozen=True)
+class AppDiagnosticsSummary:
+    """Per-app entry in the platform diagnostics bundle."""
+
+    app_id: str
+    name: str
+    status: str
+    version: str | None
+    runtime_type: str | None
+    error_message: str | None
+    git: GitInfo | None
+
+
+@attr.s(auto_attribs=True, frozen=True)
+class PlatformDiagnostics:
+    """Full instance diagnostics bundle (owner-only)."""
+
+    schema_version: int
+    generated_at: str
+    zone_domain: str
+    openhost: GitInfo
+    system: SystemInfo
+    container_runtime: ContainerRuntimeInfo
+    dependencies: dict[str, str]
+    storage: dict[str, object]
+    apps: list[AppDiagnosticsSummary]
+
+
+@attr.s(auto_attribs=True, frozen=True)
+class AppDiagnostics:
+    """Per-app diagnostics bundle (owner-only).
+
+    Includes a slice of host/system info so an app report is self-contained and
+    useful on its own, without the caller also having to grab the platform
+    bundle.
+    """
+
+    schema_version: int
+    generated_at: str
+    zone_domain: str
+    app_id: str
+    name: str
+    status: str
+    version: str | None
+    runtime_type: str | None
+    error_message: str | None
+    container_id: str | None
+    git: GitInfo | None
+    system: SystemInfo
+    container_runtime: ContainerRuntimeInfo
+    openhost: GitInfo
+
+
+# ─── low-level collectors ──────────────────────────────────────────────────
+
+
+async def _collect_git_info(repo_path: Path | None) -> GitInfo | None:
+    """Return :class:`GitInfo` for ``repo_path`` or None when it has no .git.
+
+    Never raises: any error while reading git state degrades to None so a
+    single bad repo doesn't sink the whole bundle.
+    """
+    if repo_path is None:
+        return None
+    if not (repo_path / ".git").exists():
+        return None
+    try:
+        branch = await get_branch_name(repo_path)
+        sha = await get_head_sha(repo_path)
+        dirty = await is_dirty(repo_path)
+    except Exception:
+        logger.opt(exception=True).warning("Failed to read git info for %s", repo_path)
+        return None
+    remote_url: str | None
+    try:
+        remote_url = await get_remote_url(repo_path)
+    except Exception:
+        # Missing/unreadable remote is common (no 'origin'); not worth a warning.
+        remote_url = None
+    return GitInfo(branch=branch, sha=sha, short_sha=sha[:8], dirty=dirty, remote_url=remote_url)
+
+
+def _collect_system_info() -> SystemInfo:
+    """Gather host OS / Python facts. Best-effort; missing fields become None."""
+    uname = platform.uname()
+    try:
+        cpu_count = os.cpu_count()
+    except Exception:
+        cpu_count = None
+    boot_time = _read_boot_time()
+    return SystemInfo(
+        hostname=uname.node,
+        platform=platform.platform(),
+        system=uname.system,
+        release=uname.release,
+        machine=uname.machine,
+        processor=uname.processor,
+        python_version=platform.python_version(),
+        python_implementation=platform.python_implementation(),
+        cpu_count=cpu_count,
+        boot_time=boot_time,
+    )
+
+
+def _read_boot_time() -> str | None:
+    """Return system boot time as an ISO-8601 UTC string, or None if unavailable.
+
+    Reads /proc/stat's ``btime`` (Linux only); avoids adding a psutil dependency.
+    """
+    try:
+        with open("/proc/stat") as f:
+            for line in f:
+                if line.startswith("btime "):
+                    epoch = int(line.split()[1])
+                    return datetime.fromtimestamp(epoch, UTC).isoformat()
+    except Exception:
+        return None
+    return None
+
+
+def _collect_dependencies() -> dict[str, str]:
+    """Return {distribution_name: version} for the curated key dependencies.
+
+    A dependency that isn't installed maps to ``"(not installed)"`` rather than
+    being omitted, so a missing package is visible in the report.
+    """
+    versions: dict[str, str] = {}
+    for name in _KEY_DEPENDENCIES:
+        try:
+            versions[name] = importlib.metadata.version(name)
+        except importlib.metadata.PackageNotFoundError:
+            versions[name] = "(not installed)"
+        except Exception:
+            versions[name] = "(error)"
+    return versions
+
+
+def _collect_container_runtime() -> ContainerRuntimeInfo:
+    """Probe podman for version + rootless status.
+
+    Mirrors the ``openhost doctor`` probe (parse ``podman info --format json``,
+    assert the rootless flag) so the two agree on what "healthy" looks like.
+    """
+    if shutil.which("podman") is None:
+        return ContainerRuntimeInfo(
+            available=False, version=None, rootless=None, error="podman not found on PATH"
+        )
+    try:
+        info_proc = subprocess.run(
+            ["podman", "info", "--format", "json"],
+            capture_output=True,
+            text=True,
+            timeout=_SUBPROCESS_TIMEOUT_S,
+        )
+    except subprocess.TimeoutExpired:
+        return ContainerRuntimeInfo(available=False, version=None, rootless=None, error="podman info timed out")
+    except Exception as e:
+        return ContainerRuntimeInfo(available=False, version=None, rootless=None, error=str(e))
+
+    if info_proc.returncode != 0:
+        return ContainerRuntimeInfo(available=False, version=None, rootless=None, error="podman info failed")
+
+    version: str | None = None
+    rootless: bool | None = None
+    try:
+        info = json.loads(info_proc.stdout)
+        host = info.get("host", {})
+        version = host.get("serverVersion")
+        rootless_val = host.get("security", {}).get("rootless")
+        rootless = rootless_val if isinstance(rootless_val, bool) else None
+    except (json.JSONDecodeError, AttributeError):
+        return ContainerRuntimeInfo(
+            available=True, version=None, rootless=None, error="podman info returned non-JSON output"
+        )
+    return ContainerRuntimeInfo(available=True, version=version, rootless=rootless, error=None)
+
+
+def _manifest_fields(manifest_raw: str | None) -> tuple[str | None, str | None]:
+    """Parse (version, runtime_type) from a stored manifest, or (None, None).
+
+    Re-parsing ``manifest_raw`` is more accurate than the ``apps.version``
+    column, which is only written at install time and not on reload.
+    """
+    if not manifest_raw:
+        return None, None
+    try:
+        manifest = parse_manifest_from_string(manifest_raw)
+    except Exception:
+        return None, None
+    return manifest.version, manifest.runtime_type
+
+
+# ─── platform diagnostics ────────────────────────────────────────────────────
+
+
+async def _collect_app_summary(row: sqlite3.Row) -> AppDiagnosticsSummary:
+    version, runtime_type = _manifest_fields(row["manifest_raw"])
+    # Fall back to the stored column when the manifest can't be re-parsed.
+    if version is None:
+        try:
+            version = row["version"]
+        except (IndexError, KeyError):
+            version = None
+    repo_path = row["repo_path"]
+    git = await _collect_git_info(Path(repo_path) if repo_path else None)
+    return AppDiagnosticsSummary(
+        app_id=row["app_id"],
+        name=row["name"],
+        status=row["status"],
+        version=version,
+        runtime_type=runtime_type,
+        error_message=row["error_message"],
+        git=git,
+    )
+
+
+async def collect_platform_diagnostics(db: sqlite3.Connection, config: Config) -> PlatformDiagnostics:
+    """Assemble the full instance diagnostics bundle."""
+    openhost_git = await _collect_git_info(OPENHOST_PROJECT_DIR)
+    if openhost_git is None:
+        # OPENHOST_PROJECT_DIR isn't a git checkout (tarball deploy): still
+        # emit a GitInfo so the field shape is stable for consumers.
+        openhost_git = GitInfo(branch=None, sha="", short_sha="", dirty=False, remote_url=None)
+
+    try:
+        storage = storage_status(config)
+    except Exception:
+        logger.opt(exception=True).warning("Failed to collect storage status for diagnostics")
+        storage = {}
+
+    apps: list[AppDiagnosticsSummary] = []
+    try:
+        rows = db.execute(
+            "SELECT app_id, name, status, version, runtime_type, error_message, repo_path, manifest_raw "
+            "FROM apps ORDER BY name"
+        ).fetchall()
+        for row in rows:
+            apps.append(await _collect_app_summary(row))
+    except Exception:
+        logger.opt(exception=True).warning("Failed to collect per-app diagnostics summary")
+
+    return PlatformDiagnostics(
+        schema_version=DIAGNOSTICS_SCHEMA_VERSION,
+        generated_at=datetime.now(UTC).isoformat(),
+        zone_domain=config.zone_domain,
+        openhost=openhost_git,
+        system=_collect_system_info(),
+        container_runtime=_collect_container_runtime(),
+        dependencies=_collect_dependencies(),
+        storage=storage,
+        apps=apps,
+    )
+
+
+async def collect_app_diagnostics(row: sqlite3.Row, config: Config) -> AppDiagnostics:
+    """Assemble a per-app diagnostics bundle for the given ``apps`` row."""
+    version, runtime_type = _manifest_fields(row["manifest_raw"])
+    if version is None:
+        try:
+            version = row["version"]
+        except (IndexError, KeyError):
+            version = None
+
+    repo_path = row["repo_path"]
+    git = await _collect_git_info(Path(repo_path) if repo_path else None)
+
+    openhost_git = await _collect_git_info(OPENHOST_PROJECT_DIR)
+    if openhost_git is None:
+        openhost_git = GitInfo(branch=None, sha="", short_sha="", dirty=False, remote_url=None)
+
+    return AppDiagnostics(
+        schema_version=DIAGNOSTICS_SCHEMA_VERSION,
+        generated_at=datetime.now(UTC).isoformat(),
+        zone_domain=config.zone_domain,
+        app_id=row["app_id"],
+        name=row["name"],
+        status=row["status"],
+        version=version,
+        runtime_type=runtime_type,
+        error_message=row["error_message"],
+        container_id=row["container_id"],
+        git=git,
+        system=_collect_system_info(),
+        container_runtime=_collect_container_runtime(),
+        openhost=openhost_git,
+    )

--- a/compute_space/src/compute_space/core/diagnostics.py
+++ b/compute_space/src/compute_space/core/diagnostics.py
@@ -19,6 +19,7 @@ diagnostics bundle is most valuable precisely when the instance is unhealthy.
 
 from __future__ import annotations
 
+import asyncio
 import importlib.metadata
 import json
 import os
@@ -29,8 +30,10 @@ import subprocess
 from datetime import UTC
 from datetime import datetime
 from pathlib import Path
+from typing import Any
 
 import attr
+import httpx
 
 from compute_space import OPENHOST_PROJECT_DIR
 from compute_space.config import Config
@@ -45,7 +48,10 @@ from compute_space.core.storage import storage_status
 # The schema version of the diagnostics payload.  Bump when the shape changes
 # so consumers (support tooling, the CLI, the dashboard) can detect an
 # incompatible bundle.  Present on both the platform and per-app bundles.
-DIAGNOSTICS_SCHEMA_VERSION = 1
+#
+# v2: added resource_pressure, reachability (platform) and health + resources
+#     (per-app).
+DIAGNOSTICS_SCHEMA_VERSION = 2
 
 # Distribution names whose versions are worth surfacing in a bug report.  These
 # are the packages most likely to explain a runtime bug; the full environment is
@@ -65,6 +71,22 @@ _KEY_DEPENDENCIES = (
 )
 
 _SUBPROCESS_TIMEOUT_S = 10
+
+# Per-target timeout for outbound reachability probes and per-app health checks.
+# Kept short so a diagnostics request can't hang for long on a dead network.
+_HEALTH_TIMEOUT_S = 5.0
+_REACHABILITY_TIMEOUT_S = 5.0
+
+# External hosts the platform depends on.  We probe these so a diagnostics
+# bundle shows whether the instance can reach the services it needs (app clones,
+# TLS cert issuance/brokering).  Each entry is (label, url); the URL only needs
+# to resolve + connect, so a HEAD/GET that returns any HTTP status counts as
+# "reachable".
+_STATIC_REACHABILITY_TARGETS: tuple[tuple[str, str], ...] = (
+    ("github", "https://github.com"),
+    ("github_api", "https://api.github.com"),
+    ("acme_gts", "https://dv.acme-v02.api.pki.goog/directory"),
+)
 
 
 # ─── attrs models ────────────────────────────────────────────────────────────
@@ -113,6 +135,66 @@ class ContainerRuntimeInfo:
 
 
 @attr.s(auto_attribs=True, frozen=True)
+class HostResourcePressure:
+    """Host-level memory + load, for spotting pressure / OOM conditions."""
+
+    memory_total_bytes: int | None
+    memory_available_bytes: int | None
+    memory_used_percent: float | None
+    load_avg_1m: float | None
+    load_avg_5m: float | None
+    load_avg_15m: float | None
+    cpu_count: int | None
+    error: str | None = None
+
+
+@attr.s(auto_attribs=True, frozen=True)
+class AppResourceUsage:
+    """Live container resource usage for one app vs its manifest limits.
+
+    All ``*_actual`` fields are None when the app has no running container or
+    podman stats can't be read; ``*_limit`` reflects the manifest.
+    """
+
+    running: bool
+    cpu_percent: float | None
+    memory_usage_bytes: int | None
+    memory_limit_bytes: int | None
+    memory_percent: float | None
+    cpu_cores_limit: float | None
+    memory_mb_limit: int | None
+    error: str | None = None
+
+
+@attr.s(auto_attribs=True, frozen=True)
+class AppHealth:
+    """Result of probing an app's health endpoint over the loopback proxy port.
+
+    ``checked_path`` is the app's declared ``health_check`` path, or ``/`` when
+    none is declared.  ``healthy`` is True when the endpoint responds with an
+    HTTP status < 500 (matching the router's readiness contract).
+    """
+
+    checked: bool
+    healthy: bool | None
+    status_code: int | None
+    checked_path: str
+    error: str | None = None
+
+
+@attr.s(auto_attribs=True, frozen=True)
+class ReachabilityResult:
+    """Outcome of an outbound reachability probe to one external host."""
+
+    label: str
+    url: str
+    reachable: bool
+    status_code: int | None
+    latency_ms: float | None
+    error: str | None = None
+
+
+@attr.s(auto_attribs=True, frozen=True)
 class AppDiagnosticsSummary:
     """Per-app entry in the platform diagnostics bundle."""
 
@@ -123,6 +205,8 @@ class AppDiagnosticsSummary:
     runtime_type: str | None
     error_message: str | None
     git: GitInfo | None
+    health: AppHealth | None = None
+    resources: AppResourceUsage | None = None
 
 
 @attr.s(auto_attribs=True, frozen=True)
@@ -137,6 +221,8 @@ class PlatformDiagnostics:
     container_runtime: ContainerRuntimeInfo
     dependencies: dict[str, str]
     storage: dict[str, object]
+    resource_pressure: HostResourcePressure
+    reachability: list[ReachabilityResult]
     apps: list[AppDiagnosticsSummary]
 
 
@@ -160,8 +246,11 @@ class AppDiagnostics:
     error_message: str | None
     container_id: str | None
     git: GitInfo | None
+    health: AppHealth | None
+    resources: AppResourceUsage | None
     system: SystemInfo
     container_runtime: ContainerRuntimeInfo
+    resource_pressure: HostResourcePressure
     openhost: GitInfo
 
 
@@ -305,19 +394,324 @@ def _manifest_fields(manifest_raw: str | None) -> tuple[str | None, str | None]:
     return manifest.version, manifest.runtime_type
 
 
+# ─── resource pressure ───────────────────────────────────────────────────────
+
+
+def _read_meminfo() -> tuple[int | None, int | None]:
+    """Return (MemTotal, MemAvailable) in bytes from /proc/meminfo, or (None, None).
+
+    /proc/meminfo reports values in kibibytes; we convert to bytes. Best-effort,
+    never raises (Linux-only path).
+    """
+    total: int | None = None
+    available: int | None = None
+    try:
+        with open("/proc/meminfo") as f:
+            for line in f:
+                if line.startswith("MemTotal:"):
+                    total = int(line.split()[1]) * 1024
+                elif line.startswith("MemAvailable:"):
+                    available = int(line.split()[1]) * 1024
+                if total is not None and available is not None:
+                    break
+    except Exception:
+        return None, None
+    return total, available
+
+
+def _collect_resource_pressure() -> HostResourcePressure:
+    """Gather host memory + load average. Defensive: fields degrade to None."""
+    total, available = _read_meminfo()
+    used_percent: float | None = None
+    if total and available is not None and total > 0:
+        used_percent = round((total - available) / total * 100, 1)
+
+    load_1m: float | None = None
+    load_5m: float | None = None
+    load_15m: float | None = None
+    try:
+        load_1m, load_5m, load_15m = os.getloadavg()
+    except (OSError, AttributeError):
+        pass
+
+    try:
+        cpu_count = os.cpu_count()
+    except Exception:
+        cpu_count = None
+
+    return HostResourcePressure(
+        memory_total_bytes=total,
+        memory_available_bytes=available,
+        memory_used_percent=used_percent,
+        load_avg_1m=load_1m,
+        load_avg_5m=load_5m,
+        load_avg_15m=load_15m,
+        cpu_count=cpu_count,
+    )
+
+
+def _parse_stats_bytes(value: object) -> int | None:
+    """Parse a podman-stats size token like '12.3MB' / '1.2GiB' / '512kB' to bytes.
+
+    podman renders memory usage as a human string; we normalise to bytes so the
+    bundle carries machine-comparable numbers. Returns None on anything unparseable.
+    """
+    if not isinstance(value, str):
+        return None
+    s = value.strip()
+    if not s or s.lower() in ("--", "n/a"):
+        return None
+    units = {
+        "b": 1,
+        "kb": 1000,
+        "mb": 1000**2,
+        "gb": 1000**3,
+        "tb": 1000**4,
+        "kib": 1024,
+        "mib": 1024**2,
+        "gib": 1024**3,
+        "tib": 1024**4,
+    }
+    # Split trailing unit letters from the leading number.
+    num = s
+    unit = ""
+    for i, ch in enumerate(s):
+        if ch.isalpha() or ch == "%":
+            num, unit = s[:i], s[i:]
+            break
+    try:
+        magnitude = float(num)
+    except ValueError:
+        return None
+    factor = units.get(unit.strip().lower(), 1)
+    return int(magnitude * factor)
+
+
+def _parse_stats_percent(value: object) -> float | None:
+    """Parse a podman-stats percent token like '3.14%' to a float, or None."""
+    if not isinstance(value, str):
+        return None
+    s = value.strip().rstrip("%").strip()
+    if not s or s in ("--", "N/A"):
+        return None
+    try:
+        return round(float(s), 2)
+    except ValueError:
+        return None
+
+
+def _collect_app_resources(
+    container_id: str | None, cpu_cores_limit: float | None, memory_mb_limit: int | None
+) -> AppResourceUsage:
+    """Read live container resource usage via ``podman stats`` for one app.
+
+    Never raises: a missing container / stats failure degrades to a not-running
+    or error result while still reporting the manifest limits.
+    """
+    base = AppResourceUsage(
+        running=False,
+        cpu_percent=None,
+        memory_usage_bytes=None,
+        memory_limit_bytes=None,
+        memory_percent=None,
+        cpu_cores_limit=cpu_cores_limit,
+        memory_mb_limit=memory_mb_limit,
+    )
+    if not container_id:
+        return base
+    if shutil.which("podman") is None:
+        return attr.evolve(base, error="podman not found on PATH")
+    try:
+        proc = subprocess.run(
+            ["podman", "stats", "--no-stream", "--format", "json", container_id],
+            capture_output=True,
+            text=True,
+            timeout=_SUBPROCESS_TIMEOUT_S,
+        )
+    except subprocess.TimeoutExpired:
+        return attr.evolve(base, error="podman stats timed out")
+    except Exception as e:
+        return attr.evolve(base, error=str(e))
+
+    if proc.returncode != 0:
+        # Non-zero is expected when the container isn't running.
+        return base
+
+    try:
+        data = json.loads(proc.stdout)
+    except (json.JSONDecodeError, ValueError):
+        return attr.evolve(base, error="podman stats returned non-JSON output")
+
+    # podman stats --format json returns a list of per-container objects.
+    if isinstance(data, list):
+        if not data:
+            return base
+        entry = data[0]
+    elif isinstance(data, dict):
+        entry = data
+    else:
+        return attr.evolve(base, error="unexpected podman stats shape")
+
+    if not isinstance(entry, dict):
+        return attr.evolve(base, error="unexpected podman stats entry")
+
+    cpu_percent = _parse_stats_percent(entry.get("CPU") or entry.get("cpu_percent"))
+    mem_percent = _parse_stats_percent(entry.get("MemPerc") or entry.get("mem_percent"))
+    # MemUsage looks like "12.3MB / 128MB"; split usage/limit.
+    mem_usage_bytes: int | None = None
+    mem_limit_bytes: int | None = None
+    mem_usage_raw = entry.get("MemUsage") or entry.get("mem_usage")
+    if isinstance(mem_usage_raw, str) and "/" in mem_usage_raw:
+        usage_part, _, limit_part = mem_usage_raw.partition("/")
+        mem_usage_bytes = _parse_stats_bytes(usage_part)
+        mem_limit_bytes = _parse_stats_bytes(limit_part)
+
+    return AppResourceUsage(
+        running=True,
+        cpu_percent=cpu_percent,
+        memory_usage_bytes=mem_usage_bytes,
+        memory_limit_bytes=mem_limit_bytes,
+        memory_percent=mem_percent,
+        cpu_cores_limit=cpu_cores_limit,
+        memory_mb_limit=memory_mb_limit,
+    )
+
+
+# ─── health checks ───────────────────────────────────────────────────────────
+
+
+async def _collect_app_health(local_port: int | None, health_check: str | None) -> AppHealth:
+    """Probe an app's health endpoint over its loopback proxy port.
+
+    Mirrors the router's readiness contract (any HTTP status < 500 = healthy)
+    and honours the app's declared ``health_check`` path, defaulting to ``/``.
+    Never raises: connection/timeout errors degrade to healthy=False + an error.
+    """
+    path = health_check or "/"
+    if not path.startswith("/"):
+        path = "/" + path
+    checked_path = path
+    if not local_port:
+        return AppHealth(
+            checked=False, healthy=None, status_code=None, checked_path=checked_path, error="no local port"
+        )
+    url = f"http://127.0.0.1:{local_port}{path}"
+    try:
+        async with httpx.AsyncClient(timeout=_HEALTH_TIMEOUT_S) as client:
+            resp = await client.get(url)
+    except httpx.TimeoutException:
+        return AppHealth(checked=True, healthy=False, status_code=None, checked_path=checked_path, error="timeout")
+    except httpx.HTTPError as e:
+        return AppHealth(checked=True, healthy=False, status_code=None, checked_path=checked_path, error=str(e))
+    except Exception as e:
+        return AppHealth(checked=True, healthy=False, status_code=None, checked_path=checked_path, error=str(e))
+    return AppHealth(
+        checked=True,
+        healthy=resp.status_code < 500,
+        status_code=resp.status_code,
+        checked_path=checked_path,
+    )
+
+
+# ─── outbound reachability ───────────────────────────────────────────────────
+
+
+def _reachability_targets(config: Config) -> list[tuple[str, str]]:
+    """Assemble the list of (label, url) reachability targets from static hosts
+    plus any config-driven URLs (cert broker, ACME directory, redirect domain)."""
+    targets: list[tuple[str, str]] = list(_STATIC_REACHABILITY_TARGETS)
+    if config.cert_api_base_url:
+        targets.append(("cert_api", config.cert_api_base_url))
+    if config.cert_api_keycloak_issuer_url:
+        targets.append(("cert_api_keycloak", config.cert_api_keycloak_issuer_url))
+    if config.acme_directory_url:
+        targets.append(("acme_directory", config.acme_directory_url))
+    if config.my_openhost_redirect_domain:
+        targets.append(("openhost_redirect", f"https://{config.my_openhost_redirect_domain}"))
+    # De-duplicate by URL while preserving order (static ACME may equal config ACME).
+    seen: set[str] = set()
+    deduped: list[tuple[str, str]] = []
+    for label, url in targets:
+        if url in seen:
+            continue
+        seen.add(url)
+        deduped.append((label, url))
+    return deduped
+
+
+async def _probe_reachability(client: httpx.AsyncClient, label: str, url: str) -> ReachabilityResult:
+    """Probe a single external URL. Any HTTP response = reachable (we only care
+    that DNS + TCP + TLS succeeded, not the status)."""
+    start = asyncio.get_event_loop().time()
+    try:
+        resp = await client.get(url)
+    except httpx.TimeoutException:
+        return ReachabilityResult(
+            label=label, url=url, reachable=False, status_code=None, latency_ms=None, error="timeout"
+        )
+    except httpx.HTTPError as e:
+        return ReachabilityResult(
+            label=label, url=url, reachable=False, status_code=None, latency_ms=None, error=str(e)
+        )
+    except Exception as e:
+        return ReachabilityResult(
+            label=label, url=url, reachable=False, status_code=None, latency_ms=None, error=str(e)
+        )
+    latency_ms = round((asyncio.get_event_loop().time() - start) * 1000, 1)
+    return ReachabilityResult(
+        label=label, url=url, reachable=True, status_code=resp.status_code, latency_ms=latency_ms
+    )
+
+
+async def _collect_reachability(config: Config) -> list[ReachabilityResult]:
+    """Probe all external dependency hosts concurrently. Never raises."""
+    targets = _reachability_targets(config)
+    try:
+        async with httpx.AsyncClient(timeout=_REACHABILITY_TIMEOUT_S, follow_redirects=False) as client:
+            return list(await asyncio.gather(*(_probe_reachability(client, label, url) for label, url in targets)))
+    except Exception:
+        logger.opt(exception=True).warning("Failed to collect reachability diagnostics")
+        return []
+
+
 # ─── platform diagnostics ────────────────────────────────────────────────────
+
+
+def _row_get(row: sqlite3.Row, key: str) -> Any:
+    """Safe column access: returns None when the column is absent from the row."""
+    try:
+        return row[key]
+    except (IndexError, KeyError):
+        return None
+
+
+async def _collect_app_health_and_resources(row: sqlite3.Row) -> tuple[AppHealth, AppResourceUsage]:
+    """Collect the (health, resource-usage) pair for one app row.
+
+    Shared by the platform summary and the per-app bundle so both surface the
+    same live data with the same defensive semantics.
+    """
+    local_port = _row_get(row, "local_port")
+    health = await _collect_app_health(
+        local_port if isinstance(local_port, int) else None,
+        _row_get(row, "health_check"),
+    )
+    resources = _collect_app_resources(
+        _row_get(row, "container_id"),
+        _row_get(row, "cpu_cores"),
+        _row_get(row, "memory_mb"),
+    )
+    return health, resources
 
 
 async def _collect_app_summary(row: sqlite3.Row) -> AppDiagnosticsSummary:
     version, runtime_type = _manifest_fields(row["manifest_raw"])
     # Fall back to the stored column when the manifest can't be re-parsed.
     if version is None:
-        try:
-            version = row["version"]
-        except (IndexError, KeyError):
-            version = None
+        version = _row_get(row, "version")
     repo_path = row["repo_path"]
     git = await _collect_git_info(Path(repo_path) if repo_path else None)
+    health, resources = await _collect_app_health_and_resources(row)
     return AppDiagnosticsSummary(
         app_id=row["app_id"],
         name=row["name"],
@@ -326,6 +720,8 @@ async def _collect_app_summary(row: sqlite3.Row) -> AppDiagnosticsSummary:
         runtime_type=runtime_type,
         error_message=row["error_message"],
         git=git,
+        health=health,
+        resources=resources,
     )
 
 
@@ -346,13 +742,16 @@ async def collect_platform_diagnostics(db: sqlite3.Connection, config: Config) -
     apps: list[AppDiagnosticsSummary] = []
     try:
         rows = db.execute(
-            "SELECT app_id, name, status, version, runtime_type, error_message, repo_path, manifest_raw "
+            "SELECT app_id, name, status, version, runtime_type, error_message, repo_path, "
+            "manifest_raw, local_port, health_check, container_id, cpu_cores, memory_mb "
             "FROM apps ORDER BY name"
         ).fetchall()
         for row in rows:
             apps.append(await _collect_app_summary(row))
     except Exception:
         logger.opt(exception=True).warning("Failed to collect per-app diagnostics summary")
+
+    reachability = await _collect_reachability(config)
 
     return PlatformDiagnostics(
         schema_version=DIAGNOSTICS_SCHEMA_VERSION,
@@ -363,6 +762,8 @@ async def collect_platform_diagnostics(db: sqlite3.Connection, config: Config) -
         container_runtime=_collect_container_runtime(),
         dependencies=_collect_dependencies(),
         storage=storage,
+        resource_pressure=_collect_resource_pressure(),
+        reachability=reachability,
         apps=apps,
     )
 
@@ -383,6 +784,8 @@ async def collect_app_diagnostics(row: sqlite3.Row, config: Config) -> AppDiagno
     if openhost_git is None:
         openhost_git = GitInfo(branch=None, sha="", short_sha="", dirty=False, remote_url=None)
 
+    health, resources = await _collect_app_health_and_resources(row)
+
     return AppDiagnostics(
         schema_version=DIAGNOSTICS_SCHEMA_VERSION,
         generated_at=datetime.now(UTC).isoformat(),
@@ -395,7 +798,10 @@ async def collect_app_diagnostics(row: sqlite3.Row, config: Config) -> AppDiagno
         error_message=row["error_message"],
         container_id=row["container_id"],
         git=git,
+        health=health,
+        resources=resources,
         system=_collect_system_info(),
         container_runtime=_collect_container_runtime(),
+        resource_pressure=_collect_resource_pressure(),
         openhost=openhost_git,
     )

--- a/compute_space/src/compute_space/core/diagnostics.py
+++ b/compute_space/src/compute_space/core/diagnostics.py
@@ -627,10 +627,9 @@ async def _collect_app_health(local_port: int | None, health_check: str | None) 
 
 def _reachability_targets(config: Config) -> list[tuple[str, str]]:
     """Assemble the list of (label, url) reachability targets from static hosts
-    plus any config-driven URLs (cert broker, ACME directory, redirect domain)."""
+    plus any config-driven URLs (cert-api Keycloak issuer, ACME directory,
+    redirect domain). The cert-api base URL is deliberately not probed."""
     targets: list[tuple[str, str]] = list(_STATIC_REACHABILITY_TARGETS)
-    if config.cert_api_base_url:
-        targets.append(("cert_api", config.cert_api_base_url))
     if config.cert_api_keycloak_issuer_url:
         targets.append(("cert_api_keycloak", config.cert_api_keycloak_issuer_url))
     if config.acme_directory_url:

--- a/compute_space/src/compute_space/tests/test_diagnostics.py
+++ b/compute_space/src/compute_space/tests/test_diagnostics.py
@@ -624,6 +624,7 @@ def test_collect_app_resources_running_parses_stats() -> None:
     fake = subprocess.CompletedProcess(args=[], returncode=0, stdout=stats, stderr="")
     with (
         patch("compute_space.core.diagnostics.shutil.which", return_value="/usr/bin/podman"),
+        patch("compute_space.core.diagnostics.is_container_running", return_value=True),
         patch("compute_space.core.diagnostics.subprocess.run", return_value=fake),
     ):
         r = diagnostics._collect_app_resources("cid123", 0.5, 128)
@@ -634,20 +635,28 @@ def test_collect_app_resources_running_parses_stats() -> None:
     assert r.memory_percent == 50.0
 
 
-def test_collect_app_resources_not_running_when_nonzero() -> None:
-    fake = subprocess.CompletedProcess(args=[], returncode=125, stdout="", stderr="no such container")
+def test_collect_app_resources_not_running_when_container_stopped() -> None:
+    # An exited container is reported as not-running WITHOUT invoking stats:
+    # podman stats emits a zero-valued entry for a stopped container, so we
+    # trust the authoritative container-state check instead.
     with (
         patch("compute_space.core.diagnostics.shutil.which", return_value="/usr/bin/podman"),
-        patch("compute_space.core.diagnostics.subprocess.run", return_value=fake),
+        patch("compute_space.core.diagnostics.is_container_running", return_value=False),
+        patch("compute_space.core.diagnostics.subprocess.run") as run_mock,
     ):
         r = diagnostics._collect_app_resources("cid123", 0.5, 128)
     assert r.running is False
     assert r.error is None
+    assert r.cpu_cores_limit == 0.5
+    assert r.memory_mb_limit == 128
+    # stats must not be probed once the container is known to be stopped.
+    run_mock.assert_not_called()
 
 
 def test_collect_app_resources_stats_timeout() -> None:
     with (
         patch("compute_space.core.diagnostics.shutil.which", return_value="/usr/bin/podman"),
+        patch("compute_space.core.diagnostics.is_container_running", return_value=True),
         patch(
             "compute_space.core.diagnostics.subprocess.run",
             side_effect=subprocess.TimeoutExpired(cmd="podman", timeout=10),
@@ -916,6 +925,7 @@ def test_stats_subprocess_uses_bounded_timeout() -> None:
 
     with (
         patch("compute_space.core.diagnostics.shutil.which", return_value="/usr/bin/podman"),
+        patch("compute_space.core.diagnostics.is_container_running", return_value=True),
         patch("compute_space.core.diagnostics.subprocess.run", _fake_run),
     ):
         diagnostics._collect_app_resources("cid", 0.5, 128)
@@ -1009,14 +1019,15 @@ def _stats_run(stdout: str) -> Any:
     fake = subprocess.CompletedProcess(args=[], returncode=0, stdout=stdout, stderr="")
     return (
         patch("compute_space.core.diagnostics.shutil.which", return_value="/usr/bin/podman"),
+        patch("compute_space.core.diagnostics.is_container_running", return_value=True),
         patch("compute_space.core.diagnostics.subprocess.run", return_value=fake),
     )
 
 
 def test_stats_dict_shape_not_list() -> None:
     # Some podman versions emit a bare object rather than a list.
-    which_p, run_p = _stats_run(json.dumps({"CPU": "5.0%", "MemUsage": "10MB / 100MB", "MemPerc": "10%"}))
-    with which_p, run_p:
+    which_p, running_p, run_p = _stats_run(json.dumps({"CPU": "5.0%", "MemUsage": "10MB / 100MB", "MemPerc": "10%"}))
+    with which_p, running_p, run_p:
         r = diagnostics._collect_app_resources("cid", 1.0, 100)
     assert r.running is True
     assert r.cpu_percent == 5.0
@@ -1024,15 +1035,15 @@ def test_stats_dict_shape_not_list() -> None:
 
 
 def test_stats_empty_list_is_not_running() -> None:
-    which_p, run_p = _stats_run("[]")
-    with which_p, run_p:
+    which_p, running_p, run_p = _stats_run("[]")
+    with which_p, running_p, run_p:
         r = diagnostics._collect_app_resources("cid", 1.0, 100)
     assert r.running is False
 
 
 def test_stats_missing_memusage_leaves_bytes_none() -> None:
-    which_p, run_p = _stats_run(json.dumps([{"CPU": "7.5%"}]))
-    with which_p, run_p:
+    which_p, running_p, run_p = _stats_run(json.dumps([{"CPU": "7.5%"}]))
+    with which_p, running_p, run_p:
         r = diagnostics._collect_app_resources("cid", 1.0, 100)
     assert r.running is True
     assert r.cpu_percent == 7.5
@@ -1041,8 +1052,8 @@ def test_stats_missing_memusage_leaves_bytes_none() -> None:
 
 
 def test_stats_dashes_render_as_none() -> None:
-    which_p, run_p = _stats_run(json.dumps([{"CPU": "--", "MemUsage": "-- / --", "MemPerc": "--"}]))
-    with which_p, run_p:
+    which_p, running_p, run_p = _stats_run(json.dumps([{"CPU": "--", "MemUsage": "-- / --", "MemPerc": "--"}]))
+    with which_p, running_p, run_p:
         r = diagnostics._collect_app_resources("cid", 1.0, 100)
     assert r.running is True
     assert r.cpu_percent is None

--- a/compute_space/src/compute_space/tests/test_diagnostics.py
+++ b/compute_space/src/compute_space/tests/test_diagnostics.py
@@ -2,27 +2,51 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 import sqlite3
 import subprocess
 from collections.abc import Iterator
 from pathlib import Path
 from typing import Any
+from unittest.mock import MagicMock
 from unittest.mock import patch
 
+import attr
+import git
 import pytest
 from litestar import Litestar
 from litestar.testing import TestClient
 
+from compute_space.config import Config
 from compute_space.core import diagnostics
 from compute_space.core.app_id import new_app_id
 from compute_space.core.diagnostics import DIAGNOSTICS_SCHEMA_VERSION
+from compute_space.core.diagnostics import GitInfo
 from compute_space.db.connection import init_db
 from compute_space.tests._litestar_helpers import auth_cookie
 from compute_space.tests._litestar_helpers import make_test_app
 from compute_space.tests.conftest import _make_test_config
+from compute_space.web.routes.api.apps import _app_diagnostics_filename
 from compute_space.web.routes.api.apps import api_apps_routes
+from compute_space.web.routes.api.system import _diagnostics_filename
 from compute_space.web.routes.api.system import system_routes
+
+
+def _init_git_repo(path: Path, *, remote_url: str | None = None) -> git.Repo:
+    """Create a git repo at ``path`` with one commit. Optional 'origin' remote."""
+    path.mkdir(parents=True, exist_ok=True)
+    repo = git.Repo.init(path, initial_branch="main")
+    with repo.config_writer() as cw:
+        cw.set_value("user", "name", "Test")
+        cw.set_value("user", "email", "test@example.com")
+    (path / "README.md").write_text("hello\n")
+    repo.index.add(["README.md"])
+    repo.index.commit("initial commit")
+    if remote_url is not None:
+        repo.create_remote("origin", remote_url)
+    return repo
+
 
 _MINIMAL_MANIFEST = """
 [app]
@@ -242,3 +266,241 @@ def test_app_diagnostics_download_header(cfg: Any, apps_client: TestClient[Lites
     disp = resp.headers.get("content-disposition", "")
     assert "attachment" in disp
     assert "myapp" in disp
+
+
+# ─── git collector against real repos ────────────────────────────────────────
+
+
+def test_collect_git_info_none_for_non_git_dir(tmp_path: Path) -> None:
+    (tmp_path / "notrepo").mkdir()
+    assert asyncio.run(diagnostics._collect_git_info(tmp_path / "notrepo")) is None
+
+
+def test_collect_git_info_none_for_none_path() -> None:
+    assert asyncio.run(diagnostics._collect_git_info(None)) is None
+
+
+def test_collect_git_info_clean_repo(tmp_path: Path) -> None:
+    repo_path = tmp_path / "repo"
+    _init_git_repo(repo_path, remote_url="https://github.com/owner/repo.git")
+    info = asyncio.run(diagnostics._collect_git_info(repo_path))
+    assert info is not None
+    assert info.branch == "main"
+    assert len(info.sha) == 40
+    assert info.short_sha == info.sha[:8]
+    assert info.dirty is False
+    assert info.remote_url == "https://github.com/owner/repo.git"
+
+
+def test_collect_git_info_dirty_repo(tmp_path: Path) -> None:
+    repo_path = tmp_path / "repo"
+    _init_git_repo(repo_path)
+    (repo_path / "untracked.txt").write_text("dirty\n")
+    info = asyncio.run(diagnostics._collect_git_info(repo_path))
+    assert info is not None
+    assert info.dirty is True
+
+
+def test_collect_git_info_detached_head(tmp_path: Path) -> None:
+    repo_path = tmp_path / "repo"
+    repo = _init_git_repo(repo_path)
+    repo.git.checkout(repo.head.commit.hexsha)  # detach
+    info = asyncio.run(diagnostics._collect_git_info(repo_path))
+    assert info is not None
+    assert info.branch is None  # detached HEAD reports no branch
+    assert info.sha  # but sha is still populated
+
+
+def test_collect_git_info_no_remote(tmp_path: Path) -> None:
+    repo_path = tmp_path / "repo"
+    _init_git_repo(repo_path)  # no origin
+    info = asyncio.run(diagnostics._collect_git_info(repo_path))
+    assert info is not None
+    assert info.remote_url is None
+
+
+def test_collect_git_info_strips_credentials(tmp_path: Path) -> None:
+    repo_path = tmp_path / "repo"
+    _init_git_repo(repo_path, remote_url="https://oauth2:SECRETTOKEN@github.com/owner/repo.git")
+    info = asyncio.run(diagnostics._collect_git_info(repo_path))
+    assert info is not None
+    assert info.remote_url is not None
+    assert "SECRETTOKEN" not in info.remote_url
+    assert "github.com/owner/repo.git" in info.remote_url
+
+
+# ─── podman probe edge cases ─────────────────────────────────────────────────
+
+
+def test_collect_container_runtime_timeout() -> None:
+    with (
+        patch("compute_space.core.diagnostics.shutil.which", return_value="/usr/bin/podman"),
+        patch(
+            "compute_space.core.diagnostics.subprocess.run",
+            side_effect=subprocess.TimeoutExpired(cmd="podman", timeout=10),
+        ),
+    ):
+        info = diagnostics._collect_container_runtime()
+    assert info.available is False
+    assert "timed out" in (info.error or "")
+
+
+def test_collect_container_runtime_nonzero_returncode() -> None:
+    fake = subprocess.CompletedProcess(args=[], returncode=125, stdout="", stderr="boom")
+    with (
+        patch("compute_space.core.diagnostics.shutil.which", return_value="/usr/bin/podman"),
+        patch("compute_space.core.diagnostics.subprocess.run", return_value=fake),
+    ):
+        info = diagnostics._collect_container_runtime()
+    assert info.available is False
+    assert info.error is not None
+
+
+def test_collect_container_runtime_rootful() -> None:
+    fake = subprocess.CompletedProcess(
+        args=[],
+        returncode=0,
+        stdout=json.dumps({"version": {"Version": "5.4.2"}, "host": {"security": {"rootless": False}}}),
+        stderr="",
+    )
+    with (
+        patch("compute_space.core.diagnostics.shutil.which", return_value="/usr/bin/podman"),
+        patch("compute_space.core.diagnostics.subprocess.run", return_value=fake),
+    ):
+        info = diagnostics._collect_container_runtime()
+    assert info.available is True
+    assert info.rootless is False
+    assert info.version == "5.4.2"
+
+
+def test_collect_container_runtime_missing_version_key() -> None:
+    # Some podman versions may not emit a version table; fall back gracefully.
+    fake = subprocess.CompletedProcess(
+        args=[],
+        returncode=0,
+        stdout=json.dumps({"host": {"security": {"rootless": True}}}),
+        stderr="",
+    )
+    with (
+        patch("compute_space.core.diagnostics.shutil.which", return_value="/usr/bin/podman"),
+        patch("compute_space.core.diagnostics.subprocess.run", return_value=fake),
+    ):
+        info = diagnostics._collect_container_runtime()
+    assert info.available is True
+    assert info.rootless is True
+    assert info.version is None
+
+
+# ─── resilience: partial failures degrade instead of raising ─────────────────
+
+
+def test_platform_diagnostics_survives_storage_failure(
+    cfg: Any, system_client: TestClient[Litestar], cookies: dict[str, str]
+) -> None:
+    with patch(
+        "compute_space.core.diagnostics.storage_status",
+        side_effect=OSError("disk gone"),
+    ):
+        resp = system_client.get("/api/diagnostics", cookies=cookies)
+    assert resp.status_code == 200
+    # Storage degrades to an empty dict rather than sinking the whole bundle.
+    assert resp.json()["storage"] == {}
+
+
+def test_platform_diagnostics_survives_db_failure(cfg: Any) -> None:
+    broken = MagicMock()
+    broken.execute.side_effect = sqlite3.OperationalError("no such table")
+    real_config = Config(**{f.name: getattr(cfg, f.name) for f in attr.fields(Config)})
+    with patch("compute_space.core.diagnostics.storage_status", return_value={}):
+        diag = asyncio.run(diagnostics.collect_platform_diagnostics(broken, real_config))
+    # A failing apps query leaves apps empty but still returns a bundle.
+    assert diag.apps == []
+    assert diag.system.python_version
+
+
+def test_platform_diagnostics_no_apps(cfg: Any, system_client: TestClient[Litestar], cookies: dict[str, str]) -> None:
+    resp = system_client.get("/api/diagnostics", cookies=cookies)
+    assert resp.status_code == 200
+    assert resp.json()["apps"] == []
+
+
+def test_openhost_git_info_stable_shape_when_not_a_checkout(
+    cfg: Any, system_client: TestClient[Litestar], cookies: dict[str, str]
+) -> None:
+    # When OPENHOST_PROJECT_DIR isn't a git checkout, the bundle must still
+    # carry an openhost GitInfo with a stable (empty) shape.
+    async def _none(_path: Any) -> None:
+        return None
+
+    with patch("compute_space.core.diagnostics._collect_git_info", side_effect=_none):
+        resp = system_client.get("/api/diagnostics", cookies=cookies)
+    assert resp.status_code == 200
+    oh = resp.json()["openhost"]
+    assert oh["sha"] == ""
+    assert oh["branch"] is None
+    assert oh["dirty"] is False
+
+
+# ─── filename sanitization ───────────────────────────────────────────────────
+
+
+def test_platform_filename_sanitizes_and_stamps() -> None:
+    name = _diagnostics_filename("my.zone.example.com:8443")
+    assert name.startswith("openhost-diagnostics-")
+    assert name.endswith(".json")
+    # ':' is not filename-safe and must be replaced.
+    assert ":" not in name
+    assert "my.zone.example.com" in name
+
+
+def test_platform_filename_handles_empty_zone() -> None:
+    name = _diagnostics_filename("")
+    assert "openhost" in name
+    assert name.endswith(".json")
+
+
+def test_app_filename_sanitizes_path_traversal() -> None:
+    name = _app_diagnostics_filename("../../etc/passwd")
+    # Slashes and dot-dot must not survive into the download filename.
+    assert "/" not in name
+    assert name.startswith("openhost-app-diagnostics-")
+    assert name.endswith(".json")
+
+
+def test_app_filename_handles_weird_name() -> None:
+    name = _app_diagnostics_filename('bad";name\x00')
+    assert '"' not in name
+    assert "\x00" not in name
+    assert name.endswith(".json")
+
+
+# ─── per-app diagnostics surfaces real git info ───────────────────────────────
+
+
+def test_app_diagnostics_surfaces_git(
+    cfg: Any, apps_client: TestClient[Litestar], cookies: dict[str, str], tmp_path: Path
+) -> None:
+    repo_path = tmp_path / "app_repo"
+    _init_git_repo(repo_path, remote_url="https://github.com/owner/app.git")
+    app_id = _seed_app(cfg.db_path, "gitapp", manifest_raw=_MINIMAL_MANIFEST, repo_path=str(repo_path))
+    resp = apps_client.get(f"/api/app_diagnostics/{app_id}", cookies=cookies)
+    assert resp.status_code == 200
+    git_info = resp.json()["git"]
+    assert git_info is not None
+    assert git_info["branch"] == "main"
+    assert git_info["remote_url"] == "https://github.com/owner/app.git"
+
+
+def test_app_diagnostics_git_none_for_non_git_app(
+    cfg: Any, apps_client: TestClient[Litestar], cookies: dict[str, str]
+) -> None:
+    app_id = _seed_app(cfg.db_path, "builtin", repo_path="/nonexistent")
+    resp = apps_client.get(f"/api/app_diagnostics/{app_id}", cookies=cookies)
+    assert resp.status_code == 200
+    assert resp.json()["git"] is None
+
+
+def test_gitinfo_is_frozen() -> None:
+    info = GitInfo(branch="main", sha="abc", short_sha="abc", dirty=False, remote_url=None)
+    with pytest.raises(attr.exceptions.FrozenInstanceError):
+        info.branch = "other"  # type: ignore[misc]

--- a/compute_space/src/compute_space/tests/test_diagnostics.py
+++ b/compute_space/src/compute_space/tests/test_diagnostics.py
@@ -448,9 +448,10 @@ def test_platform_filename_sanitizes_and_stamps() -> None:
     name = _diagnostics_filename("my.zone.example.com:8443")
     assert name.startswith("openhost-diagnostics-")
     assert name.endswith(".json")
-    # ':' is not filename-safe and must be replaced.
+    # ':' is not filename-safe and must be replaced with '_'; the rest of the
+    # host (dots included) is preserved verbatim.
     assert ":" not in name
-    assert "my.zone.example.com" in name
+    assert name.startswith("openhost-diagnostics-my.zone.example.com_8443-")
 
 
 def test_platform_filename_handles_empty_zone() -> None:

--- a/compute_space/src/compute_space/tests/test_diagnostics.py
+++ b/compute_space/src/compute_space/tests/test_diagnostics.py
@@ -10,10 +10,12 @@ from collections.abc import Iterator
 from pathlib import Path
 from typing import Any
 from unittest.mock import MagicMock
+from unittest.mock import mock_open
 from unittest.mock import patch
 
 import attr
 import git
+import httpx
 import pytest
 from litestar import Litestar
 from litestar.testing import TestClient
@@ -22,6 +24,7 @@ from compute_space.config import Config
 from compute_space.core import diagnostics
 from compute_space.core.app_id import new_app_id
 from compute_space.core.diagnostics import DIAGNOSTICS_SCHEMA_VERSION
+from compute_space.core.diagnostics import AppHealth
 from compute_space.core.diagnostics import GitInfo
 from compute_space.db.connection import init_db
 from compute_space.tests._litestar_helpers import auth_cookie
@@ -57,6 +60,36 @@ version = "2.3.4"
 image = "docker.io/library/nginx:latest"
 port = 80
 """
+
+
+@pytest.fixture(autouse=True)
+def _no_real_network(request: Any) -> Iterator[None]:
+    """Keep the suite hermetic + fast: stub the collectors that would otherwise
+    make real outbound HTTP calls (reachability probes, per-app health checks).
+
+    The higher-level endpoint/bundle tests don't care about the exact network
+    result, so we stub it. Tests that exercise the network collectors directly
+    mark themselves ``@pytest.mark.real_collectors`` to opt out of this stub and
+    instead patch ``httpx.AsyncClient`` themselves.
+    """
+    if request.node.get_closest_marker("real_collectors"):
+        yield
+        return
+
+    async def _fake_reachability(_config: Any) -> list[Any]:
+        return []
+
+    async def _fake_health(_local_port: Any, health_check: Any) -> AppHealth:
+        path = health_check or "/"
+        if not path.startswith("/"):
+            path = "/" + path
+        return AppHealth(checked=False, healthy=None, status_code=None, checked_path=path, error="stubbed")
+
+    with (
+        patch("compute_space.core.diagnostics._collect_reachability", side_effect=_fake_reachability),
+        patch("compute_space.core.diagnostics._collect_app_health", side_effect=_fake_health),
+    ):
+        yield
 
 
 @pytest.fixture
@@ -505,3 +538,259 @@ def test_gitinfo_is_frozen() -> None:
     info = GitInfo(branch="main", sha="abc", short_sha="abc", dirty=False, remote_url=None)
     with pytest.raises(attr.exceptions.FrozenInstanceError):
         info.branch = "other"  # type: ignore[misc]
+
+
+# ─── resource pressure ───────────────────────────────────────────────────────
+
+
+def test_read_meminfo_parses(tmp_path: Path) -> None:
+    meminfo = "MemTotal:       16384000 kB\nMemFree:         1000000 kB\nMemAvailable:    8192000 kB\n"
+    m = mock_open(read_data=meminfo)
+    with patch("compute_space.core.diagnostics.open", m):
+        total, available = diagnostics._read_meminfo()
+    assert total == 16384000 * 1024
+    assert available == 8192000 * 1024
+
+
+def test_read_meminfo_missing_file() -> None:
+    with patch("compute_space.core.diagnostics.open", side_effect=FileNotFoundError):
+        assert diagnostics._read_meminfo() == (None, None)
+
+
+def test_collect_resource_pressure_computes_percent_and_load() -> None:
+    with (
+        patch("compute_space.core.diagnostics._read_meminfo", return_value=(1000, 250)),
+        patch("compute_space.core.diagnostics.os.getloadavg", return_value=(0.5, 1.0, 2.0)),
+        patch("compute_space.core.diagnostics.os.cpu_count", return_value=4),
+    ):
+        rp = diagnostics._collect_resource_pressure()
+    assert rp.memory_total_bytes == 1000
+    assert rp.memory_available_bytes == 250
+    assert rp.memory_used_percent == 75.0  # (1000-250)/1000
+    assert rp.load_avg_1m == 0.5
+    assert rp.load_avg_15m == 2.0
+    assert rp.cpu_count == 4
+
+
+def test_collect_resource_pressure_degrades_without_loadavg() -> None:
+    with (
+        patch("compute_space.core.diagnostics._read_meminfo", return_value=(None, None)),
+        patch("compute_space.core.diagnostics.os.getloadavg", side_effect=OSError),
+    ):
+        rp = diagnostics._collect_resource_pressure()
+    assert rp.memory_total_bytes is None
+    assert rp.memory_used_percent is None
+    assert rp.load_avg_1m is None
+
+
+# ─── podman stats parsing ─────────────────────────────────────────────────────
+
+
+def test_parse_stats_bytes() -> None:
+    assert diagnostics._parse_stats_bytes("128MB") == 128 * 1000**2
+    assert diagnostics._parse_stats_bytes("1.5GiB") == int(1.5 * 1024**3)
+    assert diagnostics._parse_stats_bytes("512kB") == 512 * 1000
+    assert diagnostics._parse_stats_bytes("42B") == 42
+    assert diagnostics._parse_stats_bytes("--") is None
+    assert diagnostics._parse_stats_bytes("") is None
+    assert diagnostics._parse_stats_bytes(None) is None
+    assert diagnostics._parse_stats_bytes("garbage") is None
+
+
+def test_parse_stats_percent() -> None:
+    assert diagnostics._parse_stats_percent("3.14%") == 3.14
+    assert diagnostics._parse_stats_percent("0.00%") == 0.0
+    assert diagnostics._parse_stats_percent("--") is None
+    assert diagnostics._parse_stats_percent(None) is None
+
+
+def test_collect_app_resources_no_container() -> None:
+    r = diagnostics._collect_app_resources(None, 0.5, 256)
+    assert r.running is False
+    assert r.cpu_cores_limit == 0.5
+    assert r.memory_mb_limit == 256
+    assert r.cpu_percent is None
+
+
+def test_collect_app_resources_running_parses_stats() -> None:
+    stats = json.dumps([{"CPU": "12.50%", "MemUsage": "64MB / 128MB", "MemPerc": "50.00%"}])
+    fake = subprocess.CompletedProcess(args=[], returncode=0, stdout=stats, stderr="")
+    with (
+        patch("compute_space.core.diagnostics.shutil.which", return_value="/usr/bin/podman"),
+        patch("compute_space.core.diagnostics.subprocess.run", return_value=fake),
+    ):
+        r = diagnostics._collect_app_resources("cid123", 0.5, 128)
+    assert r.running is True
+    assert r.cpu_percent == 12.5
+    assert r.memory_usage_bytes == 64 * 1000**2
+    assert r.memory_limit_bytes == 128 * 1000**2
+    assert r.memory_percent == 50.0
+
+
+def test_collect_app_resources_not_running_when_nonzero() -> None:
+    fake = subprocess.CompletedProcess(args=[], returncode=125, stdout="", stderr="no such container")
+    with (
+        patch("compute_space.core.diagnostics.shutil.which", return_value="/usr/bin/podman"),
+        patch("compute_space.core.diagnostics.subprocess.run", return_value=fake),
+    ):
+        r = diagnostics._collect_app_resources("cid123", 0.5, 128)
+    assert r.running is False
+    assert r.error is None
+
+
+def test_collect_app_resources_stats_timeout() -> None:
+    with (
+        patch("compute_space.core.diagnostics.shutil.which", return_value="/usr/bin/podman"),
+        patch(
+            "compute_space.core.diagnostics.subprocess.run",
+            side_effect=subprocess.TimeoutExpired(cmd="podman", timeout=10),
+        ),
+    ):
+        r = diagnostics._collect_app_resources("cid123", 0.5, 128)
+    assert r.running is False
+    assert "timed out" in (r.error or "")
+
+
+# ─── health checks ────────────────────────────────────────────────────────────
+
+
+class _FakeResp:
+    def __init__(self, status_code: int) -> None:
+        self.status_code = status_code
+
+
+class _FakeAsyncClient:
+    """Minimal async-context-manager httpx.AsyncClient stand-in."""
+
+    def __init__(self, *, get_result: Any = None, get_exc: Exception | None = None, **_: Any) -> None:
+        self._result = get_result
+        self._exc = get_exc
+
+    async def __aenter__(self) -> _FakeAsyncClient:
+        return self
+
+    async def __aexit__(self, *_: Any) -> None:
+        return None
+
+    async def get(self, _url: str) -> Any:
+        if self._exc is not None:
+            raise self._exc
+        return self._result
+
+
+@pytest.mark.real_collectors
+def test_collect_app_health_no_port() -> None:
+    h = asyncio.run(diagnostics._collect_app_health(None, None))
+    assert h.checked is False
+    assert h.healthy is None
+    assert h.checked_path == "/"
+
+
+@pytest.mark.real_collectors
+def test_collect_app_health_ok() -> None:
+    def _client(**kw: Any) -> _FakeAsyncClient:
+        return _FakeAsyncClient(get_result=_FakeResp(200))
+
+    with patch("compute_space.core.diagnostics.httpx.AsyncClient", _client):
+        h = asyncio.run(diagnostics._collect_app_health(19500, "/healthz"))
+    assert h.checked is True
+    assert h.healthy is True
+    assert h.status_code == 200
+    assert h.checked_path == "/healthz"
+
+
+@pytest.mark.real_collectors
+def test_collect_app_health_5xx_is_unhealthy() -> None:
+    def _client(**kw: Any) -> _FakeAsyncClient:
+        return _FakeAsyncClient(get_result=_FakeResp(503))
+
+    with patch("compute_space.core.diagnostics.httpx.AsyncClient", _client):
+        h = asyncio.run(diagnostics._collect_app_health(19500, None))
+    assert h.healthy is False
+    assert h.status_code == 503
+
+
+@pytest.mark.real_collectors
+def test_collect_app_health_connection_error() -> None:
+    def _client(**kw: Any) -> _FakeAsyncClient:
+        return _FakeAsyncClient(get_exc=httpx.ConnectError("refused"))
+
+    with patch("compute_space.core.diagnostics.httpx.AsyncClient", _client):
+        h = asyncio.run(diagnostics._collect_app_health(19500, "healthz"))
+    assert h.checked is True
+    assert h.healthy is False
+    assert h.status_code is None
+    assert h.checked_path == "/healthz"  # leading slash normalized
+
+
+# ─── reachability ─────────────────────────────────────────────────────────────
+
+
+def test_reachability_targets_includes_config_urls(tmp_path: Path) -> None:
+    cfg = _make_test_config(tmp_path)
+    real = Config(**{f.name: getattr(cfg, f.name) for f in attr.fields(Config)})
+    targets = diagnostics._reachability_targets(real)
+    labels = {label for label, _ in targets}
+    assert "github" in labels
+    # cert_api_base_url has a default, so cert_api should be present.
+    assert "cert_api" in labels
+    # No duplicate URLs.
+    urls = [url for _, url in targets]
+    assert len(urls) == len(set(urls))
+
+
+@pytest.mark.real_collectors
+def test_collect_reachability_mixed_results(tmp_path: Path) -> None:
+    real = Config(**{f.name: getattr(_make_test_config(tmp_path), f.name) for f in attr.fields(Config)})
+
+    class _RClient:
+        def __init__(self, **_: Any) -> None:
+            pass
+
+        async def __aenter__(self) -> _RClient:
+            return self
+
+        async def __aexit__(self, *_: Any) -> None:
+            return None
+
+        async def get(self, url: str) -> Any:
+            if "github" in url:
+                return _FakeResp(200)
+            raise httpx.ConnectError("boom")
+
+    with patch("compute_space.core.diagnostics.httpx.AsyncClient", _RClient):
+        results = asyncio.run(diagnostics._collect_reachability(real))
+    by_label = {r.label: r for r in results}
+    assert by_label["github"].reachable is True
+    assert by_label["github"].status_code == 200
+    assert by_label["github"].latency_ms is not None
+    # A non-github target should be marked unreachable with an error.
+    unreachable = [r for r in results if not r.reachable]
+    assert unreachable
+    assert unreachable[0].error
+
+
+# ─── new fields present in bundles ────────────────────────────────────────────
+
+
+def test_platform_bundle_has_new_fields(
+    cfg: Any, system_client: TestClient[Litestar], cookies: dict[str, str]
+) -> None:
+    _seed_app(cfg.db_path, "myapp", manifest_raw=_MINIMAL_MANIFEST)
+    body = system_client.get("/api/diagnostics", cookies=cookies).json()
+    assert body["schema_version"] == 2
+    assert "resource_pressure" in body
+    assert "reachability" in body
+    # Per-app entries carry health + resources.
+    app = body["apps"][0]
+    assert "health" in app
+    assert "resources" in app
+
+
+def test_app_bundle_has_new_fields(cfg: Any, apps_client: TestClient[Litestar], cookies: dict[str, str]) -> None:
+    app_id = _seed_app(cfg.db_path, "myapp", manifest_raw=_MINIMAL_MANIFEST)
+    body = apps_client.get(f"/api/app_diagnostics/{app_id}", cookies=cookies).json()
+    assert body["schema_version"] == 2
+    assert "health" in body
+    assert "resources" in body
+    assert "resource_pressure" in body

--- a/compute_space/src/compute_space/tests/test_diagnostics.py
+++ b/compute_space/src/compute_space/tests/test_diagnostics.py
@@ -748,8 +748,10 @@ def test_reachability_targets_includes_config_urls(tmp_path: Path) -> None:
     targets = diagnostics._reachability_targets(real)
     labels = {label for label, _ in targets}
     assert "github" in labels
-    # cert_api_base_url has a default, so cert_api should be present.
-    assert "cert_api" in labels
+    # The cert_api base URL is intentionally NOT probed: it was noisy (it points
+    # at cert-issuance infra that isn't reachable from every instance) and its
+    # reachability isn't a useful health signal here.
+    assert "cert_api" not in labels
     # No duplicate URLs.
     urls = [url for _, url in targets]
     assert len(urls) == len(set(urls))

--- a/compute_space/src/compute_space/tests/test_diagnostics.py
+++ b/compute_space/src/compute_space/tests/test_diagnostics.py
@@ -1136,3 +1136,158 @@ def _seed_app_with_limits(db_path: str, name: str, *, memory_mb: int, cpu_cores:
     finally:
         db.close()
     return app_id
+
+
+# ─── additional unit coverage ────────────────────────────────────────────────
+
+
+def test_parse_stats_bytes_units_and_edges() -> None:
+    # Decimal (SI) vs binary (IEC) units.
+    assert diagnostics._parse_stats_bytes("1GB") == 1000**3
+    assert diagnostics._parse_stats_bytes("1GiB") == 1024**3
+    assert diagnostics._parse_stats_bytes("2TB") == 2 * 1000**4
+    assert diagnostics._parse_stats_bytes("0B") == 0
+    # Surrounding whitespace is tolerated.
+    assert diagnostics._parse_stats_bytes("  64MB  ") == 64 * 1000**2
+    # A bare number with no unit is treated as bytes (factor 1).
+    assert diagnostics._parse_stats_bytes("123") == 123
+    # Placeholder / junk tokens and non-strings degrade to None.
+    assert diagnostics._parse_stats_bytes("--") is None
+    assert diagnostics._parse_stats_bytes("garbage") is None
+    assert diagnostics._parse_stats_bytes(123) is None  # type: ignore[arg-type]
+
+
+def test_parse_stats_percent_edges() -> None:
+    assert diagnostics._parse_stats_percent("100.00%") == 100.0
+    assert diagnostics._parse_stats_percent("0%") == 0.0
+    # A number without the percent sign is still parsed.
+    assert diagnostics._parse_stats_percent("50") == 50.0
+    # Junk / non-string -> None.
+    assert diagnostics._parse_stats_percent("n/a") is None
+    assert diagnostics._parse_stats_percent(3.14) is None  # type: ignore[arg-type]
+
+
+def test_manifest_fields_parses_runtime_type() -> None:
+    version, runtime_type = diagnostics._manifest_fields(_MINIMAL_MANIFEST)
+    assert version is not None
+    assert runtime_type in ("serverfull", "serverless", None)
+
+
+def test_manifest_fields_empty_input() -> None:
+    assert diagnostics._manifest_fields(None) == (None, None)
+    assert diagnostics._manifest_fields("") == (None, None)
+
+
+def test_read_boot_time_returns_iso_or_none() -> None:
+    # On Linux CI this parses /proc/stat's btime into an ISO timestamp; the
+    # function must never raise and returns either an ISO string or None.
+    bt = diagnostics._read_boot_time()
+    assert bt is None or (isinstance(bt, str) and "T" in bt)
+
+
+def test_reachability_targets_dedupes_by_url(tmp_path: Path) -> None:
+    base = _make_test_config(tmp_path)
+    # Point the ACME directory at the same URL as a static target to force a
+    # collision, and confirm the assembled list has no duplicate URLs.
+    static_url = diagnostics._STATIC_REACHABILITY_TARGETS[0][1]
+    cfg = attr.evolve(
+        Config(**{f.name: getattr(base, f.name) for f in attr.fields(Config)}),
+        acme_directory_url=static_url,
+    )
+    targets = diagnostics._reachability_targets(cfg)
+    urls = [u for _, u in targets]
+    assert len(urls) == len(set(urls))
+
+
+def test_reachability_targets_include_configured_urls(tmp_path: Path) -> None:
+    base = _make_test_config(tmp_path)
+    cfg = attr.evolve(
+        Config(**{f.name: getattr(base, f.name) for f in attr.fields(Config)}),
+        my_openhost_redirect_domain="redirect.example.com",
+    )
+    labels = {label for label, _ in diagnostics._reachability_targets(cfg)}
+    assert "openhost_redirect" in labels
+    # cert_api is never probed regardless of config.
+    assert "cert_api" not in labels
+
+
+@pytest.mark.real_collectors
+def test_reachability_non_2xx_still_reachable(tmp_path: Path) -> None:
+    """Any HTTP response (even 4xx/5xx) means DNS+TCP+TLS worked, so the target
+    is reachable; only transport errors mark it unreachable."""
+    real = Config(**{f.name: getattr(_make_test_config(tmp_path), f.name) for f in attr.fields(Config)})
+
+    class _Client:
+        def __init__(self, **_: Any) -> None:
+            pass
+
+        async def __aenter__(self) -> _Client:
+            return self
+
+        async def __aexit__(self, *_: Any) -> None:
+            return None
+
+        async def get(self, url: str) -> Any:
+            return _FakeResp(503)
+
+    with patch("compute_space.core.diagnostics.httpx.AsyncClient", _Client):
+        results = asyncio.run(diagnostics._collect_reachability(real))
+    assert results
+    assert all(r.reachable for r in results)
+    assert all(r.status_code == 503 for r in results)
+
+
+@pytest.mark.real_collectors
+def test_reachability_collection_never_raises(tmp_path: Path) -> None:
+    """A client that blows up on construction degrades to an empty list rather
+    than propagating (diagnostics must not fail because a probe misbehaves)."""
+    real = Config(**{f.name: getattr(_make_test_config(tmp_path), f.name) for f in attr.fields(Config)})
+
+    def _boom(**_: Any) -> Any:
+        raise RuntimeError("client init failed")
+
+    with patch("compute_space.core.diagnostics.httpx.AsyncClient", _boom):
+        results = asyncio.run(diagnostics._collect_reachability(real))
+    assert results == []
+
+
+def test_app_resources_memusage_without_slash(cfg: Any) -> None:
+    """A MemUsage string without ' / ' leaves the byte fields None but still
+    reports running with the manifest limits."""
+    stats = json.dumps([{"CPU": "1.0%", "MemUsage": "10MB", "MemPerc": "5%"}])
+    fake = subprocess.CompletedProcess(args=[], returncode=0, stdout=stats, stderr="")
+    with (
+        patch("compute_space.core.diagnostics.shutil.which", return_value="/usr/bin/podman"),
+        patch("compute_space.core.diagnostics.is_container_running", return_value=True),
+        patch("compute_space.core.diagnostics.subprocess.run", return_value=fake),
+    ):
+        r = diagnostics._collect_app_resources("cid", 0.5, 128)
+    assert r.running is True
+    assert r.cpu_percent == 1.0
+    assert r.memory_usage_bytes is None
+    assert r.memory_limit_bytes is None
+
+
+def test_app_resources_unexpected_stats_shape(cfg: Any) -> None:
+    """A non-list, non-dict stats payload degrades to an error, not a crash."""
+    fake = subprocess.CompletedProcess(args=[], returncode=0, stdout='"a string"', stderr="")
+    with (
+        patch("compute_space.core.diagnostics.shutil.which", return_value="/usr/bin/podman"),
+        patch("compute_space.core.diagnostics.is_container_running", return_value=True),
+        patch("compute_space.core.diagnostics.subprocess.run", return_value=fake),
+    ):
+        r = diagnostics._collect_app_resources("cid", 0.5, 128)
+    assert r.running is False
+    assert r.error is not None
+
+
+def test_app_resources_non_json_stats(cfg: Any) -> None:
+    fake = subprocess.CompletedProcess(args=[], returncode=0, stdout="not json", stderr="")
+    with (
+        patch("compute_space.core.diagnostics.shutil.which", return_value="/usr/bin/podman"),
+        patch("compute_space.core.diagnostics.is_container_running", return_value=True),
+        patch("compute_space.core.diagnostics.subprocess.run", return_value=fake),
+    ):
+        r = diagnostics._collect_app_resources("cid", 0.5, 128)
+    assert r.running is False
+    assert "non-JSON" in (r.error or "")

--- a/compute_space/src/compute_space/tests/test_diagnostics.py
+++ b/compute_space/src/compute_space/tests/test_diagnostics.py
@@ -1173,11 +1173,6 @@ def test_manifest_fields_parses_runtime_type() -> None:
     assert runtime_type in ("serverfull", "serverless", None)
 
 
-def test_manifest_fields_empty_input() -> None:
-    assert diagnostics._manifest_fields(None) == (None, None)
-    assert diagnostics._manifest_fields("") == (None, None)
-
-
 def test_read_boot_time_returns_iso_or_none() -> None:
     # On Linux CI this parses /proc/stat's btime into an ISO timestamp; the
     # function must never raise and returns either an ISO string or None.

--- a/compute_space/src/compute_space/tests/test_diagnostics.py
+++ b/compute_space/src/compute_space/tests/test_diagnostics.py
@@ -104,6 +104,9 @@ def cookies(cfg: Any) -> dict[str, str]:
     return auth_cookie(cfg)
 
 
+_next_local_port = [19500]
+
+
 def _seed_app(
     db_path: str,
     name: str,
@@ -114,12 +117,16 @@ def _seed_app(
     repo_path: str = "/r",
 ) -> str:
     app_id = new_app_id()
+    # Unique per insert so multiple seeded apps don't collide on the
+    # apps.local_port UNIQUE constraint.
+    local_port = _next_local_port[0]
+    _next_local_port[0] += 1
     db = sqlite3.connect(db_path)
     try:
         db.execute(
             "INSERT INTO apps (app_id, name, version, runtime_type, repo_path, local_port, status, manifest_raw) "
-            "VALUES (?, ?, ?, 'serverfull', ?, 19500, ?, ?)",
-            (app_id, name, version, repo_path, status, manifest_raw),
+            "VALUES (?, ?, ?, 'serverfull', ?, ?, ?, ?)",
+            (app_id, name, version, repo_path, local_port, status, manifest_raw),
         )
         db.commit()
     finally:
@@ -794,3 +801,325 @@ def test_app_bundle_has_new_fields(cfg: Any, apps_client: TestClient[Litestar], 
     assert "health" in body
     assert "resources" in body
     assert "resource_pressure" in body
+
+
+# ─── behavioral tests: exact URL / path construction ─────────────────────────
+
+
+class _RecordingClient:
+    """httpx.AsyncClient stand-in that records the exact URL(s) requested."""
+
+    urls: list[str] = []
+
+    def __init__(self, **_: Any) -> None:
+        pass
+
+    async def __aenter__(self) -> _RecordingClient:
+        return self
+
+    async def __aexit__(self, *_: Any) -> None:
+        return None
+
+    async def get(self, url: str) -> Any:
+        _RecordingClient.urls.append(url)
+        return _FakeResp(200)
+
+
+@pytest.mark.real_collectors
+def test_health_probe_hits_exact_loopback_url_and_path() -> None:
+    _RecordingClient.urls = []
+    with patch("compute_space.core.diagnostics.httpx.AsyncClient", _RecordingClient):
+        asyncio.run(diagnostics._collect_app_health(19501, "/api/health"))
+    # Must target loopback on the app's own local_port with the declared path.
+    assert _RecordingClient.urls == ["http://127.0.0.1:19501/api/health"]
+
+
+@pytest.mark.real_collectors
+def test_health_probe_defaults_to_root_and_normalizes_missing_slash() -> None:
+    _RecordingClient.urls = []
+    with patch("compute_space.core.diagnostics.httpx.AsyncClient", _RecordingClient):
+        # No declared health_check -> "/".
+        asyncio.run(diagnostics._collect_app_health(19502, None))
+        # Declared path missing a leading slash -> normalized.
+        asyncio.run(diagnostics._collect_app_health(19503, "status"))
+    assert _RecordingClient.urls == [
+        "http://127.0.0.1:19502/",
+        "http://127.0.0.1:19503/status",
+    ]
+
+
+@pytest.mark.real_collectors
+def test_health_probe_preserves_query_string_in_path() -> None:
+    _RecordingClient.urls = []
+    with patch("compute_space.core.diagnostics.httpx.AsyncClient", _RecordingClient):
+        asyncio.run(diagnostics._collect_app_health(19504, "/health?ready=1"))
+    assert _RecordingClient.urls == ["http://127.0.0.1:19504/health?ready=1"]
+
+
+# ─── behavioral: timeouts are actually applied ───────────────────────────────
+
+
+@pytest.mark.real_collectors
+def test_health_probe_passes_configured_timeout() -> None:
+    captured: dict[str, Any] = {}
+
+    class _TimeoutCapturingClient:
+        def __init__(self, **kwargs: Any) -> None:
+            captured.update(kwargs)
+
+        async def __aenter__(self) -> _TimeoutCapturingClient:
+            return self
+
+        async def __aexit__(self, *_: Any) -> None:
+            return None
+
+        async def get(self, _url: str) -> Any:
+            return _FakeResp(200)
+
+    with patch("compute_space.core.diagnostics.httpx.AsyncClient", _TimeoutCapturingClient):
+        asyncio.run(diagnostics._collect_app_health(19505, "/"))
+    # A regression that drops the timeout would let a hung app stall diagnostics.
+    assert captured.get("timeout") == diagnostics._HEALTH_TIMEOUT_S
+
+
+@pytest.mark.real_collectors
+def test_reachability_uses_configured_timeout_and_no_redirects(tmp_path: Path) -> None:
+    captured: dict[str, Any] = {}
+    real = Config(**{f.name: getattr(_make_test_config(tmp_path), f.name) for f in attr.fields(Config)})
+
+    class _CapturingClient:
+        def __init__(self, **kwargs: Any) -> None:
+            captured.update(kwargs)
+
+        async def __aenter__(self) -> _CapturingClient:
+            return self
+
+        async def __aexit__(self, *_: Any) -> None:
+            return None
+
+        async def get(self, _url: str) -> Any:
+            return _FakeResp(204)
+
+    with patch("compute_space.core.diagnostics.httpx.AsyncClient", _CapturingClient):
+        asyncio.run(diagnostics._collect_reachability(real))
+    assert captured.get("timeout") == diagnostics._REACHABILITY_TIMEOUT_S
+    # follow_redirects must be off so a redirect can't be followed to a slow host.
+    assert captured.get("follow_redirects") is False
+
+
+def test_stats_subprocess_uses_bounded_timeout() -> None:
+    captured: dict[str, Any] = {}
+
+    def _fake_run(cmd: Any, **kwargs: Any) -> subprocess.CompletedProcess[str]:
+        captured.update(kwargs)
+        return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="[]", stderr="")
+
+    with (
+        patch("compute_space.core.diagnostics.shutil.which", return_value="/usr/bin/podman"),
+        patch("compute_space.core.diagnostics.subprocess.run", _fake_run),
+    ):
+        diagnostics._collect_app_resources("cid", 0.5, 128)
+    assert captured.get("timeout") == diagnostics._SUBPROCESS_TIMEOUT_S
+
+
+# ─── behavioral: reachability runs concurrently, not serially ────────────────
+
+
+@pytest.mark.real_collectors
+def test_reachability_probes_run_concurrently(tmp_path: Path) -> None:
+    real = Config(**{f.name: getattr(_make_test_config(tmp_path), f.name) for f in attr.fields(Config)})
+    n_targets = len(diagnostics._reachability_targets(real))
+    assert n_targets >= 2  # need >1 to distinguish concurrent from serial
+
+    concurrency = {"current": 0, "max": 0}
+
+    class _SlowClient:
+        def __init__(self, **_: Any) -> None:
+            pass
+
+        async def __aenter__(self) -> _SlowClient:
+            return self
+
+        async def __aexit__(self, *_: Any) -> None:
+            return None
+
+        async def get(self, _url: str) -> Any:
+            concurrency["current"] += 1
+            concurrency["max"] = max(concurrency["max"], concurrency["current"])
+            await asyncio.sleep(0.05)
+            concurrency["current"] -= 1
+            return _FakeResp(200)
+
+    with patch("compute_space.core.diagnostics.httpx.AsyncClient", _SlowClient):
+        results = asyncio.run(diagnostics._collect_reachability(real))
+    assert len(results) == n_targets
+    # If probes were serial, max in-flight would be 1. Concurrent gather -> >1.
+    assert concurrency["max"] > 1
+
+
+# ─── behavioral: per-app collection is individually fault-isolated ───────────
+
+
+def test_one_bad_app_does_not_drop_the_others(
+    cfg: Any, system_client: TestClient[Litestar], cookies: dict[str, str]
+) -> None:
+    _seed_app(cfg.db_path, "good-a", manifest_raw=_MINIMAL_MANIFEST)
+    _seed_app(cfg.db_path, "good-b", manifest_raw=_MINIMAL_MANIFEST)
+
+    real_summary = diagnostics._collect_app_summary
+
+    async def _flaky_summary(row: Any) -> Any:
+        if row["name"] == "good-a":
+            raise RuntimeError("boom collecting good-a")
+        return await real_summary(row)
+
+    with patch("compute_space.core.diagnostics._collect_app_summary", side_effect=_flaky_summary):
+        body = system_client.get("/api/diagnostics", cookies=cookies).json()
+    names = {a["name"] for a in body["apps"]}
+    # good-a blew up, but good-b must still be present.
+    assert "good-b" in names
+    assert "good-a" not in names
+
+
+def test_apps_query_failure_yields_empty_apps_not_500(cfg: Any) -> None:
+    """A failure querying the apps table degrades to empty apps + a valid bundle
+    (rather than raising), so the rest of the diagnostics still reach the owner."""
+    broken = MagicMock()
+    broken.execute.side_effect = sqlite3.OperationalError("apps table exploded")
+    real_config = Config(**{f.name: getattr(cfg, f.name) for f in attr.fields(Config)})
+    with (
+        patch("compute_space.core.diagnostics.storage_status", return_value={}),
+        patch("compute_space.core.diagnostics._collect_reachability", side_effect=_stub_reach),
+    ):
+        diag = asyncio.run(diagnostics.collect_platform_diagnostics(broken, real_config))
+    assert diag.apps == []
+    # The rest of the bundle is still populated.
+    assert diag.system.python_version
+    assert diag.resource_pressure is not None
+
+
+async def _stub_reach(_config: Any) -> list[Any]:
+    return []
+
+
+# ─── podman stats: partial / unusual shapes ──────────────────────────────────
+
+
+def _stats_run(stdout: str) -> Any:
+    fake = subprocess.CompletedProcess(args=[], returncode=0, stdout=stdout, stderr="")
+    return (
+        patch("compute_space.core.diagnostics.shutil.which", return_value="/usr/bin/podman"),
+        patch("compute_space.core.diagnostics.subprocess.run", return_value=fake),
+    )
+
+
+def test_stats_dict_shape_not_list() -> None:
+    # Some podman versions emit a bare object rather than a list.
+    which_p, run_p = _stats_run(json.dumps({"CPU": "5.0%", "MemUsage": "10MB / 100MB", "MemPerc": "10%"}))
+    with which_p, run_p:
+        r = diagnostics._collect_app_resources("cid", 1.0, 100)
+    assert r.running is True
+    assert r.cpu_percent == 5.0
+    assert r.memory_usage_bytes == 10 * 1000**2
+
+
+def test_stats_empty_list_is_not_running() -> None:
+    which_p, run_p = _stats_run("[]")
+    with which_p, run_p:
+        r = diagnostics._collect_app_resources("cid", 1.0, 100)
+    assert r.running is False
+
+
+def test_stats_missing_memusage_leaves_bytes_none() -> None:
+    which_p, run_p = _stats_run(json.dumps([{"CPU": "7.5%"}]))
+    with which_p, run_p:
+        r = diagnostics._collect_app_resources("cid", 1.0, 100)
+    assert r.running is True
+    assert r.cpu_percent == 7.5
+    assert r.memory_usage_bytes is None
+    assert r.memory_limit_bytes is None
+
+
+def test_stats_dashes_render_as_none() -> None:
+    which_p, run_p = _stats_run(json.dumps([{"CPU": "--", "MemUsage": "-- / --", "MemPerc": "--"}]))
+    with which_p, run_p:
+        r = diagnostics._collect_app_resources("cid", 1.0, 100)
+    assert r.running is True
+    assert r.cpu_percent is None
+    assert r.memory_usage_bytes is None
+    assert r.memory_percent is None
+
+
+# ─── full DTO JSON serialization round-trip ──────────────────────────────────
+
+
+def test_platform_bundle_fully_json_serializable_all_fields(
+    cfg: Any, system_client: TestClient[Litestar], cookies: dict[str, str]
+) -> None:
+    """Exercise the real Litestar serializer over a populated bundle so a
+    non-serializable field (e.g. a stray Path/datetime) would surface as a 500
+    rather than silently. Also asserts every declared nested field is present."""
+    _seed_app(cfg.db_path, "myapp", manifest_raw=_MINIMAL_MANIFEST)
+    resp = system_client.get("/api/diagnostics", cookies=cookies)
+    assert resp.status_code == 200
+    body = resp.json()
+    # It round-trips through JSON cleanly.
+    reparsed = json.loads(json.dumps(body))
+    assert reparsed == body
+
+    rp = body["resource_pressure"]
+    for key in (
+        "memory_total_bytes",
+        "memory_available_bytes",
+        "memory_used_percent",
+        "load_avg_1m",
+        "load_avg_5m",
+        "load_avg_15m",
+        "cpu_count",
+        "error",
+    ):
+        assert key in rp, f"resource_pressure missing {key}"
+
+    app = body["apps"][0]
+    for key in ("checked", "healthy", "status_code", "checked_path", "error"):
+        assert key in app["health"], f"health missing {key}"
+    for key in (
+        "running",
+        "cpu_percent",
+        "memory_usage_bytes",
+        "memory_limit_bytes",
+        "memory_percent",
+        "cpu_cores_limit",
+        "memory_mb_limit",
+        "error",
+    ):
+        assert key in app["resources"], f"resources missing {key}"
+
+
+def test_app_bundle_resource_limits_come_from_manifest_columns(
+    cfg: Any, apps_client: TestClient[Litestar], cookies: dict[str, str]
+) -> None:
+    """The per-app bundle must surface the manifest memory/cpu limits from the
+    apps row even when the container isn't running (so limits are always visible)."""
+    app_id = _seed_app_with_limits(cfg.db_path, "limited", memory_mb=512, cpu_cores=1.5)
+    body = apps_client.get(f"/api/app_diagnostics/{app_id}", cookies=cookies).json()
+    res = body["resources"]
+    assert res["memory_mb_limit"] == 512
+    assert res["cpu_cores_limit"] == 1.5
+    # No container_id seeded -> not running, but limits still reported.
+    assert res["running"] is False
+
+
+def _seed_app_with_limits(db_path: str, name: str, *, memory_mb: int, cpu_cores: float) -> str:
+    app_id = new_app_id()
+    db = sqlite3.connect(db_path)
+    try:
+        db.execute(
+            "INSERT INTO apps (app_id, name, version, runtime_type, repo_path, local_port, status, "
+            "memory_mb, cpu_cores) VALUES (?, ?, '1.0', 'serverfull', '/r', 19600, 'stopped', ?, ?)",
+            (app_id, name, memory_mb, cpu_cores),
+        )
+        db.commit()
+    finally:
+        db.close()
+    return app_id

--- a/compute_space/src/compute_space/tests/test_diagnostics.py
+++ b/compute_space/src/compute_space/tests/test_diagnostics.py
@@ -1,0 +1,248 @@
+"""Tests for the diagnostics collectors and their HTTP endpoints."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import subprocess
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+from litestar import Litestar
+from litestar.testing import TestClient
+
+from compute_space.core import diagnostics
+from compute_space.core.app_id import new_app_id
+from compute_space.core.diagnostics import DIAGNOSTICS_SCHEMA_VERSION
+from compute_space.db.connection import init_db
+from compute_space.tests._litestar_helpers import auth_cookie
+from compute_space.tests._litestar_helpers import make_test_app
+from compute_space.tests.conftest import _make_test_config
+from compute_space.web.routes.api.apps import api_apps_routes
+from compute_space.web.routes.api.system import system_routes
+
+_MINIMAL_MANIFEST = """
+[app]
+name = "myapp"
+version = "2.3.4"
+
+[runtime.container]
+image = "docker.io/library/nginx:latest"
+port = 80
+"""
+
+
+@pytest.fixture
+def cfg(tmp_path: Path) -> Any:
+    cfg = _make_test_config(tmp_path)
+    init_db(cfg.db_path)
+    return cfg
+
+
+@pytest.fixture
+def cookies(cfg: Any) -> dict[str, str]:
+    return auth_cookie(cfg)
+
+
+def _seed_app(
+    db_path: str,
+    name: str,
+    *,
+    status: str = "running",
+    version: str = "1.0",
+    manifest_raw: str | None = None,
+    repo_path: str = "/r",
+) -> str:
+    app_id = new_app_id()
+    db = sqlite3.connect(db_path)
+    try:
+        db.execute(
+            "INSERT INTO apps (app_id, name, version, runtime_type, repo_path, local_port, status, manifest_raw) "
+            "VALUES (?, ?, ?, 'serverfull', ?, 19500, ?, ?)",
+            (app_id, name, version, repo_path, status, manifest_raw),
+        )
+        db.commit()
+    finally:
+        db.close()
+    return app_id
+
+
+# ─── unit tests for low-level collectors ─────────────────────────────────────
+
+
+def test_collect_system_info_populated() -> None:
+    info = diagnostics._collect_system_info()
+    assert info.system  # e.g. "Linux"
+    assert info.python_version
+    assert info.python_implementation
+
+
+def test_collect_dependencies_marks_missing() -> None:
+    deps = diagnostics._collect_dependencies()
+    # Every curated dependency must appear (installed or explicitly not).
+    assert set(deps) == set(diagnostics._KEY_DEPENDENCIES)
+    # litestar is a hard runtime dep, so it must resolve to a real version.
+    assert deps["litestar"] != "(not installed)"
+
+
+def test_manifest_fields_parses_version() -> None:
+    version, runtime_type = diagnostics._manifest_fields(_MINIMAL_MANIFEST)
+    assert version == "2.3.4"
+    assert runtime_type == "serverfull"
+
+
+def test_manifest_fields_handles_bad_manifest() -> None:
+    assert diagnostics._manifest_fields("not valid toml [[[") == (None, None)
+    assert diagnostics._manifest_fields(None) == (None, None)
+    assert diagnostics._manifest_fields("") == (None, None)
+
+
+def test_collect_container_runtime_no_podman() -> None:
+    with patch("compute_space.core.diagnostics.shutil.which", return_value=None):
+        info = diagnostics._collect_container_runtime()
+    assert info.available is False
+    assert info.rootless is None
+    assert info.error is not None
+
+
+def test_collect_container_runtime_rootless_true() -> None:
+    fake = subprocess.CompletedProcess(
+        args=[],
+        returncode=0,
+        stdout=json.dumps({"host": {"serverVersion": "4.9.3", "security": {"rootless": True}}}),
+        stderr="",
+    )
+    with (
+        patch("compute_space.core.diagnostics.shutil.which", return_value="/usr/bin/podman"),
+        patch("compute_space.core.diagnostics.subprocess.run", return_value=fake),
+    ):
+        info = diagnostics._collect_container_runtime()
+    assert info.available is True
+    assert info.version == "4.9.3"
+    assert info.rootless is True
+    assert info.error is None
+
+
+def test_collect_container_runtime_non_json() -> None:
+    fake = subprocess.CompletedProcess(args=[], returncode=0, stdout="not json", stderr="")
+    with (
+        patch("compute_space.core.diagnostics.shutil.which", return_value="/usr/bin/podman"),
+        patch("compute_space.core.diagnostics.subprocess.run", return_value=fake),
+    ):
+        info = diagnostics._collect_container_runtime()
+    assert info.available is True
+    assert info.rootless is None
+    assert info.error is not None
+
+
+# ─── platform diagnostics endpoint ───────────────────────────────────────────
+
+
+@pytest.fixture
+def system_client(cfg: Any) -> Iterator[TestClient[Litestar]]:
+    with TestClient(app=make_test_app(system_routes)) as c:
+        yield c
+
+
+def test_platform_diagnostics_requires_auth(system_client: TestClient[Litestar]) -> None:
+    resp = system_client.get("/api/diagnostics")
+    assert resp.status_code in (401, 403)
+
+
+def test_platform_diagnostics_returns_bundle(
+    cfg: Any, system_client: TestClient[Litestar], cookies: dict[str, str]
+) -> None:
+    _seed_app(cfg.db_path, "myapp", manifest_raw=_MINIMAL_MANIFEST)
+    resp = system_client.get("/api/diagnostics", cookies=cookies)
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["schema_version"] == DIAGNOSTICS_SCHEMA_VERSION
+    assert body["generated_at"]
+    assert body["zone_domain"] == cfg.zone_domain
+    assert "openhost" in body
+    assert "system" in body
+    assert body["system"]["python_version"]
+    assert "container_runtime" in body
+    assert "dependencies" in body
+    assert body["dependencies"]["litestar"]
+    # The seeded app appears, with the version re-parsed from its manifest.
+    names = {a["name"]: a for a in body["apps"]}
+    assert "myapp" in names
+    assert names["myapp"]["version"] == "2.3.4"
+
+
+def test_platform_diagnostics_download_header(
+    cfg: Any, system_client: TestClient[Litestar], cookies: dict[str, str]
+) -> None:
+    resp = system_client.get("/api/diagnostics?download=1", cookies=cookies)
+    assert resp.status_code == 200
+    disp = resp.headers.get("content-disposition", "")
+    assert "attachment" in disp
+    assert ".json" in disp
+
+
+def test_platform_diagnostics_version_falls_back_to_column(
+    cfg: Any, system_client: TestClient[Litestar], cookies: dict[str, str]
+) -> None:
+    # No manifest_raw -> version must fall back to the stored apps.version column.
+    _seed_app(cfg.db_path, "noman", version="9.9", manifest_raw=None)
+    resp = system_client.get("/api/diagnostics", cookies=cookies)
+    names = {a["name"]: a for a in resp.json()["apps"]}
+    assert names["noman"]["version"] == "9.9"
+
+
+# ─── per-app diagnostics endpoint ─────────────────────────────────────────────
+
+
+@pytest.fixture
+def apps_client(cfg: Any) -> Iterator[TestClient[Litestar]]:
+    with TestClient(app=make_test_app(api_apps_routes)) as c:
+        yield c
+
+
+def test_app_diagnostics_requires_auth(apps_client: TestClient[Litestar]) -> None:
+    resp = apps_client.get(f"/api/app_diagnostics/{new_app_id()}")
+    assert resp.status_code in (401, 403)
+
+
+def test_app_diagnostics_404_when_missing(apps_client: TestClient[Litestar], cookies: dict[str, str]) -> None:
+    resp = apps_client.get(f"/api/app_diagnostics/{new_app_id()}", cookies=cookies)
+    assert resp.status_code == 404
+
+
+def test_app_diagnostics_400_on_bad_id(apps_client: TestClient[Litestar], cookies: dict[str, str]) -> None:
+    resp = apps_client.get("/api/app_diagnostics/not a valid id", cookies=cookies)
+    assert resp.status_code == 400
+
+
+def test_app_diagnostics_returns_bundle(
+    cfg: Any, apps_client: TestClient[Litestar], cookies: dict[str, str]
+) -> None:
+    app_id = _seed_app(cfg.db_path, "myapp", manifest_raw=_MINIMAL_MANIFEST)
+    resp = apps_client.get(f"/api/app_diagnostics/{app_id}", cookies=cookies)
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["schema_version"] == DIAGNOSTICS_SCHEMA_VERSION
+    assert body["app_id"] == app_id
+    assert body["name"] == "myapp"
+    assert body["version"] == "2.3.4"
+    assert body["runtime_type"] == "serverfull"
+    assert body["status"] == "running"
+    # Self-contained: carries system + openhost info too.
+    assert body["system"]["python_version"]
+    assert "container_runtime" in body
+    assert "openhost" in body
+
+
+def test_app_diagnostics_download_header(
+    cfg: Any, apps_client: TestClient[Litestar], cookies: dict[str, str]
+) -> None:
+    app_id = _seed_app(cfg.db_path, "myapp")
+    resp = apps_client.get(f"/api/app_diagnostics/{app_id}?download=1", cookies=cookies)
+    assert resp.status_code == 200
+    disp = resp.headers.get("content-disposition", "")
+    assert "attachment" in disp
+    assert "myapp" in disp

--- a/compute_space/src/compute_space/tests/test_diagnostics.py
+++ b/compute_space/src/compute_space/tests/test_diagnostics.py
@@ -112,7 +112,7 @@ def test_collect_container_runtime_rootless_true() -> None:
     fake = subprocess.CompletedProcess(
         args=[],
         returncode=0,
-        stdout=json.dumps({"host": {"serverVersion": "4.9.3", "security": {"rootless": True}}}),
+        stdout=json.dumps({"version": {"Version": "4.9.3"}, "host": {"security": {"rootless": True}}}),
         stderr="",
     )
     with (
@@ -218,9 +218,7 @@ def test_app_diagnostics_400_on_bad_id(apps_client: TestClient[Litestar], cookie
     assert resp.status_code == 400
 
 
-def test_app_diagnostics_returns_bundle(
-    cfg: Any, apps_client: TestClient[Litestar], cookies: dict[str, str]
-) -> None:
+def test_app_diagnostics_returns_bundle(cfg: Any, apps_client: TestClient[Litestar], cookies: dict[str, str]) -> None:
     app_id = _seed_app(cfg.db_path, "myapp", manifest_raw=_MINIMAL_MANIFEST)
     resp = apps_client.get(f"/api/app_diagnostics/{app_id}", cookies=cookies)
     assert resp.status_code == 200
@@ -237,9 +235,7 @@ def test_app_diagnostics_returns_bundle(
     assert "openhost" in body
 
 
-def test_app_diagnostics_download_header(
-    cfg: Any, apps_client: TestClient[Litestar], cookies: dict[str, str]
-) -> None:
+def test_app_diagnostics_download_header(cfg: Any, apps_client: TestClient[Litestar], cookies: dict[str, str]) -> None:
     app_id = _seed_app(cfg.db_path, "myapp")
     resp = apps_client.get(f"/api/app_diagnostics/{app_id}?download=1", cookies=cookies)
     assert resp.status_code == 200

--- a/compute_space/src/compute_space/tests/test_diagnostics_containers.py
+++ b/compute_space/src/compute_space/tests/test_diagnostics_containers.py
@@ -1,0 +1,205 @@
+"""Live-podman tests for the diagnostics collectors.
+
+These exercise the diagnostics code against a REAL rootless-podman container
+(no subprocess mocking), so they catch drift in podman's actual output shapes
+that the mocked unit tests in ``test_diagnostics.py`` can't. They are gated
+behind the ``requires_containers`` marker and only run with
+``pytest --run-containers`` on a host with a working rootless podman.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import socket
+import subprocess
+import time
+import uuid
+from collections.abc import Iterator
+
+import pytest
+
+from compute_space.core import diagnostics
+from compute_space.core.containers import is_container_running
+
+requires_containers = pytest.mark.requires_containers
+
+# A small image that's already used by the test-app fixtures, so it's available
+# in the container CI env without an extra pull.
+_IMAGE = "python:3.12-alpine"
+_PODMAN_TIMEOUT = 120
+
+
+def _podman(*args: str, check: bool = True) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["podman", *args], capture_output=True, text=True, timeout=_PODMAN_TIMEOUT, check=check
+    )
+
+
+def _free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return int(s.getsockname()[1])
+
+
+def _wait_running(container_id: str, timeout: float = 30.0) -> None:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if is_container_running(container_id):
+            return
+        time.sleep(0.5)
+    raise AssertionError(f"container {container_id} did not reach running within {timeout}s")
+
+
+@pytest.fixture
+def http_container() -> Iterator[tuple[str, int]]:
+    """Start a real container serving HTTP on a mapped loopback port; yield
+    ``(container_id, host_port)`` and force-remove it afterwards."""
+    port = _free_port()
+    name = f"oh-diag-test-{uuid.uuid4().hex[:8]}"
+    # Serve /tmp on :8000 inside the container; map to a free host loopback port.
+    proc = _podman(
+        "run",
+        "-d",
+        "--name",
+        name,
+        "-p",
+        f"127.0.0.1:{port}:8000",
+        "--memory=128m",
+        _IMAGE,
+        "python",
+        "-m",
+        "http.server",
+        "8000",
+        "--directory",
+        "/tmp",
+    )
+    container_id = proc.stdout.strip()
+    try:
+        _wait_running(container_id)
+        yield container_id, port
+    finally:
+        _podman("rm", "-f", name, check=False)
+
+
+# ─── container runtime ───────────────────────────────────────────────────────
+
+
+@requires_containers
+def test_container_runtime_reports_real_podman() -> None:
+    rt = diagnostics._collect_container_runtime()
+    assert rt.available is True
+    assert rt.error is None
+    # A real version string like "5.8.3".
+    assert rt.version and rt.version[0].isdigit()
+    # OpenHost's test/CI podman is rootless.
+    assert rt.rootless is True
+
+
+# ─── is_container_running ──────────────────────────────────────────────────
+
+
+@requires_containers
+def test_is_container_running_true_then_false(http_container: tuple[str, int]) -> None:
+    container_id, _ = http_container
+    assert is_container_running(container_id) is True
+    _podman("stop", "-t", "1", container_id, check=False)
+    # Poll until podman reports it stopped.
+    deadline = time.monotonic() + 30
+    while time.monotonic() < deadline and is_container_running(container_id):
+        time.sleep(0.5)
+    assert is_container_running(container_id) is False
+
+
+@requires_containers
+def test_is_container_running_false_for_unknown() -> None:
+    assert is_container_running("does-not-exist-" + uuid.uuid4().hex) is False
+
+
+# ─── app resources (podman stats) ────────────────────────────────────────────
+
+
+@requires_containers
+def test_app_resources_running_reports_live_usage(http_container: tuple[str, int]) -> None:
+    container_id, _ = http_container
+    r = diagnostics._collect_app_resources(container_id, cpu_cores_limit=1.0, memory_mb_limit=128)
+    assert r.running is True
+    assert r.error is None
+    # Manifest limits are echoed back.
+    assert r.cpu_cores_limit == 1.0
+    assert r.memory_mb_limit == 128
+    # Live memory usage was parsed from real podman stats output.
+    assert r.memory_usage_bytes is not None and r.memory_usage_bytes > 0
+    # CPU percent is a real (possibly 0.0) number, not None.
+    assert r.cpu_percent is not None
+
+
+@requires_containers
+def test_app_resources_stopped_container_not_running(http_container: tuple[str, int]) -> None:
+    """A stopped container reports running=False with no misleading zero stats,
+    while still echoing the manifest limits (regression: podman stats emits a
+    zero-valued entry for exited containers)."""
+    container_id, _ = http_container
+    _podman("stop", "-t", "1", container_id, check=False)
+    deadline = time.monotonic() + 30
+    while time.monotonic() < deadline and is_container_running(container_id):
+        time.sleep(0.5)
+    r = diagnostics._collect_app_resources(container_id, cpu_cores_limit=0.5, memory_mb_limit=64)
+    assert r.running is False
+    assert r.cpu_percent is None
+    assert r.memory_usage_bytes is None
+    assert r.cpu_cores_limit == 0.5
+    assert r.memory_mb_limit == 64
+
+
+@requires_containers
+def test_app_resources_no_container_id() -> None:
+    r = diagnostics._collect_app_resources(None, cpu_cores_limit=0.5, memory_mb_limit=64)
+    assert r.running is False
+    assert r.memory_mb_limit == 64
+
+
+# ─── app health (loopback HTTP probe) ────────────────────────────────────────
+
+
+@requires_containers
+def test_app_health_healthy_against_real_server(http_container: tuple[str, int]) -> None:
+
+    _, port = http_container
+    # http.server may take a moment to bind after the container is "running".
+    deadline = time.monotonic() + 20
+    health = None
+    while time.monotonic() < deadline:
+        health = asyncio.run(diagnostics._collect_app_health(port, "/"))
+        if health.checked and health.healthy:
+            break
+        time.sleep(0.5)
+    assert health is not None
+    assert health.checked is True
+    assert health.healthy is True
+    assert health.status_code is not None and health.status_code < 500
+    assert health.checked_path == "/"
+
+
+@requires_containers
+def test_app_health_unhealthy_on_dead_port() -> None:
+
+    # Nothing listening on this free port -> connection refused -> unhealthy.
+    health = asyncio.run(diagnostics._collect_app_health(_free_port(), "/"))
+    assert health.checked is True
+    assert health.healthy is False
+    assert health.status_code is None
+    assert health.error
+
+
+@requires_containers
+def test_app_health_custom_path_normalized(http_container: tuple[str, int]) -> None:
+
+    _, port = http_container
+    # A missing-leading-slash path is normalized; a 404 is still "healthy"
+    # (any status < 500 means the app is up and answering).
+    health = asyncio.run(diagnostics._collect_app_health(port, "healthz"))
+    assert health.checked_path == "/healthz"
+    assert health.checked is True
+    # http.server returns 404 for /healthz, which is < 500 -> healthy.
+    assert health.healthy is True
+    assert health.status_code == 404

--- a/compute_space/src/compute_space/tests/test_diagnostics_containers.py
+++ b/compute_space/src/compute_space/tests/test_diagnostics_containers.py
@@ -151,13 +151,6 @@ def test_app_resources_stopped_container_not_running(http_container: tuple[str, 
     assert r.memory_mb_limit == 64
 
 
-@requires_containers
-def test_app_resources_no_container_id() -> None:
-    r = diagnostics._collect_app_resources(None, cpu_cores_limit=0.5, memory_mb_limit=64)
-    assert r.running is False
-    assert r.memory_mb_limit == 64
-
-
 # ─── app health (loopback HTTP probe) ────────────────────────────────────────
 
 

--- a/compute_space/src/compute_space/tests/test_diagnostics_containers.py
+++ b/compute_space/src/compute_space/tests/test_diagnostics_containers.py
@@ -30,9 +30,7 @@ _PODMAN_TIMEOUT = 120
 
 
 def _podman(*args: str, check: bool = True) -> subprocess.CompletedProcess[str]:
-    return subprocess.run(
-        ["podman", *args], capture_output=True, text=True, timeout=_PODMAN_TIMEOUT, check=check
-    )
+    return subprocess.run(["podman", *args], capture_output=True, text=True, timeout=_PODMAN_TIMEOUT, check=check)
 
 
 def _free_port() -> int:
@@ -48,6 +46,19 @@ def _wait_running(container_id: str, timeout: float = 30.0) -> None:
             return
         time.sleep(0.5)
     raise AssertionError(f"container {container_id} did not reach running within {timeout}s")
+
+
+def _wait_http_ready(port: int, timeout: float = 30.0) -> None:
+    """Wait until the container's in-process http.server has actually bound the
+    port (a container reporting 'running' doesn't mean the server is serving
+    yet). Probes '/' until the health check reports the app up."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        h = asyncio.run(diagnostics._collect_app_health(port, "/"))
+        if h.checked and h.healthy:
+            return
+        time.sleep(0.5)
+    raise AssertionError(f"http server on :{port} did not become ready within {timeout}s")
 
 
 @pytest.fixture
@@ -158,15 +169,8 @@ def test_app_resources_stopped_container_not_running(http_container: tuple[str, 
 def test_app_health_healthy_against_real_server(http_container: tuple[str, int]) -> None:
 
     _, port = http_container
-    # http.server may take a moment to bind after the container is "running".
-    deadline = time.monotonic() + 20
-    health = None
-    while time.monotonic() < deadline:
-        health = asyncio.run(diagnostics._collect_app_health(port, "/"))
-        if health.checked and health.healthy:
-            break
-        time.sleep(0.5)
-    assert health is not None
+    _wait_http_ready(port)
+    health = asyncio.run(diagnostics._collect_app_health(port, "/"))
     assert health.checked is True
     assert health.healthy is True
     assert health.status_code is not None and health.status_code < 500
@@ -188,6 +192,7 @@ def test_app_health_unhealthy_on_dead_port() -> None:
 def test_app_health_custom_path_normalized(http_container: tuple[str, int]) -> None:
 
     _, port = http_container
+    _wait_http_ready(port)
     # A missing-leading-slash path is normalized; a 404 is still "healthy"
     # (any status < 500 means the app is up and answering).
     health = asyncio.run(diagnostics._collect_app_health(port, "healthz"))

--- a/compute_space/src/compute_space/web/routes/api/apps.py
+++ b/compute_space/src/compute_space/web/routes/api/apps.py
@@ -3,6 +3,8 @@ import os
 import re
 import shutil
 import sqlite3
+from datetime import UTC
+from datetime import datetime
 from pathlib import Path
 from threading import Thread
 from typing import Annotated
@@ -39,6 +41,8 @@ from compute_space.core.containers import get_docker_logs
 from compute_space.core.containers import log_timestamp
 from compute_space.core.containers import stop_app_process
 from compute_space.core.containers import stop_container
+from compute_space.core.diagnostics import AppDiagnostics
+from compute_space.core.diagnostics import collect_app_diagnostics
 from compute_space.core.git_ops import UnsupportedRepoUrlError
 from compute_space.core.git_ops import get_branch_name
 from compute_space.core.git_ops import get_head_sha
@@ -465,6 +469,35 @@ async def app_status(app_id: str, db: sqlite3.Connection) -> Response[AppStatusR
         status_code=200,
         media_type=MediaType.JSON,
     )
+
+
+def _app_diagnostics_filename(app_name: str) -> str:
+    """Build a safe, timestamped filename for a downloaded app diagnostics bundle."""
+    stamp = datetime.now(UTC).strftime("%Y%m%dT%H%M%SZ")
+    safe_name = "".join(c if c.isalnum() or c in "-." else "_" for c in app_name) or "app"
+    return f"openhost-app-diagnostics-{safe_name}-{stamp}.json"
+
+
+@get("/api/app_diagnostics/{app_id:str}", guards=[require_owner_auth])
+async def app_diagnostics(
+    app_id: str, db: sqlite3.Connection, config: Config, download: bool = False
+) -> Response[AppDiagnostics] | Response[ErrorResponse]:
+    """Return a per-app diagnostics bundle: app version + manifest git checkout,
+    container status, and a slice of host/system info so the report is
+    self-contained.
+
+    ``?download=1`` adds a Content-Disposition header so browsers save the JSON
+    to a timestamped file instead of rendering it inline.
+    """
+    app_row, err = _resolve_app_or_error(app_id, db)
+    if err is not None:
+        return err
+    assert app_row is not None
+    diagnostics = await collect_app_diagnostics(app_row, config)
+    headers = None
+    if download:
+        headers = {"Content-Disposition": f'attachment; filename="{_app_diagnostics_filename(app_row["name"])}"'}
+    return Response(content=diagnostics, status_code=200, media_type=MediaType.JSON, headers=headers)
 
 
 @get("/app_logs/{app_id:str}", guards=[require_owner_auth], media_type=MediaType.TEXT)
@@ -968,6 +1001,7 @@ api_apps_routes = Router(
         api_add_app,
         api_apps,
         app_status,
+        app_diagnostics,
         app_logs,
         stop_app,
         reload_app,

--- a/compute_space/src/compute_space/web/routes/api/system.py
+++ b/compute_space/src/compute_space/web/routes/api/system.py
@@ -22,6 +22,8 @@ from compute_space.core.auth.security_audit import is_sshd_active
 from compute_space.core.auth.security_audit import list_listening_ports
 from compute_space.core.auth.security_audit import run_audit
 from compute_space.core.containers import drop_docker_build_cache
+from compute_space.core.diagnostics import PlatformDiagnostics
+from compute_space.core.diagnostics import collect_platform_diagnostics
 from compute_space.core.git_ops import get_branch_name
 from compute_space.core.git_ops import get_head_sha
 from compute_space.core.git_ops import is_dirty
@@ -290,6 +292,36 @@ async def api_version() -> VersionInfo:
     return VersionInfo(branch=branch, sha=sha, short_sha=sha[:8], dirty=dirty)
 
 
+# ─── Diagnostics ─────────────────────────────────────────────────────────
+
+
+def _diagnostics_filename(zone_domain: str) -> str:
+    """Build a safe, timestamped filename for a downloaded diagnostics bundle."""
+    stamp = datetime.now(UTC).strftime("%Y%m%dT%H%M%SZ")
+    # zone_domain may contain a ':<port>' and dots; keep only filename-safe chars.
+    safe_zone = "".join(c if c.isalnum() or c in "-." else "_" for c in zone_domain) or "openhost"
+    return f"openhost-diagnostics-{safe_zone}-{stamp}.json"
+
+
+@get("/api/diagnostics", guards=[require_owner_auth])
+async def api_diagnostics(
+    db: sqlite3.Connection, config: Config, download: bool = False
+) -> Response[PlatformDiagnostics]:
+    """Return a full instance diagnostics bundle for debugging.
+
+    Includes the OpenHost git checkout, host OS/Python/dependency versions,
+    container runtime info, disk usage, and a summary of every installed app.
+
+    ``?download=1`` adds a Content-Disposition header so browsers save the JSON
+    to a timestamped file instead of rendering it inline.
+    """
+    diagnostics = await collect_platform_diagnostics(db, config)
+    headers = None
+    if download:
+        headers = {"Content-Disposition": f'attachment; filename="{_diagnostics_filename(config.zone_domain)}"'}
+    return Response(content=diagnostics, status_code=200, media_type=MediaType.JSON, headers=headers)
+
+
 @post("/restart_router", status_code=200, guards=[require_owner_auth], sync_to_thread=False)
 def restart_router() -> OkResponse:
     """Restart the router systemd service to pick up code changes."""
@@ -322,6 +354,7 @@ system_routes = Router(
         toggle_ssh,
         drop_docker_cache,
         api_version,
+        api_diagnostics,
         restart_router,
     ],
 )

--- a/compute_space/src/compute_space/web/routes/pages/system.py
+++ b/compute_space/src/compute_space/web/routes/pages/system.py
@@ -19,6 +19,12 @@ async def system_page() -> Template:
     return Template(template_name="system.html")
 
 
+@get("/diagnostics/", guards=[require_owner_auth])
+async def diagnostics_page() -> Template:
+    """Serve the Diagnostics page (copyable/downloadable debug bundle)."""
+    return Template(template_name="diagnostics.html")
+
+
 @get("/terminal/", guards=[require_owner_auth])
 async def terminal_page() -> Template:
     """Serve the web terminal UI."""
@@ -59,5 +65,5 @@ async def terminal_ws(socket: WebSocket[Any, Any, Any]) -> None:
 
 pages_system_routes = Router(
     path="/",
-    route_handlers=[system_page, terminal_page, terminal_ws],
+    route_handlers=[system_page, diagnostics_page, terminal_page, terminal_ws],
 )

--- a/compute_space/src/compute_space/web/static/js/diagnostics.js
+++ b/compute_space/src/compute_space/web/static/js/diagnostics.js
@@ -117,10 +117,6 @@ document.getElementById('copy-btn').addEventListener('click', function() {
   }
 });
 
-document.getElementById('download-btn').addEventListener('click', function() {
-  window.location.href = config.diagnosticsDownloadUrl;
-});
-
 document.getElementById('refresh-btn').addEventListener('click', loadDiagnostics);
 
 loadDiagnostics();

--- a/compute_space/src/compute_space/web/static/js/diagnostics.js
+++ b/compute_space/src/compute_space/web/static/js/diagnostics.js
@@ -59,14 +59,45 @@ function renderSummary(data) {
     }).join(' &middot; ');
     row('Key dependencies', depHtml);
   }
+
+  var rp = data.resource_pressure || {};
+  if (rp.memory_total_bytes != null) {
+    var memText = formatBytes(rp.memory_total_bytes - (rp.memory_available_bytes || 0))
+      + ' / ' + formatBytes(rp.memory_total_bytes)
+      + (rp.memory_used_percent != null ? ' (' + rp.memory_used_percent + '%)' : '');
+    var memCls = (rp.memory_used_percent != null && rp.memory_used_percent >= 90) ? ' class="status-error"' : '';
+    rows += '<tr><th class="label-col">Memory used</th><td' + memCls + '>' + escHtml(memText) + '</td></tr>';
+  }
+  if (rp.load_avg_1m != null) {
+    var loadText = rp.load_avg_1m + ' / ' + rp.load_avg_5m + ' / ' + rp.load_avg_15m
+      + (rp.cpu_count != null ? '  (over ' + rp.cpu_count + ' CPUs)' : '');
+    var loadCls = (rp.cpu_count && rp.load_avg_1m > rp.cpu_count) ? ' class="status-error"' : '';
+    rows += '<tr><th class="label-col">Load avg (1/5/15m)</th><td' + loadCls + '>' + escHtml(loadText) + '</td></tr>';
+  }
+
   document.getElementById('summary-body').innerHTML = rows;
+}
+
+function healthCell(h) {
+  if (!h || !h.checked) return '<span class="muted">n/a</span>';
+  if (h.healthy) return '<span class="status-running">OK' + (h.status_code ? ' (' + escHtml(h.status_code) + ')' : '') + '</span>';
+  var detail = h.status_code ? String(h.status_code) : (h.error || 'unreachable');
+  return '<span class="status-error">FAIL (' + escHtml(detail) + ')</span>';
+}
+
+function resourceCell(r) {
+  if (!r || !r.running) return '<span class="muted">not running</span>';
+  var cpu = (r.cpu_percent != null) ? (r.cpu_percent + '%') : '?';
+  var mem = (r.memory_usage_bytes != null) ? formatBytes(r.memory_usage_bytes) : '?';
+  if (r.memory_percent != null) mem += ' (' + r.memory_percent + '%)';
+  return escHtml(cpu + ' cpu, ' + mem);
 }
 
 function renderApps(data) {
   var apps = data.apps || [];
   var body = document.getElementById('apps-body');
   if (!apps.length) {
-    body.innerHTML = '<tr><td colspan="4" class="muted">No apps installed.</td></tr>';
+    body.innerHTML = '<tr><td colspan="6" class="muted">No apps installed.</td></tr>';
     return;
   }
   body.innerHTML = apps.map(function(a) {
@@ -74,7 +105,27 @@ function renderApps(data) {
     return '<tr><td>' + escHtml(a.name) + '</td>'
       + '<td>' + escHtml(a.version || '') + '</td>'
       + '<td class="' + statusCls + '">' + escHtml(a.status) + '</td>'
+      + '<td>' + healthCell(a.health) + '</td>'
+      + '<td>' + resourceCell(a.resources) + '</td>'
       + '<td>' + escHtml(gitText(a.git)) + '</td></tr>';
+  }).join('');
+}
+
+function renderReachability(data) {
+  var targets = data.reachability || [];
+  var body = document.getElementById('reachability-body');
+  if (!targets.length) {
+    body.innerHTML = '<tr><td colspan="4" class="muted">No reachability data.</td></tr>';
+    return;
+  }
+  body.innerHTML = targets.map(function(t) {
+    var cls = t.reachable ? 'status-running' : 'status-error';
+    var label = t.reachable ? ('yes' + (t.status_code ? ' (' + escHtml(t.status_code) + ')' : '')) : ('no' + (t.error ? ' (' + escHtml(t.error) + ')' : ''));
+    var latency = (t.latency_ms != null) ? (t.latency_ms + ' ms') : '';
+    return '<tr><td>' + escHtml(t.label) + '</td>'
+      + '<td><code>' + escHtml(t.url) + '</code></td>'
+      + '<td class="' + cls + '">' + label + '</td>'
+      + '<td>' + escHtml(latency) + '</td></tr>';
   }).join('');
 }
 
@@ -88,6 +139,7 @@ function loadDiagnostics() {
     .then(function(data) {
       latest = data;
       renderSummary(data);
+      renderReachability(data);
       renderApps(data);
       document.getElementById('diag-json').textContent = JSON.stringify(data, null, 2);
     })

--- a/compute_space/src/compute_space/web/static/js/diagnostics.js
+++ b/compute_space/src/compute_space/web/static/js/diagnostics.js
@@ -1,0 +1,126 @@
+var config = JSON.parse(document.getElementById('page-config').textContent);
+
+var latest = null;
+
+function escHtml(s) {
+  var d = document.createElement('div');
+  d.textContent = (s == null) ? '' : String(s);
+  return d.innerHTML;
+}
+
+function formatBytes(bytes) {
+  if (bytes == null) return '';
+  if (bytes >= 1099511627776) return (bytes / 1099511627776).toFixed(1) + ' TiB';
+  if (bytes >= 1073741824) return (bytes / 1073741824).toFixed(1) + ' GiB';
+  if (bytes >= 1048576) return (bytes / 1048576).toFixed(1) + ' MiB';
+  if (bytes >= 1024) return (bytes / 1024).toFixed(1) + ' KiB';
+  return bytes + ' B';
+}
+
+function gitText(git) {
+  if (!git || !git.sha) return '(not a git checkout)';
+  var branch = git.branch || '(detached HEAD)';
+  var dirty = git.dirty ? ' (dirty)' : '';
+  return branch + ' @ ' + (git.short_sha || git.sha) + dirty;
+}
+
+function renderSummary(data) {
+  var sys = data.system || {};
+  var rt = data.container_runtime || {};
+  var disk = (data.storage && data.storage.disk) || {};
+  var rows = '';
+  function row(label, value) {
+    rows += '<tr><th class="label-col">' + escHtml(label) + '</th><td>' + value + '</td></tr>';
+  }
+  row('Generated at', escHtml(data.generated_at));
+  row('Zone domain', escHtml(data.zone_domain));
+  row('OpenHost version', escHtml(gitText(data.openhost)));
+  if (data.openhost && data.openhost.remote_url) {
+    row('OpenHost remote', '<code>' + escHtml(data.openhost.remote_url) + '</code>');
+  }
+  row('Host', escHtml(sys.hostname) + ' — ' + escHtml(sys.platform));
+  row('Kernel', escHtml(sys.system) + ' ' + escHtml(sys.release) + ' (' + escHtml(sys.machine) + ')');
+  row('CPU count', escHtml(sys.cpu_count));
+  row('Boot time', escHtml(sys.boot_time));
+  row('Python', escHtml(sys.python_implementation) + ' ' + escHtml(sys.python_version));
+  var rtText = rt.available
+    ? ('podman ' + escHtml(rt.version || '?') + (rt.rootless === true ? ', rootless' : (rt.rootless === false ? ', ROOTFUL' : '')))
+    : ('unavailable' + (rt.error ? ' (' + escHtml(rt.error) + ')' : ''));
+  var rtCls = (rt.available && rt.rootless !== false) ? '' : ' class="status-error"';
+  rows += '<tr><th class="label-col">Container runtime</th><td' + rtCls + '>' + rtText + '</td></tr>';
+  if (disk.total_bytes != null) {
+    row('Disk', formatBytes(disk.free_bytes) + ' free / ' + formatBytes(disk.total_bytes));
+  }
+  var deps = data.dependencies || {};
+  var depNames = Object.keys(deps).sort();
+  if (depNames.length) {
+    var depHtml = depNames.map(function(n) {
+      return '<code>' + escHtml(n) + '</code> ' + escHtml(deps[n]);
+    }).join(' &middot; ');
+    row('Key dependencies', depHtml);
+  }
+  document.getElementById('summary-body').innerHTML = rows;
+}
+
+function renderApps(data) {
+  var apps = data.apps || [];
+  var body = document.getElementById('apps-body');
+  if (!apps.length) {
+    body.innerHTML = '<tr><td colspan="4" class="muted">No apps installed.</td></tr>';
+    return;
+  }
+  body.innerHTML = apps.map(function(a) {
+    var statusCls = a.status === 'running' ? 'status-running' : (a.status === 'error' ? 'status-error' : 'status-stopped');
+    return '<tr><td>' + escHtml(a.name) + '</td>'
+      + '<td>' + escHtml(a.version || '') + '</td>'
+      + '<td class="' + statusCls + '">' + escHtml(a.status) + '</td>'
+      + '<td>' + escHtml(gitText(a.git)) + '</td></tr>';
+  }).join('');
+}
+
+function loadDiagnostics() {
+  document.getElementById('copy-status').textContent = '';
+  fetch(config.diagnosticsUrl, {credentials: 'same-origin'})
+    .then(function(r) {
+      if (!r.ok) throw new Error('HTTP ' + r.status);
+      return r.json();
+    })
+    .then(function(data) {
+      latest = data;
+      renderSummary(data);
+      renderApps(data);
+      document.getElementById('diag-json').textContent = JSON.stringify(data, null, 2);
+    })
+    .catch(function(e) {
+      document.getElementById('diag-json').textContent = 'Failed to load diagnostics: ' + e.message;
+    });
+}
+
+document.getElementById('copy-btn').addEventListener('click', function() {
+  if (!latest) return;
+  var text = JSON.stringify(latest, null, 2);
+  var status = document.getElementById('copy-status');
+  var done = function() { status.textContent = 'Copied.'; };
+  var fail = function() { status.textContent = 'Copy failed — select the JSON below manually.'; };
+  if (navigator.clipboard && navigator.clipboard.writeText) {
+    navigator.clipboard.writeText(text).then(done, fail);
+  } else {
+    // Fallback for non-secure contexts (plain-HTTP dev): copy via a temp textarea.
+    var ta = document.createElement('textarea');
+    ta.value = text;
+    ta.style.position = 'fixed';
+    ta.style.opacity = '0';
+    document.body.appendChild(ta);
+    ta.select();
+    try { document.execCommand('copy') ? done() : fail(); } catch (e) { fail(); }
+    document.body.removeChild(ta);
+  }
+});
+
+document.getElementById('download-btn').addEventListener('click', function() {
+  window.location.href = config.diagnosticsDownloadUrl;
+});
+
+document.getElementById('refresh-btn').addEventListener('click', loadDiagnostics);
+
+loadDiagnostics();

--- a/compute_space/src/compute_space/web/templates/app_detail.html
+++ b/compute_space/src/compute_space/web/templates/app_detail.html
@@ -155,7 +155,7 @@
     overflow-x: auto;
     padding-bottom: 0.25rem;
   }
-  #app-action-buttons .btn { padding: 0.4em 0.6em; flex: 0 0 auto; white-space: nowrap; }
+  #app-action-buttons .btn { padding: 0.4em 0.5em; flex: 0 0 auto; white-space: nowrap; }
   #app-action-buttons #app-action-msg { flex: 0 0 auto; }
 </style>
 <div id="app-action-buttons">

--- a/compute_space/src/compute_space/web/templates/app_detail.html
+++ b/compute_space/src/compute_space/web/templates/app_detail.html
@@ -155,7 +155,7 @@
     overflow-x: auto;
     padding-bottom: 0.25rem;
   }
-  #app-action-buttons .btn { padding: 0.4em 0.5em; flex: 0 0 auto; white-space: nowrap; }
+  #app-action-buttons .btn { padding: 0.4em 0.7em; flex: 0 0 auto; white-space: nowrap; }
   #app-action-buttons #app-action-msg { flex: 0 0 auto; }
 </style>
 <div id="app-action-buttons">
@@ -174,8 +174,8 @@
       <a href="{{ edit_app.href }}" class="btn" target="_blank" rel="noopener">Edit App</a>
     {% endif %}
   {% endif %}
-  <button class="btn" onclick="if(confirm('Remove {{ app.name }} but keep its databases and files? You can re-deploy later to the same app name to reuse the data.')) appAction('/remove_app/{{ app.app_id }}', {keep_data: true}, {isRemove: true, label: 'Removing (keeping data)'})">Remove App (Keep Data)</button>
-  <button class="btn btn-danger" onclick="if(confirm('Remove {{ app.name }}? This deletes all app data permanently.')) appAction('/remove_app/{{ app.app_id }}', {}, {isRemove: true, label: 'Removing'})">Remove App &amp; Data</button>
+  <button class="btn" onclick="if(confirm('Remove {{ app.name }} but keep its databases and files? You can re-deploy later to the same app name to reuse the data.')) appAction('/remove_app/{{ app.app_id }}', {keep_data: true}, {isRemove: true, label: 'Removing (keeping data)'})">Remove (Keep Data)</button>
+  <button class="btn btn-danger" onclick="if(confirm('Remove {{ app.name }}? This deletes all app data permanently.')) appAction('/remove_app/{{ app.app_id }}', {}, {isRemove: true, label: 'Removing'})">Remove &amp; Data</button>
   <span id="app-action-msg" style="margin-left:0.5em;"></span>
 </div>
 

--- a/compute_space/src/compute_space/web/templates/app_detail.html
+++ b/compute_space/src/compute_space/web/templates/app_detail.html
@@ -140,15 +140,25 @@
 
 <br>
 <style>
-  /* Keep the app action buttons on a single row in the standard content
-     column. They still wrap on genuinely narrow (mobile) viewports rather than
-     overflowing, but the slightly tighter padding + gap lets the full set fit
-     one line at the normal desktop width instead of spilling onto two. Scoped
-     to this row so the global .btn sizing elsewhere is unchanged. */
-  #app-action-buttons { gap: 0.4rem; }
-  #app-action-buttons .btn { padding: 0.4em 0.6em; }
+  /* Keep the app action buttons on a single row. The full set (Stop / Reload /
+     Update & Reload / Copy Diagnostics / Edit / Remove / Remove & Data) is a
+     little wider than the 960px content column, which previously made it wrap
+     onto two lines. Slightly tighter padding + gap gets it close, and
+     nowrap + horizontal auto-scroll guarantees it stays on one line (scrolling
+     sideways in the rare case it still doesn't fit) rather than wrapping.
+     Scoped to this row so the global .btn sizing elsewhere is unchanged. */
+  #app-action-buttons {
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+    flex-wrap: nowrap;
+    overflow-x: auto;
+    padding-bottom: 0.25rem;
+  }
+  #app-action-buttons .btn { padding: 0.4em 0.6em; flex: 0 0 auto; white-space: nowrap; }
+  #app-action-buttons #app-action-msg { flex: 0 0 auto; }
 </style>
-<div id="app-action-buttons" style="display: flex; align-items: center; flex-wrap: wrap;">
+<div id="app-action-buttons">
   <button class="btn" onclick="appAction('/stop_app/{{ app.app_id }}', null, {label: 'Stopping'})">Stop App</button>
   <button class="btn" onclick="appAction('/reload_app/{{ app.app_id }}', null, {label: 'Reloading'})">Reload App</button>
   <button class="btn" onclick="appAction('/reload_app/{{ app.app_id }}', {update: true}, {label: 'Updating &amp; reloading'})">Update &amp; Reload</button>

--- a/compute_space/src/compute_space/web/templates/app_detail.html
+++ b/compute_space/src/compute_space/web/templates/app_detail.html
@@ -143,6 +143,7 @@
   <button class="btn" onclick="appAction('/stop_app/{{ app.app_id }}', null, {label: 'Stopping'})">Stop App</button>
   <button class="btn" onclick="appAction('/reload_app/{{ app.app_id }}', null, {label: 'Reloading'})">Reload App</button>
   <button class="btn" onclick="appAction('/reload_app/{{ app.app_id }}', {update: true}, {label: 'Updating &amp; reloading'})">Update &amp; Reload</button>
+  <a class="btn" href="/api/app_diagnostics/{{ app.app_id }}?download=1">Download Diagnostics</a>
   {% if edit_app %}
     {% if edit_app.mode == 'service' %}
       <form method="POST" action="{{ edit_app.action }}" target="_blank" style="display:contents;">

--- a/compute_space/src/compute_space/web/templates/app_detail.html
+++ b/compute_space/src/compute_space/web/templates/app_detail.html
@@ -143,7 +143,7 @@
   <button class="btn" onclick="appAction('/stop_app/{{ app.app_id }}', null, {label: 'Stopping'})">Stop App</button>
   <button class="btn" onclick="appAction('/reload_app/{{ app.app_id }}', null, {label: 'Reloading'})">Reload App</button>
   <button class="btn" onclick="appAction('/reload_app/{{ app.app_id }}', {update: true}, {label: 'Updating &amp; reloading'})">Update &amp; Reload</button>
-  <a class="btn" href="/api/app_diagnostics/{{ app.app_id }}?download=1">Download Diagnostics</a>
+  <button class="btn" id="copy-diagnostics-btn" onclick="copyAppDiagnostics(this)">Copy Diagnostics</button>
   {% if edit_app %}
     {% if edit_app.mode == 'service' %}
       <form method="POST" action="{{ edit_app.action }}" target="_blank" style="display:contents;">
@@ -182,6 +182,42 @@ async function grantPermission(btn) {
     btn.textContent = 'Error';
     btn.disabled = false;
     alert('Failed to grant: ' + e.message);
+  }
+}
+
+// Fetch this app's diagnostics bundle and copy the JSON to the clipboard.
+// Uses the async Clipboard API where available, with a textarea fallback for
+// non-secure (plain-HTTP dev) contexts, mirroring the Diagnostics page.
+async function copyAppDiagnostics(btn) {
+  const original = btn.textContent;
+  btn.disabled = true;
+  btn.textContent = 'Copying\u2026';
+  const restore = function(label) {
+    btn.textContent = label;
+    setTimeout(function() { btn.textContent = original; btn.disabled = false; }, 1500);
+  };
+  try {
+    const resp = await fetch('/api/app_diagnostics/{{ app.app_id }}');
+    if (!resp.ok) throw new Error('HTTP ' + resp.status);
+    const data = await resp.json();
+    const text = JSON.stringify(data, null, 2);
+    let copied = false;
+    if (navigator.clipboard && navigator.clipboard.writeText) {
+      try { await navigator.clipboard.writeText(text); copied = true; } catch (e) { copied = false; }
+    }
+    if (!copied) {
+      const ta = document.createElement('textarea');
+      ta.value = text;
+      ta.style.position = 'fixed';
+      ta.style.opacity = '0';
+      document.body.appendChild(ta);
+      ta.select();
+      try { copied = document.execCommand('copy'); } catch (e) { copied = false; }
+      document.body.removeChild(ta);
+    }
+    restore(copied ? 'Copied!' : 'Copy failed');
+  } catch (e) {
+    restore('Copy failed');
   }
 }
 </script>

--- a/compute_space/src/compute_space/web/templates/app_detail.html
+++ b/compute_space/src/compute_space/web/templates/app_detail.html
@@ -139,7 +139,16 @@
 <pre class="log-output" id="app-logs">{{ logs or "No log output available." }}</pre>
 
 <br>
-<div id="app-action-buttons" style="display: flex; gap: 0.5rem; align-items: center; flex-wrap: wrap;">
+<style>
+  /* Keep the app action buttons on a single row in the standard content
+     column. They still wrap on genuinely narrow (mobile) viewports rather than
+     overflowing, but the slightly tighter padding + gap lets the full set fit
+     one line at the normal desktop width instead of spilling onto two. Scoped
+     to this row so the global .btn sizing elsewhere is unchanged. */
+  #app-action-buttons { gap: 0.4rem; }
+  #app-action-buttons .btn { padding: 0.4em 0.6em; }
+</style>
+<div id="app-action-buttons" style="display: flex; align-items: center; flex-wrap: wrap;">
   <button class="btn" onclick="appAction('/stop_app/{{ app.app_id }}', null, {label: 'Stopping'})">Stop App</button>
   <button class="btn" onclick="appAction('/reload_app/{{ app.app_id }}', null, {label: 'Reloading'})">Reload App</button>
   <button class="btn" onclick="appAction('/reload_app/{{ app.app_id }}', {update: true}, {label: 'Updating &amp; reloading'})">Update &amp; Reload</button>

--- a/compute_space/src/compute_space/web/templates/diagnostics.html
+++ b/compute_space/src/compute_space/web/templates/diagnostics.html
@@ -1,0 +1,41 @@
+{% extends "layout.html" %}
+{% block title_suffix %} - Diagnostics{% endblock %}
+{% block content %}
+<h2>Diagnostics</h2>
+<p class="hint">A snapshot of this instance for debugging: OpenHost version, host system
+info, installed dependency versions, container runtime, disk usage, and every
+installed app. Copy or download it and include it in a bug report.</p>
+
+<div class="control-row">
+  <button class="btn btn-primary" id="copy-btn">Copy to clipboard</button>
+  <button class="btn" id="download-btn">Download JSON</button>
+  <button class="btn" id="refresh-btn">Refresh</button>
+  <span class="hint" id="copy-status"></span>
+</div>
+
+<h2>Summary</h2>
+<table id="summary-table">
+  <tbody id="summary-body">
+    <tr><td colspan="2" class="muted">Loading&hellip;</td></tr>
+  </tbody>
+</table>
+
+<h2>Installed Apps</h2>
+<table id="apps-table">
+  <thead><tr><th>App</th><th>Version</th><th>Status</th><th>Git</th></tr></thead>
+  <tbody id="apps-body">
+    <tr><td colspan="4" class="muted">Loading&hellip;</td></tr>
+  </tbody>
+</table>
+
+<h2>Raw JSON</h2>
+<pre class="log-output" id="diag-json" style="max-height: 40em; white-space: pre-wrap; word-break: break-all;">Loading...</pre>
+
+<script id="page-config" type="application/json">
+{
+  "diagnosticsUrl": "/api/diagnostics",
+  "diagnosticsDownloadUrl": "/api/diagnostics?download=1"
+}
+</script>
+<script src="{{ static_url('js/diagnostics.js') }}"></script>
+{% endblock %}

--- a/compute_space/src/compute_space/web/templates/diagnostics.html
+++ b/compute_space/src/compute_space/web/templates/diagnostics.html
@@ -20,11 +20,19 @@ installed app. Copy or download it and include it in a bug report.</p>
   </tbody>
 </table>
 
+<h2>Outbound Reachability</h2>
+<table id="reachability-table">
+  <thead><tr><th>Target</th><th>URL</th><th>Reachable</th><th>Latency</th></tr></thead>
+  <tbody id="reachability-body">
+    <tr><td colspan="4" class="muted">Loading&hellip;</td></tr>
+  </tbody>
+</table>
+
 <h2>Installed Apps</h2>
 <table id="apps-table">
-  <thead><tr><th>App</th><th>Version</th><th>Status</th><th>Git</th></tr></thead>
+  <thead><tr><th>App</th><th>Version</th><th>Status</th><th>Health</th><th>CPU / Mem</th><th>Git</th></tr></thead>
   <tbody id="apps-body">
-    <tr><td colspan="4" class="muted">Loading&hellip;</td></tr>
+    <tr><td colspan="6" class="muted">Loading&hellip;</td></tr>
   </tbody>
 </table>
 

--- a/compute_space/src/compute_space/web/templates/diagnostics.html
+++ b/compute_space/src/compute_space/web/templates/diagnostics.html
@@ -8,7 +8,7 @@ installed app. Copy or download it and include it in a bug report.</p>
 
 <div class="control-row">
   <button class="btn btn-primary" id="copy-btn">Copy to clipboard</button>
-  <button class="btn" id="download-btn">Download JSON</button>
+  <a class="btn" id="download-btn" href="/api/diagnostics?download=1">Download JSON</a>
   <button class="btn" id="refresh-btn">Refresh</button>
   <span class="hint" id="copy-status"></span>
 </div>
@@ -33,8 +33,7 @@ installed app. Copy or download it and include it in a bug report.</p>
 
 <script id="page-config" type="application/json">
 {
-  "diagnosticsUrl": "/api/diagnostics",
-  "diagnosticsDownloadUrl": "/api/diagnostics?download=1"
+  "diagnosticsUrl": "/api/diagnostics"
 }
 </script>
 <script src="{{ static_url('js/diagnostics.js') }}"></script>

--- a/compute_space/src/compute_space/web/templates/layout.html
+++ b/compute_space/src/compute_space/web/templates/layout.html
@@ -53,6 +53,7 @@
     <a href="/add_app" class="nav-tab">Deploy App</a>
     <a href="/terminal/" class="nav-tab">Terminal</a>
     <a href="/system/" class="nav-tab">System Info</a>
+    <a href="/diagnostics/" class="nav-tab">Diagnostics</a>
     <a href="/settings" class="nav-tab">Settings</a>
     <span class="spacer"></span>
     {% if display_name %}<span class="nav-user">Logged in as {{ display_name }}</span>{% endif %}

--- a/compute_space_cli/src/compute_space_cli/main.py
+++ b/compute_space_cli/src/compute_space_cli/main.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import shlex
 import shutil
 import subprocess
@@ -283,6 +284,17 @@ class AppCmd:
             if err:
                 line += f"  ({err})"
             print(line)
+
+    @cappa.command(name="diagnostics")
+    def diagnostics(
+        self,
+        app_name: Annotated[str, cappa.Arg(help="App name")],
+        cfg: Annotated[config.Instance, Dep(resolve_instance)],
+    ) -> None:
+        """Print a per-app diagnostics bundle (JSON) for debugging."""
+        app_id = resolve_app_id_by_name(cfg.url, cfg.token, app_name)
+        result = make_api_request(cfg.url, cfg.token, "GET", f"/api/app_diagnostics/{app_id}")
+        print(json.dumps(result.json(), indent=2))
 
 
 @cappa.command(name="tokens", help="Manage API tokens.")
@@ -580,6 +592,14 @@ class Version:
         print(f"  full sha: {sha}")
 
 
+@cappa.command(name="diagnostics", help="Print a full instance diagnostics bundle (JSON) for debugging.")
+@attrs.define
+class Diagnostics:
+    def __call__(self, cfg: Annotated[config.Instance, Dep(resolve_instance)]) -> None:
+        result = make_api_request(cfg.url, cfg.token, "GET", "/api/diagnostics")
+        print(json.dumps(result.json(), indent=2))
+
+
 @cappa.command(name="curl", help="curl with your OpenHost bearer token injected.")
 @attrs.define
 class Curl:
@@ -600,7 +620,7 @@ class Curl:
 @cappa.command(name="oh", help="OpenHost compute space CLI — manage things in your compute space.")
 @attrs.define
 class Oh:
-    subcommand: cappa.Subcommands[Status | AppCmd | TokensCmd | LogsCmd | InstanceCmd | Curl | Version]
+    subcommand: cappa.Subcommands[Status | AppCmd | TokensCmd | LogsCmd | InstanceCmd | Curl | Version | Diagnostics]
     instance: Annotated[
         str | None,
         cappa.Arg(long=True, default=None, propagate=True, help="Target a specific named instance"),

--- a/compute_space_cli/src/compute_space_cli/tests/test_diagnostics_cli.py
+++ b/compute_space_cli/src/compute_space_cli/tests/test_diagnostics_cli.py
@@ -1,0 +1,48 @@
+"""Tests for the ``oh diagnostics`` and ``oh app diagnostics`` CLI commands."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+from compute_space_cli import config
+from compute_space_cli.main import AppCmd
+from compute_space_cli.main import Diagnostics
+
+
+def _instance() -> config.Instance:
+    return config.Instance(hostname="x", token="tok", alias="x")
+
+
+def _resp(payload: dict[str, object]) -> MagicMock:
+    r = MagicMock()
+    r.status_code = 200
+    r.json.return_value = payload
+    return r
+
+
+def test_platform_diagnostics_hits_endpoint_and_prints(capsys: object) -> None:
+    payload = {"schema_version": 1, "zone_domain": "x"}
+    with patch("compute_space_cli.main.make_api_request", return_value=_resp(payload)) as mock_req:
+        Diagnostics()(_instance())
+    mock_req.assert_called_once()
+    args = mock_req.call_args.args
+    assert args[2] == "GET"
+    assert args[3] == "/api/diagnostics"
+    out = capsys.readouterr().out  # type: ignore[attr-defined]
+    assert json.loads(out) == payload
+
+
+def test_app_diagnostics_resolves_id_and_hits_endpoint(capsys: object) -> None:
+    payload = {"schema_version": 1, "name": "myapp"}
+    with (
+        patch("compute_space_cli.main.resolve_app_id_by_name", return_value="APPID123"),
+        patch("compute_space_cli.main.make_api_request", return_value=_resp(payload)) as mock_req,
+    ):
+        AppCmd().diagnostics("myapp", _instance())
+    args = mock_req.call_args.args
+    assert args[2] == "GET"
+    assert args[3] == "/api/app_diagnostics/APPID123"
+    out = capsys.readouterr().out  # type: ignore[attr-defined]
+    assert json.loads(out) == payload

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,6 +70,7 @@ addopts = "-p no:randomly -v"
 markers = [
     "requires_containers: needs --run-containers flag and a working rootless podman setup",
     "requires_tls: needs --run-tls flag, pebble, and coredns",
+    "real_collectors: opt out of the diagnostics network-collector stub (patches httpx directly)",
 ]
 
 [tool.ruff]

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -490,6 +490,191 @@ class TestSelfHost:
 
         asyncio.run(_ws_echo())
 
+    # -- 12e-12t. Diagnostics ----------------------------------------------
+    # Exercised while ``test-app`` is deployed (test_04) and before it is
+    # removed (test_14), so per-app diagnostics has a real, running app.
+
+    def test_12e_platform_diagnostics_top_level(self, session, router_url):
+        """GET /api/diagnostics returns a full bundle with all top-level keys."""
+        r = session.get(f"{router_url}/api/diagnostics", timeout=60)
+        assert r.status_code == 200, f"{r.status_code}: {r.text[:400]}"
+        assert r.headers.get("content-type", "").startswith("application/json")
+        d = r.json()
+        expected = {
+            "schema_version",
+            "generated_at",
+            "zone_domain",
+            "openhost",
+            "system",
+            "container_runtime",
+            "dependencies",
+            "storage",
+            "resource_pressure",
+            "reachability",
+            "apps",
+        }
+        assert expected <= set(d), f"missing keys: {expected - set(d)}"
+        assert d["schema_version"] == 2
+        assert d["zone_domain"] == DOMAIN
+
+    def test_12f_platform_openhost_git(self, session, router_url):
+        """The openhost section reports a real git checkout (sha + remote)."""
+        d = session.get(f"{router_url}/api/diagnostics", timeout=60).json()
+        oh = d["openhost"]
+        for key in ("branch", "sha", "short_sha", "dirty", "remote_url"):
+            assert key in oh, f"openhost missing {key}"
+        assert oh["sha"], "openhost sha should be populated on a git deploy"
+        assert isinstance(oh["dirty"], bool)
+
+    def test_12g_platform_system_and_runtime(self, session, router_url):
+        """System info + container runtime are populated with real values."""
+        d = session.get(f"{router_url}/api/diagnostics", timeout=60).json()
+        sysinfo = d["system"]
+        assert sysinfo["system"] == "Linux"
+        assert sysinfo["python_version"]
+        assert isinstance(sysinfo["cpu_count"], int) and sysinfo["cpu_count"] >= 1
+        rt = d["container_runtime"]
+        assert rt["available"] is True, f"podman should be available: {rt}"
+        assert rt["version"], "podman version should be populated"
+        # OpenHost runs rootless podman.
+        assert rt["rootless"] is True
+
+    def test_12h_platform_storage_and_deps(self, session, router_url):
+        """Storage disk metrics and key dependency versions are present."""
+        d = session.get(f"{router_url}/api/diagnostics", timeout=60).json()
+        disk = d["storage"]["disk"]
+        assert disk["total_bytes"] > 0
+        assert disk["free_bytes"] >= 0
+        deps = d["dependencies"]
+        assert isinstance(deps, dict) and deps, "dependencies should be a non-empty map"
+        assert "litestar" in deps
+
+    def test_12i_platform_resource_pressure(self, session, router_url):
+        """Resource-pressure memory metrics are present and self-consistent."""
+        d = session.get(f"{router_url}/api/diagnostics", timeout=60).json()
+        rp = d["resource_pressure"]
+        assert rp["memory_total_bytes"] and rp["memory_total_bytes"] > 0
+        assert rp["memory_available_bytes"] is not None
+        # used% is a percentage in [0, 100] when both memory numbers are present.
+        if rp["memory_used_percent"] is not None:
+            assert 0.0 <= rp["memory_used_percent"] <= 100.0
+        assert isinstance(rp["cpu_count"], int) and rp["cpu_count"] >= 1
+
+    def test_12j_platform_reachability_shape(self, session, router_url):
+        """Reachability is a list of probes with the expected fields, and the
+        static github probe is present and reachable from the instance."""
+        d = session.get(f"{router_url}/api/diagnostics", timeout=60).json()
+        reach = d["reachability"]
+        assert isinstance(reach, list) and reach
+        labels = {p["label"] for p in reach}
+        assert "github" in labels
+        for p in reach:
+            assert {"label", "url", "reachable", "status_code", "latency_ms", "error"} <= set(p)
+        gh = next(p for p in reach if p["label"] == "github")
+        assert gh["reachable"] is True, f"github should be reachable: {gh}"
+
+    def test_12k_reachability_excludes_cert_api(self, session, router_url):
+        """The cert-api base URL reachability probe was removed."""
+        d = session.get(f"{router_url}/api/diagnostics", timeout=60).json()
+        labels = {p["label"] for p in d["reachability"]}
+        assert "cert_api" not in labels
+
+    def test_12l_platform_apps_summary(self, session, router_url):
+        """Every installed app appears in the summary with a stable shape;
+        the running test-app reports healthy with live resource usage."""
+        d = session.get(f"{router_url}/api/diagnostics", timeout=60).json()
+        apps = d["apps"]
+        assert isinstance(apps, list) and apps
+        names = {a["name"] for a in apps}
+        assert "test-app" in names
+        for a in apps:
+            assert {"app_id", "name", "status", "version", "health", "resources", "git"} <= set(a)
+            assert {"running", "cpu_cores_limit", "memory_mb_limit"} <= set(a["resources"])
+            assert {"checked", "healthy", "status_code", "checked_path"} <= set(a["health"])
+        test_app = next(a for a in apps if a["name"] == "test-app")
+        assert test_app["status"] == "running"
+        assert test_app["resources"]["running"] is True
+        assert test_app["health"]["healthy"] is True
+
+    def test_12m_platform_download_header(self, session, router_url):
+        """?download=1 sets a timestamped attachment filename."""
+        r = session.get(f"{router_url}/api/diagnostics?download=1", timeout=60)
+        assert r.status_code == 200
+        cd = r.headers.get("content-disposition", "")
+        assert "attachment" in cd and DOMAIN in cd and cd.endswith('.json"')
+        # Still valid JSON.
+        assert r.json()["schema_version"] == 2
+
+    def test_12n_per_app_diagnostics(self, session, router_url):
+        """GET /api/app_diagnostics/<id> returns a self-contained per-app bundle."""
+        app_id = app_id_for(session, router_url, "test-app")
+        r = session.get(f"{router_url}/api/app_diagnostics/{app_id}", timeout=60)
+        assert r.status_code == 200, f"{r.status_code}: {r.text[:400]}"
+        d = r.json()
+        expected = {
+            "schema_version",
+            "app_id",
+            "name",
+            "status",
+            "version",
+            "git",
+            "health",
+            "resources",
+            "container_runtime",
+            "system",
+            "resource_pressure",
+            "zone_domain",
+        }
+        assert expected <= set(d), f"missing keys: {expected - set(d)}"
+        assert d["schema_version"] == 2
+        assert d["name"] == "test-app"
+        assert d["app_id"] == app_id
+
+    def test_12o_per_app_download_header(self, session, router_url):
+        """Per-app ?download=1 sets a timestamped attachment filename."""
+        app_id = app_id_for(session, router_url, "test-app")
+        r = session.get(f"{router_url}/api/app_diagnostics/{app_id}?download=1", timeout=60)
+        assert r.status_code == 200
+        cd = r.headers.get("content-disposition", "")
+        assert "attachment" in cd and "test-app" in cd
+
+    def test_12p_diagnostics_auth_required(self, router_url):
+        """Both diagnostics endpoints require owner auth (no cookies/token)."""
+        for path in ("/api/diagnostics", "/api/app_diagnostics/AAAAAAAAAAAA"):
+            r = requests.get(f"{router_url}{path}", allow_redirects=False, timeout=10)
+            assert r.status_code in (302, 401), f"{path} not gated: {r.status_code}"
+
+    def test_12q_diagnostics_bad_token_rejected(self, router_url):
+        """A bogus Bearer token cannot read diagnostics."""
+        r = requests.get(
+            f"{router_url}/api/diagnostics",
+            headers={"Authorization": "Bearer bogus-token-value"},
+            allow_redirects=False,
+            timeout=10,
+        )
+        assert r.status_code in (302, 401)
+
+    def test_12r_diagnostics_method_not_allowed(self, session, router_url):
+        """The GET-only diagnostics endpoint rejects other methods."""
+        for method in ("POST", "PUT", "DELETE"):
+            r = session.request(method, f"{router_url}/api/diagnostics", timeout=10)
+            assert r.status_code == 405, f"{method} -> {r.status_code}"
+
+    def test_12s_per_app_diagnostics_errors(self, session, router_url):
+        """Invalid-format app_id -> 400; valid-format-but-missing -> 404."""
+        r = session.get(f"{router_url}/api/app_diagnostics/not-a-valid-id!!", timeout=10)
+        assert r.status_code == 400
+        # 12 base58 chars: valid format, no such app.
+        r = session.get(f"{router_url}/api/app_diagnostics/ABCDEFGH1234", timeout=10)
+        assert r.status_code == 404
+
+    def test_12t_diagnostics_page_renders(self, session, router_url):
+        """The Diagnostics dashboard page loads and links the JSON endpoint."""
+        r = session.get(f"{router_url}/diagnostics/", timeout=30)
+        assert r.status_code == 200
+        assert "Diagnostics" in r.text
+        assert "/api/diagnostics" in r.text
+
     # -- 13. TLS certificate -----------------------------------------------
 
     def test_13_tls_cert(self, domain):


### PR DESCRIPTION
Adds an owner-only diagnostics feature for debugging OpenHost instances and apps.

Platform diagnostics (GET /api/diagnostics) bundles: OpenHost git checkout (branch/SHA/dirty/remote), host OS/kernel, Python and key dependency versions, container runtime (podman) version and rootless status, disk usage, host resource pressure (memory + load average), outbound reachability probes to external dependencies, and a per-app summary (version, status, git commit, health check, live CPU/memory usage).

Per-app diagnostics (GET /api/app_diagnostics/{app_id}) bundles the app version, manifest git checkout, container status, health check, live resource usage, plus a slice of host/system info so the report is self-contained.

Both endpoints return JSON and support ?download=1 for a timestamped attachment filename. Also adds a Diagnostics dashboard page (copy-to-clipboard, download, refresh), a Copy Diagnostics button on the app detail page, and CLI commands (oh diagnostics, oh app diagnostics <name>).

Collectors are defensive: a failure gathering one field degrades that field to null rather than failing the whole bundle, since a diagnostics report is most useful when the instance is unhealthy. App resource usage reports running only when the container is actually running (not merely when podman stats returns data).

Tested with unit tests, and an extensive diagnostics block in the cloud e2e suite (tests/test_e2e.py) covering the platform bundle and every section, the per-app bundle, download headers, owner-auth gating, method enforcement, error cases, and the dashboard page.
