### PR TITLE
Forward request headers to apps in canonical Title-Case

### DIFF
--- a/compute_space/src/compute_space/tests/test_proxy_forwarded_headers.py
+++ b/compute_space/src/compute_space/tests/test_proxy_forwarded_headers.py
@@ -1,0 +1,48 @@
+"""Unit tests for the request-header forwarding helpers in web/helpers/proxy.py."""
+
+from litestar.datastructures import Headers
+
+from compute_space.core.auth.auth import SESSION_COOKIE_NAME
+from compute_space.web.helpers.proxy import _HTTP_REQUEST_EXCLUDED_HEADERS
+from compute_space.web.helpers.proxy import _build_forwarded_request_headers
+from compute_space.web.helpers.proxy import _canonicalize_header_name
+
+
+def _build(raw: list[tuple[bytes, bytes]], extra: list[tuple[str, str]] | None = None) -> list[tuple[str, str]]:
+    return _build_forwarded_request_headers(Headers(raw), _HTTP_REQUEST_EXCLUDED_HEADERS, extra or [])
+
+
+def test_canonicalize_header_name() -> None:
+    assert _canonicalize_header_name("authorization") == "Authorization"
+    assert _canonicalize_header_name("content-type") == "Content-Type"
+    assert _canonicalize_header_name("x-real-ip") == "X-Real-Ip"
+
+
+def test_forwarded_headers_are_canonically_cased() -> None:
+    """ASGI lowercases inbound header names; backends that read names case-sensitively (e.g. PHP's
+    getallheaders()) must still see the conventional Title-Case form."""
+    result = _build([(b"authorization", b"Bearer tok"), (b"x-custom-thing", b"v")])
+    assert ("Authorization", "Bearer tok") in result
+    assert ("X-Custom-Thing", "v") in result
+
+
+def test_excluded_and_openhost_headers_still_dropped() -> None:
+    result = _build(
+        [
+            (b"host", b"example.com"),
+            (b"connection", b"keep-alive"),
+            (b"x-openhost-is-owner", b"true"),
+            (b"accept", b"*/*"),
+        ]
+    )
+    assert result == [("Accept", "*/*")]
+
+
+def test_session_cookie_still_stripped() -> None:
+    result = _build([(b"cookie", f"{SESSION_COOKIE_NAME}=secret; other=1".encode())])
+    assert result == [("Cookie", "other=1")]
+
+
+def test_extra_headers_keep_given_casing() -> None:
+    result = _build([(b"accept", b"*/*")], extra=[("X-OpenHost-Is-Owner", "true")])
+    assert ("X-OpenHost-Is-Owner", "true") in result

--- a/compute_space/src/compute_space/web/helpers/proxy.py
+++ b/compute_space/src/compute_space/web/helpers/proxy.py
@@ -64,11 +64,22 @@ def _sanitize_forwarded_headers(headers: Iterable[tuple[str, str]]) -> list[tupl
     return sanitized
 
 
+def _canonicalize_header_name(name: str) -> str:
+    """ASGI hands us header names lowercased (required by spec), and forwarding them that way breaks backends
+    that read header names case-sensitively — e.g. PHP's getallheaders() preserves wire casing, so LimeSurvey's
+    REST auth misses a lowercase `authorization` and 401s.  Forward in canonical Title-Case form instead,
+    matching what clients conventionally send: authorization -> Authorization, x-real-ip -> X-Real-Ip.
+    """
+    return "-".join(part.capitalize() for part in name.split("-"))
+
+
 def _build_forwarded_request_headers(
     headers: Headers, proto_excluded_headers: Set[str], extra_headers: Iterable[tuple[str, str]]
 ) -> list[tuple[str, str]]:
     new_headers = _sanitize_forwarded_headers(headers.multi_items())
-    new_headers = [(k, v) for k, v in new_headers if k.lower() not in proto_excluded_headers]
+    new_headers = [
+        (_canonicalize_header_name(k), v) for k, v in new_headers if k.lower() not in proto_excluded_headers
+    ]
     new_headers.extend(extra_headers)
     return new_headers
 


### PR DESCRIPTION
## Problem

ASGI requires servers to lowercase all inbound header names, so every header the router forwards to a backend app arrives as e.g. `authorization` instead of `Authorization`. Header names are case-insensitive per the HTTP spec, but some backends read them case-sensitively anyway — notably PHP's `getallheaders()`, which preserves wire casing.

Concrete failure: LimeSurvey's REST API does `isset(getallheaders()['Authorization'])`, so behind the router its bearer token was invisible, every `/rest/v1/*` call returned 401, and the new survey editor hung forever on "Checking permissions..." ([the case-sensitive lookup](https://github.com/LimeSurvey/LimeSurvey/blob/master/application/libraries/Api/Rest/Endpoint/EndpointFactory.php#L226-L242)). The same request sent directly to the container (title-cased by curl/browsers) worked fine, which is why this class of bug only appears behind the router.

## Fix

Canonicalize header names to conventional Title-Case (`authorization` → `Authorization`, `x-real-ip` → `X-Real-Ip`) in `_build_forwarded_request_headers`, which covers both the HTTP and WebSocket proxy paths. `extra_headers` (e.g. `X-OpenHost-Is-Owner`) already carry their intended casing and are unchanged; exclusion/stripping logic is case-insensitive and unaffected.

The original client casing is unrecoverable at the ASGI layer, so canonical form is the closest achievable to "preserve what the client sent" — it matches what clients conventionally put on the wire.

## Testing

- New unit tests in `test_proxy_forwarded_headers.py` (canonicalization, exclusions, cookie stripping, extra-header casing).
- Full `compute_space` suite: 683 passed, 32 skipped (linux-only markers on mac).
- Verified end-to-end against a live LimeSurvey container: with lowercase forwarding the editor's REST calls 401; with title-cased forwarding they 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)