### PR TITLE
Replace built-in apps list with catalog callout on Deploy page

### DIFF
--- a/compute_space/src/compute_space/core/apps.py
+++ b/compute_space/src/compute_space/core/apps.py
@@ -147,32 +147,6 @@ def find_app_by_name(name: str) -> App | None:
     return App.from_row(row) if row else None
 
 
-def list_builtin_apps(config: Config) -> list[dict[str, str]]:
-    """Return list of dicts with name/url for each app in the builtin apps dir.
-
-    Apps with ``hidden = true`` in their ``[app]`` section are excluded so they
-    don't appear on the dashboard but remain deployable via direct URL.
-    """
-    builtin: list[dict[str, str]] = []
-    if not os.path.isdir(config.apps_dir):
-        return builtin
-    for entry in sorted(os.listdir(config.apps_dir)):
-        app_dir = os.path.join(config.apps_dir, entry)
-        manifest_path = os.path.join(app_dir, "openhost.toml")
-        if not os.path.isfile(manifest_path):
-            continue
-        try:
-            manifest = parse_manifest(app_dir)
-            if manifest.hidden:
-                continue
-        except Exception:
-            # Unparseable manifest — still list it so the user sees the error
-            # at deploy time rather than the app silently disappearing.
-            pass
-        builtin.append({"name": entry, "url": f"file://{app_dir}"})
-    return builtin
-
-
 def inject_github_token_in_url(url: str, token: str) -> str:
     """Inject a GitHub OAuth token into an HTTP(S) URL for authentication."""
     parsed = urllib.parse.urlparse(url)

--- a/compute_space/src/compute_space/tests/test_add_app_page.py
+++ b/compute_space/src/compute_space/tests/test_add_app_page.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+import sqlite3
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Any
+
+import pytest
+from litestar import Litestar
+from litestar.contrib.jinja import JinjaTemplateEngine
+from litestar.di import Provide
+from litestar.template.config import TemplateConfig
+from litestar.testing import TestClient
+
+from compute_space.config import provide_config
+from compute_space.config import set_active_config
+from compute_space.db import provide_db
+from compute_space.db.connection import init_db
+from compute_space.web.app import _template_globals
+from compute_space.web.routes.pages.apps import add_app
+
+from ._litestar_helpers import auth_cookie
+from .conftest import _make_test_config
+
+
+@pytest.fixture
+def cfg(tmp_path: Path) -> Iterator[Any]:
+    config = _make_test_config(tmp_path)
+    init_db(config.db_path)
+    yield config
+
+
+def _build_app(cfg: Any) -> Litestar:
+    web_dir = Path(__file__).resolve().parents[1] / "web"
+    template_config: TemplateConfig[JinjaTemplateEngine] = TemplateConfig(
+        directory=web_dir / "templates",
+        engine=JinjaTemplateEngine,
+    )
+
+    def _install_globals(app: Litestar) -> None:
+        engine = app.template_engine
+        if isinstance(engine, JinjaTemplateEngine):
+            engine.engine.globals.update(_template_globals(cfg, web_dir / "static"))
+
+    return Litestar(
+        route_handlers=[add_app],
+        template_config=template_config,
+        dependencies={
+            "config": Provide(provide_config, sync_to_thread=False),
+            "db": Provide(provide_db),
+        },
+        on_startup=[_install_globals],
+        openapi_config=None,
+    )
+
+
+def _seed_catalog_app(db_path: str) -> None:
+    conn = sqlite3.connect(db_path)
+    try:
+        conn.execute(
+            "INSERT INTO apps (app_id, name, version, repo_path, local_port, status)"
+            " VALUES ('catalogappid', 'catalog', '0.1.0', '/tmp/catalog', 19123, 'running')"
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def test_callout_links_to_catalog_when_installed(cfg: Any) -> None:
+    set_active_config(cfg)
+    cookie = auth_cookie(cfg)
+    _seed_catalog_app(cfg.db_path)
+
+    with TestClient(app=_build_app(cfg)) as client:
+        resp = client.get("/add_app", cookies=cookie)
+    assert resp.status_code == 200
+    assert "Explore the App Catalog" in resp.text
+    assert f"http://catalog.{cfg.zone_domain}/" in resp.text
+    assert "Install the catalog" not in resp.text
+    assert "Available Built-in Apps" not in resp.text
+
+
+def test_callout_offers_install_when_catalog_missing(cfg: Any) -> None:
+    set_active_config(cfg)
+    cookie = auth_cookie(cfg)
+
+    with TestClient(app=_build_app(cfg)) as client:
+        resp = client.get("/add_app", cookies=cookie)
+    assert resp.status_code == 200
+    assert "Explore the App Catalog" in resp.text
+    assert "Install the catalog" in resp.text
+    assert "https://github.com/imbue-openhost/openhost-catalog" in resp.text
+    assert f"http://catalog.{cfg.zone_domain}/" not in resp.text

--- a/compute_space/src/compute_space/tests/test_integration.py
+++ b/compute_space/src/compute_space/tests/test_integration.py
@@ -289,17 +289,15 @@ class TestRouterCore:
         assert r.status_code == 403
         assert "already been set up" in r.text
 
-    def test_add_app_page_hides_hidden_builtin_apps(self, admin_session, config):
-        """Apps with hidden=true in their manifest must not appear on the Deploy page."""
+    def test_add_app_page_shows_catalog_callout(self, admin_session, config):
+        """The Deploy page points at the app catalog instead of listing builtin apps."""
         base_url = _zone_url(config)
         r = admin_session.get(f"{base_url}/add_app")
         assert r.status_code == 200
-        # test_app has hidden = true — it must not show up
+        assert "Explore the App Catalog" in r.text
+        assert "Deploy from Git URL" in r.text
+        assert "Available Built-in Apps" not in r.text
         assert "test_app" not in r.text
-        # Non-hidden apps should still be listed (pick one that definitely exists)
-        assert "file_browser" in r.text or "oauth" in r.text, (
-            "Expected at least one non-hidden builtin app on the Deploy page"
-        )
 
     def test_add_app_no_url(self, admin_session, config):
         base_url = _zone_url(config)

--- a/compute_space/src/compute_space/web/routes/pages/apps.py
+++ b/compute_space/src/compute_space/web/routes/pages/apps.py
@@ -11,7 +11,6 @@ from litestar.response import Template
 from compute_space.config import Config
 from compute_space.core.app_id import is_valid_app_name
 from compute_space.core.apps import deserialize_links
-from compute_space.core.apps import list_builtin_apps
 from compute_space.core.auth.permissions_v2 import get_all_permissions_v2
 from compute_space.core.containers import get_docker_logs
 from compute_space.core.git_ops import UnsupportedRepoUrlError
@@ -26,6 +25,11 @@ from compute_space.web.auth.auth import require_owner_auth
 
 EDIT_APP_SERVICE_URL = "github.com/imbue-openhost/claude-code-container/services/open-workspace"
 EDIT_APP_VERSION_SPEC = "<1.0"
+
+# The app catalog ships as a default app (see Config.default_apps); the Deploy
+# page links to it when installed and offers to install it otherwise.
+CATALOG_APP_NAME = "catalog"
+CATALOG_REPO_URL = "https://github.com/imbue-openhost/openhost-catalog"
 
 
 @get(["/", "/dashboard"], guards=[require_owner_auth])
@@ -170,11 +174,14 @@ async def _resolve_edit_app(
 
 
 @get("/add_app", guards=[require_owner_auth])
-async def add_app(config: Config, repo: str = "", next: str = "") -> Template:
+async def add_app(db: sqlite3.Connection, repo: str = "", next: str = "") -> Template:
+    catalog_installed = db.execute("SELECT 1 FROM apps WHERE name = ?", (CATALOG_APP_NAME,)).fetchone() is not None
     return Template(
         template_name="add_app.html",
         context={
-            "builtin_apps": list_builtin_apps(config),
+            "catalog_installed": catalog_installed,
+            "catalog_app_name": CATALOG_APP_NAME,
+            "catalog_repo_url": CATALOG_REPO_URL,
             "initial_repo": repo,
             "next_url": next,
         },

--- a/compute_space/src/compute_space/web/templates/add_app.html
+++ b/compute_space/src/compute_space/web/templates/add_app.html
@@ -1,46 +1,57 @@
 {% extends "layout.html" %}
 {% block title_suffix %} - Deploy App{% endblock %}
 {% block content %}
+<style>
+  .catalog-callout { display: flex; align-items: center; gap: 1.2em; border: 1px solid #cfdcf5; background: #f5f8fe; border-radius: 8px; padding: 1.1em 1.4em; margin: 1.2em 0 2em; }
+  .catalog-callout .callout-icon { font-size: 2.1em; line-height: 1; }
+  .catalog-callout h3 { margin: 0 0 0.25em; }
+  .catalog-callout p { margin: 0; color: #555; }
+  .catalog-callout .callout-action { margin-left: auto; white-space: nowrap; }
+  .repo-url-row { display: flex; gap: 0.5em; margin-top: 0.6em; }
+  .repo-url-row input { flex: 1; }
+  .repo-url-row .btn { white-space: nowrap; }
+  details.url-help { margin-top: 0.8em; color: #555; font-size: 0.9em; }
+  details.url-help summary { cursor: pointer; color: #36c; }
+  details.url-help ul { margin: 0.5em 0 0; }
+</style>
+
 <h2>Deploy New App</h2>
 
 <p id="error" class="error" style="display:none;"></p>
 
 <div id="clone-form">
 
-{% if builtin_apps %}
-<h3>Available Built-in Apps</h3>
-<table>
-  <tr>
-    <th>Name</th>
-    <th>Actions</th>
-  </tr>
-  {% for ba in builtin_apps %}
-  <tr>
-    <td>{{ ba.name }}</td>
-    <td>
-      <button class="btn btn-primary" onclick="cloneApp('{{ ba.url }}')">Deploy</button>
-    </td>
-  </tr>
-  {% endfor %}
-</table>
-{% endif %}
+  <div class="catalog-callout">
+    <span class="callout-icon">🧭</span>
+    <div>
+      <h3>Explore the App Catalog</h3>
+      <p>Discover new apps for your compute space and install them with a click.</p>
+    </div>
+    {% if catalog_installed %}
+    <a class="btn btn-primary callout-action" href="{{ app_url(catalog_app_name) }}">Browse the catalog</a>
+    {% else %}
+    <button class="btn btn-primary callout-action" onclick="cloneApp('{{ catalog_repo_url }}')">Install the catalog</button>
+    {% endif %}
+  </div>
 
   <h3>Deploy from Git URL</h3>
   <p>Clone a git repository containing an <code>openhost.toml</code> manifest file.
   Private GitHub repos are supported automatically &mdash; you'll be prompted to connect your
-  GitHub account if needed. You can also access private repos by including an access token directly in the URL.</p>
-  <p>To specify a branch, tag, or commit, append <code>@ref</code> to the URL:</p>
-  <ul style="font-size:0.9em; color:#555">
-    <li><code>https://github.com/user/repo</code> &mdash; default branch</li>
-    <li><code>https://github.com/user/repo@my-branch</code> &mdash; specific branch</li>
-    <li><code>https://github.com/user/repo@v1.0</code> &mdash; tag</li>
-    <li><code>https://github.com/user/repo@abc123</code> &mdash; commit hash</li>
-    <li><code>https://&lt;token&gt;@github.com/user/private-repo</code> &mdash; private repo via access token</li>
-  </ul>
-  <label>Git repository URL</label>
-  <input type="text" id="repo-url" required placeholder="https://github.com/user/my-app@branch">
-  <br><br>
-  <button onclick="cloneApp()" class="btn btn-primary">Deploy</button>
+  GitHub account if needed.</p>
+  <div class="repo-url-row">
+    <input type="text" id="repo-url" required placeholder="https://github.com/user/my-app@branch">
+    <button onclick="cloneApp()" class="btn btn-primary">Deploy</button>
+  </div>
+  <details class="url-help">
+    <summary>URL format examples</summary>
+    <ul>
+      <li><code>https://github.com/user/repo</code> &mdash; default branch</li>
+      <li><code>https://github.com/user/repo@my-branch</code> &mdash; specific branch</li>
+      <li><code>https://github.com/user/repo@v1.0</code> &mdash; tag</li>
+      <li><code>https://github.com/user/repo@abc123</code> &mdash; commit hash</li>
+      <li><code>https://&lt;token&gt;@github.com/user/private-repo</code> &mdash; private repo via access token</li>
+    </ul>
+  </details>
 </div>
 
 <div id="cloning-status" style="display:none;">


### PR DESCRIPTION
The Deploy page no longer lists the vendored builtin apps. In their place is an "Explore the App Catalog" callout:

- If an app named `catalog` is installed, it links to the catalog app's subdomain.
- Otherwise the button starts the normal deploy flow with the catalog repo URL pre-filled, so one click installs it.

The "Deploy from Git URL" section is also tidied: the input and Deploy button share one row, and the URL format examples are collapsed behind a disclosure.

`list_builtin_apps` had no remaining callers and is removed.

Pairs with imbue-openhost/openhost-catalog PR adding a "Back to Openhost Dashboard" nav link to the catalog, so navigation works in both directions.

## Testing

- New `test_add_app_page.py` covers both callout variants (catalog installed / missing).
- `test_add_app_page_hides_hidden_builtin_apps` became `test_add_app_page_shows_catalog_callout`.
- Full lightweight suite passes: 882 passed, 52 skipped. Ruff + mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)