### PR TITLE
Add custom (CNAME) domains for apps

### DIFF
--- a/compute_space/src/compute_space/config.py
+++ b/compute_space/src/compute_space/config.py
@@ -195,6 +195,12 @@ class Config:
         return self.openhost_data_path / "Caddyfile"
 
     @property
+    def caddy_storage_dir(self) -> Path:
+        # Caddy's cert storage — holds on-demand TLS certs issued for apps'
+        # custom domains, so they survive Caddy restarts.
+        return self.openhost_data_path / "caddy"
+
+    @property
     def keys_dir(self) -> str:
         return str(Path(self.openhost_data_path) / "keys")
 
@@ -215,6 +221,7 @@ class Config:
         # the JuiceFS mount once attach_on_startup brings it up.
         os.makedirs(self.apps_dir, exist_ok=True)
         os.makedirs(self.openhost_data_path, exist_ok=True)
+        os.makedirs(self.caddy_storage_dir, exist_ok=True)
         os.makedirs(self.keys_dir, exist_ok=True)
 
 

--- a/compute_space/src/compute_space/core/apps.py
+++ b/compute_space/src/compute_space/core/apps.py
@@ -147,6 +147,24 @@ def find_app_by_name(name: str) -> App | None:
     return App.from_row(row) if row else None
 
 
+def find_app_by_alt_domain(host: str) -> App | None:
+    """Find an app by a registered alternate (custom) domain, exact match only.
+
+    ``host`` must already be normalized: lowercase, no port, no trailing dot.
+    """
+    row = (
+        get_db()
+        .execute(
+            "SELECT apps.* FROM apps"
+            " JOIN app_alt_domains ON app_alt_domains.app_id = apps.app_id"
+            " WHERE app_alt_domains.domain = ?",
+            (host,),
+        )
+        .fetchone()
+    )
+    return App.from_row(row) if row else None
+
+
 def list_builtin_apps(config: Config) -> list[dict[str, str]]:
     """Return list of dicts with name/url for each app in the builtin apps dir.
 
@@ -1012,8 +1030,10 @@ def remove_app_background(app_id: str, keep_data: bool, config: Config) -> None:
 
 
 def get_app_from_hostname(host: str) -> App | None:
-    """Extract+validate app name from a Host header value (or litestar's request.url.netloc; ie example.com[:port])
-    by assuming that app_name is a subdir of zone_domain (as is convention).
+    """Match a Host header value (or litestar's request.url.netloc; ie example.com[:port]) to an app.
+
+    Hosts under zone_domain match by app name (app_name is a subdir of zone_domain, as is convention);
+    any other host matches a registered alternate (custom) domain, if one exists.
 
     returns None if an app cannot be matched from the header.
 
@@ -1024,7 +1044,7 @@ def get_app_from_hostname(host: str) -> App | None:
     """
     config = get_config()
     zone_domain_no_port = config.zone_domain_no_port
-    host_no_port = host.split(":", 1)[0]
+    host_no_port = host.split(":", 1)[0].lower().rstrip(".")
     if host_no_port == zone_domain_no_port:
         return None
     if host_no_port.endswith("." + zone_domain_no_port):
@@ -1032,7 +1052,8 @@ def get_app_from_hostname(host: str) -> App | None:
         if "." not in app_name:
             if app := find_app_by_name(app_name):
                 return app
-    return None
+        return None
+    return find_app_by_alt_domain(host_no_port)
 
 
 def is_public_path(app: App, request_path: str) -> bool:

--- a/compute_space/src/compute_space/core/caddy.py
+++ b/compute_space/src/compute_space/core/caddy.py
@@ -4,23 +4,49 @@ from pathlib import Path
 
 import attr
 
+from compute_space.config import Config
 from compute_space.core.logging import logger
 
 
-def generate_caddyfile(tls_enabled: bool, tls_cert_path: Path, tls_key_path: Path, web_server_port: int) -> str:
+def generate_caddyfile(config: Config) -> str:
     """Generate Caddyfile content based on config."""
-    if tls_enabled:
+    if config.tls_enabled:
+        zone = config.zone_domain_no_port
+        email_line = f"    email {config.acme_email}\n" if config.acme_email else ""
         return (
             "{\n"
-            "    auto_https off\n"
             "    admin off\n"
+            # ACME must stay enabled for on-demand issuance; we own the :80
+            # redirect ourselves via the http:// site below.
+            "    auto_https disable_redirects\n"
+            "    storage file_system {\n"
+            f"        root {config.caddy_storage_dir}\n"
+            "    }\n"
+            f"{email_line}"
+            "    on_demand_tls {\n"
+            f"        ask http://127.0.0.1:{config.port}/api/tls/on_demand_check\n"
+            "    }\n"
             "}\n"
-            ":443 {\n"
-            f"    tls {tls_cert_path} {tls_key_path}\n"
+            # Zone + app subdomains: served from the wildcard cert on disk
+            # (DNS-01 acquired); the explicit cert/key means Caddy never
+            # attempts ACME for these hosts.
+            f"https://{zone}, https://*.{zone} {{\n"
+            f"    tls {config.tls_cert_path} {config.tls_key_path}\n"
             "    encode gzip zstd\n"
-            f"    reverse_proxy localhost:{web_server_port}\n"
+            f"    reverse_proxy localhost:{config.port}\n"
             "}\n"
-            ":80 {\n"
+            # Any other hostname is a custom (alternate) app domain: Caddy
+            # obtains a Let's Encrypt cert on first handshake, gated by the
+            # ask endpoint above so only registered domains get certs.
+            "https:// {\n"
+            "    tls {\n"
+            "        on_demand\n"
+            "    }\n"
+            "    encode gzip zstd\n"
+            f"    reverse_proxy localhost:{config.port}\n"
+            "}\n"
+            # Caddy serves /.well-known/acme-challenge/ on :80 ahead of this site.
+            "http:// {\n"
             "    redir https://{host}{uri} permanent\n"
             "}\n"
         )
@@ -32,7 +58,7 @@ def generate_caddyfile(tls_enabled: bool, tls_cert_path: Path, tls_key_path: Pat
             "}\n"
             ":80 {\n"
             "    encode gzip zstd\n"
-            f"    reverse_proxy localhost:{web_server_port}\n"
+            f"    reverse_proxy localhost:{config.port}\n"
             "}\n"
         )
 
@@ -79,10 +105,9 @@ class CaddyProcess:
         self.proc = _spawn_caddy(self.caddyfile_path)
 
 
-def start_caddy(
-    caddyfile_path: Path, tls_enabled: bool, tls_cert_path: Path, tls_key_path: Path, web_server_port: int
-) -> CaddyProcess:
+def start_caddy(config: Config) -> CaddyProcess:
     """Generate Caddyfile and start Caddy."""
+    caddyfile_path = config.caddyfile_path
     caddyfile_path.parent.mkdir(parents=True, exist_ok=True)
-    caddyfile_path.write_text(generate_caddyfile(tls_enabled, tls_cert_path, tls_key_path, web_server_port))
+    caddyfile_path.write_text(generate_caddyfile(config))
     return CaddyProcess(proc=_spawn_caddy(caddyfile_path), caddyfile_path=caddyfile_path)

--- a/compute_space/src/compute_space/db/schema.sql
+++ b/compute_space/src/compute_space/db/schema.sql
@@ -46,6 +46,18 @@ CREATE TABLE IF NOT EXISTS app_port_mappings (
     UNIQUE(app_id, label)
 );
 
+-- Custom domains (CNAME'd at <app_name>.<zone_domain>) that route to an app.
+-- ``domain`` is globally UNIQUE so two apps can't claim the same domain.
+CREATE TABLE IF NOT EXISTS app_alt_domains (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    app_id TEXT NOT NULL,
+    domain TEXT NOT NULL UNIQUE,
+    created_at TEXT NOT NULL DEFAULT (datetime('now')),
+    FOREIGN KEY (app_id) REFERENCES apps(app_id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_alt_domains_app_id ON app_alt_domains(app_id);
+
 CREATE UNIQUE INDEX IF NOT EXISTS idx_port_mappings_host_port ON app_port_mappings(host_port);
 CREATE INDEX IF NOT EXISTS idx_apps_status ON apps(status);
 CREATE UNIQUE INDEX IF NOT EXISTS idx_apps_app_id ON apps(app_id);

--- a/compute_space/src/compute_space/db/versioned/migrations/v0012_app_alt_domains.py
+++ b/compute_space/src/compute_space/db/versioned/migrations/v0012_app_alt_domains.py
@@ -1,0 +1,10 @@
+"""v12: add ``app_alt_domains`` table.  Body in v0012_app_alt_domains.sql."""
+
+from __future__ import annotations
+
+from compute_space.db.versioned.base import SqlFileMigration
+
+
+class Migration0012AppAltDomains(SqlFileMigration):
+    version = 12
+    sql_file = "v0012_app_alt_domains.sql"

--- a/compute_space/src/compute_space/db/versioned/migrations/v0012_app_alt_domains.sql
+++ b/compute_space/src/compute_space/db/versioned/migrations/v0012_app_alt_domains.sql
@@ -1,0 +1,17 @@
+-- v12: add ``app_alt_domains`` table.
+--
+-- Each row maps a custom domain (e.g. "myapp.example.com") to an app. The
+-- owner points a CNAME at <app_name>.<zone_domain>; the router matches
+-- inbound Host headers against this table and Caddy issues on-demand TLS
+-- certs gated by these rows. ``domain`` is globally UNIQUE so two apps
+-- can't claim the same custom domain.
+
+CREATE TABLE IF NOT EXISTS app_alt_domains (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    app_id TEXT NOT NULL,
+    domain TEXT NOT NULL UNIQUE,
+    created_at TEXT NOT NULL DEFAULT (datetime('now')),
+    FOREIGN KEY (app_id) REFERENCES apps(app_id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_alt_domains_app_id ON app_alt_domains(app_id);

--- a/compute_space/src/compute_space/db/versioned/registry.py
+++ b/compute_space/src/compute_space/db/versioned/registry.py
@@ -18,6 +18,7 @@ from compute_space.db.versioned.migrations.v0008_drop_v1_service_tables import M
 from compute_space.db.versioned.migrations.v0009_session_auth import Migration0009SessionAuth
 from compute_space.db.versioned.migrations.v0010_app_links import Migration0010AppLinks
 from compute_space.db.versioned.migrations.v0011_cpu_cores import Migration0011CpuCores
+from compute_space.db.versioned.migrations.v0012_app_alt_domains import Migration0012AppAltDomains
 
 # Numbered migrations in apply order. Versions MUST start at 2 and be
 # contiguous. v0 (legacy) and v1 (baseline produced by the existing
@@ -33,4 +34,5 @@ REGISTRY: list[Migration] = [
     Migration0009SessionAuth(),
     Migration0010AppLinks(),
     Migration0011CpuCores(),
+    Migration0012AppAltDomains(),
 ]

--- a/compute_space/src/compute_space/tests/snapshots/empty/v0012.sql
+++ b/compute_space/src/compute_space/tests/snapshots/empty/v0012.sql
@@ -6,6 +6,13 @@ CREATE TABLE api_tokens (
     expires_at TEXT NOT NULL,
     created_at TEXT NOT NULL DEFAULT (datetime('now'))
 );
+CREATE TABLE app_alt_domains (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    app_id TEXT NOT NULL,
+    domain TEXT NOT NULL UNIQUE,
+    created_at TEXT NOT NULL DEFAULT (datetime('now')),
+    FOREIGN KEY (app_id) REFERENCES apps(app_id) ON DELETE CASCADE
+);
 CREATE TABLE "app_databases" (
                 id INTEGER PRIMARY KEY AUTOINCREMENT,
                 app_id TEXT NOT NULL,
@@ -79,7 +86,7 @@ CREATE TABLE schema_version (
     id INTEGER PRIMARY KEY CHECK (id = 1),
     version INTEGER NOT NULL
 );
-INSERT INTO "schema_version" VALUES(1,11);
+INSERT INTO "schema_version" VALUES(1,12);
 CREATE TABLE "service_defaults" (
                 service_url TEXT PRIMARY KEY,
                 app_id TEXT NOT NULL,
@@ -108,4 +115,5 @@ CREATE INDEX idx_apps_status ON apps(status);
 CREATE UNIQUE INDEX idx_apps_app_id ON apps(app_id);
 CREATE UNIQUE INDEX idx_port_mappings_host_port ON app_port_mappings(host_port);
 CREATE INDEX sessions_user_id_idx ON sessions(user_id);
+CREATE INDEX idx_alt_domains_app_id ON app_alt_domains(app_id);
 COMMIT;

--- a/compute_space/src/compute_space/tests/snapshots/owner_null_password/v0012.sql
+++ b/compute_space/src/compute_space/tests/snapshots/owner_null_password/v0012.sql
@@ -6,8 +6,13 @@ CREATE TABLE api_tokens (
     expires_at TEXT NOT NULL,
     created_at TEXT NOT NULL DEFAULT (datetime('now'))
 );
-INSERT INTO "api_tokens" VALUES(1,'ci-deploy','api-hash-ci','2099-01-01T00:00:00','2024-01-01T00:00:00');
-INSERT INTO "api_tokens" VALUES(2,'monitoring','api-hash-mon','2099-12-31T00:00:00','2024-03-01T00:00:00');
+CREATE TABLE app_alt_domains (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    app_id TEXT NOT NULL,
+    domain TEXT NOT NULL UNIQUE,
+    created_at TEXT NOT NULL DEFAULT (datetime('now')),
+    FOREIGN KEY (app_id) REFERENCES apps(app_id) ON DELETE CASCADE
+);
 CREATE TABLE "app_databases" (
                 id INTEGER PRIMARY KEY AUTOINCREMENT,
                 app_id TEXT NOT NULL,
@@ -16,8 +21,6 @@ CREATE TABLE "app_databases" (
                 FOREIGN KEY (app_id) REFERENCES apps(app_id) ON DELETE CASCADE,
                 UNIQUE(app_id, db_name)
             );
-INSERT INTO "app_databases" VALUES(1,'111111111112','orders_db','/data/orders/orders.db');
-INSERT INTO "app_databases" VALUES(2,'111111111113','billing_db','/data/billing/billing.db');
 CREATE TABLE "app_port_mappings" (
                 id INTEGER PRIMARY KEY AUTOINCREMENT,
                 app_id TEXT NOT NULL,
@@ -27,16 +30,11 @@ CREATE TABLE "app_port_mappings" (
                 FOREIGN KEY (app_id) REFERENCES apps(app_id) ON DELETE CASCADE,
                 UNIQUE(app_id, label)
             );
-INSERT INTO "app_port_mappings" VALUES(1,'111111111112','grpc',8000,19500);
-INSERT INTO "app_port_mappings" VALUES(2,'111111111112','health',8080,19501);
-INSERT INTO "app_port_mappings" VALUES(3,'111111111113','http',8000,19502);
 CREATE TABLE "app_tokens" (
                 app_id TEXT PRIMARY KEY,
                 token_hash TEXT NOT NULL UNIQUE,
                 FOREIGN KEY (app_id) REFERENCES apps(app_id) ON DELETE CASCADE
             );
-INSERT INTO "app_tokens" VALUES('111111111112','app-hash-orders');
-INSERT INTO "app_tokens" VALUES('111111111113','app-hash-billing');
 CREATE TABLE "apps" (
                 id INTEGER PRIMARY KEY AUTOINCREMENT,
                 app_id TEXT NOT NULL UNIQUE,
@@ -61,8 +59,6 @@ CREATE TABLE "apps" (
                 created_at TEXT NOT NULL DEFAULT (datetime('now')),
                 updated_at TEXT NOT NULL DEFAULT (datetime('now'))
             , links TEXT NOT NULL DEFAULT '[]', cpu_cores REAL NOT NULL DEFAULT 0.1);
-INSERT INTO "apps" VALUES(1,'111111111112','orders','orders','1.0.0','Order service','serverfull','/repo/orders',NULL,NULL,19100,NULL,NULL,'stopped',NULL,256,0,'[]',NULL,NULL,'2024-01-01T00:00:00','2024-01-01T00:00:00','[]',0.5);
-INSERT INTO "apps" VALUES(2,'111111111113','billing','billing','2.1.0','Billing service','serverfull','/repo/billing','https://git.example/billing',NULL,19101,NULL,NULL,'running',NULL,512,0,'["/invoices"]',NULL,NULL,'2024-02-15T10:00:00','2024-02-15T10:00:00','[]',1.0);
 CREATE TABLE archive_backend (
     id INTEGER PRIMARY KEY CHECK (id = 1),
     backend TEXT NOT NULL DEFAULT 'disabled' CHECK(backend IN ('disabled', 's3')),
@@ -90,7 +86,7 @@ CREATE TABLE schema_version (
     id INTEGER PRIMARY KEY CHECK (id = 1),
     version INTEGER NOT NULL
 );
-INSERT INTO "schema_version" VALUES(1,11);
+INSERT INTO "schema_version" VALUES(1,12);
 CREATE TABLE "service_defaults" (
                 service_url TEXT PRIMARY KEY,
                 app_id TEXT NOT NULL,
@@ -115,9 +111,9 @@ CREATE TABLE users (
     password_hash TEXT NOT NULL,
     created_at TEXT NOT NULL DEFAULT (datetime('now'))
 );
-INSERT INTO "users" VALUES(1,'admin','argon2-stub-owner-hash','2024-01-01T00:00:00');
 CREATE INDEX idx_apps_status ON apps(status);
 CREATE UNIQUE INDEX idx_apps_app_id ON apps(app_id);
 CREATE UNIQUE INDEX idx_port_mappings_host_port ON app_port_mappings(host_port);
 CREATE INDEX sessions_user_id_idx ON sessions(user_id);
+CREATE INDEX idx_alt_domains_app_id ON app_alt_domains(app_id);
 COMMIT;

--- a/compute_space/src/compute_space/tests/snapshots/service_with_ports/v0012.sql
+++ b/compute_space/src/compute_space/tests/snapshots/service_with_ports/v0012.sql
@@ -6,6 +6,15 @@ CREATE TABLE api_tokens (
     expires_at TEXT NOT NULL,
     created_at TEXT NOT NULL DEFAULT (datetime('now'))
 );
+INSERT INTO "api_tokens" VALUES(1,'ci-deploy','api-hash-ci','2099-01-01T00:00:00','2024-01-01T00:00:00');
+INSERT INTO "api_tokens" VALUES(2,'monitoring','api-hash-mon','2099-12-31T00:00:00','2024-03-01T00:00:00');
+CREATE TABLE app_alt_domains (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    app_id TEXT NOT NULL,
+    domain TEXT NOT NULL UNIQUE,
+    created_at TEXT NOT NULL DEFAULT (datetime('now')),
+    FOREIGN KEY (app_id) REFERENCES apps(app_id) ON DELETE CASCADE
+);
 CREATE TABLE "app_databases" (
                 id INTEGER PRIMARY KEY AUTOINCREMENT,
                 app_id TEXT NOT NULL,
@@ -14,6 +23,8 @@ CREATE TABLE "app_databases" (
                 FOREIGN KEY (app_id) REFERENCES apps(app_id) ON DELETE CASCADE,
                 UNIQUE(app_id, db_name)
             );
+INSERT INTO "app_databases" VALUES(1,'111111111112','orders_db','/data/orders/orders.db');
+INSERT INTO "app_databases" VALUES(2,'111111111113','billing_db','/data/billing/billing.db');
 CREATE TABLE "app_port_mappings" (
                 id INTEGER PRIMARY KEY AUTOINCREMENT,
                 app_id TEXT NOT NULL,
@@ -23,11 +34,16 @@ CREATE TABLE "app_port_mappings" (
                 FOREIGN KEY (app_id) REFERENCES apps(app_id) ON DELETE CASCADE,
                 UNIQUE(app_id, label)
             );
+INSERT INTO "app_port_mappings" VALUES(1,'111111111112','grpc',8000,19500);
+INSERT INTO "app_port_mappings" VALUES(2,'111111111112','health',8080,19501);
+INSERT INTO "app_port_mappings" VALUES(3,'111111111113','http',8000,19502);
 CREATE TABLE "app_tokens" (
                 app_id TEXT PRIMARY KEY,
                 token_hash TEXT NOT NULL UNIQUE,
                 FOREIGN KEY (app_id) REFERENCES apps(app_id) ON DELETE CASCADE
             );
+INSERT INTO "app_tokens" VALUES('111111111112','app-hash-orders');
+INSERT INTO "app_tokens" VALUES('111111111113','app-hash-billing');
 CREATE TABLE "apps" (
                 id INTEGER PRIMARY KEY AUTOINCREMENT,
                 app_id TEXT NOT NULL UNIQUE,
@@ -52,6 +68,8 @@ CREATE TABLE "apps" (
                 created_at TEXT NOT NULL DEFAULT (datetime('now')),
                 updated_at TEXT NOT NULL DEFAULT (datetime('now'))
             , links TEXT NOT NULL DEFAULT '[]', cpu_cores REAL NOT NULL DEFAULT 0.1);
+INSERT INTO "apps" VALUES(1,'111111111112','orders','orders','1.0.0','Order service','serverfull','/repo/orders',NULL,NULL,19100,NULL,NULL,'stopped',NULL,256,0,'[]',NULL,NULL,'2024-01-01T00:00:00','2024-01-01T00:00:00','[]',0.5);
+INSERT INTO "apps" VALUES(2,'111111111113','billing','billing','2.1.0','Billing service','serverfull','/repo/billing','https://git.example/billing',NULL,19101,NULL,NULL,'running',NULL,512,0,'["/invoices"]',NULL,NULL,'2024-02-15T10:00:00','2024-02-15T10:00:00','[]',1.0);
 CREATE TABLE archive_backend (
     id INTEGER PRIMARY KEY CHECK (id = 1),
     backend TEXT NOT NULL DEFAULT 'disabled' CHECK(backend IN ('disabled', 's3')),
@@ -79,7 +97,7 @@ CREATE TABLE schema_version (
     id INTEGER PRIMARY KEY CHECK (id = 1),
     version INTEGER NOT NULL
 );
-INSERT INTO "schema_version" VALUES(1,11);
+INSERT INTO "schema_version" VALUES(1,12);
 CREATE TABLE "service_defaults" (
                 service_url TEXT PRIMARY KEY,
                 app_id TEXT NOT NULL,
@@ -104,8 +122,10 @@ CREATE TABLE users (
     password_hash TEXT NOT NULL,
     created_at TEXT NOT NULL DEFAULT (datetime('now'))
 );
+INSERT INTO "users" VALUES(1,'admin','argon2-stub-owner-hash','2024-01-01T00:00:00');
 CREATE INDEX idx_apps_status ON apps(status);
 CREATE UNIQUE INDEX idx_apps_app_id ON apps(app_id);
 CREATE UNIQUE INDEX idx_port_mappings_host_port ON app_port_mappings(host_port);
 CREATE INDEX sessions_user_id_idx ON sessions(user_id);
+CREATE INDEX idx_alt_domains_app_id ON app_alt_domains(app_id);
 COMMIT;

--- a/compute_space/src/compute_space/tests/test_caddyfile.py
+++ b/compute_space/src/compute_space/tests/test_caddyfile.py
@@ -1,0 +1,90 @@
+"""Tests for Caddyfile generation, including on-demand TLS for custom domains."""
+
+from __future__ import annotations
+
+import datetime
+import shutil
+import subprocess
+from typing import Any
+
+import pytest
+
+from compute_space.core.caddy import generate_caddyfile
+
+from .conftest import _make_test_config
+from .test_cert_renewal import _write_self_signed_cert
+
+
+@pytest.fixture
+def tls_cfg(tmp_path_factory: pytest.TempPathFactory) -> Any:
+    return _make_test_config(
+        tmp_path_factory.mktemp("caddyfile"),
+        port=20980,
+        tls_enabled=True,
+        zone_domain="zone.example.org",
+    )
+
+
+def test_tls_caddyfile_zone_site_uses_static_cert(tls_cfg: Any) -> None:
+    caddyfile = generate_caddyfile(tls_cfg)
+    assert "https://zone.example.org, https://*.zone.example.org {" in caddyfile
+    assert f"tls {tls_cfg.tls_cert_path} {tls_cfg.tls_key_path}" in caddyfile
+
+
+def test_tls_caddyfile_on_demand_for_custom_domains(tls_cfg: Any) -> None:
+    caddyfile = generate_caddyfile(tls_cfg)
+    assert "on_demand_tls {" in caddyfile
+    assert "ask http://127.0.0.1:20980/api/tls/on_demand_check" in caddyfile
+    # Catch-all https:// site issues certs on demand for registered domains.
+    assert "https:// {" in caddyfile
+    assert "on_demand" in caddyfile.split("https:// {")[1]
+    # ACME machinery must stay enabled (auto_https off would break on-demand);
+    # only Caddy's automatic :80 redirect site is suppressed.
+    assert "auto_https disable_redirects" in caddyfile
+    assert "auto_https off" not in caddyfile
+    assert f"root {tls_cfg.caddy_storage_dir}" in caddyfile
+
+
+def test_tls_caddyfile_http_redirect(tls_cfg: Any) -> None:
+    """When TLS is enabled, plain HTTP redirects to HTTPS (and does not proxy)."""
+    caddyfile = generate_caddyfile(tls_cfg)
+    assert "http:// {" in caddyfile
+    assert "redir https://{host}{uri} permanent" in caddyfile
+    lines_in_http_block = caddyfile.split("http:// {")[1].split("}")[0]
+    assert "reverse_proxy" not in lines_in_http_block
+
+
+def test_tls_caddyfile_email_only_when_configured(tmp_path_factory: pytest.TempPathFactory) -> None:
+    no_email = _make_test_config(tmp_path_factory.mktemp("caddyfile-nomail"), port=20981, tls_enabled=True)
+    assert "\n    email " not in generate_caddyfile(no_email)
+    with_email = _make_test_config(
+        tmp_path_factory.mktemp("caddyfile-email"), port=20982, tls_enabled=True, acme_email="owner@example.com"
+    )
+    assert "    email owner@example.com\n" in generate_caddyfile(with_email)
+
+
+def test_non_tls_caddyfile_plain_proxy(tmp_path_factory: pytest.TempPathFactory) -> None:
+    cfg = _make_test_config(tmp_path_factory.mktemp("caddyfile-plain"), port=20983, tls_enabled=False)
+    caddyfile = generate_caddyfile(cfg)
+    assert "auto_https off" in caddyfile
+    assert ":80 {" in caddyfile
+    assert "reverse_proxy localhost:20983" in caddyfile
+    assert "on_demand" not in caddyfile
+
+
+@pytest.mark.skipif(shutil.which("caddy") is None, reason="caddy binary not available")
+def test_tls_caddyfile_validates(tls_cfg: Any) -> None:
+    """The generated config must be accepted by ``caddy validate``."""
+    _write_self_signed_cert(
+        tls_cfg.tls_cert_path,
+        tls_cfg.tls_key_path,
+        datetime.datetime.now(datetime.UTC) + datetime.timedelta(days=30),
+    )
+    caddyfile_path = tls_cfg.caddyfile_path
+    caddyfile_path.write_text(generate_caddyfile(tls_cfg))
+    result = subprocess.run(
+        ["caddy", "validate", "--config", str(caddyfile_path), "--adapter", "caddyfile"],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr

--- a/compute_space/src/compute_space/tests/test_get_app_from_hostname.py
+++ b/compute_space/src/compute_space/tests/test_get_app_from_hostname.py
@@ -1,0 +1,98 @@
+"""Unit tests for hostname -> app resolution, including alternate (custom) domains."""
+
+from __future__ import annotations
+
+import sqlite3
+from typing import Any
+
+import pytest
+
+from compute_space.core.app_id import new_app_id
+from compute_space.core.apps import find_app_by_alt_domain
+from compute_space.core.apps import get_app_from_hostname
+from compute_space.db.connection import init_db
+
+from .conftest import _make_test_config
+
+
+@pytest.fixture
+def cfg(tmp_path_factory: pytest.TempPathFactory) -> Any:
+    c = _make_test_config(tmp_path_factory.mktemp("hostname"), port=20950)
+    init_db(c.db_path)
+    return c
+
+
+def _seed_app(cfg: Any, name: str, local_port: int, alt_domains: list[str] | None = None) -> str:
+    app_id = new_app_id()
+    db = sqlite3.connect(cfg.db_path)
+    try:
+        db.execute(
+            """INSERT INTO apps (app_id, name, version, repo_path, local_port, status)
+               VALUES (?, ?, '1.0', '/tmp/none', ?, 'running')""",
+            (app_id, name, local_port),
+        )
+        for domain in alt_domains or []:
+            db.execute("INSERT INTO app_alt_domains (app_id, domain) VALUES (?, ?)", (app_id, domain))
+        db.commit()
+    finally:
+        db.close()
+    return app_id
+
+
+def test_zone_domain_itself_matches_nothing(cfg: Any) -> None:
+    _seed_app(cfg, "myapp", 20951)
+    assert get_app_from_hostname(cfg.zone_domain) is None
+
+
+def test_app_subdomain_matches_by_name(cfg: Any) -> None:
+    app_id = _seed_app(cfg, "myapp", 20951)
+    app = get_app_from_hostname(f"myapp.{cfg.zone_domain}")
+    assert app is not None and app.app_id == app_id
+
+
+def test_app_subdomain_with_port_and_case(cfg: Any) -> None:
+    app_id = _seed_app(cfg, "myapp", 20951)
+    app = get_app_from_hostname(f"MyApp.{cfg.zone_domain}:8443")
+    assert app is not None and app.app_id == app_id
+
+
+def test_multi_label_subdomain_matches_nothing(cfg: Any) -> None:
+    _seed_app(cfg, "myapp", 20951)
+    assert get_app_from_hostname(f"extra.myapp.{cfg.zone_domain}") is None
+
+
+def test_unknown_subdomain_matches_nothing(cfg: Any) -> None:
+    _seed_app(cfg, "myapp", 20951)
+    assert get_app_from_hostname(f"other.{cfg.zone_domain}") is None
+
+
+def test_alt_domain_matches(cfg: Any) -> None:
+    app_id = _seed_app(cfg, "myapp", 20951, alt_domains=["myapp.example.com"])
+    app = get_app_from_hostname("myapp.example.com")
+    assert app is not None and app.app_id == app_id
+
+
+def test_alt_domain_normalizes_case_port_and_trailing_dot(cfg: Any) -> None:
+    app_id = _seed_app(cfg, "myapp", 20951, alt_domains=["myapp.example.com"])
+    for host in ("MyApp.Example.COM", "myapp.example.com:443", "myapp.example.com."):
+        app = get_app_from_hostname(host)
+        assert app is not None and app.app_id == app_id, host
+
+
+def test_alt_domain_routes_to_owning_app(cfg: Any) -> None:
+    _seed_app(cfg, "appa", 20951, alt_domains=["a.example.com"])
+    app_id_b = _seed_app(cfg, "appb", 20952, alt_domains=["b.example.com"])
+    app = get_app_from_hostname("b.example.com")
+    assert app is not None and app.app_id == app_id_b
+
+
+def test_unregistered_external_host_matches_nothing(cfg: Any) -> None:
+    _seed_app(cfg, "myapp", 20951, alt_domains=["myapp.example.com"])
+    assert get_app_from_hostname("other.example.com") is None
+    assert get_app_from_hostname("localhost:8080") is None
+
+
+def test_alt_domain_is_exact_match_not_suffix(cfg: Any) -> None:
+    _seed_app(cfg, "myapp", 20951, alt_domains=["myapp.example.com"])
+    assert get_app_from_hostname("sub.myapp.example.com") is None
+    assert find_app_by_alt_domain("sub.myapp.example.com") is None

--- a/compute_space/src/compute_space/tests/test_integration.py
+++ b/compute_space/src/compute_space/tests/test_integration.py
@@ -14,14 +14,12 @@ import sqlite3
 import subprocess
 import tempfile
 import time
-from pathlib import Path
 
 import pytest
 import requests
 from loguru import logger
 
 from compute_space import OPENHOST_PROJECT_DIR
-from compute_space.core.caddy import generate_caddyfile
 from compute_space.core.data import provision_data
 from compute_space.core.manifest import AppManifest
 from compute_space.tests.conftest import _make_config_and_env
@@ -102,28 +100,6 @@ def test_pre_setup_health(tmp_path):
     finally:
         if router is not None:
             _stop_router_process(router)
-
-
-def test_caddyfile_http_redirect():
-    """When TLS is enabled, port 80 redirects to HTTPS."""
-    caddyfile = generate_caddyfile(
-        tls_enabled=True,
-        tls_cert_path=Path("/etc/ssl/cert.pem"),
-        tls_key_path=Path("/etc/ssl/key.pem"),
-        web_server_port=8080,
-    )
-
-    # Should have an :80 block with a permanent redirect to https
-    assert ":80 {" in caddyfile
-    assert "redir https://{host}{uri} permanent" in caddyfile
-
-    # Should also have an :443 block with TLS configured
-    assert ":443 {" in caddyfile
-    assert "tls /etc/ssl/cert.pem /etc/ssl/key.pem" in caddyfile
-
-    # The :80 block should NOT reverse_proxy (it only redirects)
-    lines_in_80_block = caddyfile.split(":80 {")[1].split("}")[0]
-    assert "reverse_proxy" not in lines_in_80_block
 
 
 def _setup_owner(session, base_url, password="testpass123", username=None, timeout=30):

--- a/compute_space/src/compute_space/tests/test_set_app_domains.py
+++ b/compute_space/src/compute_space/tests/test_set_app_domains.py
@@ -1,0 +1,221 @@
+"""Tests for the ``/set_app_domains/<app_id>`` route (alternate/custom domains for an app)."""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+from typing import Any
+
+import pytest
+from litestar import Litestar
+from litestar.contrib.jinja import JinjaTemplateEngine
+from litestar.di import Provide
+from litestar.template.config import TemplateConfig
+from litestar.testing import TestClient
+
+import compute_space.web
+from compute_space.config import provide_config
+from compute_space.core.app_id import new_app_id
+from compute_space.db import provide_db
+from compute_space.db.connection import init_db
+from compute_space.web.app import _template_globals
+from compute_space.web.routes.api.apps import api_apps_routes
+from compute_space.web.routes.pages.apps import pages_apps_routes
+
+from ._litestar_helpers import auth_cookie
+from ._litestar_helpers import make_test_app
+from .conftest import _make_test_config
+
+
+@pytest.fixture
+def cfg(tmp_path_factory: pytest.TempPathFactory) -> Any:
+    c = _make_test_config(tmp_path_factory.mktemp("set-domains"), port=20970)
+    init_db(c.db_path)
+    return c
+
+
+def _seed_app(cfg: Any, name: str, local_port: int, alt_domains: list[str] | None = None) -> str:
+    app_id = new_app_id()
+    db = sqlite3.connect(cfg.db_path)
+    try:
+        db.execute(
+            """INSERT INTO apps (app_id, name, version, repo_path, local_port, status)
+               VALUES (?, ?, '1.0', '/tmp/none', ?, 'stopped')""",
+            (app_id, name, local_port),
+        )
+        for domain in alt_domains or []:
+            db.execute("INSERT INTO app_alt_domains (app_id, domain) VALUES (?, ?)", (app_id, domain))
+        db.commit()
+    finally:
+        db.close()
+    return app_id
+
+
+def _stored_domains(cfg: Any, app_id: str) -> list[str]:
+    db = sqlite3.connect(cfg.db_path)
+    try:
+        rows = db.execute("SELECT domain FROM app_alt_domains WHERE app_id = ? ORDER BY domain", (app_id,)).fetchall()
+        return [r[0] for r in rows]
+    finally:
+        db.close()
+
+
+def test_set_domains_persists_and_normalizes(cfg: Any) -> None:
+    app_id = _seed_app(cfg, "myapp", 20971)
+    cookies = auth_cookie(cfg)
+    with TestClient(app=make_test_app(api_apps_routes)) as client:
+        r = client.post(
+            f"/set_app_domains/{app_id}",
+            json={"domains": [" MyApp.Example.com ", "b.example.com.", ""]},
+            cookies=cookies,
+        )
+    assert r.status_code == 200, r.text
+    assert r.json() == {"ok": True, "alt_domains": ["myapp.example.com", "b.example.com"]}
+    assert _stored_domains(cfg, app_id) == ["b.example.com", "myapp.example.com"]
+
+
+def test_set_domains_replaces_existing_set(cfg: Any) -> None:
+    app_id = _seed_app(cfg, "myapp", 20971, alt_domains=["old.example.com"])
+    cookies = auth_cookie(cfg)
+    with TestClient(app=make_test_app(api_apps_routes)) as client:
+        r = client.post(f"/set_app_domains/{app_id}", json={"domains": ["new.example.com"]}, cookies=cookies)
+    assert r.status_code == 200, r.text
+    assert _stored_domains(cfg, app_id) == ["new.example.com"]
+
+
+def test_set_domains_empty_list_clears(cfg: Any) -> None:
+    app_id = _seed_app(cfg, "myapp", 20971, alt_domains=["old.example.com"])
+    cookies = auth_cookie(cfg)
+    with TestClient(app=make_test_app(api_apps_routes)) as client:
+        r = client.post(f"/set_app_domains/{app_id}", json={"domains": []}, cookies=cookies)
+    assert r.status_code == 200, r.text
+    assert _stored_domains(cfg, app_id) == []
+
+
+@pytest.mark.parametrize(
+    "bad",
+    [
+        "no-tld",
+        "has space.example.com",
+        "-leading.example.com",
+        "trailing-.example.com",
+        "under_score.example.com",
+        "double..dot.example.com",
+        "a" * 254 + ".com",
+    ],
+)
+def test_set_domains_rejects_invalid(cfg: Any, bad: str) -> None:
+    app_id = _seed_app(cfg, "myapp", 20971)
+    cookies = auth_cookie(cfg)
+    with TestClient(app=make_test_app(api_apps_routes)) as client:
+        r = client.post(f"/set_app_domains/{app_id}", json={"domains": [bad]}, cookies=cookies)
+    assert r.status_code == 400, bad
+    assert _stored_domains(cfg, app_id) == []
+
+
+def test_set_domains_rejects_zone_and_zone_subdomains(cfg: Any) -> None:
+    app_id = _seed_app(cfg, "myapp", 20971)
+    cookies = auth_cookie(cfg)
+    zone = cfg.zone_domain_no_port
+    with TestClient(app=make_test_app(api_apps_routes)) as client:
+        for domain in (zone, f"other.{zone}"):
+            r = client.post(f"/set_app_domains/{app_id}", json={"domains": [domain]}, cookies=cookies)
+            assert r.status_code == 400, domain
+
+
+def test_set_domains_dedupes_within_request(cfg: Any) -> None:
+    app_id = _seed_app(cfg, "myapp", 20971)
+    cookies = auth_cookie(cfg)
+    with TestClient(app=make_test_app(api_apps_routes)) as client:
+        r = client.post(
+            f"/set_app_domains/{app_id}",
+            json={"domains": ["a.example.com", "A.example.COM."]},
+            cookies=cookies,
+        )
+    assert r.status_code == 200, r.text
+    assert _stored_domains(cfg, app_id) == ["a.example.com"]
+
+
+def test_set_domains_rejects_cross_app_duplicate(cfg: Any) -> None:
+    _seed_app(cfg, "appa", 20971, alt_domains=["taken.example.com"])
+    app_id_b = _seed_app(cfg, "appb", 20972, alt_domains=["mine.example.com"])
+    cookies = auth_cookie(cfg)
+    with TestClient(app=make_test_app(api_apps_routes)) as client:
+        r = client.post(
+            f"/set_app_domains/{app_id_b}",
+            json={"domains": ["taken.example.com"]},
+            cookies=cookies,
+        )
+    assert r.status_code == 409, r.text
+    assert "taken.example.com" in r.json()["error"]
+    # B's previous set is untouched by the failed replace.
+    assert _stored_domains(cfg, app_id_b) == ["mine.example.com"]
+
+
+def test_set_domains_max_count(cfg: Any) -> None:
+    app_id = _seed_app(cfg, "myapp", 20971)
+    cookies = auth_cookie(cfg)
+    domains = [f"d{i}.example.com" for i in range(21)]
+    with TestClient(app=make_test_app(api_apps_routes)) as client:
+        r = client.post(f"/set_app_domains/{app_id}", json={"domains": domains}, cookies=cookies)
+    assert r.status_code == 400
+
+
+def test_set_domains_removing_app_409(cfg: Any) -> None:
+    app_id = _seed_app(cfg, "myapp", 20971)
+    db = sqlite3.connect(cfg.db_path)
+    db.execute("UPDATE apps SET status = 'removing' WHERE app_id = ?", (app_id,))
+    db.commit()
+    db.close()
+    cookies = auth_cookie(cfg)
+    with TestClient(app=make_test_app(api_apps_routes)) as client:
+        r = client.post(f"/set_app_domains/{app_id}", json={"domains": ["a.example.com"]}, cookies=cookies)
+    assert r.status_code == 409
+
+
+def test_set_domains_unknown_and_invalid_app_id(cfg: Any) -> None:
+    cookies = auth_cookie(cfg)
+    with TestClient(app=make_test_app(api_apps_routes)) as client:
+        r = client.post(f"/set_app_domains/{new_app_id()}", json={"domains": []}, cookies=cookies)
+        assert r.status_code == 404
+        r = client.post("/set_app_domains/not-an-id!", json={"domains": []}, cookies=cookies)
+        assert r.status_code == 400
+
+
+def test_set_domains_requires_owner_auth(cfg: Any) -> None:
+    app_id = _seed_app(cfg, "myapp", 20971)
+    with TestClient(app=make_test_app(api_apps_routes)) as client:
+        r = client.post(f"/set_app_domains/{app_id}", json={"domains": ["a.example.com"]})
+    assert r.status_code in (401, 302, 307)
+    assert _stored_domains(cfg, app_id) == []
+
+
+def _make_pages_app(cfg: Any) -> Litestar:
+    """Litestar app that can render the real app_detail template (with globals installed)."""
+    web_dir = Path(compute_space.web.__file__).parent
+
+    def _install_globals(app: Litestar) -> None:
+        engine = app.template_engine
+        assert isinstance(engine, JinjaTemplateEngine)
+        engine.engine.globals.update(_template_globals(cfg, web_dir / "static"))
+
+    return Litestar(
+        route_handlers=[pages_apps_routes],
+        template_config=TemplateConfig(directory=web_dir / "templates", engine=JinjaTemplateEngine),
+        dependencies={
+            "config": Provide(provide_config, sync_to_thread=False),
+            "db": Provide(provide_db),
+        },
+        on_startup=[_install_globals],
+        openapi_config=None,
+    )
+
+
+def test_app_detail_page_shows_domains_and_cname_hint(cfg: Any) -> None:
+    _seed_app(cfg, "myapp", 20971, alt_domains=["myapp.example.com"])
+    cookies = auth_cookie(cfg)
+    with TestClient(app=_make_pages_app(cfg)) as client:
+        r = client.get("/app_detail/myapp", cookies=cookies)
+    assert r.status_code == 200, r.text
+    assert "myapp.example.com" in r.text
+    assert f"CNAME &rarr; myapp.{cfg.zone_domain_no_port}" in r.text

--- a/compute_space/src/compute_space/tests/test_tls_on_demand_check.py
+++ b/compute_space/src/compute_space/tests/test_tls_on_demand_check.py
@@ -1,0 +1,67 @@
+"""Tests for the Caddy on-demand TLS "ask" endpoint."""
+
+from __future__ import annotations
+
+import sqlite3
+from typing import Any
+
+import pytest
+from litestar.testing import TestClient
+
+from compute_space.core.app_id import new_app_id
+from compute_space.db.connection import init_db
+from compute_space.web.routes.api.tls import api_tls_routes
+
+from ._litestar_helpers import make_test_app
+from .conftest import _make_test_config
+
+
+@pytest.fixture
+def cfg(tmp_path_factory: pytest.TempPathFactory) -> Any:
+    c = _make_test_config(tmp_path_factory.mktemp("tls-check"), port=20960)
+    init_db(c.db_path)
+    return c
+
+
+def _seed_app_with_domain(cfg: Any, domain: str) -> None:
+    app_id = new_app_id()
+    db = sqlite3.connect(cfg.db_path)
+    try:
+        db.execute(
+            """INSERT INTO apps (app_id, name, version, repo_path, local_port, status)
+               VALUES (?, 'myapp', '1.0', '/tmp/none', 20961, 'running')""",
+            (app_id,),
+        )
+        db.execute("INSERT INTO app_alt_domains (app_id, domain) VALUES (?, ?)", (app_id, domain))
+        db.commit()
+    finally:
+        db.close()
+
+
+def test_registered_domain_allowed(cfg: Any) -> None:
+    _seed_app_with_domain(cfg, "myapp.example.com")
+    with TestClient(app=make_test_app(api_tls_routes)) as client:
+        # No auth cookie: Caddy calls this endpoint before any session exists.
+        r = client.get("/api/tls/on_demand_check", params={"domain": "myapp.example.com"})
+        assert r.status_code == 200
+
+
+def test_registered_domain_normalizes_case_and_trailing_dot(cfg: Any) -> None:
+    _seed_app_with_domain(cfg, "myapp.example.com")
+    with TestClient(app=make_test_app(api_tls_routes)) as client:
+        for domain in ("MyApp.Example.COM", "myapp.example.com."):
+            r = client.get("/api/tls/on_demand_check", params={"domain": domain})
+            assert r.status_code == 200, domain
+
+
+def test_unregistered_domain_refused(cfg: Any) -> None:
+    _seed_app_with_domain(cfg, "myapp.example.com")
+    with TestClient(app=make_test_app(api_tls_routes)) as client:
+        r = client.get("/api/tls/on_demand_check", params={"domain": "other.example.com"})
+        assert r.status_code == 404
+
+
+def test_missing_domain_param_rejected(cfg: Any) -> None:
+    with TestClient(app=make_test_app(api_tls_routes)) as client:
+        r = client.get("/api/tls/on_demand_check")
+        assert r.status_code == 400

--- a/compute_space/src/compute_space/web/app.py
+++ b/compute_space/src/compute_space/web/app.py
@@ -40,6 +40,7 @@ from compute_space.web.routes.api.permissions_v2 import api_permissions_v2_route
 from compute_space.web.routes.api.services_v2 import api_services_v2_routes
 from compute_space.web.routes.api.settings import api_settings_routes
 from compute_space.web.routes.api.system import system_routes
+from compute_space.web.routes.api.tls import api_tls_routes
 from compute_space.web.routes.docs import docs_routes
 from compute_space.web.routes.pages.apps import pages_apps_routes
 from compute_space.web.routes.pages.login import pages_login_routes
@@ -203,6 +204,7 @@ def create_app(config: Config) -> ASGIApp:
             api_permissions_v2_routes,
             api_services_v2_routes,
             api_settings_routes,
+            api_tls_routes,
             system_routes,
             identity_routes,
             docs_routes,

--- a/compute_space/src/compute_space/web/routes/api/apps.py
+++ b/compute_space/src/compute_space/web/routes/api/apps.py
@@ -181,6 +181,17 @@ class SetAppRemoteResponse:
     repo_url: str
 
 
+@attr.s(auto_attribs=True, frozen=True)
+class SetAppDomainsRequest:
+    domains: list[str]
+
+
+@attr.s(auto_attribs=True, frozen=True)
+class SetAppDomainsResponse:
+    ok: bool
+    alt_domains: list[str]
+
+
 # ─── helpers ───────────────────────────────────────────────────────────────
 
 
@@ -960,6 +971,81 @@ async def set_app_remote(
     )
 
 
+_MAX_ALT_DOMAINS_PER_APP = 20
+# FQDN: two or more dot-separated labels, each 1-63 chars of lowercase alnum with interior hyphens.
+_DOMAIN_LABEL = r"[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?"
+_ALT_DOMAIN_RE = re.compile(rf"^{_DOMAIN_LABEL}(\.{_DOMAIN_LABEL})+$")
+
+
+@post("/set_app_domains/{app_id:str}", status_code=200, guards=[require_owner_auth])
+async def set_app_domains(
+    app_id: str,
+    data: SetAppDomainsRequest,
+    db: sqlite3.Connection,
+    config: Config,
+) -> Response[SetAppDomainsResponse] | Response[ErrorResponse]:
+    """Replace an app's set of alternate (custom) domains.
+
+    Registered domains are matched against incoming Host headers by ``get_app_from_hostname`` and
+    gate on-demand TLS issuance. The owner must point a CNAME at ``<app_name>.<zone_domain>``
+    themselves; openhost does not manage the external DNS.
+    """
+    app_row, err = _resolve_app_or_error(app_id, db)
+    if err is not None:
+        return err
+    assert app_row is not None
+    if _is_removing(app_row):
+        return Response(content=ErrorResponse(error="App is being removed"), status_code=409)
+
+    zone = config.zone_domain_no_port
+    domains: list[str] = []
+    for raw in data.domains:
+        domain = raw.strip().lower().rstrip(".")
+        if not domain:
+            continue
+        if len(domain) > 253 or not _ALT_DOMAIN_RE.match(domain):
+            return Response(content=ErrorResponse(error=f"Invalid domain: {raw.strip()!r}"), status_code=400)
+        if domain == zone or domain.endswith("." + zone):
+            return Response(
+                content=ErrorResponse(
+                    error=f"'{domain}' is under {zone}; custom domains must be outside the openhost zone"
+                ),
+                status_code=400,
+            )
+        if domain not in domains:
+            domains.append(domain)
+    if len(domains) > _MAX_ALT_DOMAINS_PER_APP:
+        return Response(
+            content=ErrorResponse(error=f"At most {_MAX_ALT_DOMAINS_PER_APP} custom domains per app"),
+            status_code=400,
+        )
+
+    # Replace the whole set atomically. The UNIQUE(domain) constraint is the
+    # race-safe cross-app duplicate check: a concurrent claim surfaces as
+    # IntegrityError rather than a TOCTOU window.
+    try:
+        db.execute("DELETE FROM app_alt_domains WHERE app_id = ?", (app_id,))
+        db.executemany("INSERT INTO app_alt_domains (app_id, domain) VALUES (?, ?)", [(app_id, d) for d in domains])
+        db.commit()
+    except sqlite3.IntegrityError:
+        db.rollback()
+        taken = [
+            d
+            for d in domains
+            if db.execute("SELECT 1 FROM app_alt_domains WHERE domain = ? AND app_id != ?", (d, app_id)).fetchone()
+        ]
+        return Response(
+            content=ErrorResponse(error=f"Already used by another app: {', '.join(taken)}"),
+            status_code=409,
+        )
+
+    return Response(
+        content=SetAppDomainsResponse(ok=True, alt_domains=domains),
+        status_code=200,
+        media_type=MediaType.JSON,
+    )
+
+
 api_apps_routes = Router(
     path="/",
     route_handlers=[
@@ -975,5 +1061,6 @@ api_apps_routes = Router(
         remove_app,
         rename_app,
         set_app_remote,
+        set_app_domains,
     ],
 )

--- a/compute_space/src/compute_space/web/routes/api/tls.py
+++ b/compute_space/src/compute_space/web/routes/api/tls.py
@@ -1,0 +1,24 @@
+from litestar import Response
+from litestar import Router
+from litestar import get
+
+from compute_space.core.apps import find_app_by_alt_domain
+
+
+@get("/api/tls/on_demand_check")
+async def on_demand_check(domain: str) -> Response[str]:
+    """Caddy on-demand TLS "ask" hook: 2xx allows cert issuance for ``domain``, anything else refuses.
+
+    Unauthenticated by design — Caddy calls it over loopback before any TLS handshake completes, and it
+    reveals only whether a hostname is a registered alternate domain.
+    """
+    host = domain.strip().lower().rstrip(".")
+    if host and find_app_by_alt_domain(host) is not None:
+        return Response(content="", status_code=200)
+    return Response(content="", status_code=404)
+
+
+api_tls_routes = Router(
+    path="/",
+    route_handlers=[on_demand_check],
+)

--- a/compute_space/src/compute_space/web/routes/pages/apps.py
+++ b/compute_space/src/compute_space/web/routes/pages/apps.py
@@ -56,6 +56,13 @@ async def app_detail(app_name: str, db: sqlite3.Connection, config: Config, next
     # User-facing links the app advertised in its manifest's [[links]].
     links = deserialize_links(app_row["links"])
 
+    alt_domains = [
+        r["domain"]
+        for r in db.execute(
+            "SELECT domain FROM app_alt_domains WHERE app_id = ? ORDER BY domain", (app_id,)
+        ).fetchall()
+    ]
+
     # Permissions: granted + manifest-declared but not yet granted
     granted_perms = [
         {"service_url": p.service_url, "grant": p.grant, "scope": p.scope}
@@ -87,6 +94,7 @@ async def app_detail(app_name: str, db: sqlite3.Connection, config: Config, next
         template_name="app_detail.html",
         context={
             "app": app_row,
+            "alt_domains": alt_domains,
             "links": links,
             "databases": databases,
             "port_mappings": port_mappings,

--- a/compute_space/src/compute_space/web/start.py
+++ b/compute_space/src/compute_space/web/start.py
@@ -110,9 +110,7 @@ def main() -> None:
     # Caddy reverse proxy. mainly for TLS termination, but also some other features
     caddy: CaddyProcess | None = None
     if config.start_caddy:
-        caddy = start_caddy(
-            config.caddyfile_path, config.tls_enabled, config.tls_cert_path, config.tls_key_path, config.port
-        )
+        caddy = start_caddy(config)
         if config.tls_enabled and config.coredns_enabled and config.acquire_tls_cert_if_missing:
             start_renewal_thread(config, caddy.restart)
     else:

--- a/compute_space/src/compute_space/web/static/js/app-detail.js
+++ b/compute_space/src/compute_space/web/static/js/app-detail.js
@@ -68,6 +68,42 @@ function saveRemote() {
     .catch(function() { errEl.textContent = 'Failed to save'; });
 }
 
+// ─── Edit custom domains ───
+
+function editDomains() {
+  document.getElementById('domains-display').style.display = 'none';
+  document.getElementById('domains-edit').style.display = '';
+  document.getElementById('domains-input').focus();
+  document.getElementById('domains-error').textContent = '';
+}
+
+function cancelDomains() {
+  document.getElementById('domains-edit').style.display = 'none';
+  document.getElementById('domains-display').style.display = '';
+}
+
+function saveDomains() {
+  var input = document.getElementById('domains-input');
+  var errEl = document.getElementById('domains-error');
+  errEl.textContent = '';
+  var domains = input.value.split('\n').map(function(s) { return s.trim(); }).filter(Boolean);
+  fetch(config.setAppDomainsUrl, {
+    method: 'POST',
+    credentials: 'same-origin',
+    headers: {'Content-Type': 'application/json'},
+    body: JSON.stringify({domains: domains}),
+  })
+    .then(function(r) { return r.json().then(function(d) { return {ok: r.ok, data: d}; }); })
+    .then(function(res) {
+      if (!res.ok || (res.data && res.data.error)) {
+        errEl.textContent = (res.data && res.data.error) || 'Failed to save';
+        return;
+      }
+      location.reload();
+    })
+    .catch(function() { errEl.textContent = 'Failed to save'; });
+}
+
 // ─── App Actions (stop, reload, remove) ───
 
 function setActionsBusy(label) {

--- a/compute_space/src/compute_space/web/templates/app_detail.html
+++ b/compute_space/src/compute_space/web/templates/app_detail.html
@@ -43,6 +43,25 @@
     </span>
   </td></tr>
   {% endif %}
+  <tr><th>Custom Domains</th><td>
+    <span id="domains-display">
+      {% if alt_domains %}{% for d in alt_domains %}<code>{{ d }}</code>{% if not loop.last %}, {% endif %}{% endfor %}{% else %}---{% endif %}
+      <button class="btn" onclick="editDomains()" style="margin-left:0.5em;">Edit</button>
+    </span>
+    <span id="domains-edit" style="display:none;">
+      <textarea id="domains-input" rows="3" style="font-family:monospace;width:28em;vertical-align:top;" placeholder="myapp.example.com">{{ alt_domains | join('\n') }}</textarea>
+      <button class="btn btn-primary" onclick="saveDomains()">Save</button>
+      <button class="btn" onclick="cancelDomains()">Cancel</button>
+      <div class="hint" style="margin-top:0.25em;">
+        One domain per line. For each, create a DNS record at your provider pointing it at this app:
+        <code>CNAME &rarr; {{ app.name }}.{{ zone_domain.split(':')[0] }}</code>
+        (apex/root domains need an ALIAS or ANAME record instead).
+        The first HTTPS request to a new domain takes a few seconds while a certificate is issued.
+        Custom domains serve the app's public paths; owner-only paths stay on <code>{{ app.name }}.{{ zone_domain }}</code>.
+      </div>
+      <span id="domains-error" class="field-error"></span>
+    </span>
+  </td></tr>
   <tr><th>Repo Path</th><td>{{ app.repo_path }}</td></tr>
   <tr><th>Created</th><td>{{ app.created_at }}</td></tr>
   {% if app.error_message %}
@@ -194,6 +213,7 @@ async function grantPermission(btn) {
   "nextUrl": {{ next_url | default("", true) | tojson }},
   "reloadAppUrl": "/reload_app/{{ app.app_id }}",
   "setAppRemoteUrl": "/set_app_remote/{{ app.app_id }}",
+  "setAppDomainsUrl": "/set_app_domains/{{ app.app_id }}",
   "dropBuildCacheUrl": "/api/drop-docker-cache"
 }
 </script>


### PR DESCRIPTION
Apps can now be made available on other domain names. The owner registers alternate domains on the app detail page and points a CNAME at `<app_name>.<zone_domain>`; openhost routes those requests to the app and serves valid TLS.

## How it works

- **Routing**: `get_app_from_hostname` now falls back to a new `app_alt_domains` table (migration v0012) for any Host header outside the zone domain. Lookup is exact-match against a globally-UNIQUE indexed column; rows cascade-delete with the app.
- **TLS**: Caddy on-demand TLS. The Caddyfile keeps the existing wildcard cert in an explicit `https://zone, https://*.zone` site, and adds a catch-all `https://` site with `tls { on_demand }`. Before issuing, Caddy calls a new unauthenticated loopback endpoint (`GET /api/tls/on_demand_check?domain=...`) that returns 200 only for registered domains, so arbitrary hostnames pointed at the server can't mint certs. Issued certs persist in `persistent_data/openhost/caddy/` across restarts; adding/removing a domain needs no Caddy restart.
- **Editing**: new `POST /set_app_domains/{app_id}` (mirrors `set_app_remote`) replaces the app's domain set. Validation: FQDN syntax, rejects the zone domain and anything under it, max 20 per app, cross-app duplicates rejected race-safely via the UNIQUE constraint (409 naming the conflicting domain).
- **UI**: "Custom Domains" row on the app detail page with an inline textarea editor and help text showing the CNAME record to create (plus apex ALIAS/ANAME note and first-request cert-issuance delay).

## Notes

- `auto_https off` → `auto_https disable_redirects`: ACME machinery must be enabled for on-demand issuance. The zone site has an explicit cert/key so Caddy never attempts ACME for it; the `http://` catch-all keeps our permanent redirect while Caddy serves HTTP-01 challenges on :80 ahead of it. Worth a staging-zone sanity check that the wildcard path still serves the on-disk cert.
- On-demand certs come from Let's Encrypt directly (bypassing the cert_api broker) and require inbound port 80. `email` is emitted when `acme_email` is set.
- Custom domains serve the app's **public paths** only — the owner session cookie is scoped to the zone domain, so owner-only paths remain on `<app_name>.<zone_domain>`. The UI hint says this.

## Testing

- 917 lightweight tests pass; ruff + mypy clean.
- New: `test_set_app_domains.py` (endpoint validation + a real render of the detail page), `test_get_app_from_hostname.py`, `test_tls_on_demand_check.py`, `test_caddyfile.py` (includes `caddy validate` where the binary exists).
- Migration snapshots regenerated for all three sets; the old Caddyfile test moved from `test_integration.py` into `test_caddyfile.py` and updated for the new layout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)