### PR TITLE
Redesign System Info page

### DIFF
--- a/compute_space/src/compute_space/core/auth/security_audit.py
+++ b/compute_space/src/compute_space/core/auth/security_audit.py
@@ -167,7 +167,7 @@ def _secure_ports() -> dict[int, str]:
     return secure
 
 
-def _is_loopback(addr: str) -> bool:
+def is_loopback_address(addr: str) -> bool:
     host = addr.rsplit(":", 1)[0]
     host = host.strip("[]")
     return host in ("127.0.0.1", "::1") or host.startswith("127.")
@@ -229,7 +229,7 @@ def list_listening_ports(db: sqlite3.Connection | None = None) -> list[Listening
             classification, label = "allocated", f"App: {app_by_port[port]}"
         elif 9000 <= port <= 9999:
             classification, label = "app_range", "App range (9000-9999)"
-        elif _is_loopback(addr) and 6060 <= port <= 6099:
+        elif is_loopback_address(addr) and 6060 <= port <= 6099:
             classification, label = "secure", "JuiceFS pprof agent (loopback)"
         else:
             classification, label = "unexpected", "Unexpected"
@@ -240,6 +240,11 @@ def list_listening_ports(db: sqlite3.Connection | None = None) -> list[Listening
 
     ports.sort(key=lambda p: (p["port"], p["address"]))
     return ports
+
+
+def external_ports(ports: list[ListeningPort]) -> list[ListeningPort]:
+    """Filter to ports bound to external-facing or wildcard addresses (loopback excluded)."""
+    return [p for p in ports if not is_loopback_address(p["address"])]
 
 
 def _check_no_unexpected_ports(db: sqlite3.Connection | None = None) -> CheckResult:

--- a/compute_space/src/compute_space/core/auth/security_audit.py
+++ b/compute_space/src/compute_space/core/auth/security_audit.py
@@ -11,6 +11,8 @@ import sqlite3
 import subprocess
 from typing import TypedDict
 
+from compute_space.core.containers import CONTAINER_GATEWAY_IP
+
 
 class CheckResult(TypedDict):
     ok: bool
@@ -243,8 +245,17 @@ def list_listening_ports(db: sqlite3.Connection | None = None) -> list[Listening
 
 
 def external_ports(ports: list[ListeningPort]) -> list[ListeningPort]:
-    """Filter to ports bound to external-facing or wildcard addresses (loopback excluded)."""
-    return [p for p in ports if not is_loopback_address(p["address"])]
+    """Filter to ports reachable from outside the VM.
+
+    Loopback and the internal container-gateway interface (``openhost0``,
+    10.200.0.1) are excluded; wildcard and specific external binds are kept.
+    """
+
+    def _internal(addr: str) -> bool:
+        host = addr.rsplit(":", 1)[0].strip("[]")
+        return is_loopback_address(addr) or host == CONTAINER_GATEWAY_IP
+
+    return [p for p in ports if not _internal(p["address"])]
 
 
 def _check_no_unexpected_ports(db: sqlite3.Connection | None = None) -> CheckResult:

--- a/compute_space/src/compute_space/core/containers.py
+++ b/compute_space/src/compute_space/core/containers.py
@@ -19,6 +19,7 @@ via ``--add-host`` so existing Dockerfiles keep resolving.
 
 from __future__ import annotations
 
+import json
 import os
 import re
 import sqlite3
@@ -444,6 +445,30 @@ def remove_image(app_name: str) -> None:
     """Remove the image built for an app.  Idempotent."""
     image_tag = f"openhost-{app_name}:latest"
     subprocess.run(["podman", "rmi", image_tag], capture_output=True, timeout=30)
+
+
+def container_image_storage_bytes() -> int | None:
+    """Total bytes podman uses for image storage (the build cache), from ``podman system df``.
+
+    Returns None when podman is unavailable or the output can't be parsed,
+    so status reporting degrades instead of failing the whole endpoint.
+    """
+    try:
+        result = subprocess.run(
+            ["podman", "system", "df", "--format", "json"],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        if result.returncode != 0:
+            return None
+        for row in json.loads(result.stdout):
+            if row.get("Type") == "Images":
+                return int(row["RawSize"])
+        return None
+    except Exception as e:
+        logger.warning("Could not query podman image storage size: %s", e)
+        return None
 
 
 def drop_docker_build_cache() -> str:

--- a/compute_space/src/compute_space/core/storage.py
+++ b/compute_space/src/compute_space/core/storage.py
@@ -80,18 +80,24 @@ def _dir_size_bytes(path: str) -> int:
     """Return total size of all files under *path* in bytes.
 
     There is no stdlib equivalent — ``shutil.disk_usage`` reports whole-disk
-    stats, not per-directory totals.  ``os.walk`` + ``os.path.getsize`` is the
-    standard approach.
+    stats, not per-directory totals.  Uses ``os.scandir`` recursion rather
+    than ``os.walk`` + ``getsize`` so each file is stat'd once, not twice —
+    this endpoint walks entire app data trees.  Symlinks are not followed.
     """
-    if not os.path.exists(path):
+    try:
+        entries = os.scandir(path)
+    except OSError:
         return 0
-
     total = 0
-    for root, _dirs, files in os.walk(path):
-        for filename in files:
-            file_path = os.path.join(root, filename)
+    with entries:
+        for entry in entries:
             try:
-                total += os.path.getsize(file_path)
+                if entry.is_symlink():
+                    continue
+                if entry.is_dir(follow_symlinks=False):
+                    total += _dir_size_bytes(entry.path)
+                else:
+                    total += entry.stat(follow_symlinks=False).st_size
             except OSError:
                 pass
     return total
@@ -116,11 +122,6 @@ def openhost_data_usage_bytes(config: Config) -> int:
     return _dir_size_bytes(os.path.join(config.persistent_data_dir, "vm_data"))
 
 
-def app_data_usage_bytes(config: Config) -> int:
-    _ensure_storage_roots(config)
-    return _dir_size_bytes(os.path.join(config.persistent_data_dir, "app_data"))
-
-
 def per_app_usage(config: Config) -> dict[str, int]:
     """Return ``{app_name: bytes_used}`` for each subdirectory of app_data."""
     _ensure_storage_roots(config)
@@ -133,6 +134,24 @@ def per_app_usage(config: Config) -> dict[str, int]:
         if os.path.isdir(entry_path):
             result[entry] = _dir_size_bytes(entry_path)
     return result
+
+
+def _app_data_loose_file_bytes(config: Config) -> int:
+    """Size of files sitting directly in app_data (not inside a per-app dir)."""
+    app_data_root = os.path.join(config.persistent_data_dir, "app_data")
+    try:
+        entries = os.scandir(app_data_root)
+    except OSError:
+        return 0
+    total = 0
+    with entries:
+        for entry in entries:
+            try:
+                if entry.is_file(follow_symlinks=False):
+                    total += entry.stat(follow_symlinks=False).st_size
+            except OSError:
+                pass
+    return total
 
 
 def _check_min_free(config: Config) -> tuple[int, int] | None:
@@ -171,6 +190,10 @@ def storage_status(config: Config) -> dict[str, object]:
 
     min_free = storage_min_free_bytes(config)
 
+    # The app_data total is derived from the per-app walk rather than walked
+    # again — these trees are large enough that a second pass is noticeable.
+    per_app = per_app_usage(config)
+
     return {
         "disk": {
             "total_bytes": disk.total,
@@ -178,9 +201,9 @@ def storage_status(config: Config) -> dict[str, object]:
             "free_bytes": disk.free,
         },
         "openhost_data_used_bytes": openhost_data_usage_bytes(config),
-        "app_data_used_bytes": app_data_usage_bytes(config),
+        "app_data_used_bytes": sum(per_app.values()) + _app_data_loose_file_bytes(config),
         "build_cache_bytes": container_image_storage_bytes(),
-        "per_app": per_app_usage(config),
+        "per_app": per_app,
         "storage_min_free_bytes": min_free,
         "storage_low": storage_low(config),
         "guard_paused": is_guard_paused(),

--- a/compute_space/src/compute_space/core/storage.py
+++ b/compute_space/src/compute_space/core/storage.py
@@ -17,6 +17,7 @@ import threading
 import time
 
 from compute_space.config import Config
+from compute_space.core.containers import container_image_storage_bytes
 from compute_space.core.containers import stop_app_process
 from compute_space.core.logging import logger
 
@@ -178,6 +179,7 @@ def storage_status(config: Config) -> dict[str, object]:
         },
         "openhost_data_used_bytes": openhost_data_usage_bytes(config),
         "app_data_used_bytes": app_data_usage_bytes(config),
+        "build_cache_bytes": container_image_storage_bytes(),
         "per_app": per_app_usage(config),
         "storage_min_free_bytes": min_free,
         "storage_low": storage_low(config),

--- a/compute_space/src/compute_space/tests/test_containers.py
+++ b/compute_space/src/compute_space/tests/test_containers.py
@@ -7,6 +7,7 @@ end-to-end tests that actually exercise podman live under the
 
 from __future__ import annotations
 
+import json
 import os
 import subprocess
 
@@ -826,3 +827,32 @@ def test_bind_mount_arg_preserves_absolute_paths_verbatim() -> None:
     target vs. what the app's env var points at."""
     arg = _bind_mount_arg("/a/b/c/", "/data/app_data/myapp/")
     assert arg == "/a/b/c/:/data/app_data/myapp/:idmap"
+
+
+# ---------------------------------------------------------------------------
+# container_image_storage_bytes
+# ---------------------------------------------------------------------------
+
+
+def test_container_image_storage_bytes_parses_images_row(monkeypatch: pytest.MonkeyPatch) -> None:
+    df_json = json.dumps(
+        [
+            {"Type": "Images", "Total": 3, "Active": 1, "RawSize": 4567, "RawReclaimable": 100},
+            {"Type": "Containers", "Total": 1, "Active": 1, "RawSize": 99, "RawReclaimable": 0},
+        ]
+    )
+    _patch_subprocess_run(monkeypatch, lambda *a, **k: _FakeCompleted(stdout=df_json))
+    assert containers.container_image_storage_bytes() == 4567
+
+
+def test_container_image_storage_bytes_none_on_nonzero_exit(monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_subprocess_run(monkeypatch, lambda *a, **k: _FakeCompleted(returncode=1))
+    assert containers.container_image_storage_bytes() is None
+
+
+def test_container_image_storage_bytes_none_when_podman_missing(monkeypatch: pytest.MonkeyPatch) -> None:
+    def _raise(*a, **k):
+        raise FileNotFoundError("podman")
+
+    _patch_subprocess_run(monkeypatch, _raise)
+    assert containers.container_image_storage_bytes() is None

--- a/compute_space/src/compute_space/tests/test_integration.py
+++ b/compute_space/src/compute_space/tests/test_integration.py
@@ -184,23 +184,6 @@ class TestRouterCore:
         assert data["status"] == "ok"
         assert "security" not in data
 
-    def test_post_setup_security_audit(self, admin_session, config):
-        """Post-setup audit returns valid structure from /api/security-audit."""
-        base_url = _zone_url(config)
-        r = admin_session.get(f"{base_url}/api/security-audit")
-        assert r.status_code == 200
-        data = r.json()
-        assert isinstance(data["secure"], bool)
-        expected_checks = {
-            "ssh_password_disabled",
-            "tls_active",
-            "no_unexpected_ports",
-        }
-        assert set(data["checks"].keys()) == expected_checks
-        for name, check in data["checks"].items():
-            assert isinstance(check["ok"], bool), f"{name}: ok not bool"
-            assert isinstance(check["detail"], str), f"{name}: detail not str"
-
     def test_dashboard_requires_auth(self, admin_session, config):
         """Unauthenticated requests to /dashboard redirect to /login."""
         base_url = _zone_url(config)
@@ -227,10 +210,8 @@ class TestRouterCore:
         r = admin_session.get(f"{base_url}/dashboard")
         assert r.status_code == 200
         assert "Deployed Apps" in r.text
-        # Security audit, storage status, and SSH toggle live on the System page,
-        # not the dashboard.
+        # Storage status and SSH toggle live on the System page, not the dashboard.
         for system_only_element in (
-            'id="security-table"',
             'id="storage-table"',
             'id="ports-table"',
             'id="ssh-btn"',
@@ -251,25 +232,29 @@ class TestRouterCore:
         base_url = _zone_url(config)
         r = admin_session.get(f"{base_url}/system/")
         assert r.status_code == 200
-        assert 'id="security-table"' in r.text
         assert 'id="ports-table"' in r.text
         assert 'id="storage-table"' in r.text
         assert 'id="cs-logs"' in r.text
+        assert 'id="security-table"' not in r.text
 
     def test_listening_ports_endpoint(self, admin_session, config):
-        """GET /api/listening-ports returns a list of classified ports."""
+        """GET /api/listening-ports returns classified external-facing ports."""
         base_url = _zone_url(config)
         r = admin_session.get(f"{base_url}/api/listening-ports")
         assert r.status_code == 200
         data = r.json()
         assert "ports" in data
         assert isinstance(data["ports"], list)
-        # Each entry must have the expected shape.
+        # True on hosts without ``ss`` (e.g. macOS dev machines); the filter still applies.
+        assert isinstance(data["enumeration_failed"], bool)
+        # Each entry must have the expected shape, and loopback-only listeners are excluded.
         for entry in data["ports"]:
             assert isinstance(entry["port"], int)
             assert isinstance(entry["address"], str)
             assert entry["classification"] in {"secure", "app_range", "allocated", "unexpected"}
             assert isinstance(entry["label"], str)
+            host = entry["address"].rsplit(":", 1)[0].strip("[]")
+            assert host != "::1" and not host.startswith("127."), entry
 
     def test_setup_returns_403_if_already_set_up(self, admin_session, config):
         """GET /setup returns 403 when owner already exists."""

--- a/compute_space/src/compute_space/tests/test_security_ports.py
+++ b/compute_space/src/compute_space/tests/test_security_ports.py
@@ -108,6 +108,18 @@ def test_external_ports_excludes_loopback(fake_ss) -> None:
     assert addrs == {"0.0.0.0:443", "[::]:80", "10.0.0.5:9100", "*:53"}
 
 
+def test_external_ports_excludes_container_gateway(fake_ss) -> None:
+    """The openhost0 container-gateway interface (10.200.0.1) is internal —
+    listeners bound to it are not reachable from outside the VM and must not
+    appear in the externally-open-ports table.
+    """
+    fake_ss(["10.200.0.1:8080", "0.0.0.0:443"])
+
+    ports = security.external_ports(security.list_listening_ports(db=None))
+
+    assert {p["address"] for p in ports} == {"0.0.0.0:443"}
+
+
 def test_external_ports_empty_when_all_loopback(fake_ss) -> None:
     fake_ss(["127.0.0.1:8080", "[::1]:9090"])
 

--- a/compute_space/src/compute_space/tests/test_security_ports.py
+++ b/compute_space/src/compute_space/tests/test_security_ports.py
@@ -93,3 +93,24 @@ def test_ipv6_loopback_juicefs_range(fake_ss) -> None:
     ports = security.list_listening_ports(db=None)
 
     assert _classify(ports, 6060) == "secure"
+
+
+def test_external_ports_excludes_loopback(fake_ss) -> None:
+    """The System page shows only externally reachable listeners:
+    loopback-bound entries (IPv4 and IPv6) are filtered out, while
+    wildcard and specific-interface binds are kept.
+    """
+    fake_ss(["127.0.0.1:8080", "[::1]:6060", "127.9.9.9:5000", "0.0.0.0:443", "[::]:80", "10.0.0.5:9100", "*:53"])
+
+    ports = security.external_ports(security.list_listening_ports(db=None))
+
+    addrs = {p["address"] for p in ports}
+    assert addrs == {"0.0.0.0:443", "[::]:80", "10.0.0.5:9100", "*:53"}
+
+
+def test_external_ports_empty_when_all_loopback(fake_ss) -> None:
+    fake_ss(["127.0.0.1:8080", "[::1]:9090"])
+
+    ports = security.external_ports(security.list_listening_ports(db=None))
+
+    assert ports == []

--- a/compute_space/src/compute_space/tests/test_storage.py
+++ b/compute_space/src/compute_space/tests/test_storage.py
@@ -33,6 +33,7 @@ def test_storage_status_includes_disk_totals(tmp_path, monkeypatch):
         return usage(total=10 * 1024**3, used=4 * 1024**3, free=6 * 1024**3)
 
     monkeypatch.setattr(storage.shutil, "disk_usage", fake_disk_usage)
+    monkeypatch.setattr(storage, "container_image_storage_bytes", lambda: 7 * 1024**3)
 
     status = cast(dict[str, Any], storage.storage_status(config))
 
@@ -44,6 +45,7 @@ def test_storage_status_includes_disk_totals(tmp_path, monkeypatch):
     assert "temporary" not in status
     assert status["openhost_data_used_bytes"] > 0
     assert status["app_data_used_bytes"] > 0
+    assert status["build_cache_bytes"] == 7 * 1024**3
     assert status["storage_min_free_bytes"] is None
     assert status["storage_low"] is False
     assert status["guard_paused"] is False
@@ -60,12 +62,15 @@ def test_storage_status_with_min_free(tmp_path, monkeypatch):
         return usage(total=10 * 1024**3, used=4 * 1024**3, free=6 * 1024**3)
 
     monkeypatch.setattr(storage.shutil, "disk_usage", fake_disk_usage)
+    monkeypatch.setattr(storage, "container_image_storage_bytes", lambda: None)
 
     status = cast(dict[str, Any], storage.storage_status(config))
 
     assert config.data_root_dir in calls, "storage_status should query data_root_dir"
     assert status["storage_min_free_bytes"] == 1000 * 1024 * 1024
     assert status["storage_low"] is False  # 6 GiB free > 1000 MiB required
+    # Podman unavailable → the category degrades to None rather than failing the endpoint.
+    assert status["build_cache_bytes"] is None
 
 
 def test_disk_free_bytes_uses_data_root_dir(tmp_path, monkeypatch):

--- a/compute_space/src/compute_space/tests/test_storage.py
+++ b/compute_space/src/compute_space/tests/test_storage.py
@@ -73,6 +73,24 @@ def test_storage_status_with_min_free(tmp_path, monkeypatch):
     assert status["build_cache_bytes"] is None
 
 
+def test_app_data_total_combines_per_app_and_loose_files(tmp_path, monkeypatch):
+    """The app_data total is derived from the per-app walk plus loose root
+    files — not a second full walk of the tree."""
+    config = _make_test_config(tmp_path)
+    app_data = os.path.join(config.persistent_data_dir, "app_data")
+    os.makedirs(os.path.join(app_data, "immich"), exist_ok=True)
+    with open(os.path.join(app_data, "immich", "photo.bin"), "wb") as f:
+        f.write(b"x" * (300 * 1024))
+    with open(os.path.join(app_data, "loose.bin"), "wb") as f:
+        f.write(b"x" * (200 * 1024))
+    monkeypatch.setattr(storage, "container_image_storage_bytes", lambda: None)
+
+    status = cast(dict[str, Any], storage.storage_status(config))
+
+    assert status["per_app"] == {"immich": 300 * 1024}
+    assert status["app_data_used_bytes"] == 500 * 1024
+
+
 def test_disk_free_bytes_uses_data_root_dir(tmp_path, monkeypatch):
     config = _make_test_config(tmp_path)
     usage = namedtuple("usage", ["total", "used", "free"])

--- a/compute_space/src/compute_space/tests/test_system_logs.py
+++ b/compute_space/src/compute_space/tests/test_system_logs.py
@@ -1,0 +1,35 @@
+"""Tests for the /api/compute_space_logs tail behavior."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+import compute_space.web.routes.api.system as system_api
+
+
+def test_logs_smaller_than_tail_served_whole(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    log = tmp_path / "cs.log"
+    log.write_text("first line\nsecond line\n")
+    monkeypatch.setattr(system_api, "get_log_path", lambda: log)
+
+    resp = system_api.compute_space_logs.fn()
+
+    assert resp.status_code == 200
+    assert resp.content == "first line\nsecond line\n"
+
+
+def test_logs_larger_than_tail_served_from_line_boundary(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    log = tmp_path / "cs.log"
+    line = "x" * 99 + "\n"
+    log.write_text(line * 4000)  # 400 KB, above the 256 KiB tail
+    monkeypatch.setattr(system_api, "get_log_path", lambda: log)
+
+    resp = system_api.compute_space_logs.fn()
+
+    assert resp.status_code == 200
+    assert len(resp.content) <= system_api._LOG_TAIL_BYTES
+    # The tail starts at a line boundary, not mid-line.
+    assert resp.content.startswith("x" * 99 + "\n")
+    assert resp.content.endswith(line)

--- a/compute_space/src/compute_space/web/routes/api/system.py
+++ b/compute_space/src/compute_space/web/routes/api/system.py
@@ -1,4 +1,5 @@
 import hashlib
+import os
 import secrets
 import sqlite3
 import subprocess
@@ -193,14 +194,24 @@ async def api_tokens_delete(token_id: int, db: sqlite3.Connection) -> None:
 # ─── Compute Space Logs ────────────────────────────────────────────────────
 
 
+# The System page polls this every few seconds; serving the whole file (up to
+# the 10 MB rotation limit) makes each poll take ~1s on a small VPS.
+_LOG_TAIL_BYTES = 256 * 1024
+
+
 @get("/api/compute_space_logs", guards=[require_owner_auth], media_type=MediaType.TEXT, sync_to_thread=False)
 def compute_space_logs() -> Response[str]:
-    """Return the compute space log file contents."""
+    """Return the tail (last 256 KiB) of the compute space log file."""
     log_path = get_log_path()
     if log_path is None:
         return Response(content="Log file not configured", status_code=503, media_type=MediaType.TEXT)
-    with open(log_path) as f:
-        return Response(content=f.read(), status_code=200, media_type=MediaType.TEXT)
+    with open(log_path, "rb") as f:
+        size = f.seek(0, os.SEEK_END)
+        f.seek(max(0, size - _LOG_TAIL_BYTES))
+        text = f.read().decode("utf-8", errors="replace")
+    if size > _LOG_TAIL_BYTES:
+        text = text[text.find("\n") + 1 :]
+    return Response(content=text, status_code=200, media_type=MediaType.TEXT)
 
 
 # ─── Health & Security ─────────────────────────────────────────────────────
@@ -223,7 +234,9 @@ def listening_ports(db: sqlite3.Connection) -> ListeningPortsResponse:
     return ListeningPortsResponse(ports=external_ports(all_ports), enumeration_failed=not all_ports)
 
 
-@get("/api/storage-status", guards=[require_owner_auth], sync_to_thread=False)
+# sync_to_thread: walking app_data and querying podman take ~1s on a real
+# instance; running on the event loop would stall every concurrent request.
+@get("/api/storage-status", guards=[require_owner_auth], sync_to_thread=True)
 def api_storage_status(config: Config) -> dict[str, object]:
     return storage_status(config)
 

--- a/compute_space/src/compute_space/web/routes/api/system.py
+++ b/compute_space/src/compute_space/web/routes/api/system.py
@@ -16,11 +16,10 @@ from litestar import post
 
 from compute_space import OPENHOST_PROJECT_DIR
 from compute_space.config import Config
-from compute_space.core.auth.security_audit import AuditResult
 from compute_space.core.auth.security_audit import ListeningPort
+from compute_space.core.auth.security_audit import external_ports
 from compute_space.core.auth.security_audit import is_sshd_active
 from compute_space.core.auth.security_audit import list_listening_ports
-from compute_space.core.auth.security_audit import run_audit
 from compute_space.core.containers import drop_docker_build_cache
 from compute_space.core.git_ops import get_branch_name
 from compute_space.core.git_ops import get_head_sha
@@ -87,6 +86,9 @@ class HealthRestarting:
 @attr.s(auto_attribs=True, frozen=True)
 class ListeningPortsResponse:
     ports: list[ListeningPort]
+    # True when the port list could not be enumerated at all (e.g. ``ss`` failed),
+    # as opposed to no ports surviving the external-interface filter.
+    enumeration_failed: bool
 
 
 @attr.s(auto_attribs=True, frozen=True)
@@ -211,15 +213,14 @@ def health() -> Response[HealthRestarting] | HealthOk:
     return HealthOk(status="ok")
 
 
-@get("/api/security-audit", guards=[require_owner_auth], sync_to_thread=False)
-def security_audit(db: sqlite3.Connection) -> AuditResult:
-    return run_audit(db=db)
-
-
 @get("/api/listening-ports", guards=[require_owner_auth], sync_to_thread=False)
 def listening_ports(db: sqlite3.Connection) -> ListeningPortsResponse:
-    """Return every TCP port the VM is listening on, with classification."""
-    return ListeningPortsResponse(ports=list_listening_ports(db=db))
+    """Return TCP ports listening on external-facing or wildcard interfaces, with classification.
+
+    Loopback-only listeners are excluded — they are not reachable from outside the VM.
+    """
+    all_ports = list_listening_ports(db=db)
+    return ListeningPortsResponse(ports=external_ports(all_ports), enumeration_failed=not all_ports)
 
 
 @get("/api/storage-status", guards=[require_owner_auth], sync_to_thread=False)
@@ -314,7 +315,6 @@ system_routes = Router(
         api_tokens_delete,
         compute_space_logs,
         health,
-        security_audit,
         listening_ports,
         api_storage_status,
         toggle_storage_guard,

--- a/compute_space/src/compute_space/web/setup_app.py
+++ b/compute_space/src/compute_space/web/setup_app.py
@@ -165,9 +165,7 @@ async def _trigger_restart_after_response() -> None:
 
 @get("/health", sync_to_thread=False)
 def health() -> Response[dict[str, str]]:
-    """Liveness probe.  Returns ``{"status": "ok"}`` (or 503 when restarting).
-    Security audit data is only available via the authenticated
-    ``/api/security-audit`` endpoint."""
+    """Liveness probe.  Returns ``{"status": "ok"}`` (or 503 when restarting)."""
     if is_shutdown_pending() or _setup_completed:
         return Response(content={"status": "restarting"}, status_code=503)
     return Response(content={"status": "ok"})

--- a/compute_space/src/compute_space/web/static/js/settings.js
+++ b/compute_space/src/compute_space/web/static/js/settings.js
@@ -1,7 +1,16 @@
+let pageHidden = false;
+window.addEventListener('pagehide', () => { pageHidden = true; });
+
 function showError(msg) {
-  const el = document.getElementById('error');
-  el.textContent = msg;
-  el.style.display = '';
+  // Deferred: navigating away aborts in-flight fetches, whose catch handlers
+  // would otherwise flash this banner during page teardown. Timers don't run
+  // once the page is gone, and pageHidden covers the bfcache edge.
+  setTimeout(() => {
+    if (pageHidden) return;
+    const el = document.getElementById('error');
+    el.textContent = msg;
+    el.style.display = '';
+  }, 100);
 }
 function clearError() { document.getElementById('error').style.display = 'none'; }
 function esc(s) { const d = document.createElement('div'); d.textContent = s; return d.innerHTML; }

--- a/compute_space/src/compute_space/web/static/js/system.js
+++ b/compute_space/src/compute_space/web/static/js/system.js
@@ -22,12 +22,12 @@ function updateListeningPorts() {
     .then(function(data) {
       var body = document.getElementById('ports-body');
       if (!data || data.enumeration_failed) {
-        body.innerHTML = '<tr><td colspan="4" class="error">Could not enumerate listening ports.</td></tr>';
+        body.innerHTML = '<tr><td colspan="3" class="error">Could not enumerate listening ports.</td></tr>';
         return;
       }
       var ports = data.ports || [];
       if (!ports.length) {
-        body.innerHTML = '<tr><td colspan="4" class="muted">No externally exposed ports.</td></tr>';
+        body.innerHTML = '<tr><td colspan="3" class="muted">No externally exposed ports.</td></tr>';
         return;
       }
       body.innerHTML = ports.map(function(p) {
@@ -41,8 +41,7 @@ function updateListeningPorts() {
         }
         return '<tr><td><code>' + escHtml(p.port) + '</code></td>'
           + '<td><code>' + escHtml(p.address) + '</code></td>'
-          + '<td' + cls + '>' + escHtml(p.classification) + '</td>'
-          + '<td>' + label + '</td></tr>';
+          + '<td' + cls + '>' + label + '</td></tr>';
       }).join('');
     });
 }
@@ -58,17 +57,73 @@ function toggleStorageGuard(pause) {
   }).then(function() { updateStorageStatus(); });
 }
 
-function perAppBarsHtml(perApp) {
+function escAttr(s) {
+  return escHtml(s).replace(/"/g, '&quot;');
+}
+
+// Donut chart of per-app usage. Hovering a slice shows the app name and size
+// in the center; slices are sorted by size, largest first at 12 o'clock.
+function perAppPieHtml(perApp) {
   var names = Object.keys(perApp).sort(function(a, b) { return perApp[b] - perApp[a]; });
-  var maxBytes = names.length ? (perApp[names[0]] || 1) : 1;
-  return names.map(function(name) {
-    var pct = Math.max(1, Math.round((perApp[name] / maxBytes) * 100));
-    return '<div class="usage-bar-row">'
-      + '<span class="usage-bar-name">' + escHtml(name) + '</span>'
-      + '<div class="usage-bar-track"><div class="usage-bar-fill" style="width:' + pct + '%"></div></div>'
-      + '<span class="usage-bar-size">' + escHtml(formatBytes(perApp[name])) + '</span>'
-      + '</div>';
+  var total = 0;
+  names.forEach(function(n) { total += perApp[n]; });
+  if (!total) return '<span class="muted">No app data yet.</span>';
+
+  var cx = 100, cy = 100, rOuter = 92, rInner = 58;
+  var TAU = 2 * Math.PI;
+  var angle = -Math.PI / 2;
+
+  function pt(r, a) {
+    return (cx + r * Math.cos(a)).toFixed(2) + ' ' + (cy + r * Math.sin(a)).toFixed(2);
+  }
+
+  var slices = names.map(function(name, i) {
+    var frac = perApp[name] / total;
+    // Clamp just under a full turn so a single-app "circle" still renders as one arc.
+    var sweep = Math.min(frac * TAU, TAU - 0.0004);
+    var a0 = angle;
+    var a1 = a0 + sweep;
+    angle += frac * TAU;
+    var large = sweep > Math.PI ? 1 : 0;
+    // Golden-angle hue steps keep adjacent slices distinct at any app count;
+    // fixed low saturation keeps the palette muted.
+    var hue = (215 + i * 137.5) % 360;
+    var d = 'M ' + pt(rOuter, a0) + ' A ' + rOuter + ' ' + rOuter + ' 0 ' + large + ' 1 ' + pt(rOuter, a1)
+      + ' L ' + pt(rInner, a1) + ' A ' + rInner + ' ' + rInner + ' 0 ' + large + ' 0 ' + pt(rInner, a0) + ' Z';
+    return '<path class="pie-slice" d="' + d + '" fill="hsl(' + hue.toFixed(1) + ', 45%, 62%)"'
+      + ' data-name="' + escAttr(name) + '" data-size="' + escAttr(formatBytes(perApp[name])) + '"></path>';
   }).join('');
+
+  var defaultName = names.length + (names.length === 1 ? ' app' : ' apps');
+  return '<svg id="per-app-pie" viewBox="0 0 200 200" width="220" height="220" role="img"'
+    + ' data-default-name="' + escAttr(defaultName) + '" data-default-size="' + escAttr(formatBytes(total)) + '">'
+    + slices
+    + '<text id="pie-label-name" class="pie-center-name" x="100" y="96">' + escHtml(defaultName) + '</text>'
+    + '<text id="pie-label-size" class="pie-center-size" x="100" y="114">' + escHtml(formatBytes(total)) + '</text>'
+    + '</svg>';
+}
+
+function wirePerAppPie() {
+  var svg = document.getElementById('per-app-pie');
+  if (!svg) return;
+  var nameEl = document.getElementById('pie-label-name');
+  var sizeEl = document.getElementById('pie-label-size');
+  function setLabel(name, size) {
+    nameEl.textContent = name.length > 18 ? name.slice(0, 17) + '…' : name;
+    sizeEl.textContent = size;
+  }
+  function reset() {
+    setLabel(svg.getAttribute('data-default-name'), svg.getAttribute('data-default-size'));
+  }
+  svg.addEventListener('mouseover', function(e) {
+    var t = e.target;
+    if (t && t.classList && t.classList.contains('pie-slice')) {
+      setLabel(t.getAttribute('data-name'), t.getAttribute('data-size'));
+    } else if (t === svg) {
+      reset();
+    }
+  });
+  svg.addEventListener('mouseleave', reset);
 }
 
 function updateStorageStatus() {
@@ -91,12 +146,12 @@ function updateStorageStatus() {
       var buildCache = (data.build_cache_bytes == null)
         ? '<span class="muted">unavailable</span>'
         : escHtml(formatBytes(data.build_cache_bytes));
-      rows += '<tr><th>Build cache</th><td>' + buildCache + '</td></tr>';
+      rows += '<tr><th>App Build Cache</th><td>' + buildCache + '</td></tr>';
       rows += '<tr><th>App data</th><td>' + escHtml(formatBytes(data.app_data_used_bytes || 0)) + '</td></tr>';
 
       var perApp = data.per_app || {};
       if (Object.keys(perApp).length > 0) {
-        rows += '<tr><th>Per app</th><td>' + perAppBarsHtml(perApp) + '</td></tr>';
+        rows += '<tr><th>Per app</th><td>' + perAppPieHtml(perApp) + '</td></tr>';
       }
 
       if (hasMinFree) {
@@ -105,6 +160,7 @@ function updateStorageStatus() {
         rows += '<tr><th>Storage guard</th><td' + guardCls + '>' + escHtml(guardText) + '</td></tr>';
       }
       document.getElementById('storage-body').innerHTML = rows;
+      wirePerAppPie();
 
       // Guard toggle button (separate row below the table for clarity)
       var guardRow = document.getElementById('storage-guard-row');

--- a/compute_space/src/compute_space/web/static/js/system.js
+++ b/compute_space/src/compute_space/web/static/js/system.js
@@ -14,36 +14,70 @@ function formatBytes(bytes) {
   return bytes + ' B';
 }
 
+// ─── First-paint coordination ───
+// All sections fetch immediately on load, but nothing renders until every
+// section is ready or the deadline elapses — avoids a staggered flash of
+// loading/error states on page open. Sections still pending at the deadline
+// show a loading placeholder and fill in when their fetch completes.
+
+var FIRST_PAINT_DEADLINE_MS = 500;
+var sectionRenderers = {ports: null, storage: null, logs: null};
+var firstPaintDone = false;
+
+function presentSection(section, render) {
+  if (firstPaintDone) { render(); return; }
+  sectionRenderers[section] = render;
+  var allReady = Object.keys(sectionRenderers).every(function(k) { return sectionRenderers[k]; });
+  if (allReady) paintAllSections();
+}
+
+function paintAllSections() {
+  if (firstPaintDone) return;
+  firstPaintDone = true;
+  if (sectionRenderers.ports) sectionRenderers.ports();
+  else document.getElementById('ports-body').innerHTML = '<tr><td colspan="3" class="muted">Loading&hellip;</td></tr>';
+  if (sectionRenderers.storage) sectionRenderers.storage();
+  else document.getElementById('storage-body').innerHTML = '<tr><td colspan="2" class="muted">Loading&hellip;</td></tr>';
+  if (sectionRenderers.logs) sectionRenderers.logs();
+  else document.getElementById('cs-logs').textContent = 'Loading...';
+}
+
+setTimeout(paintAllSections, FIRST_PAINT_DEADLINE_MS);
+
 // ─── Listening Ports ───
 
 function updateListeningPorts() {
   fetch(config.listeningPortsUrl, {credentials: 'same-origin'})
     .then(function(r) { return r.json(); })
     .then(function(data) {
-      var body = document.getElementById('ports-body');
-      if (!data || data.enumeration_failed) {
-        body.innerHTML = '<tr><td colspan="3" class="error">Could not enumerate listening ports.</td></tr>';
-        return;
-      }
-      var ports = data.ports || [];
-      if (!ports.length) {
-        body.innerHTML = '<tr><td colspan="3" class="muted">No externally exposed ports.</td></tr>';
-        return;
-      }
-      body.innerHTML = ports.map(function(p) {
-        var cls = '';
-        var label = escHtml(p.label);
-        if (p.classification === 'unexpected') {
-          cls = ' class="status-error"';
-          label = '<strong>' + label + '</strong>';
-        } else if (p.classification === 'secure') {
-          cls = ' class="status-running"';
-        }
-        return '<tr><td><code>' + escHtml(p.port) + '</code></td>'
-          + '<td><code>' + escHtml(p.address) + '</code></td>'
-          + '<td' + cls + '>' + label + '</td></tr>';
-      }).join('');
+      presentSection('ports', function() { renderListeningPorts(data); });
     });
+}
+
+function renderListeningPorts(data) {
+  var body = document.getElementById('ports-body');
+  if (!data || data.enumeration_failed) {
+    body.innerHTML = '<tr><td colspan="3" class="error">Could not enumerate listening ports.</td></tr>';
+    return;
+  }
+  var ports = data.ports || [];
+  if (!ports.length) {
+    body.innerHTML = '<tr><td colspan="3" class="muted">No externally exposed ports.</td></tr>';
+    return;
+  }
+  body.innerHTML = ports.map(function(p) {
+    var cls = '';
+    var label = escHtml(p.label);
+    if (p.classification === 'unexpected') {
+      cls = ' class="status-error"';
+      label = '<strong>' + label + '</strong>';
+    } else if (p.classification === 'secure') {
+      cls = ' class="status-running"';
+    }
+    return '<tr><td><code>' + escHtml(p.port) + '</code></td>'
+      + '<td><code>' + escHtml(p.address) + '</code></td>'
+      + '<td' + cls + '>' + label + '</td></tr>';
+  }).join('');
 }
 
 // ─── Storage Status ───
@@ -130,50 +164,53 @@ function updateStorageStatus() {
   fetch(config.storageStatusUrl, {credentials: 'same-origin'})
     .then(function(r) { return r.json(); })
     .then(function(data) {
-      var disk = data.disk || {};
-      var hasMinFree = data.storage_min_free_bytes != null;
-      var isLow = !!data.storage_low;
-      var guardPaused = !!data.guard_paused;
-
-      var rows = '';
-      var freeText = formatBytes(disk.free_bytes || 0) + ' / ' + formatBytes(disk.total_bytes || 0);
-      if (hasMinFree) {
-        freeText += ' (min ' + formatBytes(data.storage_min_free_bytes) + ' required)';
-      }
-      var freeCls = (hasMinFree && isLow) ? ' class="status-error"' : '';
-      rows += '<tr><th>Disk free</th><td' + freeCls + '>' + escHtml(freeText) + '</td></tr>';
-      rows += '<tr><th>OpenHost data</th><td>' + escHtml(formatBytes(data.openhost_data_used_bytes || 0)) + '</td></tr>';
-      var buildCache = (data.build_cache_bytes == null)
-        ? '<span class="muted">unavailable</span>'
-        : escHtml(formatBytes(data.build_cache_bytes));
-      rows += '<tr><th>App Build Cache</th><td>' + buildCache + '</td></tr>';
-      rows += '<tr><th>App data</th><td>' + escHtml(formatBytes(data.app_data_used_bytes || 0)) + '</td></tr>';
-
-      var perApp = data.per_app || {};
-      if (Object.keys(perApp).length > 0) {
-        rows += '<tr><th>Per app</th><td>' + perAppPieHtml(perApp) + '</td></tr>';
-      }
-
-      if (hasMinFree) {
-        var guardText = guardPaused ? 'Paused' : (isLow ? 'Active (low storage)' : 'Active');
-        var guardCls = (guardPaused || isLow) ? ' class="status-error"' : '';
-        rows += '<tr><th>Storage guard</th><td' + guardCls + '>' + escHtml(guardText) + '</td></tr>';
-      }
-      document.getElementById('storage-body').innerHTML = rows;
-      wirePerAppPie();
-
-      // Guard toggle button (separate row below the table for clarity)
-      var guardRow = document.getElementById('storage-guard-row');
-      if (hasMinFree && guardPaused) {
-        guardRow.innerHTML = '<div class="control-row"><button class="btn" onclick="toggleStorageGuard(false)">Resume Guard</button>'
-          + '<span class="hint">Apps will not be stopped while paused.</span></div>';
-      } else if (hasMinFree && isLow) {
-        guardRow.innerHTML = '<div class="control-row"><button class="btn" onclick="toggleStorageGuard(true)">Pause Guard</button>'
-          + '<span class="hint">Pause to start an app for cleanup.</span></div>';
-      } else {
-        guardRow.innerHTML = '';
-      }
+      presentSection('storage', function() { renderStorageStatus(data); });
     });
+}
+
+function renderStorageStatus(data) {
+  var disk = data.disk || {};
+  var hasMinFree = data.storage_min_free_bytes != null;
+  var isLow = !!data.storage_low;
+  var guardPaused = !!data.guard_paused;
+
+  var rows = '';
+  var freeText = formatBytes(disk.free_bytes || 0) + ' / ' + formatBytes(disk.total_bytes || 0);
+  if (hasMinFree) {
+    freeText += ' (min ' + formatBytes(data.storage_min_free_bytes) + ' required)';
+  }
+  var freeCls = (hasMinFree && isLow) ? ' class="status-error"' : '';
+  rows += '<tr><th>Disk free</th><td' + freeCls + '>' + escHtml(freeText) + '</td></tr>';
+  rows += '<tr><th>OpenHost data</th><td>' + escHtml(formatBytes(data.openhost_data_used_bytes || 0)) + '</td></tr>';
+  var buildCache = (data.build_cache_bytes == null)
+    ? '<span class="muted">unavailable</span>'
+    : escHtml(formatBytes(data.build_cache_bytes));
+  rows += '<tr><th>App Build Cache</th><td>' + buildCache + '</td></tr>';
+
+  var perApp = data.per_app || {};
+  if (Object.keys(perApp).length > 0) {
+    rows += '<tr><th>App data</th><td>' + perAppPieHtml(perApp) + '</td></tr>';
+  }
+
+  if (hasMinFree) {
+    var guardText = guardPaused ? 'Paused' : (isLow ? 'Active (low storage)' : 'Active');
+    var guardCls = (guardPaused || isLow) ? ' class="status-error"' : '';
+    rows += '<tr><th>Storage guard</th><td' + guardCls + '>' + escHtml(guardText) + '</td></tr>';
+  }
+  document.getElementById('storage-body').innerHTML = rows;
+  wirePerAppPie();
+
+  // Guard toggle button (separate row below the table for clarity)
+  var guardRow = document.getElementById('storage-guard-row');
+  if (hasMinFree && guardPaused) {
+    guardRow.innerHTML = '<div class="control-row"><button class="btn" onclick="toggleStorageGuard(false)">Resume Guard</button>'
+      + '<span class="hint">Apps will not be stopped while paused.</span></div>';
+  } else if (hasMinFree && isLow) {
+    guardRow.innerHTML = '<div class="control-row"><button class="btn" onclick="toggleStorageGuard(true)">Pause Guard</button>'
+      + '<span class="hint">Pause to start an app for cleanup.</span></div>';
+  } else {
+    guardRow.innerHTML = '';
+  }
 }
 
 // ─── Logs ───
@@ -183,11 +220,13 @@ function fetchLogs() {
   fetch('/api/compute_space_logs', {credentials: 'same-origin'})
     .then(function(r) { return r.text(); })
     .then(function(text) {
-      var sel = window.getSelection();
-      if (sel && !sel.isCollapsed && logEl.contains(sel.anchorNode)) return;
-      var wasAtBottom = logEl.scrollHeight - logEl.scrollTop - logEl.clientHeight < 50;
-      logEl.textContent = text || 'No log output available.';
-      if (wasAtBottom) logEl.scrollTop = logEl.scrollHeight;
+      presentSection('logs', function() {
+        var sel = window.getSelection();
+        if (sel && !sel.isCollapsed && logEl.contains(sel.anchorNode)) return;
+        var wasAtBottom = logEl.scrollHeight - logEl.scrollTop - logEl.clientHeight < 50;
+        logEl.textContent = text || 'No log output available.';
+        if (wasAtBottom) logEl.scrollTop = logEl.scrollHeight;
+      });
     });
 }
 

--- a/compute_space/src/compute_space/web/static/js/system.js
+++ b/compute_space/src/compute_space/web/static/js/system.js
@@ -231,12 +231,11 @@ function fetchLogs() {
 }
 
 // ─── Init ───
+// Ports and storage load once per visit (storage also re-fetches after a
+// guard toggle); only the logs tail keeps polling.
 
 updateListeningPorts();
-setInterval(updateListeningPorts, 10000);
-
 updateStorageStatus();
-setInterval(updateStorageStatus, 5000);
 
 fetchLogs();
 setInterval(fetchLogs, 3000);

--- a/compute_space/src/compute_space/web/static/js/system.js
+++ b/compute_space/src/compute_space/web/static/js/system.js
@@ -14,26 +14,6 @@ function formatBytes(bytes) {
   return bytes + ' B';
 }
 
-// ─── Security Audit ───
-
-function updateSecurityAudit() {
-  fetch(config.securityAuditUrl, {credentials: 'same-origin'})
-    .then(function(r) { return r.json(); })
-    .then(function(data) {
-      var body = document.getElementById('security-body');
-      var rows = '';
-      Object.keys(data.checks).sort().forEach(function(name) {
-        var c = data.checks[name];
-        var statusCls = c.ok ? 'status-running' : 'status-error';
-        var statusText = c.ok ? 'OK' : 'FAIL';
-        rows += '<tr><td><code>' + escHtml(name) + '</code></td>'
-          + '<td class="' + statusCls + '">' + statusText + '</td>'
-          + '<td>' + escHtml(c.detail) + '</td></tr>';
-      });
-      body.innerHTML = rows || '<tr><td colspan="3" class="muted">No checks reported.</td></tr>';
-    });
-}
-
 // ─── Listening Ports ───
 
 function updateListeningPorts() {
@@ -41,9 +21,13 @@ function updateListeningPorts() {
     .then(function(r) { return r.json(); })
     .then(function(data) {
       var body = document.getElementById('ports-body');
-      var ports = (data && data.ports) || [];
-      if (!ports.length) {
+      if (!data || data.enumeration_failed) {
         body.innerHTML = '<tr><td colspan="4" class="error">Could not enumerate listening ports.</td></tr>';
+        return;
+      }
+      var ports = data.ports || [];
+      if (!ports.length) {
+        body.innerHTML = '<tr><td colspan="4" class="muted">No externally exposed ports.</td></tr>';
         return;
       }
       body.innerHTML = ports.map(function(p) {
@@ -74,6 +58,19 @@ function toggleStorageGuard(pause) {
   }).then(function() { updateStorageStatus(); });
 }
 
+function perAppBarsHtml(perApp) {
+  var names = Object.keys(perApp).sort(function(a, b) { return perApp[b] - perApp[a]; });
+  var maxBytes = names.length ? (perApp[names[0]] || 1) : 1;
+  return names.map(function(name) {
+    var pct = Math.max(1, Math.round((perApp[name] / maxBytes) * 100));
+    return '<div class="usage-bar-row">'
+      + '<span class="usage-bar-name">' + escHtml(name) + '</span>'
+      + '<div class="usage-bar-track"><div class="usage-bar-fill" style="width:' + pct + '%"></div></div>'
+      + '<span class="usage-bar-size">' + escHtml(formatBytes(perApp[name])) + '</span>'
+      + '</div>';
+  }).join('');
+}
+
 function updateStorageStatus() {
   fetch(config.storageStatusUrl, {credentials: 'same-origin'})
     .then(function(r) { return r.json(); })
@@ -89,23 +86,23 @@ function updateStorageStatus() {
         freeText += ' (min ' + formatBytes(data.storage_min_free_bytes) + ' required)';
       }
       var freeCls = (hasMinFree && isLow) ? ' class="status-error"' : '';
-      rows += '<tr><th class="label-col">Disk free</th><td' + freeCls + '>' + escHtml(freeText) + '</td></tr>';
-      rows += '<tr><th class="label-col">OpenHost data</th><td>' + escHtml(formatBytes(data.openhost_data_used_bytes || 0)) + '</td></tr>';
-      rows += '<tr><th class="label-col">App data</th><td>' + escHtml(formatBytes(data.app_data_used_bytes || 0)) + '</td></tr>';
+      rows += '<tr><th>Disk free</th><td' + freeCls + '>' + escHtml(freeText) + '</td></tr>';
+      rows += '<tr><th>OpenHost data</th><td>' + escHtml(formatBytes(data.openhost_data_used_bytes || 0)) + '</td></tr>';
+      var buildCache = (data.build_cache_bytes == null)
+        ? '<span class="muted">unavailable</span>'
+        : escHtml(formatBytes(data.build_cache_bytes));
+      rows += '<tr><th>Build cache</th><td>' + buildCache + '</td></tr>';
+      rows += '<tr><th>App data</th><td>' + escHtml(formatBytes(data.app_data_used_bytes || 0)) + '</td></tr>';
 
       var perApp = data.per_app || {};
-      var appNames = Object.keys(perApp).sort();
-      if (appNames.length > 0) {
-        var perAppHtml = appNames.map(function(name) {
-          return escHtml(name) + ' ' + escHtml(formatBytes(perApp[name]));
-        }).join(' &middot; ');
-        rows += '<tr><th class="label-col">Per app</th><td>' + perAppHtml + '</td></tr>';
+      if (Object.keys(perApp).length > 0) {
+        rows += '<tr><th>Per app</th><td>' + perAppBarsHtml(perApp) + '</td></tr>';
       }
 
       if (hasMinFree) {
         var guardText = guardPaused ? 'Paused' : (isLow ? 'Active (low storage)' : 'Active');
         var guardCls = (guardPaused || isLow) ? ' class="status-error"' : '';
-        rows += '<tr><th class="label-col">Storage guard</th><td' + guardCls + '>' + escHtml(guardText) + '</td></tr>';
+        rows += '<tr><th>Storage guard</th><td' + guardCls + '>' + escHtml(guardText) + '</td></tr>';
       }
       document.getElementById('storage-body').innerHTML = rows;
 
@@ -139,9 +136,6 @@ function fetchLogs() {
 }
 
 // ─── Init ───
-
-updateSecurityAudit();
-setInterval(updateSecurityAudit, 10000);
 
 updateListeningPorts();
 setInterval(updateListeningPorts, 10000);

--- a/compute_space/src/compute_space/web/templates/layout.html
+++ b/compute_space/src/compute_space/web/templates/layout.html
@@ -43,6 +43,11 @@
     table.form-table input[type="text"], table.form-table input[type="password"] { width: 24em; max-width: 100%; }
     table.form-table td p { margin: 0.4em 0 0; }
     table.form-table td p:first-child { margin-top: 0; }
+    .usage-bar-row { display: flex; align-items: center; gap: 0.8em; margin: 0.15em 0; }
+    .usage-bar-name { flex: 0 0 10em; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+    .usage-bar-track { flex: 1; height: 1.1em; background: #f0f0f0; border-radius: 3px; overflow: hidden; }
+    .usage-bar-fill { height: 100%; background: #8fb0e8; }
+    .usage-bar-size { flex: 0 0 6em; text-align: right; color: #555; font-variant-numeric: tabular-nums; }
   </style>
 </head>
 <body>

--- a/compute_space/src/compute_space/web/templates/layout.html
+++ b/compute_space/src/compute_space/web/templates/layout.html
@@ -43,11 +43,10 @@
     table.form-table input[type="text"], table.form-table input[type="password"] { width: 24em; max-width: 100%; }
     table.form-table td p { margin: 0.4em 0 0; }
     table.form-table td p:first-child { margin-top: 0; }
-    .usage-bar-row { display: flex; align-items: center; gap: 0.8em; margin: 0.15em 0; }
-    .usage-bar-name { flex: 0 0 10em; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-    .usage-bar-track { flex: 1; height: 1.1em; background: #f0f0f0; border-radius: 3px; overflow: hidden; }
-    .usage-bar-fill { height: 100%; background: #8fb0e8; }
-    .usage-bar-size { flex: 0 0 6em; text-align: right; color: #555; font-variant-numeric: tabular-nums; }
+    .pie-slice { stroke: #fff; stroke-width: 1.5; }
+    .pie-slice:hover { filter: brightness(0.88); }
+    .pie-center-name { font-size: 14px; font-weight: 600; fill: #222; text-anchor: middle; }
+    .pie-center-size { font-size: 12px; fill: #666; text-anchor: middle; }
   </style>
 </head>
 <body>

--- a/compute_space/src/compute_space/web/templates/system.html
+++ b/compute_space/src/compute_space/web/templates/system.html
@@ -9,12 +9,11 @@
 </table>
 <div id="storage-guard-row"></div>
 
-<h2 class="section-title">Listening ports</h2>
-<p class="hint">Ports listening on external-facing or wildcard interfaces. Loopback-only listeners are not shown.</p>
+<h2 class="section-title">Externally Open Ports</h2>
 <table id="ports-table">
-  <thead><tr><th>Port</th><th>Address</th><th>Classification</th><th>Detail</th></tr></thead>
+  <thead><tr><th>Port</th><th>Address</th><th>Detail</th></tr></thead>
   <tbody id="ports-body">
-    <tr><td colspan="4" class="muted">Loading&hellip;</td></tr>
+    <tr><td colspan="3" class="muted">Loading&hellip;</td></tr>
   </tbody>
 </table>
 

--- a/compute_space/src/compute_space/web/templates/system.html
+++ b/compute_space/src/compute_space/web/templates/system.html
@@ -3,22 +3,18 @@
 {% block content %}
 <h2 class="section-title">Storage</h2>
 <table id="storage-table" class="form-table">
-  <tbody id="storage-body">
-    <tr><td colspan="2" class="muted">Loading&hellip;</td></tr>
-  </tbody>
+  <tbody id="storage-body"></tbody>
 </table>
 <div id="storage-guard-row"></div>
 
 <h2 class="section-title">Externally Open Ports</h2>
 <table id="ports-table">
   <thead><tr><th>Port</th><th>Address</th><th>Detail</th></tr></thead>
-  <tbody id="ports-body">
-    <tr><td colspan="3" class="muted">Loading&hellip;</td></tr>
-  </tbody>
+  <tbody id="ports-body"></tbody>
 </table>
 
 <h2 class="section-title">Logs</h2>
-<pre class="log-output" id="cs-logs" style="max-height: 120em; white-space: pre-wrap; word-break: break-all; width: calc(100vw - 2em); position: relative; left: 50%; margin-left: calc(-50vw + 1em); box-sizing: border-box;">Loading...</pre>
+<pre class="log-output" id="cs-logs" style="max-height: 120em; white-space: pre-wrap; word-break: break-all; width: calc(100vw - 2em); position: relative; left: 50%; margin-left: calc(-50vw + 1em); box-sizing: border-box;"></pre>
 
 <script id="page-config" type="application/json">
 {

--- a/compute_space/src/compute_space/web/templates/system.html
+++ b/compute_space/src/compute_space/web/templates/system.html
@@ -1,15 +1,16 @@
 {% extends "layout.html" %}
 {% block title_suffix %} - System Info{% endblock %}
 {% block content %}
-<h2>Security Audit</h2>
-<table id="security-table">
-  <thead><tr><th>Check</th><th>Status</th><th>Detail</th></tr></thead>
-  <tbody id="security-body">
-    <tr><td colspan="3" class="muted">Loading&hellip;</td></tr>
+<h2 class="section-title">Storage</h2>
+<table id="storage-table" class="form-table">
+  <tbody id="storage-body">
+    <tr><td colspan="2" class="muted">Loading&hellip;</td></tr>
   </tbody>
 </table>
+<div id="storage-guard-row"></div>
 
-<h2>Listening Ports</h2>
+<h2 class="section-title">Listening ports</h2>
+<p class="hint">Ports listening on external-facing or wildcard interfaces. Loopback-only listeners are not shown.</p>
 <table id="ports-table">
   <thead><tr><th>Port</th><th>Address</th><th>Classification</th><th>Detail</th></tr></thead>
   <tbody id="ports-body">
@@ -17,20 +18,11 @@
   </tbody>
 </table>
 
-<h2>Storage</h2>
-<table id="storage-table">
-  <tbody id="storage-body">
-    <tr><td colspan="2" class="muted">Loading&hellip;</td></tr>
-  </tbody>
-</table>
-<div id="storage-guard-row"></div>
-
-<h2>Logs</h2>
+<h2 class="section-title">Logs</h2>
 <pre class="log-output" id="cs-logs" style="max-height: 120em; white-space: pre-wrap; word-break: break-all; width: calc(100vw - 2em); position: relative; left: 50%; margin-left: calc(-50vw + 1em); box-sizing: border-box;">Loading...</pre>
 
 <script id="page-config" type="application/json">
 {
-  "securityAuditUrl": "/api/security-audit",
   "listeningPortsUrl": "/api/listening-ports",
   "storageStatusUrl": "/api/storage-status",
   "toggleStorageGuardUrl": "/api/storage-guard"


### PR DESCRIPTION
## Summary

- **Storage moved to the top**, rendered with the shared `form-table` pattern:
  - New **App Build Cache** category showing podman image storage, read from `podman system df --format json` (`RawSize` of the Images row). Degrades to "unavailable" when podman can't be queried.
  - **Per-app usage is a donut chart** (inline SVG, no dependencies): slices sorted largest-first from 12 o'clock, hovering a slice shows the app name and size in the center (total shown by default). Golden-angle hue steps keep adjacent slices distinct at any app count.
- **Externally Open Ports** (formerly Listening Ports) shows only ports bound to external-facing or wildcard interfaces; loopback-only listeners are filtered out via a new `external_ports()` helper. The classification column is gone — classification still drives row coloring, and the Detail cell names the owning app for allocated ports. The API response gained an `enumeration_failed` flag so the UI can distinguish "`ss` failed" from "no externally exposed ports".
- **Security Audit section removed** from the page along with the `/api/security-audit` endpoint. The audit logic in `core/auth/security_audit.py` is untouched in case we want to bring it back.

## Testing

- New unit tests: `external_ports` loopback filtering (IPv4/IPv6/wildcard), `container_image_storage_bytes` parsing and failure modes, `build_cache_bytes` in `storage_status`.
- Integration tests updated for the removed endpoint/section and the filtered ports response.
- `pixi run -e dev pytest -x` — 886 passed, 52 skipped.
- Verified visually via the local stack + Playwright, including donut hover states.

🤖 Generated with [Claude Code](https://claude.com/claude-code)