### PR TITLE
fix coredns issue on upgrade

### DIFF
--- a/compute_space/src/compute_space/core/dns.py
+++ b/compute_space/src/compute_space/core/dns.py
@@ -97,6 +97,7 @@ def start_coredns(
     corefile_path: Path,
     zonefile_path: Path,
     container_gateway_ip: str | None = CONTAINER_GATEWAY_IP,
+    coredns_bin: str = "coredns",
 ) -> subprocess.Popen[bytes]:
     """Write CoreDNS config + zone file, start CoreDNS, return the process.
 
@@ -154,7 +155,7 @@ def start_coredns(
 
     logger.info(f"Starting CoreDNS for {zone_domain}")
     proc = subprocess.Popen(
-        ["coredns", "-conf", corefile_path],
+        [coredns_bin, "-conf", corefile_path],
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
     )

--- a/compute_space/src/compute_space/core/pinned_binary.py
+++ b/compute_space/src/compute_space/core/pinned_binary.py
@@ -4,8 +4,12 @@ Some tools we depend on at runtime aren't packaged for every arch we run on, so
 we fetch a pinned vendor release and verify its sha256 before use.  The pins are
 declared as data in ``_MANIFEST`` below -- one entry per program, with the
 download URL + sha256 for each arch.  Adding a pinned tool or arch is a data-only
-change here.  Caller: ``archive_backend`` (JuiceFS).  Provisioning-time binaries
-(e.g. CoreDNS) are pinned in their own ansible task, not here."""
+change here.  Callers: ``archive_backend`` (JuiceFS) and ``web/start`` (CoreDNS).
+
+CoreDNS is normally installed by provisioning (``ansible/tasks/coredns.yml``);
+the pin here is a startup fallback so a host upgraded in place -- which loses the
+coredns pixi used to provide -- can re-fetch it.  Keep the CoreDNS version + per-
+arch sha256 here in sync with that ansible task."""
 
 from __future__ import annotations
 
@@ -59,6 +63,22 @@ _MANIFEST: dict[str, PinnedBinary] = {
             "arm64": ArchAsset(
                 url="https://github.com/juicedata/juicefs/releases/download/v1.3.1/juicefs-1.3.1-linux-arm64.tar.gz",
                 sha256="c29bff8f609366011cee03b9abcc76c11a06308b2c314364b8c340a2bfbc6c48",
+            ),
+        },
+    ),
+    # Keep in sync with ansible/tasks/coredns.yml (bump version + both sha256 together).
+    "coredns": PinnedBinary(
+        name="coredns",
+        version="1.14.4",
+        archive_member="coredns",  # file to extract from the tarball
+        assets={
+            "amd64": ArchAsset(
+                url="https://github.com/coredns/coredns/releases/download/v1.14.4/coredns_1.14.4_linux_amd64.tgz",
+                sha256="5b0e6a6a8b97bdcaec65baa70e83ca88ce03ab852355c656e3f7953405cfe36e",
+            ),
+            "arm64": ArchAsset(
+                url="https://github.com/coredns/coredns/releases/download/v1.14.4/coredns_1.14.4_linux_arm64.tgz",
+                sha256="b3491ed0fbe530a549640a4073d90037ffafa483f007936e1943c1ae0def7325",
             ),
         },
     ),

--- a/compute_space/src/compute_space/tests/test_start_coredns.py
+++ b/compute_space/src/compute_space/tests/test_start_coredns.py
@@ -1,0 +1,41 @@
+from pathlib import Path
+
+import pytest
+
+from compute_space.config import DefaultConfig
+from compute_space.core.pinned_binary import get_pinned_binary
+from compute_space.web import start as start_mod
+
+
+def _cfg(tmp_path: Path) -> DefaultConfig:
+    return DefaultConfig(zone_domain="zone.example.com", data_root_dir=str(tmp_path))
+
+
+def test_ensure_coredns_uses_path_binary_when_present(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(start_mod.shutil, "which", lambda name: "/usr/local/bin/coredns")
+    installs: list[object] = []
+    monkeypatch.setattr(start_mod, "install_pinned_binary", lambda *a, **k: installs.append(a))
+
+    result = start_mod._ensure_coredns_binary(_cfg(tmp_path))
+
+    assert result == "/usr/local/bin/coredns"
+    assert installs == []  # provisioned binary on PATH -> no self-heal download
+
+
+def test_ensure_coredns_self_heals_when_missing(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(start_mod.shutil, "which", lambda name: None)
+    installed: dict[str, object] = {}
+
+    def fake_install(binary: object, dest: str) -> None:
+        installed["binary"] = binary
+        installed["dest"] = dest
+
+    monkeypatch.setattr(start_mod, "install_pinned_binary", fake_install)
+
+    cfg = _cfg(tmp_path)
+    result = start_mod._ensure_coredns_binary(cfg)
+
+    expected = str(cfg.openhost_data_path / "coredns")
+    assert result == expected
+    assert installed["dest"] == expected
+    assert installed["binary"] == get_pinned_binary("coredns")

--- a/compute_space/src/compute_space/web/start.py
+++ b/compute_space/src/compute_space/web/start.py
@@ -1,5 +1,6 @@
 import asyncio
 import os
+import shutil
 import signal
 import socket
 import sqlite3
@@ -20,6 +21,8 @@ from compute_space.core.caddy import start_caddy
 from compute_space.core.dns import start_coredns
 from compute_space.core.logging import logger
 from compute_space.core.logging import setup_file_logging
+from compute_space.core.pinned_binary import get_pinned_binary
+from compute_space.core.pinned_binary import install_pinned_binary
 from compute_space.core.terminal import cleanup_all as cleanup_terminal_sessions
 from compute_space.core.tls.provision import provision_cert
 from compute_space.core.tls.renewal import CertStatus
@@ -86,6 +89,26 @@ def _ensure_tls_cert(config: Config) -> None:
         provision_cert(config)
 
 
+def _ensure_coredns_binary(config: Config) -> str:
+    """Return the CoreDNS binary to launch, self-healing a missing one.
+
+    Provisioning installs CoreDNS at /usr/local/bin/coredns (on the service
+    PATH).  Hosts upgraded in place can lose it -- it used to come from pixi,
+    which no longer ships it -- leaving ``coredns`` on no PATH directory and
+    crashing startup.  When that happens, download the pinned release (same
+    version as ansible/tasks/coredns.yml) into the data dir and launch it by
+    absolute path.  Binding :53 works without setcap thanks to the provisioned
+    net.ipv4.ip_unprivileged_port_start=25 sysctl.
+    """
+    found = shutil.which("coredns")
+    if found:
+        return found
+    dest = str(config.openhost_data_path / "coredns")
+    logger.warning(f"coredns not found on PATH; installing pinned release to {dest}")
+    install_pinned_binary(get_pinned_binary("coredns"), dest)
+    return dest
+
+
 def main() -> None:
     # Allow group members to write files/dirs we create (files 664, dirs 775).
     os.umask(0o002)
@@ -100,7 +123,11 @@ def main() -> None:
             raise RuntimeError("Public IP must be set in config to use CoreDNS")
         children.append(
             start_coredns(
-                config.zone_domain, config.public_ip, config.coredns_corefile_path, config.coredns_zonefile_path
+                config.zone_domain,
+                config.public_ip,
+                config.coredns_corefile_path,
+                config.coredns_zonefile_path,
+                coredns_bin=_ensure_coredns_binary(config),
             )
         )
 


### PR DESCRIPTION
check coredns installation at runtime
works both from restarting a previous broken instance and working old instance