### PR TITLE
Add automatic TLS cert renewal

### DIFF
--- a/compute_space/src/compute_space/core/caddy.py
+++ b/compute_space/src/compute_space/core/caddy.py
@@ -2,6 +2,8 @@ import subprocess
 import threading
 from pathlib import Path
 
+import attr
+
 from compute_space.core.logging import logger
 
 
@@ -35,12 +37,7 @@ def generate_caddyfile(tls_enabled: bool, tls_cert_path: Path, tls_key_path: Pat
         )
 
 
-def start_caddy(
-    caddyfile_path: Path, tls_enabled: bool, tls_cert_path: Path, tls_key_path: Path, web_server_port: int
-) -> subprocess.Popen[bytes]:
-    """Generate Caddyfile and start Caddy."""
-    caddyfile_path.parent.mkdir(parents=True, exist_ok=True)
-    caddyfile_path.write_text(generate_caddyfile(tls_enabled, tls_cert_path, tls_key_path, web_server_port))
+def _spawn_caddy(caddyfile_path: Path) -> subprocess.Popen[bytes]:
     proc = subprocess.Popen(
         ["caddy", "run", "--config", str(caddyfile_path), "--adapter", "caddyfile"],
         stdout=subprocess.PIPE,
@@ -57,3 +54,35 @@ def start_caddy(
     threading.Thread(target=_stream_caddy_logs, args=(proc,), daemon=True).start()
     logger.info(f"Started Caddy (pid {proc.pid})")
     return proc
+
+
+@attr.s(auto_attribs=True)
+class CaddyProcess:
+    """Handle to the running Caddy child.  Mutable: restart() replaces proc with a fresh one."""
+
+    proc: subprocess.Popen[bytes]
+    caddyfile_path: Path
+
+    def restart(self) -> None:
+        """Restart Caddy so it picks up renewed TLS cert files (it runs with `admin off`, so there
+        is no live-reload path).  The old process must stop before the new one starts since both
+        bind :80/:443.
+        """
+        if self.proc.poll() is None:
+            self.proc.terminate()
+            try:
+                self.proc.wait(timeout=3)
+            except subprocess.TimeoutExpired:
+                logger.warning(f"Caddy (pid {self.proc.pid}) did not exit after terminate, killing")
+                self.proc.kill()
+                self.proc.wait()
+        self.proc = _spawn_caddy(self.caddyfile_path)
+
+
+def start_caddy(
+    caddyfile_path: Path, tls_enabled: bool, tls_cert_path: Path, tls_key_path: Path, web_server_port: int
+) -> CaddyProcess:
+    """Generate Caddyfile and start Caddy."""
+    caddyfile_path.parent.mkdir(parents=True, exist_ok=True)
+    caddyfile_path.write_text(generate_caddyfile(tls_enabled, tls_cert_path, tls_key_path, web_server_port))
+    return CaddyProcess(proc=_spawn_caddy(caddyfile_path), caddyfile_path=caddyfile_path)

--- a/compute_space/src/compute_space/core/tls/acquire_cert.py
+++ b/compute_space/src/compute_space/core/tls/acquire_cert.py
@@ -9,13 +9,6 @@ from compute_space.core.tls.util import load_account_key
 GTS_PRODUCTION = "https://dv.acme-v02.api.pki.goog/directory"
 
 
-def check_if_cert_exists(cert_path: Path, key_path: Path) -> bool:
-    if os.path.exists(cert_path) and os.path.exists(key_path):
-        logger.info(f"Using existing TLS cert from {cert_path}")
-        return True
-    return False
-
-
 def write_cert_and_key(cert_path: Path, key_path: Path, cert_pem: bytes, key_pem: bytes) -> None:
     """Write the cert chain and private key to disk, locking the key to 0600.
 

--- a/compute_space/src/compute_space/core/tls/provision.py
+++ b/compute_space/src/compute_space/core/tls/provision.py
@@ -1,0 +1,59 @@
+import asyncio
+from pathlib import Path
+
+from compute_space.config import CERT_PROVIDER_ACME
+from compute_space.config import Config
+from compute_space.core.tls.acquire_cert import acquire_tls_cert
+from compute_space.core.tls.acquire_cert_broker import acquire_tls_cert_via_broker
+from compute_space.core.tls.cert_api_client import CertApiClient
+from compute_space.core.tls.keycloak import KeycloakClientCredentials
+from compute_space.core.tls.keycloak import KeycloakTokenProvider
+
+
+def provision_cert(config: Config) -> None:
+    """Acquire a TLS cert with the configured provider and install it at the config's cert/key paths.
+
+    Used both for the initial acquisition at startup and for renewals.  The default "acme" provider
+    is the BYO-ACME path; "cert_api" fetches from the openhost-cert-api broker.  Caller must ensure
+    CoreDNS is running (both providers answer DNS-01 challenges through the local zone file).
+
+    The cert_provider value and its required settings are validated when the Config is constructed
+    (Config.__attrs_post_init__), so here we only narrow the optional fields for the type checker.
+    """
+    if config.cert_provider == CERT_PROVIDER_ACME:
+        if not config.acme_account_key_path:
+            raise RuntimeError("ACME account key path must be set in config to acquire TLS cert")
+        asyncio.run(
+            acquire_tls_cert(
+                domain=config.zone_domain,
+                cert_path=config.tls_cert_path,
+                key_path=config.tls_key_path,
+                acme_account_key_path=Path(config.acme_account_key_path),
+                coredns_zonefile_path=config.coredns_zonefile_path,
+                acme_email=config.acme_email,
+                directory_url=config.acme_directory_url,
+            )
+        )
+    else:
+        # cert_provider is guaranteed to be CERT_PROVIDER_CERT_API with all of
+        # the cert_api settings populated (validated in Config.__attrs_post_init__).
+        assert config.cert_api_base_url is not None
+        assert config.cert_api_keycloak_issuer_url is not None
+        assert config.cert_api_keycloak_client_id is not None
+        assert config.cert_api_keycloak_client_secret is not None
+        credentials = KeycloakClientCredentials(
+            issuer_url=config.cert_api_keycloak_issuer_url,
+            client_id=config.cert_api_keycloak_client_id,
+            client_secret=config.cert_api_keycloak_client_secret,
+        )
+        # The token provider fetches a bearer from Keycloak (client-credentials) and
+        # refreshes it transparently across the broker's finalize-poll loop.
+        with KeycloakTokenProvider.create(credentials) as token_provider:
+            with CertApiClient.create(config.cert_api_base_url, token_provider) as client:
+                acquire_tls_cert_via_broker(
+                    domain=config.zone_domain,
+                    cert_path=config.tls_cert_path,
+                    key_path=config.tls_key_path,
+                    coredns_zonefile_path=config.coredns_zonefile_path,
+                    client=client,
+                )

--- a/compute_space/src/compute_space/core/tls/renewal.py
+++ b/compute_space/src/compute_space/core/tls/renewal.py
@@ -1,0 +1,80 @@
+import datetime
+import enum
+import threading
+import time
+from collections.abc import Callable
+from pathlib import Path
+
+from cryptography import x509
+
+from compute_space.config import Config
+from compute_space.core.logging import logger
+from compute_space.core.tls.provision import provision_cert
+
+# Renew well before expiry so transient ACME/DNS failures have days of retries left, not hours.
+RENEW_BEFORE = datetime.timedelta(days=7)
+CHECK_INTERVAL = datetime.timedelta(hours=12)
+RETRY_INTERVAL = datetime.timedelta(hours=1)
+
+
+class CertStatus(enum.Enum):
+    MISSING = "missing"
+    EXPIRED = "expired"
+    EXPIRING_SOON = "expiring_soon"
+    OK = "ok"
+
+
+def get_cert_status(cert_path: Path, key_path: Path, now: datetime.datetime | None = None) -> CertStatus:
+    if not cert_path.exists() or not key_path.exists():
+        return CertStatus.MISSING
+    try:
+        cert = x509.load_pem_x509_certificate(cert_path.read_bytes())
+    except ValueError:
+        # An unreadable cert can't be served; re-acquiring is the remedy, same as expired.
+        logger.warning(f"Could not parse TLS cert at {cert_path}; treating it as expired")
+        return CertStatus.EXPIRED
+    if now is None:
+        now = datetime.datetime.now(datetime.UTC)
+    expires_at = cert.not_valid_after_utc
+    if expires_at <= now:
+        return CertStatus.EXPIRED
+    if expires_at <= now + RENEW_BEFORE:
+        return CertStatus.EXPIRING_SOON
+    return CertStatus.OK
+
+
+def renew_cert_if_needed(
+    config: Config,
+    restart_caddy: Callable[[], None],
+    provision: Callable[[Config], None] = provision_cert,
+) -> bool:
+    """Renew the cert if it is missing, expired, or inside the renewal window.
+
+    Returns True if a new cert was installed (and Caddy restarted to pick it up).
+    """
+    status = get_cert_status(config.tls_cert_path, config.tls_key_path)
+    if status == CertStatus.OK:
+        return False
+    logger.info(f"TLS cert for {config.zone_domain} is {status.value}; renewing")
+    provision(config)
+    restart_caddy()
+    logger.info(f"TLS cert for {config.zone_domain} renewed")
+    return True
+
+
+def start_renewal_thread(config: Config, restart_caddy: Callable[[], None]) -> threading.Thread:
+    """Run renew_cert_if_needed periodically in a daemon thread, retrying sooner after failures."""
+
+    def _loop() -> None:
+        while True:
+            interval = CHECK_INTERVAL
+            try:
+                renew_cert_if_needed(config, restart_caddy)
+            except Exception:
+                logger.exception(f"TLS cert renewal failed; retrying in {RETRY_INTERVAL}")
+                interval = RETRY_INTERVAL
+            time.sleep(interval.total_seconds())
+
+    thread = threading.Thread(target=_loop, name="tls-cert-renewal", daemon=True)
+    thread.start()
+    return thread

--- a/compute_space/src/compute_space/tests/test_cert_renewal.py
+++ b/compute_space/src/compute_space/tests/test_cert_renewal.py
@@ -1,0 +1,122 @@
+import datetime
+from pathlib import Path
+
+import pytest
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import ec
+
+from compute_space.config import Config
+from compute_space.config import DefaultConfig
+from compute_space.core.tls.renewal import RENEW_BEFORE
+from compute_space.core.tls.renewal import CertStatus
+from compute_space.core.tls.renewal import get_cert_status
+from compute_space.core.tls.renewal import renew_cert_if_needed
+
+_NOW = datetime.datetime(2026, 7, 9, tzinfo=datetime.UTC)
+
+
+def _write_self_signed_cert(cert_path: Path, key_path: Path, not_valid_after: datetime.datetime) -> None:
+    key = ec.generate_private_key(ec.SECP256R1())
+    name = x509.Name([x509.NameAttribute(x509.oid.NameOID.COMMON_NAME, "test.example.com")])
+    cert = (
+        x509.CertificateBuilder()
+        .subject_name(name)
+        .issuer_name(name)
+        .public_key(key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(not_valid_after - datetime.timedelta(days=90))
+        .not_valid_after(not_valid_after)
+        .sign(key, hashes.SHA256())
+    )
+    cert_path.write_bytes(cert.public_bytes(serialization.Encoding.PEM))
+    key_path.write_bytes(
+        key.private_bytes(
+            serialization.Encoding.PEM,
+            serialization.PrivateFormat.TraditionalOpenSSL,
+            serialization.NoEncryption(),
+        )
+    )
+
+
+def test_status_missing_when_no_files(tmp_path: Path) -> None:
+    assert get_cert_status(tmp_path / "cert.pem", tmp_path / "key.pem", now=_NOW) == CertStatus.MISSING
+
+
+def test_status_missing_when_key_absent(tmp_path: Path) -> None:
+    cert_path = tmp_path / "cert.pem"
+    _write_self_signed_cert(cert_path, tmp_path / "elsewhere.pem", _NOW + datetime.timedelta(days=60))
+    assert get_cert_status(cert_path, tmp_path / "key.pem", now=_NOW) == CertStatus.MISSING
+
+
+def test_status_expired(tmp_path: Path) -> None:
+    cert_path, key_path = tmp_path / "cert.pem", tmp_path / "key.pem"
+    _write_self_signed_cert(cert_path, key_path, _NOW - datetime.timedelta(days=1))
+    assert get_cert_status(cert_path, key_path, now=_NOW) == CertStatus.EXPIRED
+
+
+def test_status_expiring_soon(tmp_path: Path) -> None:
+    cert_path, key_path = tmp_path / "cert.pem", tmp_path / "key.pem"
+    _write_self_signed_cert(cert_path, key_path, _NOW + RENEW_BEFORE - datetime.timedelta(days=1))
+    assert get_cert_status(cert_path, key_path, now=_NOW) == CertStatus.EXPIRING_SOON
+
+
+def test_status_ok_when_outside_renewal_window(tmp_path: Path) -> None:
+    cert_path, key_path = tmp_path / "cert.pem", tmp_path / "key.pem"
+    _write_self_signed_cert(cert_path, key_path, _NOW + RENEW_BEFORE + datetime.timedelta(days=1))
+    assert get_cert_status(cert_path, key_path, now=_NOW) == CertStatus.OK
+
+
+def test_status_unparseable_cert_treated_as_expired(tmp_path: Path) -> None:
+    cert_path, key_path = tmp_path / "cert.pem", tmp_path / "key.pem"
+    cert_path.write_text("not a certificate")
+    key_path.write_text("not a key")
+    assert get_cert_status(cert_path, key_path, now=_NOW) == CertStatus.EXPIRED
+
+
+def _config(tmp_path: Path) -> Config:
+    config = DefaultConfig(zone_domain="test.example.com", data_root_dir=str(tmp_path))
+    config.openhost_data_path.mkdir(parents=True)
+    return config
+
+
+def test_renew_skips_valid_cert(tmp_path: Path) -> None:
+    config = _config(tmp_path)
+    _write_self_signed_cert(
+        config.tls_cert_path, config.tls_key_path, datetime.datetime.now(datetime.UTC) + datetime.timedelta(days=60)
+    )
+    calls: list[str] = []
+    renewed = renew_cert_if_needed(
+        config, lambda: calls.append("restart"), provision=lambda c: calls.append("provision")
+    )
+    assert renewed is False
+    assert calls == []
+
+
+@pytest.mark.parametrize("days_until_expiry", [-1, 10])
+def test_renew_provisions_and_restarts_caddy(tmp_path: Path, days_until_expiry: int) -> None:
+    config = _config(tmp_path)
+    _write_self_signed_cert(
+        config.tls_cert_path,
+        config.tls_key_path,
+        datetime.datetime.now(datetime.UTC) + datetime.timedelta(days=days_until_expiry),
+    )
+    calls: list[str] = []
+    renewed = renew_cert_if_needed(
+        config, lambda: calls.append("restart"), provision=lambda c: calls.append("provision")
+    )
+    assert renewed is True
+    assert calls == ["provision", "restart"]
+
+
+def test_renew_failure_does_not_restart_caddy(tmp_path: Path) -> None:
+    config = _config(tmp_path)
+    calls: list[str] = []
+
+    def _failing_provision(config: Config) -> None:
+        raise RuntimeError("ACME is down")
+
+    with pytest.raises(RuntimeError, match="ACME is down"):
+        renew_cert_if_needed(config, lambda: calls.append("restart"), provision=_failing_provision)
+    assert calls == []

--- a/compute_space/src/compute_space/tests/test_cert_renewal.py
+++ b/compute_space/src/compute_space/tests/test_cert_renewal.py
@@ -94,13 +94,15 @@ def test_renew_skips_valid_cert(tmp_path: Path) -> None:
     assert calls == []
 
 
-@pytest.mark.parametrize("days_until_expiry", [-1, 10])
-def test_renew_provisions_and_restarts_caddy(tmp_path: Path, days_until_expiry: int) -> None:
+@pytest.mark.parametrize(
+    "expires_in", [datetime.timedelta(days=-1), RENEW_BEFORE - datetime.timedelta(days=1)], ids=["expired", "expiring"]
+)
+def test_renew_provisions_and_restarts_caddy(tmp_path: Path, expires_in: datetime.timedelta) -> None:
     config = _config(tmp_path)
     _write_self_signed_cert(
         config.tls_cert_path,
         config.tls_key_path,
-        datetime.datetime.now(datetime.UTC) + datetime.timedelta(days=days_until_expiry),
+        datetime.datetime.now(datetime.UTC) + expires_in,
     )
     calls: list[str] = []
     renewed = renew_cert_if_needed(

--- a/compute_space/src/compute_space/web/start.py
+++ b/compute_space/src/compute_space/web/start.py
@@ -11,22 +11,20 @@ from typing import Any
 import hypercorn.asyncio
 import hypercorn.config
 
-from compute_space.config import CERT_PROVIDER_ACME
 from compute_space.config import Config
 from compute_space.config import load_config
 from compute_space.config import set_active_config
 from compute_space.core.auth.keys import load_keys
+from compute_space.core.caddy import CaddyProcess
 from compute_space.core.caddy import start_caddy
 from compute_space.core.dns import start_coredns
 from compute_space.core.logging import logger
 from compute_space.core.logging import setup_file_logging
 from compute_space.core.terminal import cleanup_all as cleanup_terminal_sessions
-from compute_space.core.tls.acquire_cert import acquire_tls_cert
-from compute_space.core.tls.acquire_cert import check_if_cert_exists
-from compute_space.core.tls.acquire_cert_broker import acquire_tls_cert_via_broker
-from compute_space.core.tls.cert_api_client import CertApiClient
-from compute_space.core.tls.keycloak import KeycloakClientCredentials
-from compute_space.core.tls.keycloak import KeycloakTokenProvider
+from compute_space.core.tls.provision import provision_cert
+from compute_space.core.tls.renewal import CertStatus
+from compute_space.core.tls.renewal import get_cert_status
+from compute_space.core.tls.renewal import start_renewal_thread
 from compute_space.core.updates import RESTART_EXIT_CODE
 from compute_space.core.updates import initialize_shutdown_event
 from compute_space.db import init_db
@@ -63,54 +61,29 @@ def _owner_exists(config: Config) -> bool:
         db.close()
 
 
-def _acquire_missing_tls_cert(config: Config) -> None:
-    """Acquire a missing TLS cert using the configured provider.
-
-    Caller has already verified the cert is missing, CoreDNS is enabled, and
-    acquire_tls_cert_if_missing is set.  The default "acme" provider is the
-    unchanged BYO-ACME path; "cert_api" fetches from the openhost-cert-api broker.
-
-    The cert_provider value and its required settings are validated when the
-    Config is constructed (Config.__attrs_post_init__), so here we only narrow
-    the optional fields for the type checker.
-    """
-    if config.cert_provider == CERT_PROVIDER_ACME:
-        if not config.acme_account_key_path:
-            raise RuntimeError("ACME account key path must be set in config to acquire TLS cert")
-        asyncio.run(
-            acquire_tls_cert(
-                domain=config.zone_domain,
-                cert_path=config.tls_cert_path,
-                key_path=config.tls_key_path,
-                acme_account_key_path=Path(config.acme_account_key_path),
-                coredns_zonefile_path=config.coredns_zonefile_path,
-                acme_email=config.acme_email,
-                directory_url=config.acme_directory_url,
-            )
-        )
+def _ensure_tls_cert(config: Config) -> None:
+    """Make sure a usable cert+key pair is on disk before Caddy starts, acquiring or renewing as configured."""
+    status = get_cert_status(config.tls_cert_path, config.tls_key_path)
+    if status == CertStatus.OK:
+        logger.info(f"Using existing TLS cert from {config.tls_cert_path}")
+        return
+    if not config.coredns_enabled or not config.acquire_tls_cert_if_missing:
+        # A cert nearing expiry still works, so don't block startup over it.
+        if status == CertStatus.EXPIRING_SOON:
+            logger.warning("TLS cert expires soon but automatic cert acquisition is not enabled; cannot renew")
+            return
+        if not config.coredns_enabled:
+            raise RuntimeError("CoreDNS must be enabled to acquire TLS cert via DNS-01 challenge")
+        raise RuntimeError(f"TLS cert is {status.value} and acquire_tls_cert_if_missing is False")
+    if status == CertStatus.EXPIRING_SOON:
+        # The existing cert is still valid, so a failed renewal shouldn't block
+        # startup — the background renewal loop will keep retrying.
+        try:
+            provision_cert(config)
+        except Exception:
+            logger.exception("TLS cert renewal failed; serving the existing cert and retrying in the background")
     else:
-        # cert_provider is guaranteed to be CERT_PROVIDER_CERT_API with all of
-        # the cert_api settings populated (validated in Config.__attrs_post_init__).
-        assert config.cert_api_base_url is not None
-        assert config.cert_api_keycloak_issuer_url is not None
-        assert config.cert_api_keycloak_client_id is not None
-        assert config.cert_api_keycloak_client_secret is not None
-        credentials = KeycloakClientCredentials(
-            issuer_url=config.cert_api_keycloak_issuer_url,
-            client_id=config.cert_api_keycloak_client_id,
-            client_secret=config.cert_api_keycloak_client_secret,
-        )
-        # The token provider fetches a bearer from Keycloak (client-credentials) and
-        # refreshes it transparently across the broker's finalize-poll loop.
-        with KeycloakTokenProvider.create(credentials) as token_provider:
-            with CertApiClient.create(config.cert_api_base_url, token_provider) as client:
-                acquire_tls_cert_via_broker(
-                    domain=config.zone_domain,
-                    cert_path=config.tls_cert_path,
-                    key_path=config.tls_key_path,
-                    coredns_zonefile_path=config.coredns_zonefile_path,
-                    client=client,
-                )
+        provision_cert(config)
 
 
 def main() -> None:
@@ -132,23 +105,23 @@ def main() -> None:
         )
 
     if config.tls_enabled:
-        if not check_if_cert_exists(config.tls_cert_path, config.tls_key_path):
-            if not config.coredns_enabled:
-                raise RuntimeError("CoreDNS must be enabled to acquire TLS cert via DNS-01 challenge")
-            if not config.acquire_tls_cert_if_missing:
-                raise RuntimeError("TLS cert not found and acquire_tls_cert_if_missing is False")
-            _acquire_missing_tls_cert(config)
+        _ensure_tls_cert(config)
 
     # Caddy reverse proxy. mainly for TLS termination, but also some other features
+    caddy: CaddyProcess | None = None
     if config.start_caddy:
-        children.append(
-            start_caddy(
-                config.caddyfile_path, config.tls_enabled, config.tls_cert_path, config.tls_key_path, config.port
-            )
+        caddy = start_caddy(
+            config.caddyfile_path, config.tls_enabled, config.tls_cert_path, config.tls_key_path, config.port
         )
+        if config.tls_enabled and config.coredns_enabled and config.acquire_tls_cert_if_missing:
+            start_renewal_thread(config, caddy.restart)
     else:
         if config.tls_enabled:
             raise RuntimeError("TLS is enabled but start_caddy is False. Caddy is required for TLS termination.")
+
+    def _all_children() -> list[subprocess.Popen[bytes]]:
+        # Read caddy.proc at shutdown time: restart() may have replaced it.
+        return children + ([caddy.proc] if caddy is not None else [])
 
     hypercorn_config = hypercorn.config.Config()
     # Bind the primary address (127.0.0.1 in production) plus the container
@@ -178,7 +151,7 @@ def main() -> None:
         setup_completed = asyncio.run(_serve(create_setup_app(config), hypercorn_config))
         if not setup_completed:
             logger.info("Setup interrupted by signal; exiting")
-            _terminate_children(children)
+            _terminate_children(_all_children())
             time.sleep(0.1)
             os._exit(0)
 
@@ -188,7 +161,7 @@ def main() -> None:
     restart_requested = asyncio.run(_serve(app, hypercorn_config))
     logger.info(f"hypercorn serve returned, restart_requested={restart_requested}")
 
-    _terminate_children(children)
+    _terminate_children(_all_children())
 
     if restart_requested:
         logger.info(f"Calling os._exit({RESTART_EXIT_CODE})")


### PR DESCRIPTION
## Problem

TLS certs were only acquired when the cert/key files were **missing** — `check_if_cert_exists` never looked at expiry, and nothing re-checked while the router ran. Instances got a 90-day cert on first boot and it silently expired (this bit the `personal` instance). Restarting didn't help since the expired files still existed.

## Changes

- **`core/tls/renewal.py`** (new): `get_cert_status()` parses the cert's notAfter and classifies it as `MISSING` / `EXPIRED` / `EXPIRING_SOON` (within 7 days) / `OK`, plus `start_renewal_thread()` — a daemon thread that checks every 12h, renews when inside the window, and retries hourly after failures.
- **`core/tls/provision.py`** (new): the provider dispatch (BYO-ACME vs cert_api broker) moved verbatim out of `web/start.py` so startup and the renewal loop share one path.
- **`core/caddy.py`**: `start_caddy` now returns a `CaddyProcess` handle with a `restart()` method. Caddy runs with `admin off`, so restarting is the only way to make it pick up renewed cert files; the old process is stopped first since both bind :80/:443.
- **`web/start.py`**: startup uses the expiry-aware check. Missing/expired certs are acquired before serving (fatal if acquisition is disabled, as before). An expiring-but-still-valid cert renews best-effort: failure logs and defers to the background loop instead of blocking startup. A cert nearing expiry with renewal disabled warns instead of crashing (previously it booted fine, and still does).

Renewal answers DNS-01 through the local CoreDNS zone file exactly like initial acquisition; the TXT helpers are only used for ACME challenges, so runtime renewal can't clobber anything.

An instance with an already-expired cert self-heals on its next router restart.

## Testing

- New `tests/test_cert_renewal.py`: status classification (missing/expired/expiring/ok/unparseable) and renew ordering (provision before Caddy restart, no restart on failure, no-op on valid cert).
- Full lightweight suite: 880 passed, 52 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)