### PR TITLE
Redesign settings page for clearer information presentation

### DIFF
--- a/compute_space/src/compute_space/tests/test_dashboard_title.py
+++ b/compute_space/src/compute_space/tests/test_dashboard_title.py
@@ -27,6 +27,7 @@ from compute_space.db import provide_db
 from compute_space.db.connection import init_db
 from compute_space.web.app import _template_globals
 from compute_space.web.routes.pages.apps import dashboard
+from compute_space.web.routes.pages.settings import settings_page
 
 from ._litestar_helpers import auth_cookie
 from ._litestar_helpers import seed_user
@@ -51,7 +52,7 @@ def cfg(tmp_path: Path) -> Iterator[Any]:
 
 
 def _build_app(cfg: Any) -> Litestar:
-    """A minimal app with the real dashboard route + Jinja globals installed."""
+    """A minimal app with the real dashboard + settings routes and Jinja globals installed."""
     web_dir = Path(__file__).resolve().parents[1] / "web"
     template_config: TemplateConfig[JinjaTemplateEngine] = TemplateConfig(
         directory=web_dir / "templates",
@@ -64,7 +65,7 @@ def _build_app(cfg: Any) -> Litestar:
             engine.engine.globals.update(_template_globals(cfg, web_dir / "static"))
 
     app = Litestar(
-        route_handlers=[dashboard],
+        route_handlers=[dashboard, settings_page],
         template_config=template_config,
         dependencies={
             "config": Provide(provide_config, sync_to_thread=False),
@@ -105,8 +106,8 @@ def test_heading_uses_owner_username_when_set(cfg: Any) -> None:
     assert "alice-zone's personal compute space" not in resp.text
 
 
-def test_dashboard_renders_logout_button(cfg: Any) -> None:
-    """The shared layout nav exposes a Log out control that POSTs to /logout.
+def test_settings_renders_logout_button(cfg: Any) -> None:
+    """The settings page exposes a Log out control that POSTs to /logout.
 
     The session cookie is httponly, so logout must round-trip through the
     server; a top-level form POST (samesite=lax) is the correct mechanism.
@@ -115,11 +116,14 @@ def test_dashboard_renders_logout_button(cfg: Any) -> None:
     cookie = auth_cookie(cfg, username="owner")
 
     with TestClient(app=_build_app(cfg)) as client:
-        resp = client.get("/dashboard", cookies=cookie)
-    assert resp.status_code == 200
-    assert 'action="/logout"' in resp.text
-    assert 'method="post"' in resp.text
-    assert "Log out" in resp.text
+        settings_resp = client.get("/settings", cookies=cookie)
+        dashboard_resp = client.get("/dashboard", cookies=cookie)
+    assert settings_resp.status_code == 200
+    assert 'action="/logout"' in settings_resp.text
+    assert 'method="post"' in settings_resp.text
+    assert "Log out" in settings_resp.text
+    # The control lives only on the settings page, not in the shared nav.
+    assert "Log out" not in dashboard_resp.text
 
 
 def test_owner_name_global_reads_live(cfg: Any) -> None:

--- a/compute_space/src/compute_space/web/static/js/settings.js
+++ b/compute_space/src/compute_space/web/static/js/settings.js
@@ -15,7 +15,8 @@ async function checkForUpdates() {
     const resp = await fetch('/api/settings/update');
     if (!resp.ok) {
       const err = await resp.json();
-      el.innerHTML = '<p class="error">Repo is in an invalid state for updating (no .git perhaps?): ' + esc(err.detail || '') + '</p>'
+      el.innerHTML = '<p class="error">Repo is in an invalid state for updating (no .git perhaps?)</p>'
+        + (err.detail ? '<div class="error-inline">' + esc(err.detail) + '</div>' : '')
         + '<button onclick="checkForUpdates()" class="btn" style="margin-top:0.5em;">Retry</button>';
       return;
     }
@@ -26,13 +27,15 @@ async function checkForUpdates() {
     if (data.state === 'UP_TO_DATE') {
       el.innerHTML = '<p style="color:#080;">Up to date.</p>' + checkAgainBtn;
     } else if (data.state === 'UPDATE_AVAILABLE') {
-      const notice = data.error ? '<p class="error">' + esc(data.error) + '</p>' : '';
+      const notice = data.error ? '<div class="error-inline">' + esc(data.error) + '</div>' : '';
       el.innerHTML = '<p>Updates available.</p>'
         + notice
-        + '<button onclick="applyUpdate()" class="btn btn-primary">Update &amp; restart</button> '
+        + '<button onclick="applyUpdate()" class="btn btn-primary" style="margin-top:0.5em;">Update &amp; restart</button> '
         + checkAgainBtn;
     } else if (data.state === 'ERROR') {
-      el.innerHTML = '<p class="error">' + esc(data.error || 'Unknown error') + '</p>' + checkAgainBtn;
+      el.innerHTML = '<p class="error">Update check failed.</p>'
+        + '<div class="error-inline">' + esc(data.error || 'Unknown error') + '</div>'
+        + checkAgainBtn;
     }
   } catch (e) {
     showError('Failed to check for updates: ' + e.message);
@@ -120,7 +123,11 @@ async function loadRemote() {
       btn.disabled = input.value.trim() === savedRemote;
     });
   } catch (e) {
-    input.placeholder = 'Failed to load remote';
+    input.placeholder = '';
+    const msg = document.getElementById('remote-msg');
+    msg.textContent = 'Failed to load current remote. Reload the page to retry.';
+    msg.className = 'error';
+    msg.style.display = '';
   }
 }
 
@@ -398,7 +405,7 @@ function renderArchiveBackend(state) {
   var el = document.getElementById('archive-backend-status');
   var rows = '';
   if (state.backend === 's3') {
-    rows += '<tr><th class="label-col">Backend</th>'
+    rows += '<tr><th>Backend</th>'
       + '<td><span class="status-running">S3 (JuiceFS)</span>'
       + (state.state_message ? ' <span class="error">' + escSettingsHtml(state.state_message) + '</span>' : '')
       + '</td></tr>';
@@ -429,7 +436,7 @@ function renderArchiveBackend(state) {
     }
     rows += '<tr><th>Latest meta dump</th><td>' + dumpLine + '</td></tr>';
   } else {
-    rows += '<tr><th class="label-col">Backend</th>'
+    rows += '<tr><th>Backend</th>'
       + '<td><span class="status-stopped">not configured</span></td></tr>';
   }
 
@@ -439,17 +446,12 @@ function renderArchiveBackend(state) {
       + 'Filename-to-S3-chunk mappings live in a SQLite metadata DB on this zone’s local disk; '
       + 'recovery after the local disk is wiped requires the latest meta dump in S3 plus a manual <code>juicefs load</code>.</p>';
   }
-  var disabledNote = '';
   var configureBtn = '';
   if (state.backend === 'disabled') {
-    disabledNote = '<p class="hint"><strong>No archive backend configured.</strong> '
-      + 'Apps that opt into the <code>app_archive</code> data tier (such as Immich) will refuse to install until S3 storage is configured below. Apps that don’t use the archive tier are unaffected. '
-      + '<strong>This is a one-time setup; reconfiguration is not supported.</strong></p>';
     configureBtn = '<div class="control-row"><button class="btn" id="archive-backend-configure-btn">Configure S3 backend…</button></div>';
   }
 
-  el.innerHTML = '<table id="archive-backend-table"><tbody>' + rows + '</tbody></table>'
-    + disabledNote
+  el.innerHTML = '<table id="archive-backend-table" class="form-table"><tbody>' + rows + '</tbody></table>'
     + experimentalNote
     + configureBtn
     + '<div id="archive-backend-form" hidden></div>';

--- a/compute_space/src/compute_space/web/templates/layout.html
+++ b/compute_space/src/compute_space/web/templates/layout.html
@@ -15,10 +15,7 @@
     .btn-danger { background: #fee; border-color: #c00; color: #c00; }
     .btn-primary { background: #e8f0fe; border-color: #36c; color: #36c; }
     nav { display: flex; align-items: flex-end; gap: 0.25em; border-bottom: 1px solid #e8e8e8; }
-    nav .spacer { flex: 1; }
     nav .nav-user { color: #888; font-size: 0.9em; margin-right: 0.5em; align-self: center; }
-    nav form.logout-form { margin: 0; align-self: center; }
-    nav .btn-logout { padding: 0.3em 0.9em; font-size: 0.9em; }
     .nav-tab { display: inline-block; padding: 0.4em 1em; border: 1px solid transparent; border-bottom: none; border-radius: 4px 4px 0 0; text-decoration: none; color: #444; background: transparent; }
     .nav-tab:hover { background: #f0f0f0; color: #222; border-color: #ddd; }
     .nav-tab.active { background: #fff; border-color: #ddd; color: #222; margin-bottom: -1px; padding-bottom: calc(0.4em + 1px); }
@@ -34,6 +31,7 @@
     .toast p { margin: 0 0 0.75em 0; }
     .toast .toast-actions { display: flex; gap: 0.5em; }
     h2 { margin-top: 2em; }
+    h2.section-title { border-bottom: 1px solid #eee; padding-bottom: 0.3em; }
     .app-link { color: #36c; text-decoration: none; font-weight: bold; }
     .app-link:visited { color: #36c; }
     .app-link:hover { text-decoration: underline; }
@@ -43,6 +41,8 @@
     .control-row { display: flex; gap: 0.5em; align-items: center; flex-wrap: wrap; margin: 1em 0; }
     table.form-table th { font-weight: normal; width: 12em; vertical-align: top; }
     table.form-table input[type="text"], table.form-table input[type="password"] { width: 24em; max-width: 100%; }
+    table.form-table td p { margin: 0.4em 0 0; }
+    table.form-table td p:first-child { margin-top: 0; }
   </style>
 </head>
 <body>
@@ -54,10 +54,6 @@
     <a href="/terminal/" class="nav-tab">Terminal</a>
     <a href="/system/" class="nav-tab">System Info</a>
     <a href="/settings" class="nav-tab">Settings</a>
-    <span class="spacer"></span>
-    <form class="logout-form" method="post" action="/logout">
-      <button type="submit" class="btn btn-danger btn-logout">Log out</button>
-    </form>
   </nav>
   <script>
     (function() {

--- a/compute_space/src/compute_space/web/templates/settings.html
+++ b/compute_space/src/compute_space/web/templates/settings.html
@@ -1,69 +1,81 @@
 {% extends "layout.html" %}
 {% block title_suffix %} - Settings{% endblock %}
 {% block content %}
-<h2>Settings</h2>
-
 <p id="error" class="error" style="display:none;"></p>
 
-<h3>Owner username</h3>
-<p style="font-size:0.85em; color:#666; margin:0 0 0.5em;">
-  The name apps you install (PeerTube, Mastodon, etc.) use as your
-  account name when they receive your identity from OpenHost. Sign-in
-  only requires the password; this name is for downstream apps.
-  Already-running apps will pick up changes on their next reload.
-  <br>
-  Allowed: lowercase letters, digits, and <code>.</code>
-  <code>_</code> <code>-</code>; must start with a letter or digit;
-  max&nbsp;30 characters. No <code>@</code>, spaces, or uppercase.
-</p>
-<div id="username-status">
-  <div style="display:flex; gap:0.5em; align-items:center;">
-    <input type="text" id="username-input"
-           pattern="[a-z0-9][a-z0-9._\-]{0,29}" maxlength="30"
-           aria-describedby="username-msg"
-           placeholder="Loading…" disabled style="flex:1;">
-    <button onclick="setOwnerUsername()" class="btn btn-primary"
-            id="set-username-btn" disabled>Save</button>
-  </div>
-  <p id="username-msg" style="margin-top:0.3em; display:none;"></p>
-</div>
+<h2 class="section-title">Account</h2>
+<table class="form-table">
+  <tr>
+    <th><label for="username-input">Owner username</label></th>
+    <td>
+      <input type="text" id="username-input"
+             pattern="[a-z0-9][a-z0-9._\-]{0,29}" maxlength="30"
+             aria-describedby="username-msg"
+             placeholder="Loading…" disabled>
+      <button onclick="setOwnerUsername()" class="btn btn-primary"
+              id="set-username-btn" disabled>Save</button>
+      <p class="hint">Used as your account name inside installed apps.</p>
+      <p id="username-msg" style="display:none;"></p>
+    </td>
+  </tr>
+  <tr>
+    <th>Password</th>
+    <td>
+      <button id="show-pw-form-btn" class="btn"
+              onclick="this.style.display = 'none'; document.getElementById('pw-form').hidden = false;">Change password</button>
+      <div id="pw-form" hidden>
+        <input type="password" id="current-pw" placeholder="Current password" style="display:block; margin-bottom:0.3em;">
+        <input type="password" id="new-pw" placeholder="New password" style="display:block; margin-bottom:0.3em;">
+        <input type="password" id="confirm-pw" placeholder="Confirm new password" style="display:block; margin-bottom:0.5em;">
+        <button onclick="changePassword()" class="btn btn-primary">Change password</button>
+        <span id="pw-msg" style="display:none;"></span>
+      </div>
+    </td>
+  </tr>
+  <tr>
+    <th>Session</th>
+    <td>
+      <form method="post" action="/logout" style="margin:0;">
+        <button type="submit" class="btn btn-danger">Log out</button>
+      </form>
+    </td>
+  </tr>
+</table>
 
-<h3>Git Remote</h3>
-<div id="remote-status">
-  <div style="display:flex; gap:0.5em; align-items:center;">
-    <input type="text" id="remote-url" placeholder="Loading…" disabled style="flex:1;">
-    <button onclick="setRemote()" class="btn btn-primary" id="set-remote-btn" disabled>Set &amp; restart</button>
-  </div>
-  <p id="remote-msg" style="margin-top:0.3em; display:none;"></p>
-</div>
+<h2 class="section-title">Software updates</h2>
+<table class="form-table">
+  <tr>
+    <th><label for="remote-url">Git remote</label></th>
+    <td>
+      <input type="text" id="remote-url" placeholder="Loading…" disabled style="width:32em;">
+      <button onclick="setRemote()" class="btn btn-primary" id="set-remote-btn" disabled>Set &amp; restart</button>
+      <p class="hint">Repository this instance updates from.</p>
+      <p id="remote-msg" style="display:none;"></p>
+    </td>
+  </tr>
+  <tr>
+    <th>Status</th>
+    <td>
+      <div id="update-status">
+        <p>Checking for updates&hellip;</p>
+      </div>
+      <div id="restart-overlay" style="display:none;">
+        <p id="restart-status"><strong>Waiting for shutdown&hellip;</strong></p>
+      </div>
+    </td>
+  </tr>
+</table>
 
-<h3>Updates</h3>
-<div id="update-status">
-  <p>Checking for updates&hellip;</p>
-</div>
-<div id="restart-overlay" style="display:none;">
-  <p id="restart-status"><strong>Waiting for shutdown&hellip;</strong></p>
-</div>
+<h2 class="section-title">API tokens</h2>
+<p class="hint">Bearer tokens for programmatic access (e.g. AI agents). Each token grants owner-level access until it expires.</p>
 
-<h3>Change Password</h3>
-<div>
-  <input type="password" id="current-pw" placeholder="Current password" style="margin-bottom:0.3em;">
-  <input type="password" id="new-pw" placeholder="New password" style="margin-bottom:0.3em;">
-  <input type="password" id="confirm-pw" placeholder="Confirm new password" style="margin-bottom:0.3em;">
-  <button onclick="changePassword()" class="btn btn-primary">Change Password</button>
-  <p id="pw-msg" style="display:none; margin-top:0.3em;"></p>
-</div>
-
-<h2>API Tokens</h2>
-<p style="color: #666; font-size: 0.9em;">Bearer tokens for programmatic access (e.g. AI agents). Each token grants owner-level access until it expires.</p>
-
-<div style="margin-bottom: 1em; display: flex; gap: 0.5em; align-items: center; flex-wrap: wrap;">
-  <label>name: <input type="text" id="token-name" style="width: 200px;"></label>
+<div class="control-row">
+  <label>Name <input type="text" id="token-name" style="width: 200px;"></label>
   <label>Expires in
     <input type="number" id="token-expiry" value="8" min="0.1" step="any" style="width: 70px;" disabled> hours
   </label>
   <label><input type="checkbox" id="token-no-expiry" checked onchange="document.getElementById('token-expiry').disabled = this.checked;"> Never expires</label>
-  <button class="btn btn-primary" onclick="createToken()">Create Token</button>
+  <button class="btn btn-primary" onclick="createToken()">Create token</button>
 </div>
 
 <div id="token-created" style="display:none; background: #d4edda; border: 1px solid #28a745; padding: 0.8em 1em; border-radius: 4px; margin-bottom: 1em;">
@@ -76,32 +88,34 @@
   <thead><tr><th>Name</th><th>Created</th><th>Expires</th><th>Actions</th></tr></thead>
   <tbody id="tokens-body"></tbody>
 </table>
-<p id="no-tokens" style="color: #888;">No API tokens.</p>
+<p id="no-tokens" class="muted">No API tokens.</p>
 
-<h2>Archive Backend</h2>
-<p class="hint">Where the <code>app_archive</code> data tier lives. Disabled by default; configure an S3 bucket here once and apps with <code>app_archive = true</code> get a JuiceFS-backed mount whose contents survive a zone reinstall. The prefix lets multiple zones share one bucket. Configuration is one-shot per zone.</p>
+<h2 class="section-title">Archive backend</h2>
+<p class="hint">An optional S3-backed data tier (<code>app_archive</code>), used by apps that store large amounts of data which might not fit an instance's local storage.</p>
 <div id="archive-backend-status">
   <div class="muted">Loading&hellip;</div>
 </div>
 
-<h2>Maintenance</h2>
-<table>
+<h2 class="section-title">Maintenance</h2>
+<table class="form-table">
   <tr>
-    <th class="label-col">Restart compute space</th>
+    <th>Restart compute space</th>
     <td>
-      <button class="btn btn-danger" onclick="restartComputeSpace()">Restart Compute Space</button>
+      <button class="btn btn-danger" onclick="restartComputeSpace()">Restart compute space</button>
       <span id="restart-msg" class="muted"></span>
+      <p class="hint">Restarts the router process; running apps are not interrupted.</p>
     </td>
   </tr>
   <tr>
-    <th class="label-col">Build cache</th>
+    <th>Build cache</th>
     <td>
-      <button class="btn btn-danger" id="drop-build-cache-btn" onclick="dropBuildCache()">Drop Build Cache</button>
+      <button class="btn btn-danger" id="drop-build-cache-btn" onclick="dropBuildCache()">Drop build cache</button>
       <span id="drop-build-cache-msg" class="muted"></span>
+      <p class="hint">Removes images for stopped apps; they are rebuilt on next deploy.</p>
     </td>
   </tr>
   <tr>
-    <th class="label-col">SSH</th>
+    <th>SSH</th>
     <td>
       <button class="btn" id="ssh-btn" onclick="toggleSsh()" disabled>SSH</button>
       <span id="ssh-status" class="muted"></span>


### PR DESCRIPTION
## Summary

A minimal redesign of the settings page focused on information presentation, keeping the project's existing flat, utilitarian style.

- Regroup the page into five sections with a consistent heading hierarchy: **Account** (username, password, log out), **Software updates** (git remote + update status, united since the remote feeds updates), **API tokens**, **Archive backend**, **Maintenance**
- Use the existing `form-table` label+control pattern for all sections, capping input widths instead of full-page-width fields
- Move **Log out** from the shared nav (shown on every tab) into the Account section
- Collapse the change-password form behind a single "Change password" button
- Present update-check failures as a one-line summary with raw command output contained in an `error-inline` box; surface the git-remote load failure as a visible error instead of placeholder text in a disabled input
- Trim hint text (username, git remote, archive backend) and standardize button casing
- Update `test_dashboard_renders_logout_button` → `test_settings_renders_logout_button` to match the logout control's new home

## Testing

- `pixi run -e dev pytest -x` — 880 passed, 52 skipped
- Verified visually via `scripts/run_local_stack.py` + Playwright screenshots (collapsed and expanded password form states)

🤖 Generated with [Claude Code](https://claude.com/claude-code)