### PR TITLE
Serve in-space docs with the nav header, in the same tab

### DIFF
--- a/compute_space/src/compute_space/tests/test_docs.py
+++ b/compute_space/src/compute_space/tests/test_docs.py
@@ -174,6 +174,26 @@ def test_active_sidebar_link_marked(client_with_docs: TestClient[Litestar]) -> N
     assert 'href="/docs/manifest_spec"' in body and "active" in body
 
 
+def test_page_carries_space_nav_header(client_with_docs: TestClient[Litestar]) -> None:
+    """The docs page must render the shared compute-space nav header
+    (Dashboard / Docs / Deploy App / ...) so the manual reads as an
+    in-space page rather than a standalone site."""
+    resp = client_with_docs.get("/docs/")
+    body = resp.text
+    assert 'id="main-nav"' in body
+    assert 'href="/dashboard"' in body
+    assert 'href="/add_app"' in body
+    assert 'href="/settings"' in body
+
+
+def test_docs_nav_link_stays_in_same_tab(client_with_docs: TestClient[Litestar]) -> None:
+    """The Docs nav link must not open in a new tab — no
+    ``target="_blank"`` on any nav tab in the rendered header."""
+    resp = client_with_docs.get("/docs/")
+    body = resp.text
+    assert 'target="_blank"' not in body
+
+
 def test_internal_md_links_rewritten(client_with_docs: TestClient[Litestar]) -> None:
     """Markdown like ``[manifest spec](./manifest_spec.md)`` should
     render as a link to ``/docs/manifest_spec``, NOT a literal

--- a/compute_space/src/compute_space/web/routes/docs.py
+++ b/compute_space/src/compute_space/web/routes/docs.py
@@ -5,6 +5,16 @@ through ``markdown-it-py`` + ``pygments``, and inject into a Jinja
 template that matches the OpenHost dashboard's visual language.
 There is no build step: ``git pull`` is enough to ship doc changes.
 
+The rendered page carries the same top navigation header as the rest
+of the compute space (Dashboard / Docs / Deploy App / ...), so the
+manual reads as an in-space page rather than a standalone site — the
+Docs nav link stays in the same tab.  The nav tab list + active-tab
+highlighter are shared with ``layout.html`` via the ``_nav_header.html``
+partial (this route's inline template ``{% include %}``s it through a
+Jinja ``Environment`` whose loader points at the templates dir), so the
+nav can't drift from the rest of the UI.  The docs page's own
+body/sidebar layout stays inline here.
+
 Why server-side render instead of mdBook (or any other static-site
 generator)?
 
@@ -52,7 +62,8 @@ import threading
 from dataclasses import dataclass
 from pathlib import Path
 
-from jinja2 import Template as JinjaTemplate
+from jinja2 import Environment
+from jinja2 import FileSystemLoader
 from litestar import MediaType
 from litestar import Response
 from litestar import Router
@@ -68,6 +79,9 @@ from pygments.lexers import get_lexer_by_name
 from pygments.util import ClassNotFound
 
 from compute_space.config import get_config
+from compute_space.core.auth.auth import read_owner_username
+from compute_space.core.logging import logger
+from compute_space.db import get_db
 
 # ─── Filesystem layout ──────────────────────────────────────────────
 
@@ -83,6 +97,41 @@ def _docs_src_dir() -> Path:
 
 _DEFAULT_INDEX = "introduction"
 _SUMMARY_FILENAME = "SUMMARY.md"
+
+
+# ─── Space navigation header ────────────────────────────────────────
+
+
+def _space_display_name() -> str | None:
+    """The instance name shown in the nav header — owner username if
+    set, else the zone subdomain, mirroring ``layout.html``.
+
+    Every lookup is wrapped defensively: the docs template renders
+    through a standalone Jinja environment (not the app engine), so the
+    header must degrade gracefully rather than break the manual if the
+    DB or config is unavailable (e.g. pre-setup, or the route-level test
+    harness that stubs a minimal config without ``zone_domain``).
+    """
+    owner: str | None = None
+    try:
+        db = get_db()
+        try:
+            owner = read_owner_username(db)
+        finally:
+            db.close()
+    except Exception as exc:
+        # Benign pre-setup / uninitialised-DB paths (and the route-level
+        # test harness) land here; the header just falls back to the zone
+        # name.  Debug-level so we don't spam ERROR logs for an expected,
+        # non-fatal condition.
+        logger.debug("could not read owner username for docs header: {}", exc)
+    if owner:
+        return owner
+    try:
+        zone_domain = get_config().zone_domain
+    except Exception:
+        return None
+    return zone_domain.split(".")[0] if zone_domain else None
 
 
 # ─── Markdown engine ────────────────────────────────────────────────
@@ -415,7 +464,6 @@ _TEMPLATE = """<!DOCTYPE html>
       display: flex;
       max-width: 1200px;
       margin: 0 auto;
-      min-height: 100vh;
     }
     aside.sidebar {
       width: 240px;
@@ -521,10 +569,29 @@ _TEMPLATE = """<!DOCTYPE html>
       font-size: 0.9em;
     }
     .footer-nav a { color: var(--link); text-decoration: none; }
+    /* Space navigation header — mirrors layout.html so the docs page
+       keeps the same top nav as the rest of the compute space. */
+    .space-header { max-width: 1200px; margin: 0 auto; padding: 1.5em 2.5em 0; box-sizing: border-box; }
+    .space-header h1.space-title { font-size: 1.5em; margin: 0 0 0.5em; }
+    nav#main-nav { display: flex; align-items: flex-end; gap: 0.25em; border-bottom: 1px solid var(--border); }
+    nav#main-nav .nav-tab {
+      display: inline-block; padding: 0.4em 1em; border: 1px solid transparent;
+      border-bottom: none; border-radius: 4px 4px 0 0; text-decoration: none;
+      color: var(--fg); background: transparent;
+    }
+    nav#main-nav .nav-tab:hover { background: rgba(0,0,0,0.05); border-color: var(--border); }
+    nav#main-nav .nav-tab.active {
+      background: var(--bg); border-color: var(--border); color: var(--fg);
+      margin-bottom: -1px; padding-bottom: calc(0.4em + 1px);
+    }
     {{ pygments_css }}
   </style>
 </head>
 <body>
+  <header class="space-header">
+    <h1 class="space-title">{% if display_name %}{{ display_name }}'s personal compute space{% else %}OpenHost{% endif %}</h1>
+    {% include "_nav_header.html" %}
+  </header>
   <div class="layout">
     <aside class="sidebar">
       <h1><a href="/docs/">OpenHost Manual</a></h1>
@@ -555,7 +622,15 @@ _TEMPLATE = """<!DOCTYPE html>
 """
 
 
-_COMPILED_TEMPLATE = JinjaTemplate(_TEMPLATE)
+# Build the docs template through a Jinja Environment whose loader points at
+# the shared templates directory, so ``{% include "_nav_header.html" %}`` pulls
+# in the same nav partial the rest of the compute space uses (rather than
+# duplicating the tab list + highlighter here).  The docs page's HTML body
+# itself is still an inline string — only the shared partial is loaded from
+# disk — keeping the route's serving surface self-contained.
+_TEMPLATES_DIR = Path(__file__).resolve().parent.parent / "templates"
+_JINJA_ENV = Environment(loader=FileSystemLoader(str(_TEMPLATES_DIR)), autoescape=True)
+_COMPILED_TEMPLATE = _JINJA_ENV.from_string(_TEMPLATE)
 
 
 def _flatten_links(sections: tuple[_SidebarSection, ...]) -> list[_SidebarLink]:
@@ -669,6 +744,7 @@ def _render_doc(slug: str) -> Response[str]:
         prev_link=prev_l,
         next_link=next_l,
         pygments_css=PYGMENTS_CSS,
+        display_name=_space_display_name(),
     )
     return Response(content=html, media_type=MediaType.HTML)
 

--- a/compute_space/src/compute_space/web/routes/docs.py
+++ b/compute_space/src/compute_space/web/routes/docs.py
@@ -422,44 +422,19 @@ _TEMPLATE = """<!DOCTYPE html>
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>{{ page_title }} - OpenHost Manual</title>
   <style>
-    :root {
-      --bg: #ffffff;
-      --fg: #222222;
-      --muted: #666666;
-      --border: #dddddd;
-      --sidebar-bg: #fafafa;
-      --sidebar-active: #3366cc;
-      --table-header: #f5f5f5;
-      --link: #3366cc;
-      --code-bg: #1e1e1e;
-      --code-fg: #d4d4d4;
-      --inline-code-bg: #f5f5f5;
-      --inline-code-fg: #c0392b;
-    }
-    @media (prefers-color-scheme: dark) {
-      :root {
-        --bg: #1e1e1e;
-        --fg: #d4d4d4;
-        --muted: #888888;
-        --border: #444444;
-        --sidebar-bg: #181818;
-        --sidebar-active: #6ea8e6;
-        --table-header: #2a2a2a;
-        --link: #6ea8e6;
-        --code-bg: #161616;
-        --code-fg: #d4d4d4;
-        --inline-code-bg: #2a2a2a;
-        --inline-code-fg: #e89999;
-      }
-    }
+    /* The docs page deliberately reuses layout.html's exact palette and
+       typography (hardcoded light colours, #222 text on #fff, #ddd
+       borders, #36c links, #f5f5f5 table headers) rather than its own
+       CSS-variable theme.  layout.html has no dark-mode media query, so
+       neither does this page — otherwise a dark-preference browser would
+       flip from light (Dashboard) to dark (Docs) mid-navigation.  Keeping
+       the two in lockstep is the whole point: the manual should look like
+       just another in-space page. */
     body {
-      /* Match layout.html's font stack so the docs page reads with the
-         same typography as the rest of the compute space. */
       font-family: -apple-system, system-ui, sans-serif;
-      color: var(--fg);
-      background: var(--bg);
+      color: #222;
+      background: #fff;
       margin: 0;
-      line-height: 1.55;
     }
     /* The docs layout is pinned to the same centred column as every other
        in-space page (layout.html uses max-width:960px + 1em side padding),
@@ -475,8 +450,7 @@ _TEMPLATE = """<!DOCTYPE html>
     aside.sidebar {
       width: 200px;
       flex-shrink: 0;
-      background: var(--sidebar-bg);
-      border-right: 1px solid var(--border);
+      border-right: 1px solid #e8e8e8;
       /* No left padding so the sidebar text lines up with the nav header
          and title above it (both sit at the .layout's 1em left edge). */
       padding: 1.5em 1em 1.5em 0;
@@ -488,40 +462,45 @@ _TEMPLATE = """<!DOCTYPE html>
       margin: 0 0 1em;
       padding: 0;
     }
-    aside.sidebar h1 a { color: var(--fg); text-decoration: none; }
+    aside.sidebar h1 a { color: #222; text-decoration: none; }
     aside.sidebar .section { margin: 1.2em 0; }
     aside.sidebar .section-title {
       font-size: 0.8em;
       text-transform: uppercase;
       letter-spacing: 0.05em;
-      color: var(--muted);
+      color: #888;
       margin: 0 0 0.4em;
     }
     aside.sidebar ul { list-style: none; margin: 0; padding: 0; }
     aside.sidebar li { margin: 0.25em 0; }
     aside.sidebar li a {
-      color: var(--fg);
+      color: #222;
       text-decoration: none;
       display: block;
       padding: 0.2em 0.4em;
       border-radius: 3px;
     }
-    aside.sidebar li a:hover { background: rgba(0,0,0,0.04); }
+    aside.sidebar li a:hover { background: #f0f0f0; }
     aside.sidebar li a.active {
-      color: var(--sidebar-active);
-      font-weight: 600;
-      background: rgba(51,102,204,0.08);
+      color: #36c;
+      font-weight: bold;
+      background: #e8f0fe;
     }
+    /* line-height lives on the prose column only (like the dashboard's
+       default body line-height) so the space-title h1 above renders at
+       the same height as layout.html's <h1> — otherwise the nav row would
+       sit lower here than on the dashboard and appear to jump on nav. */
     main.content {
       flex: 1;
       padding: 1.5em 0 2em 1.5em;
       box-sizing: border-box;
       min-width: 0;
+      line-height: 1.55;
     }
     main.content h1 { margin-top: 0; font-size: 1.7em; }
     main.content h2 { margin-top: 2em; font-size: 1.3em; }
     main.content h3 { margin-top: 1.5em; font-size: 1.1em; }
-    main.content a { color: var(--link); text-decoration: none; }
+    main.content a { color: #36c; text-decoration: none; }
     main.content a:hover { text-decoration: underline; }
     main.content table {
       border-collapse: collapse;
@@ -529,29 +508,32 @@ _TEMPLATE = """<!DOCTYPE html>
       margin: 1em 0;
     }
     main.content th, main.content td {
-      border: 1px solid var(--border);
+      border: 1px solid #ddd;
       padding: 0.5em 0.8em;
       text-align: left;
     }
-    main.content th { background: var(--table-header); font-weight: 600; }
+    main.content th { background: #f5f5f5; font-weight: bold; }
     main.content blockquote {
       margin: 1em 0;
       padding: 0.4em 1em;
-      border-left: 4px solid var(--border);
-      background: var(--sidebar-bg);
-      color: var(--muted);
+      border-left: 4px solid #ddd;
+      background: #fafafa;
+      color: #666;
     }
     main.content code {
-      background: var(--inline-code-bg);
-      color: var(--inline-code-fg);
+      background: #f5f5f5;
+      color: #c0392b;
       padding: 0.1em 0.35em;
       border-radius: 3px;
       font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
       font-size: 0.9em;
     }
+    /* Code blocks reuse the dashboard's .log-output panel styling
+       (dark #1e1e1e panel, #d4d4d4 text) so fenced code looks the same
+       as the log output shown elsewhere in the space. */
     main.content pre {
-      background: var(--code-bg);
-      color: var(--code-fg);
+      background: #1e1e1e;
+      color: #d4d4d4;
       padding: 1em;
       border-radius: 4px;
       overflow-x: auto;
@@ -567,30 +549,33 @@ _TEMPLATE = """<!DOCTYPE html>
     }
     main.content .codehilite pre { background: transparent; padding: 0; }
     main.content ul, main.content ol { padding-left: 1.5em; }
-    main.content hr { border: 0; border-top: 1px solid var(--border); margin: 2em 0; }
+    main.content hr { border: 0; border-top: 1px solid #ddd; margin: 2em 0; }
     main.content img { max-width: 100%; }
     .footer-nav {
       display: flex;
       justify-content: space-between;
       margin-top: 3em;
       padding-top: 1em;
-      border-top: 1px solid var(--border);
+      border-top: 1px solid #ddd;
       font-size: 0.9em;
     }
-    .footer-nav a { color: var(--link); text-decoration: none; }
-    /* Space navigation header — mirrors layout.html so the docs page
-       keeps the same top nav as the rest of the compute space. */
+    .footer-nav a { color: #36c; text-decoration: none; }
+    /* Space navigation header — mirrors layout.html so the docs page keeps
+       the same top nav (and header geometry) as the rest of the compute
+       space.  The h1 uses the browser-default h1 size/margins (2em, 0.67em)
+       exactly like layout.html's bare <h1>, so the title + nav land at the
+       same vertical position on both pages. */
     .space-header { max-width: 960px; margin: 2em auto 0; padding: 0 1em; }
-    .space-header h1.space-title { font-size: 2em; font-weight: bold; margin: 0 0 0.67em; }
-    nav#main-nav { display: flex; align-items: flex-end; gap: 0.25em; border-bottom: 1px solid var(--border); }
+    .space-header h1.space-title { font-size: 2em; font-weight: bold; margin: 0.67em 0; }
+    nav#main-nav { display: flex; align-items: flex-end; gap: 0.25em; border-bottom: 1px solid #e8e8e8; }
     nav#main-nav .nav-tab {
       display: inline-block; padding: 0.4em 1em; border: 1px solid transparent;
       border-bottom: none; border-radius: 4px 4px 0 0; text-decoration: none;
-      color: var(--fg); background: transparent;
+      color: #444; background: transparent;
     }
-    nav#main-nav .nav-tab:hover { background: rgba(0,0,0,0.05); border-color: var(--border); }
+    nav#main-nav .nav-tab:hover { background: #f0f0f0; color: #222; border-color: #ddd; }
     nav#main-nav .nav-tab.active {
-      background: var(--bg); border-color: var(--border); color: var(--fg);
+      background: #fff; border-color: #ddd; color: #222;
       margin-bottom: -1px; padding-bottom: calc(0.4em + 1px);
     }
     {{ pygments_css }}

--- a/compute_space/src/compute_space/web/routes/docs.py
+++ b/compute_space/src/compute_space/web/routes/docs.py
@@ -453,24 +453,33 @@ _TEMPLATE = """<!DOCTYPE html>
       }
     }
     body {
-      font-family: -apple-system, system-ui, BlinkMacSystemFont, "Segoe UI",
-                   Roboto, "Helvetica Neue", Arial, sans-serif;
+      /* Match layout.html's font stack so the docs page reads with the
+         same typography as the rest of the compute space. */
+      font-family: -apple-system, system-ui, sans-serif;
       color: var(--fg);
       background: var(--bg);
       margin: 0;
       line-height: 1.55;
     }
+    /* The docs layout is pinned to the same centred column as every other
+       in-space page (layout.html uses max-width:960px + 1em side padding),
+       so navigating between Dashboard and Docs doesn't jump the header
+       wider or shift it sideways.  The sidebar's left edge lines up with
+       the nav header / title above it. */
     .layout {
       display: flex;
-      max-width: 1200px;
+      max-width: 960px;
       margin: 0 auto;
+      padding: 0 1em;
     }
     aside.sidebar {
-      width: 240px;
+      width: 200px;
       flex-shrink: 0;
       background: var(--sidebar-bg);
       border-right: 1px solid var(--border);
-      padding: 1.5em 1em;
+      /* No left padding so the sidebar text lines up with the nav header
+         and title above it (both sit at the .layout's 1em left edge). */
+      padding: 1.5em 1em 1.5em 0;
       box-sizing: border-box;
       font-size: 0.95em;
     }
@@ -505,7 +514,7 @@ _TEMPLATE = """<!DOCTYPE html>
     }
     main.content {
       flex: 1;
-      padding: 2em 2.5em;
+      padding: 1.5em 0 2em 1.5em;
       box-sizing: border-box;
       min-width: 0;
     }
@@ -571,8 +580,8 @@ _TEMPLATE = """<!DOCTYPE html>
     .footer-nav a { color: var(--link); text-decoration: none; }
     /* Space navigation header — mirrors layout.html so the docs page
        keeps the same top nav as the rest of the compute space. */
-    .space-header { max-width: 1200px; margin: 0 auto; padding: 1.5em 2.5em 0; box-sizing: border-box; }
-    .space-header h1.space-title { font-size: 1.5em; margin: 0 0 0.5em; }
+    .space-header { max-width: 960px; margin: 2em auto 0; padding: 0 1em; }
+    .space-header h1.space-title { font-size: 2em; font-weight: bold; margin: 0 0 0.67em; }
     nav#main-nav { display: flex; align-items: flex-end; gap: 0.25em; border-bottom: 1px solid var(--border); }
     nav#main-nav .nav-tab {
       display: inline-block; padding: 0.4em 1em; border: 1px solid transparent;

--- a/compute_space/src/compute_space/web/templates/_nav_header.html
+++ b/compute_space/src/compute_space/web/templates/_nav_header.html
@@ -1,0 +1,25 @@
+{#- Shared compute-space navigation header: the tab list + active-tab
+    highlighter.  Included by ``layout.html`` (every standard page) and by
+    the docs route's standalone template so the manual carries the same nav.
+    Keeping the tab list + script here means adding/renaming a tab or tweaking
+    the highlight logic touches exactly one file. Styling is left to each
+    including template (they use different colour palettes). -#}
+<nav id="main-nav">
+  <a href="/dashboard" class="nav-tab">Dashboard</a>
+  <a href="/docs/" class="nav-tab">Docs</a>
+  <a href="/add_app" class="nav-tab">Deploy App</a>
+  <a href="/terminal/" class="nav-tab">Terminal</a>
+  <a href="/system/" class="nav-tab">System Info</a>
+  <a href="/settings" class="nav-tab">Settings</a>
+</nav>
+<script>
+  (function() {
+    var p = window.location.pathname.replace(/\/+$/, '') || '/';
+    document.querySelectorAll('#main-nav .nav-tab').forEach(function(a) {
+      var href = a.getAttribute('href').replace(/\/+$/, '') || '/';
+      if (p === href || p === '/' && href === '/dashboard' || (href !== '/dashboard' && p.startsWith(href))) {
+        a.classList.add('active');
+      }
+    });
+  })();
+</script>

--- a/compute_space/src/compute_space/web/templates/layout.html
+++ b/compute_space/src/compute_space/web/templates/layout.html
@@ -47,25 +47,7 @@
 </head>
 <body>
   <h1>{% if display_name %}{{ display_name }}'s personal compute space{% else %}OpenHost{% endif %}</h1>
-  <nav id="main-nav">
-    <a href="/dashboard" class="nav-tab">Dashboard</a>
-    <a href="/docs/" target="_blank" rel="noopener" class="nav-tab">Docs</a>
-    <a href="/add_app" class="nav-tab">Deploy App</a>
-    <a href="/terminal/" class="nav-tab">Terminal</a>
-    <a href="/system/" class="nav-tab">System Info</a>
-    <a href="/settings" class="nav-tab">Settings</a>
-  </nav>
-  <script>
-    (function() {
-      var p = window.location.pathname.replace(/\/+$/, '') || '/';
-      document.querySelectorAll('#main-nav .nav-tab').forEach(function(a) {
-        var href = a.getAttribute('href').replace(/\/+$/, '') || '/';
-        if (href !== '/docs' && (p === href || p === '/' && href === '/dashboard' || (href !== '/dashboard' && p.startsWith(href)))) {
-          a.classList.add('active');
-        }
-      });
-    })();
-  </script>
+  {% include "_nav_header.html" %}
   {% block content %}{% endblock %}
 </body>
 </html>


### PR DESCRIPTION
The Docs nav link opened in a new tab (target=_blank) and the /docs manual rendered as a standalone page without the compute-space navigation header. This makes the docs behave like every other in-space page: same tab, same top nav.