### PR TITLE
ansible: split provisioning into prebake + finalize for warm pool

### DIFF
--- a/ansible/finalize.yml
+++ b/ansible/finalize.yml
@@ -1,0 +1,32 @@
+---
+# Finalize a warm-pool host: the domain-dependent last mile only.
+#
+# Runs against a host that prebake.yml (or `setup.yml -e skip_service_start=true`)
+# already baked — user, packages, docker, code, pixi env, and the systemd unit
+# files are all in place. All this play does is render config.toml with the real
+# domain + cert creds, write the claim token, and start the service. That's a
+# few seconds instead of re-walking the whole apt/docker/pixi setup.
+#
+# Usage: ansible-playbook ansible/finalize.yml -i <IP>, -e domain=<domain>
+#
+# The trailing comma after the IP is required (tells ansible it's a host list).
+#
+# Extra-vars (same names setup.yml accepts, so vm-manager passes them unchanged):
+#   -e domain=host.example.com     (required)
+#   -e public_ip=1.2.3.4           (defaults to target IP)
+#   -e claim_token=<secret>        (gates /setup; random if omitted)
+#   -e cert_provider=cert_api      (+ cert_api_keycloak_issuer_url,
+#                                     cert_api_keycloak_client_id,
+#                                     cert_api_keycloak_client_secret,
+#                                     optional cert_api_base_url)
+#
+# Leave skip_service_start unset/false so the service actually starts.
+
+- name: Finalize OpenHost (domain-dependent last mile)
+  hosts: all
+  user: host
+  vars:
+    ansible_python_interpreter: /usr/bin/python3
+  tasks:
+    - import_tasks: tasks/write_openhost_config.yml
+    - import_tasks: tasks/restart_openhost_service.yml

--- a/ansible/local_setup.yml
+++ b/ansible/local_setup.yml
@@ -49,5 +49,6 @@
     ansible_become_method: sudo
   tasks:
     - import_tasks: tasks/pixi.yml
-    - import_tasks: tasks/setup_openhost_service.yml
+    - import_tasks: tasks/write_openhost_config.yml
+    - import_tasks: tasks/install_openhost_units.yml
     - import_tasks: tasks/restart_openhost_service.yml

--- a/ansible/prebake.yml
+++ b/ansible/prebake.yml
@@ -1,0 +1,63 @@
+---
+# Prebake a warm-pool host: everything domain-INDEPENDENT.
+#
+# This is setup.yml with the last mile removed. It does the slow, domain-free
+# 90% — bootstrap the host user, install apt packages + Docker/containers, the
+# dev environment, sync the code, build the pixi env, and install the systemd
+# unit files — but NOT config.toml, the claim token, or enabling/starting the
+# service. The service is left dormant (not enabled, so it won't come up even on
+# a reboot) since a domain-less host has no config and must not let anyone in.
+# Enabling + starting, and the domain-dependent config, are done by finalize.yml.
+#
+# vm-manager runs this to park hosts "warm", then runs finalize.yml at claim time
+# with the real domain + cert vars.
+#
+# Usage: ansible-playbook ansible/prebake.yml -i <IP>,
+#
+# The trailing comma after the IP is required (tells ansible it's a host list).
+#
+# Optional variables (same names setup.yml accepts):
+#   -e initial_user=ubuntu         (defaults to root)
+#   -e openhost_commit=<sha>       (git commit to deploy; defaults to main)
+#
+# No `domain` is required — that's the whole point.
+
+- name: Bootstrap host user
+  hosts: all
+  user: "{{ initial_user | default('root') }}"
+  become: "{{ initial_user | default('root') != 'root' }}"
+  gather_facts: false
+  vars:
+    ansible_python_interpreter: /usr/bin/python3
+  tasks:
+    - import_tasks: tasks/user_setup.yml
+
+- name: Install system dependencies
+  hosts: all
+  user: host
+  become: yes
+  gather_facts: yes
+  vars:
+    ansible_python_interpreter: /usr/bin/python3
+  tasks:
+    - import_tasks: tasks/apt_packages.yml
+    - import_tasks: tasks/containers.yml
+
+- name: Dev environment
+  hosts: all
+  user: host
+  gather_facts: yes
+  vars:
+    ansible_python_interpreter: /usr/bin/python3
+  tasks:
+    - import_tasks: tasks/dev_machine.yml
+
+- name: Prebake OpenHost (code, pixi, and systemd units — no domain)
+  hosts: all
+  user: host
+  vars:
+    ansible_python_interpreter: /usr/bin/python3
+  tasks:
+    - import_tasks: tasks/sync_code.yml
+    - import_tasks: tasks/pixi.yml
+    - import_tasks: tasks/install_openhost_units.yml

--- a/ansible/setup.yml
+++ b/ansible/setup.yml
@@ -52,5 +52,6 @@
   tasks:
     - import_tasks: tasks/sync_code.yml
     - import_tasks: tasks/pixi.yml
-    - import_tasks: tasks/setup_openhost_service.yml
+    - import_tasks: tasks/write_openhost_config.yml
+    - import_tasks: tasks/install_openhost_units.yml
     - import_tasks: tasks/restart_openhost_service.yml

--- a/ansible/tasks/install_openhost_units.yml
+++ b/ansible/tasks/install_openhost_units.yml
@@ -1,52 +1,16 @@
 ---
-# Write config, install and start the openhost systemd service.
-
-- name: Create config directory
-  file:
-    path: /home/host/.openhost/local_compute_space
-    state: directory
-    owner: host
-    group: host
-
-- name: Write compute_space config
-  template:
-    src: templates/config.toml.j2
-    dest: /home/host/.openhost/local_compute_space/config.toml
-    owner: host
-    group: host
-  register: config_file
-
-# First-boot claim token. `claim_token_required = true` is baked into the
-# rendered config above, so /setup rejects every caller unless their request
-# carries a token matching this file. If the operator doesn't pass
-# `-e claim_token=…`, we generate a fresh URL-safe random one and print the
-# claim URL at the end of the play — handing the secret to the human who
-# will claim the workspace. vm-manager passes the var to control the value.
-# setup_app deletes this file after a successful claim, so on re-deploys
-# (where the instance is already claimed) the rewritten file is inert.
-- name: Ensure claim-token directory exists
-  file:
-    path: /home/host/.openhost/local_compute_space/persistent_data/openhost
-    state: directory
-    owner: host
-    group: host
-    mode: "0755"
-
-- name: Resolve effective claim token
-  set_fact:
-    effective_claim_token: "{{ claim_token | default(lookup('password', '/dev/null length=32 chars=ascii_letters,digits')) }}"
-
-- name: Write claim token
-  copy:
-    content: "{{ effective_claim_token }}"
-    dest: /home/host/.openhost/local_compute_space/persistent_data/openhost/claim_token
-    owner: host
-    group: host
-    mode: "0600"
-
-- name: Show claim URL
-  debug:
-    msg: "Claim URL: https://{{ domain }}/setup?claim={{ effective_claim_token }}"
+# Domain-INDEPENDENT systemd unit install: resolve the host UID, symlink the
+# system-agent onto sudo's secure_path, install the pixi-reclaim script, render
+# and install the openhost + openhost-juicefs unit files, reload systemd, and
+# enable the service. Contains NOTHING that needs `domain` — so a warm-pool
+# prebake can install the units without knowing the eventual domain. The
+# domain-dependent config.toml + claim token live in tasks/write_openhost_config.yml.
+#
+# Note: this installs the unit files but does NOT enable or start the service.
+# Both enable (boot persistence) and start live in
+# tasks/restart_openhost_service.yml, gated by skip_service_start — so a
+# domain-less prebaked host never auto-starts openhost (e.g. on reboot) with no
+# config.toml and no claim token. Finalize is what enables + starts it.
 
 # Look up the host user's UID so the service template can reference
 # the right /run/user/<uid> path and user@<uid>.service unit. The
@@ -125,12 +89,9 @@
     daemon_reload: yes
   when: service_file.changed or juicefs_service_file.changed
 
-- name: Enable openhost service
-  become: yes
-  become_user: root
-  systemd:
-    name: openhost
-    enabled: yes
+# Enabling openhost is deliberately NOT done here — see the note at the top of
+# this file. It happens in tasks/restart_openhost_service.yml alongside the
+# start, so a prebaked (domain-less) host stays fully dormant.
 
 # Do NOT enable openhost-juicefs here; it stays disabled until the
 # operator configures the archive backend via the dashboard.  The

--- a/ansible/tasks/restart_openhost_service.yml
+++ b/ansible/tasks/restart_openhost_service.yml
@@ -1,4 +1,17 @@
 ---
+# Enable (boot persistence) and start the openhost service. Both are gated by
+# skip_service_start so a prebake / warm-pool bake leaves the service fully
+# dormant — not started now, and not started on reboot either — since a
+# domain-less host has no config.toml and no claim token and must not let anyone
+# in. Finalize runs this with skip_service_start unset/false to bring it up.
+- name: Enable openhost service
+  become: yes
+  become_user: root
+  systemd:
+    name: openhost
+    enabled: yes
+  when: not (skip_service_start | default(false) | bool)
+
 - name: Restart openhost service
   become: yes
   become_user: root

--- a/ansible/tasks/write_openhost_config.yml
+++ b/ansible/tasks/write_openhost_config.yml
@@ -1,0 +1,54 @@
+---
+# Domain-DEPENDENT last mile: render config.toml, write the claim token, and
+# show the claim URL. Needs `domain` (and the cert_provider/cert_api_* vars the
+# config template references). Imported by setup.yml (full run), local_setup.yml,
+# and finalize.yml (warm-pool claim-time). Deliberately contains NOTHING that a
+# domain-less prebake needs — the systemd unit install lives in
+# tasks/install_openhost_units.yml.
+
+- name: Create config directory
+  file:
+    path: /home/host/.openhost/local_compute_space
+    state: directory
+    owner: host
+    group: host
+
+- name: Write compute_space config
+  template:
+    src: templates/config.toml.j2
+    dest: /home/host/.openhost/local_compute_space/config.toml
+    owner: host
+    group: host
+  register: config_file
+
+# First-boot claim token. `claim_token_required = true` is baked into the
+# rendered config above, so /setup rejects every caller unless their request
+# carries a token matching this file. If the operator doesn't pass
+# `-e claim_token=…`, we generate a fresh URL-safe random one and print the
+# claim URL at the end of the play — handing the secret to the human who
+# will claim the workspace. vm-manager passes the var to control the value.
+# setup_app deletes this file after a successful claim, so on re-deploys
+# (where the instance is already claimed) the rewritten file is inert.
+- name: Ensure claim-token directory exists
+  file:
+    path: /home/host/.openhost/local_compute_space/persistent_data/openhost
+    state: directory
+    owner: host
+    group: host
+    mode: "0755"
+
+- name: Resolve effective claim token
+  set_fact:
+    effective_claim_token: "{{ claim_token | default(lookup('password', '/dev/null length=32 chars=ascii_letters,digits')) }}"
+
+- name: Write claim token
+  copy:
+    content: "{{ effective_claim_token }}"
+    dest: /home/host/.openhost/local_compute_space/persistent_data/openhost/claim_token
+    owner: host
+    group: host
+    mode: "0600"
+
+- name: Show claim URL
+  debug:
+    msg: "Claim URL: https://{{ domain }}/setup?claim={{ effective_claim_token }}"

--- a/compute_space/src/compute_space/core/system_agent.py
+++ b/compute_space/src/compute_space/core/system_agent.py
@@ -38,7 +38,7 @@ def _run_system_agent(*args: str, timeout: int = 300) -> str:
             error = result.stderr or result.stdout
         # sudo prints `sudo: openhost_system_agent: command not found` when
         # the symlink at /usr/local/bin/openhost_system_agent is missing.
-        # ansible installs it (setup_openhost_service.yml); pre-symlink
+        # ansible installs it (install_openhost_units.yml); pre-symlink
         # installs hit this and need to re-run ansible to fix it.
         if "openhost_system_agent: command not found" in str(error):
             raise SystemAgentError(

--- a/scripts/provision.sh
+++ b/scripts/provision.sh
@@ -122,9 +122,13 @@ if [ ! -f "$ACME_KEY_PATH" ]; then
     chown host:host "$ACME_KEY_PATH"
 fi
 
-# ---- Start the service ----
+# ---- Enable + start the service ----
+# `enable` here (not just `start`) because the ansible run above was invoked
+# with skip_service_start=true, which now also skips enabling the unit for boot
+# persistence (so warm-pool prebakes stay fully dormant). This is the point in
+# the bare-metal flow where openhost is meant to come up for good, so enable it.
 echo "--- Starting OpenHost ---"
-systemctl start openhost
+systemctl enable --now openhost
 
 echo ""
 echo "=== OpenHost provisioning complete ==="


### PR DESCRIPTION
Enable vm-manager to keep a warm pool of mostly-provisioned openhost instances, deferring the domain-dependent last mile (config.toml render, claim token, cert creds, service start) to claim time.

Refactor the coupled tasks/setup_openhost_service.yml into two files:
- tasks/install_openhost_units.yml: domain-free unit install (UID lookup, system-agent symlink, pixi-reclaim script, unit files, daemon_reload).
- tasks/write_openhost_config.yml: domain-dependent config.toml + claim token.

Add prebake.yml (everything domain-independent; leaves the service dormant) and finalize.yml (write config + enable + start), which accepts the same extra-var names setup.yml already takes so vm-manager only changes which playbook it runs.

Move `enable` from the unit install into restart_openhost_service.yml alongside the start, both gated by skip_service_start. A prebaked host is now neither enabled nor started, so it won't auto-start openhost on reboot with no config.toml and no claim token.

Because enabling is now gated by skip_service_start, update scripts/provision.sh to `systemctl enable --now` (it bakes with skip_service_start=true then starts the service by hand, and previously relied on ansible having enabled the unit).

setup.yml / local_setup.yml import both split files in sequence; end state is unchanged. Old vm-manager (bake via skip_service_start + full-setup finalize) still ends up with an enabled, started host — this is a drop-in.