### PR TITLE
ansible: preserve existing cert creds/config on re-deploy

### DIFF
--- a/ansible/readme.md
+++ b/ansible/readme.md
@@ -49,6 +49,7 @@ pass with `-e key=value`.
 | `acme_directory_url` | LE production | override, e.g. staging or a local pebble |
 | `skip_apt_upgrade` | `false` | skip `apt upgrade` in the packages step |
 | `skip_service_start` | `false` | don't start the service at the end |
+| `overwrite_existing` | `false` | overwrite existing config/secrets instead of preserving them (see [re-deploying](#re-deploying-an-existing-instance)) |
 
 version precedence: `openhost_branch` > `openhost_commit` > default `main`.
 
@@ -61,6 +62,32 @@ version precedence: `openhost_branch` > `openhost_commit` > default `main`.
 | `cert_api_keycloak_issuer_url` | keycloak issuer (required with `cert_api`) |
 | `cert_api_keycloak_client_id` | keycloak client id (required with `cert_api`) |
 | `cert_api_keycloak_client_secret` | keycloak client secret (required with `cert_api`) |
+
+## re-deploying an existing instance
+
+re-running `setup.yml` (or `finalize.yml`) against a host that's already
+configured is safe: anything already present on the host is left alone. so you
+can re-ansible after a breaking change without re-supplying every `-e` var or
+copying secrets back off the instance. specifically, on a re-run:
+
+- the **cert credential** is left alone if the host already has one — either a
+  google ACME account key (`secrets/certbot_private_key.json`, gitignored so the
+  code sync's `git clean` leaves it in place) or a cert_api keycloak secret baked
+  into `config.toml`. so you don't need any cert secret on your control machine
+  to redeploy an already-configured instance.
+- **`config.toml`** is left untouched if it exists, so the cert creds, domain,
+  and other settings baked in at first setup are preserved.
+- the **claim token** is left untouched if it exists.
+
+on a **first** deploy the host has no cert credential yet, so the run honors the
+`cert_provider` flag: cert_api bakes the keycloak secret into `config.toml`,
+otherwise the google ACME key is pushed from your control machine. a genuinely
+missing ACME key fails the run there — as it should, since it's actually needed.
+
+pass `-e overwrite_existing=true` to override all of the above and overwrite
+with freshly rendered values — you'll need to re-supply the relevant vars (cert
+creds, etc.) and have the ACME key locally when you do. use this when a breaking
+change requires the `config.toml` template itself to be re-rendered.
 
 ## after setup
 

--- a/ansible/tasks/sync_code.yml
+++ b/ansible/tasks/sync_code.yml
@@ -22,6 +22,38 @@
   register: git_clean_result
   changed_when: git_clean_result.stdout | length > 0
 
+# Provision the cert credential the host needs. An instance gets its certs one
+# of two ways: the bring-your-own google ACME account key
+# (secrets/certbot_private_key.json), or the cert_api broker (a keycloak
+# client_secret baked into config.toml). We decide off what the HOST already
+# has, not what's on the control machine:
+#
+#   first deploy  — host has neither → honor the cert_provider flag and push the
+#                   ACME key (unless cert_api / http_only). A genuinely missing
+#                   key fails the copy, which is correct: it's actually needed.
+#   re-deploy     — host already has an ACME key OR a keycloak secret → skip and
+#                   leave the working credential alone, without re-supplying it.
+#
+# Pass -e overwrite_existing=true to re-push the ACME key regardless.
+- name: Stat ACME account key on host
+  ansible.builtin.stat:
+    path: /home/host/openhost/ansible/secrets/certbot_private_key.json
+  register: remote_acme_key
+
+- name: Read existing compute_space config on host
+  ansible.builtin.slurp:
+    src: /home/host/.openhost/local_compute_space/config.toml
+  register: remote_compute_space_config
+  failed_when: false
+
+- name: Detect existing cert credential on host
+  set_fact:
+    host_has_cert_credential: >-
+      {{ remote_acme_key.stat.exists
+         or (remote_compute_space_config.content is defined
+             and 'cert_api_keycloak_client_secret'
+                 in (remote_compute_space_config.content | b64decode)) }}
+
 - name: Copy ACME account key
   copy:
     src: "{{ playbook_dir }}/secrets/certbot_private_key.json"
@@ -29,3 +61,7 @@
     owner: host
     group: host
     mode: "0600"
+  when:
+    - not (host_has_cert_credential | bool) or (overwrite_existing | default(false) | bool)
+    - not (local_http_only | default(false) | bool)
+    - (cert_provider | default('')) != 'cert_api'

--- a/ansible/tasks/write_openhost_config.yml
+++ b/ansible/tasks/write_openhost_config.yml
@@ -13,12 +13,24 @@
     owner: host
     group: host
 
+- name: Stat existing compute_space config
+  ansible.builtin.stat:
+    path: /home/host/.openhost/local_compute_space/config.toml
+  register: existing_config
+
+# Render config.toml from the operator-supplied vars. On a re-deploy against an
+# already-configured host we skip this and respect the config that's there, so
+# you don't have to re-pass every -e var — or re-copy secrets like the cert_api
+# client_secret — just to redeploy code. Pass -e overwrite_existing=true to
+# re-render (needed to pick up a breaking change to the template; re-supply the
+# vars when you do).
 - name: Write compute_space config
   template:
     src: templates/config.toml.j2
     dest: /home/host/.openhost/local_compute_space/config.toml
     owner: host
     group: host
+  when: (overwrite_existing | default(false) | bool) or not existing_config.stat.exists
   register: config_file
 
 # First-boot claim token. `claim_token_required = true` is baked into the
@@ -37,9 +49,20 @@
     group: host
     mode: "0755"
 
+# On a re-deploy we leave an existing claim token alone (skip unless forced), so
+# a claim URL already handed out keeps working and we don't churn the secret.
+# A claimed instance has no token file (setup_app deletes it after claim), so
+# this writes a fresh — inert — one there, same as before. Pass
+# -e overwrite_existing=true to rotate the token on a still-unclaimed instance.
+- name: Stat existing claim token
+  ansible.builtin.stat:
+    path: /home/host/.openhost/local_compute_space/persistent_data/openhost/claim_token
+  register: existing_claim_token
+
 - name: Resolve effective claim token
   set_fact:
     effective_claim_token: "{{ claim_token | default(lookup('password', '/dev/null length=32 chars=ascii_letters,digits')) }}"
+  when: (overwrite_existing | default(false) | bool) or not existing_claim_token.stat.exists
 
 - name: Write claim token
   copy:
@@ -48,7 +71,9 @@
     owner: host
     group: host
     mode: "0600"
+  when: (overwrite_existing | default(false) | bool) or not existing_claim_token.stat.exists
 
 - name: Show claim URL
   debug:
     msg: "Claim URL: {{ ('http://' + domain + ':8080') if (local_http_only | default(false) | bool) else ('https://' + domain) }}/setup?claim={{ effective_claim_token }}"
+  when: (overwrite_existing | default(false) | bool) or not existing_claim_token.stat.exists


### PR DESCRIPTION
## Problem

Re-running `ansible/setup.yml` against an already-configured openhost instance fails complaining about a missing `secrets/certbot_private_key.json`, or silently clobbers existing config when the operator doesn't re-pass every `-e` var. This makes it painful to re-ansible after a breaking change without worrying about messing up config or copying secrets back off the instance.

## Change

Re-deploys now respect what's already on the host, gated by a new `-e overwrite_existing=true` flag (default `false`):

- **Cert credential** (`sync_code.yml`) — the ACME key copy keys off what the **host** has, not the control machine. Skip if the host already has a google ACME key **or** a `cert_api_keycloak_client_secret` in its `config.toml`. On a first deploy (host has neither), the `cert_provider` flag is honored; a genuinely missing ACME key fails the copy, as it should.
- **`config.toml`** (`write_openhost_config.yml`) — left untouched if it exists, so domain + cert creds baked in at first setup survive.
- **Claim token** — left untouched if it exists, so an already-handed-out claim URL keeps working.

`-e overwrite_existing=true` overrides all three (re-render config, re-push key, rotate token) — needed when a breaking change requires the `config.toml` template itself to be re-rendered.

Fixes the cert-api re-deploy case specifically: you no longer need to re-pass `-e cert_provider=cert_api`, since the keycloak secret already in `config.toml` is detected as the existing credential.

## Testing

`ansible-playbook --syntax-check` passes for `setup.yml`, `finalize.yml`, and `deploy.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)