### PR TITLE
Require owner approval of new permissions on app update

### DIFF
--- a/compute_space/src/compute_space/core/apps.py
+++ b/compute_space/src/compute_space/core/apps.py
@@ -22,6 +22,7 @@ from compute_space.core.app_id import new_app_id
 from compute_space.core.auth.auth import DEFAULT_OWNER_USERNAME
 from compute_space.core.auth.auth import read_owner_username
 from compute_space.core.auth.permissions_v2 import Grant
+from compute_space.core.auth.permissions_v2 import PermissionRecord
 from compute_space.core.auth.permissions_v2 import grant_permission_v2
 from compute_space.core.containers import BUILD_CACHE_CORRUPT_MARKER
 from compute_space.core.containers import build_image
@@ -338,6 +339,44 @@ def all_manifest_permissions_v2(manifest: AppManifest) -> list[PermissionGrant]:
         for grant_payload in perm.grants:
             grants.append(PermissionGrant(service_url=perm.service, grant=grant_payload))
     return grants
+
+
+def _permission_key(service_url: str, grant_payload: Grant) -> tuple[str, str]:
+    """Normalized identity for a (service, grant) pair.
+
+    Uses the same ``json.dumps(..., sort_keys=True)`` serialization that
+    :func:`grant_permission_v2` stores, so a declared grant and a stored grant
+    compare equal regardless of dict key order.
+    """
+    return (service_url, json.dumps(grant_payload, sort_keys=True))
+
+
+def manifest_ungranted_permissions_v2(
+    manifest: AppManifest,
+    granted: list[PermissionRecord],
+) -> list[PermissionGrant]:
+    """The permissions a manifest declares that are NOT already granted.
+
+    Single source of truth for the "which manifest permissions still need owner
+    approval" diff, shared by the app-detail page (post-install display) and the
+    update/reload gate (so an app update can't silently pick up newly declared
+    permissions). ``granted`` is the app's current ``permissions_v2`` rows
+    (e.g. from :func:`get_all_permissions_v2`).
+
+    Duplicate manifest declarations collapse to a single entry, and each new
+    permission is returned only once even if declared multiple times.
+    """
+    granted_keys = {_permission_key(rec.service_url, rec.grant) for rec in granted}
+    ungranted: list[PermissionGrant] = []
+    seen: set[tuple[str, str]] = set(granted_keys)
+    for perm in manifest.consumes_services_v2:
+        for grant_payload in perm.grants:
+            key = _permission_key(perm.service, grant_payload)
+            if key in seen:
+                continue
+            seen.add(key)
+            ungranted.append(PermissionGrant(service_url=perm.service, grant=grant_payload))
+    return ungranted
 
 
 def insert_and_deploy(
@@ -932,10 +971,11 @@ def reload_app_background(app_id: str, repo_path: str, config: Config) -> None:
                 db.commit()
             except ValueError:
                 logger.warning("Failed to re-read manifest for %s during reload", app_id)
-            # New permissions declared in the updated manifest are NOT
-            # auto-granted on reload.  They show up as "ungranted" on the
-            # app detail page where the owner can approve them, or the
-            # in-app grant_url flow handles them at runtime.
+            # Permissions are not touched here. New permissions declared in an
+            # updated manifest are gated before this background reload even
+            # starts: _reload_app_impl refuses to rebuild until the owner has
+            # explicitly approved them (mirroring the install-time approval),
+            # so by the time we get here the required grants already exist.
 
         start_app_process(app_id, db, config)
     except Exception as e:

--- a/compute_space/src/compute_space/core/git_ops.py
+++ b/compute_space/src/compute_space/core/git_ops.py
@@ -138,6 +138,17 @@ def get_head_sha(repo_path: Path) -> str:
 
 
 @async_wrap
+def reset_hard(repo_path: Path, sha: str) -> None:
+    """Hard-reset the working tree back to ``sha``.
+
+    Used to undo a git pull whose resulting update was refused (e.g. the owner
+    has not approved new permissions the pulled manifest declares), so the
+    on-disk repo keeps matching the version the app is actually running.
+    """
+    git.Repo(repo_path).git.reset("--hard", sha)
+
+
+@async_wrap
 def get_branch_name(repo_path: Path) -> str | None:
     """Return the current branch name, or None if HEAD is detached."""
     repo = git.Repo(repo_path)

--- a/compute_space/src/compute_space/tests/test_reload_permissions.py
+++ b/compute_space/src/compute_space/tests/test_reload_permissions.py
@@ -1,0 +1,326 @@
+"""Tests that an app update requiring NEW service permissions is gated on
+explicit owner approval, mirroring the approval required at install time.
+
+Before this, ``reload_app_background`` re-synced manifest-derived columns but
+silently left newly declared permissions ungranted — the update proceeded and
+the new permissions only showed up passively on the app detail page. Now
+``_reload_app_impl`` refuses the reload (via ``_gate_new_permissions``) until
+the owner approves, and the app keeps running its current version meanwhile.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+from litestar import Litestar
+from litestar.testing import TestClient
+
+from compute_space.core.app_id import new_app_id
+from compute_space.core.apps import manifest_ungranted_permissions_v2
+from compute_space.core.auth.permissions_v2 import PermissionRecord
+from compute_space.core.auth.permissions_v2 import get_all_permissions_v2
+from compute_space.core.auth.permissions_v2 import grant_permission_v2
+from compute_space.core.manifest import parse_manifest
+from compute_space.db.connection import init_db
+from compute_space.tests._litestar_helpers import auth_cookie
+from compute_space.tests._litestar_helpers import make_test_app
+from compute_space.web.routes.api.apps import _gate_new_permissions
+from compute_space.web.routes.api.apps import api_apps_routes
+
+from .conftest import _make_test_config
+
+_CONSUMES = """\
+[app]
+name = "perm-app"
+version = "1.0.0"
+
+[runtime.container]
+image = "Dockerfile"
+port = 5000
+
+{consumes}
+"""
+
+
+def _manifest_with_consumes(repo: Path, consumes: str) -> Any:
+    repo.mkdir(parents=True, exist_ok=True)
+    (repo / "openhost.toml").write_text(_CONSUMES.format(consumes=consumes))
+    return parse_manifest(str(repo))
+
+
+def _consume_block(service: str, shortname: str, grants: str) -> str:
+    return (
+        "[[services.v2.consumes]]\n"
+        f'service = "{service}"\n'
+        f'shortname = "{shortname}"\n'
+        'version = ">=0.1.0"\n'
+        f"grants = [{grants}]\n"
+    )
+
+
+# ─── the shared diff helper ───────────────────────────────────────────────────
+
+
+def test_ungranted_empty_when_no_consumes(tmp_path: Path) -> None:
+    manifest = _manifest_with_consumes(tmp_path / "m", "")
+    assert manifest_ungranted_permissions_v2(manifest, []) == []
+
+
+def test_ungranted_lists_declared_when_nothing_granted(tmp_path: Path) -> None:
+    manifest = _manifest_with_consumes(
+        tmp_path / "m", _consume_block("github.com/x/secrets", "secrets", '{ key = "API_KEY" }')
+    )
+    ungranted = manifest_ungranted_permissions_v2(manifest, [])
+    assert len(ungranted) == 1
+    assert ungranted[0].service_url == "github.com/x/secrets"
+    assert ungranted[0].grant == {"key": "API_KEY"}
+
+
+def test_ungranted_excludes_already_granted(tmp_path: Path) -> None:
+    manifest = _manifest_with_consumes(
+        tmp_path / "m", _consume_block("github.com/x/secrets", "secrets", '{ key = "API_KEY" }')
+    )
+    granted = [
+        PermissionRecord(
+            consumer_app_id="a1",
+            service_url="github.com/x/secrets",
+            grant={"key": "API_KEY"},
+            scope="global",
+            provider_app_id=None,
+        )
+    ]
+    assert manifest_ungranted_permissions_v2(manifest, granted) == []
+
+
+def test_ungranted_grant_match_is_key_order_insensitive(tmp_path: Path) -> None:
+    """A stored grant and a declared grant compare equal regardless of dict key
+    order (both normalize via json.dumps(sort_keys=True))."""
+    manifest = _manifest_with_consumes(
+        tmp_path / "m",
+        _consume_block("github.com/x/svc", "svc", '{ a = "1", b = "2" }'),
+    )
+    granted = [
+        PermissionRecord(
+            consumer_app_id="a1",
+            service_url="github.com/x/svc",
+            # Same content, different insertion order.
+            grant={"b": "2", "a": "1"},
+            scope="global",
+            provider_app_id=None,
+        )
+    ]
+    assert manifest_ungranted_permissions_v2(manifest, granted) == []
+
+
+def test_ungranted_dedups_repeated_declarations(tmp_path: Path) -> None:
+    manifest = _manifest_with_consumes(
+        tmp_path / "m",
+        _consume_block("github.com/x/svc", "svc", '{ key = "K" }, { key = "K" }'),
+    )
+    ungranted = manifest_ungranted_permissions_v2(manifest, [])
+    assert len(ungranted) == 1
+
+
+def test_ungranted_reports_only_the_new_grant(tmp_path: Path) -> None:
+    """When one of two declared grants is already held, only the other is new."""
+    manifest = _manifest_with_consumes(
+        tmp_path / "m",
+        _consume_block("github.com/x/svc", "svc", '{ key = "OLD" }, { key = "NEW" }'),
+    )
+    granted = [
+        PermissionRecord(
+            consumer_app_id="a1",
+            service_url="github.com/x/svc",
+            grant={"key": "OLD"},
+            scope="global",
+            provider_app_id=None,
+        )
+    ]
+    ungranted = manifest_ungranted_permissions_v2(manifest, granted)
+    assert len(ungranted) == 1
+    assert ungranted[0].grant == {"key": "NEW"}
+
+
+# ─── the reload gate ──────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def cfg(tmp_path_factory: pytest.TempPathFactory) -> Any:
+    c = _make_test_config(tmp_path_factory.mktemp("perm-gate"), port=20900)
+    init_db(c.db_path)
+    return c
+
+
+def _seed_perm_app(cfg: Any, repo_path: str) -> str:
+    app_id = new_app_id()
+    db = sqlite3.connect(cfg.db_path)
+    try:
+        db.execute(
+            "INSERT INTO apps (app_id, name, version, repo_path, local_port, status) "
+            "VALUES (?, 'perm-app', '1.0', ?, 20901, 'running')",
+            (app_id, repo_path),
+        )
+        db.commit()
+    finally:
+        db.close()
+    return app_id
+
+
+def test_gate_returns_none_when_no_new_permissions(cfg: Any, tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    _manifest_with_consumes(repo, "")  # no consumes
+    app_id = _seed_perm_app(cfg, str(repo))
+
+    assert _gate_new_permissions(app_id, str(repo), approve_new_permissions=False) is None
+
+
+def test_gate_refuses_new_permission_without_approval(cfg: Any, tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    _manifest_with_consumes(repo, _consume_block("github.com/x/secrets", "secrets", '{ key = "API_KEY" }'))
+    app_id = _seed_perm_app(cfg, str(repo))
+
+    result = _gate_new_permissions(app_id, str(repo), approve_new_permissions=False)
+    assert result is not None
+    assert result.ok is False
+    assert len(result.permissions_required) == 1
+    assert result.permissions_required[0]["service_url"] == "github.com/x/secrets"
+    assert result.permissions_required[0]["shortname"] == "secrets"
+    # Nothing was granted (the gate must not persist anything when refusing).
+    assert get_all_permissions_v2(consumer_app_id=app_id) == []
+
+
+def test_gate_grants_and_proceeds_when_approved(cfg: Any, tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    _manifest_with_consumes(repo, _consume_block("github.com/x/secrets", "secrets", '{ key = "API_KEY" }'))
+    app_id = _seed_perm_app(cfg, str(repo))
+
+    result = _gate_new_permissions(app_id, str(repo), approve_new_permissions=True)
+    assert result is None
+    granted = get_all_permissions_v2(consumer_app_id=app_id)
+    assert len(granted) == 1
+    assert granted[0].service_url == "github.com/x/secrets"
+    assert granted[0].grant == {"key": "API_KEY"}
+
+
+def test_gate_ignores_already_granted_permission(cfg: Any, tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    _manifest_with_consumes(repo, _consume_block("github.com/x/secrets", "secrets", '{ key = "API_KEY" }'))
+    app_id = _seed_perm_app(cfg, str(repo))
+    grant_permission_v2(consumer_app_id=app_id, service_url="github.com/x/secrets", grant_payload={"key": "API_KEY"})
+
+    # Already held -> not "new" -> gate passes without prompting.
+    assert _gate_new_permissions(app_id, str(repo), approve_new_permissions=False) is None
+
+
+def test_gate_returns_none_for_unparseable_manifest(cfg: Any, tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "openhost.toml").write_text("not = valid [ toml")
+    app_id = _seed_perm_app(cfg, str(repo))
+
+    # A broken manifest isn't the gate's problem; the reload path surfaces it.
+    assert _gate_new_permissions(app_id, str(repo), approve_new_permissions=False) is None
+
+
+# ─── the /reload_app route end-to-end ─────────────────────────────────────────
+
+
+@pytest.fixture
+def client(cfg: Any) -> Iterator[TestClient[Litestar]]:
+    with TestClient(app=make_test_app(api_apps_routes)) as c:
+        yield c
+
+
+@pytest.fixture
+def cookies(cfg: Any) -> dict[str, str]:
+    return auth_cookie(cfg)
+
+
+def _seed_git_app_with_consumes(cfg: Any, repo: Path, consumes: str) -> str:
+    """Seed a running app whose on-disk repo is a git checkout declaring
+    ``consumes`` permissions. A plain (non-update) reload reads this manifest."""
+    _manifest_with_consumes(repo, consumes)
+    (repo / ".git").mkdir()  # marks it a git checkout so reload uses it in place
+    return _seed_perm_app(cfg, str(repo))
+
+
+def test_reload_route_refuses_when_new_permission_unapproved(
+    cfg: Any, client: TestClient[Litestar], cookies: dict[str, str], tmp_path: Path
+) -> None:
+    repo = tmp_path / "repo"
+    app_id = _seed_git_app_with_consumes(
+        cfg, repo, _consume_block("github.com/x/secrets", "secrets", '{ key = "API_KEY" }')
+    )
+
+    with (
+        patch("compute_space.web.routes.api.apps.stop_app_process") as stop,
+        patch("compute_space.web.routes.api.apps.Thread") as thread,
+    ):
+        resp = client.post(f"/reload_app/{app_id}", json={"update": False}, cookies=cookies)
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["ok"] is False
+    assert body["permissions_required"][0]["service_url"] == "github.com/x/secrets"
+    # The running app was NOT touched and no reload thread was spawned.
+    stop.assert_not_called()
+    thread.assert_not_called()
+    assert get_all_permissions_v2(consumer_app_id=app_id) == []
+    # App row stays 'running' (not flipped to 'building').
+    db = sqlite3.connect(cfg.db_path)
+    try:
+        status = db.execute("SELECT status FROM apps WHERE app_id = ?", (app_id,)).fetchone()[0]
+    finally:
+        db.close()
+    assert status == "running"
+
+
+def test_reload_route_grants_and_reloads_when_approved(
+    cfg: Any, client: TestClient[Litestar], cookies: dict[str, str], tmp_path: Path
+) -> None:
+    repo = tmp_path / "repo"
+    app_id = _seed_git_app_with_consumes(
+        cfg, repo, _consume_block("github.com/x/secrets", "secrets", '{ key = "API_KEY" }')
+    )
+
+    with (
+        patch("compute_space.web.routes.api.apps.stop_app_process") as stop,
+        patch("compute_space.web.routes.api.apps.Thread") as thread,
+    ):
+        resp = client.post(
+            f"/reload_app/{app_id}",
+            json={"update": False, "approve_new_permissions": True},
+            cookies=cookies,
+        )
+
+    assert resp.status_code == 200
+    assert resp.json() == {"ok": True}
+    # The permission was granted and the reload proceeded.
+    granted = get_all_permissions_v2(consumer_app_id=app_id)
+    assert len(granted) == 1
+    assert granted[0].service_url == "github.com/x/secrets"
+    stop.assert_called_once()
+    thread.assert_called_once()
+
+
+def test_reload_route_proceeds_when_no_new_permissions(
+    cfg: Any, client: TestClient[Litestar], cookies: dict[str, str], tmp_path: Path
+) -> None:
+    repo = tmp_path / "repo"
+    app_id = _seed_git_app_with_consumes(cfg, repo, "")  # no consumes
+
+    with (
+        patch("compute_space.web.routes.api.apps.stop_app_process") as stop,
+        patch("compute_space.web.routes.api.apps.Thread") as thread,
+    ):
+        resp = client.post(f"/reload_app/{app_id}", json={"update": False}, cookies=cookies)
+
+    assert resp.status_code == 200
+    assert resp.json() == {"ok": True}
+    stop.assert_called_once()
+    thread.assert_called_once()

--- a/compute_space/src/compute_space/tests/test_reload_permissions.py
+++ b/compute_space/src/compute_space/tests/test_reload_permissions.py
@@ -10,6 +10,7 @@ the owner approves, and the app keeps running its current version meanwhile.
 
 from __future__ import annotations
 
+import contextlib
 import sqlite3
 from collections.abc import Iterator
 from pathlib import Path
@@ -146,6 +147,81 @@ def test_ungranted_reports_only_the_new_grant(tmp_path: Path) -> None:
     assert ungranted[0].grant == {"key": "NEW"}
 
 
+def test_ungranted_string_grant(tmp_path: Path) -> None:
+    """Grants can be bare strings (e.g. "FULL_ACCESS"), not just tables."""
+    manifest = _manifest_with_consumes(tmp_path / "m", _consume_block("github.com/x/svc", "svc", '"FULL_ACCESS"'))
+    ungranted = manifest_ungranted_permissions_v2(manifest, [])
+    assert len(ungranted) == 1
+    assert ungranted[0].grant == "FULL_ACCESS"
+
+    granted = [
+        PermissionRecord(
+            consumer_app_id="a1",
+            service_url="github.com/x/svc",
+            grant="FULL_ACCESS",
+            scope="global",
+            provider_app_id=None,
+        )
+    ]
+    assert manifest_ungranted_permissions_v2(manifest, granted) == []
+
+
+def test_ungranted_spans_multiple_services(tmp_path: Path) -> None:
+    """A new permission is detected per-service; a grant held for one service
+    does not satisfy a same-named grant declared for a different service."""
+    consumes = _consume_block("github.com/x/a", "a", '{ key = "K" }') + _consume_block(
+        "github.com/x/b", "b", '{ key = "K" }'
+    )
+    manifest = _manifest_with_consumes(tmp_path / "m", consumes)
+    granted = [
+        PermissionRecord(
+            consumer_app_id="a1",
+            service_url="github.com/x/a",
+            grant={"key": "K"},
+            scope="global",
+            provider_app_id=None,
+        )
+    ]
+    ungranted = manifest_ungranted_permissions_v2(manifest, granted)
+    assert len(ungranted) == 1
+    assert ungranted[0].service_url == "github.com/x/b"
+
+
+def test_ungranted_same_grant_different_service_not_satisfied(tmp_path: Path) -> None:
+    """Identity is (service, grant): the same grant payload under a different
+    service is still ungranted."""
+    manifest = _manifest_with_consumes(tmp_path / "m", _consume_block("github.com/x/a", "a", '{ key = "K" }'))
+    granted = [
+        PermissionRecord(
+            consumer_app_id="a1",
+            service_url="github.com/x/other",
+            grant={"key": "K"},
+            scope="global",
+            provider_app_id=None,
+        )
+    ]
+    ungranted = manifest_ungranted_permissions_v2(manifest, granted)
+    assert len(ungranted) == 1
+    assert ungranted[0].service_url == "github.com/x/a"
+
+
+def test_ungranted_app_scoped_grant_counts_as_held(tmp_path: Path) -> None:
+    """A permission held under 'app' scope (not just 'global') still counts as
+    already granted — the diff is scope-insensitive, so an update won't
+    re-prompt for something the app already holds under any scope."""
+    manifest = _manifest_with_consumes(tmp_path / "m", _consume_block("github.com/x/svc", "svc", '{ key = "K" }'))
+    granted = [
+        PermissionRecord(
+            consumer_app_id="a1",
+            service_url="github.com/x/svc",
+            grant={"key": "K"},
+            scope="app",
+            provider_app_id="prov1",
+        )
+    ]
+    assert manifest_ungranted_permissions_v2(manifest, granted) == []
+
+
 # ─── the reload gate ──────────────────────────────────────────────────────────
 
 
@@ -243,10 +319,43 @@ def cookies(cfg: Any) -> dict[str, str]:
 
 def _seed_git_app_with_consumes(cfg: Any, repo: Path, consumes: str) -> str:
     """Seed a running app whose on-disk repo is a git checkout declaring
-    ``consumes`` permissions. A plain (non-update) reload reads this manifest."""
+    ``consumes`` permissions, with a repo_url so ``update`` can run git_pull."""
     _manifest_with_consumes(repo, consumes)
-    (repo / ".git").mkdir()  # marks it a git checkout so reload uses it in place
-    return _seed_perm_app(cfg, str(repo))
+    (repo / ".git").mkdir()  # marks it a git checkout
+    app_id = new_app_id()
+    db = sqlite3.connect(cfg.db_path)
+    try:
+        db.execute(
+            "INSERT INTO apps (app_id, name, version, repo_path, repo_url, local_port, status) "
+            "VALUES (?, 'perm-app', '1.0', ?, 'https://github.com/x/perm-app', 20901, 'running')",
+            (app_id, str(repo)),
+        )
+        db.commit()
+    finally:
+        db.close()
+    return app_id
+
+
+@contextlib.contextmanager
+def _mocked_reload_side_effects() -> Iterator[dict[str, Any]]:
+    """Stub out the heavy/side-effecting bits of an update reload so route tests
+    exercise the permission gate hermetically: a successful git pull, no ref
+    re-pin, no container stop, no background reload thread."""
+    with (
+        patch("compute_space.web.routes.api.apps.git_pull", return_value=(True, None)),
+        patch("compute_space.web.routes.api.apps._pin_refless_to_landed_branch", return_value=None),
+        patch("compute_space.web.routes.api.apps.stop_app_process") as stop,
+        patch("compute_space.web.routes.api.apps.Thread") as thread,
+    ):
+        yield {"stop": stop, "thread": thread}
+
+
+def _app_status(cfg: Any, app_id: str) -> str:
+    db = sqlite3.connect(cfg.db_path)
+    try:
+        return str(db.execute("SELECT status FROM apps WHERE app_id = ?", (app_id,)).fetchone()[0])
+    finally:
+        db.close()
 
 
 def test_reload_route_refuses_when_new_permission_unapproved(
@@ -257,27 +366,19 @@ def test_reload_route_refuses_when_new_permission_unapproved(
         cfg, repo, _consume_block("github.com/x/secrets", "secrets", '{ key = "API_KEY" }')
     )
 
-    with (
-        patch("compute_space.web.routes.api.apps.stop_app_process") as stop,
-        patch("compute_space.web.routes.api.apps.Thread") as thread,
-    ):
-        resp = client.post(f"/reload_app/{app_id}", json={"update": False}, cookies=cookies)
+    with _mocked_reload_side_effects() as m:
+        resp = client.post(f"/reload_app/{app_id}", json={"update": True}, cookies=cookies)
 
     assert resp.status_code == 200
     body = resp.json()
     assert body["ok"] is False
     assert body["permissions_required"][0]["service_url"] == "github.com/x/secrets"
     # The running app was NOT touched and no reload thread was spawned.
-    stop.assert_not_called()
-    thread.assert_not_called()
+    m["stop"].assert_not_called()
+    m["thread"].assert_not_called()
     assert get_all_permissions_v2(consumer_app_id=app_id) == []
     # App row stays 'running' (not flipped to 'building').
-    db = sqlite3.connect(cfg.db_path)
-    try:
-        status = db.execute("SELECT status FROM apps WHERE app_id = ?", (app_id,)).fetchone()[0]
-    finally:
-        db.close()
-    assert status == "running"
+    assert _app_status(cfg, app_id) == "running"
 
 
 def test_reload_route_grants_and_reloads_when_approved(
@@ -288,13 +389,10 @@ def test_reload_route_grants_and_reloads_when_approved(
         cfg, repo, _consume_block("github.com/x/secrets", "secrets", '{ key = "API_KEY" }')
     )
 
-    with (
-        patch("compute_space.web.routes.api.apps.stop_app_process") as stop,
-        patch("compute_space.web.routes.api.apps.Thread") as thread,
-    ):
+    with _mocked_reload_side_effects() as m:
         resp = client.post(
             f"/reload_app/{app_id}",
-            json={"update": False, "approve_new_permissions": True},
+            json={"update": True, "approve_new_permissions": True},
             cookies=cookies,
         )
 
@@ -304,8 +402,8 @@ def test_reload_route_grants_and_reloads_when_approved(
     granted = get_all_permissions_v2(consumer_app_id=app_id)
     assert len(granted) == 1
     assert granted[0].service_url == "github.com/x/secrets"
-    stop.assert_called_once()
-    thread.assert_called_once()
+    m["stop"].assert_called_once()
+    m["thread"].assert_called_once()
 
 
 def test_reload_route_proceeds_when_no_new_permissions(
@@ -313,6 +411,26 @@ def test_reload_route_proceeds_when_no_new_permissions(
 ) -> None:
     repo = tmp_path / "repo"
     app_id = _seed_git_app_with_consumes(cfg, repo, "")  # no consumes
+
+    with _mocked_reload_side_effects() as m:
+        resp = client.post(f"/reload_app/{app_id}", json={"update": True}, cookies=cookies)
+
+    assert resp.status_code == 200
+    assert resp.json() == {"ok": True}
+    m["stop"].assert_called_once()
+    m["thread"].assert_called_once()
+
+
+def test_plain_reload_does_not_gate_declared_but_ungranted_permission(
+    cfg: Any, client: TestClient[Litestar], cookies: dict[str, str], tmp_path: Path
+) -> None:
+    """A plain reload (update=False) deploys the manifest already on disk, so it
+    must NOT re-prompt for a permission the owner declined at install and chose
+    to keep running without. Only an actual code pull (update) can gate."""
+    repo = tmp_path / "repo"
+    app_id = _seed_git_app_with_consumes(
+        cfg, repo, _consume_block("github.com/x/secrets", "secrets", '{ key = "API_KEY" }')
+    )
 
     with (
         patch("compute_space.web.routes.api.apps.stop_app_process") as stop,
@@ -322,5 +440,64 @@ def test_reload_route_proceeds_when_no_new_permissions(
 
     assert resp.status_code == 200
     assert resp.json() == {"ok": True}
+    # Reload proceeded; nothing was granted (plain reload never grants).
     stop.assert_called_once()
     thread.assert_called_once()
+    assert get_all_permissions_v2(consumer_app_id=app_id) == []
+
+
+def test_reload_route_lists_all_new_permissions(
+    cfg: Any, client: TestClient[Litestar], cookies: dict[str, str], tmp_path: Path
+) -> None:
+    """An update declaring several new permissions reports all of them."""
+    repo = tmp_path / "repo"
+    consumes = _consume_block("github.com/x/a", "a", '{ key = "K1" }') + _consume_block(
+        "github.com/x/b", "b", '"FULL"'
+    )
+    app_id = _seed_git_app_with_consumes(cfg, repo, consumes)
+
+    with _mocked_reload_side_effects():
+        resp = client.post(f"/reload_app/{app_id}", json={"update": True}, cookies=cookies)
+
+    body = resp.json()
+    assert body["ok"] is False
+    services = sorted(p["service_url"] for p in body["permissions_required"])
+    assert services == ["github.com/x/a", "github.com/x/b"]
+    assert get_all_permissions_v2(consumer_app_id=app_id) == []
+
+
+def test_reload_route_only_gates_the_newly_added_permission(
+    cfg: Any, client: TestClient[Litestar], cookies: dict[str, str], tmp_path: Path
+) -> None:
+    """If the app already holds one declared permission, an update adding a
+    second is gated only on the new one; approving grants only the new one
+    (the already-held one is untouched, INSERT OR IGNORE)."""
+    repo = tmp_path / "repo"
+    consumes = _consume_block("github.com/x/a", "a", '{ key = "OLD" }') + _consume_block(
+        "github.com/x/b", "b", '{ key = "NEW" }'
+    )
+    app_id = _seed_git_app_with_consumes(cfg, repo, consumes)
+    grant_permission_v2(consumer_app_id=app_id, service_url="github.com/x/a", grant_payload={"key": "OLD"})
+
+    # Without approval: refused, and only the NEW one is listed.
+    with _mocked_reload_side_effects() as m:
+        resp = client.post(f"/reload_app/{app_id}", json={"update": True}, cookies=cookies)
+    body = resp.json()
+    assert body["ok"] is False
+    assert len(body["permissions_required"]) == 1
+    assert body["permissions_required"][0]["service_url"] == "github.com/x/b"
+    m["thread"].assert_not_called()
+
+    # With approval: proceeds; now both are held.
+    with _mocked_reload_side_effects() as m:
+        resp = client.post(
+            f"/reload_app/{app_id}", json={"update": True, "approve_new_permissions": True}, cookies=cookies
+        )
+    assert resp.json() == {"ok": True}
+    held = {
+        (p.service_url, tuple(sorted(p.grant.items())) if isinstance(p.grant, dict) else p.grant)
+        for p in get_all_permissions_v2(consumer_app_id=app_id)
+    }
+    assert ("github.com/x/a", (("key", "OLD"),)) in held
+    assert ("github.com/x/b", (("key", "NEW"),)) in held
+    m["thread"].assert_called_once()

--- a/compute_space/src/compute_space/tests/test_reload_permissions.py
+++ b/compute_space/src/compute_space/tests/test_reload_permissions.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import contextlib
 import sqlite3
+import subprocess
 from collections.abc import Iterator
 from pathlib import Path
 from typing import Any
@@ -501,3 +502,98 @@ def test_reload_route_only_gates_the_newly_added_permission(
     assert ("github.com/x/a", (("key", "OLD"),)) in held
     assert ("github.com/x/b", (("key", "NEW"),)) in held
     m["thread"].assert_called_once()
+
+
+# ─── regression: a refused update must not leave the pulled code on disk ───────
+# Guards against the bug where the git pull advanced the working tree to the
+# new (unapproved) version, the gate refused, but the tree stayed on the new
+# version — so a later PLAIN reload (which is intentionally not gated, on the
+# assumption the on-disk manifest matches the running one) would silently deploy
+# the unapproved code + its new permissions.
+
+
+def _git(repo: Path, *args: str) -> str:
+    return subprocess.run(
+        ["git", "-C", str(repo), *args],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+
+
+def _init_two_commit_repo(tmp_path: Path) -> tuple[Path, Path, str, str]:
+    """Create an 'origin' repo with v1 (no consumes) then v2 (adds a consume),
+    and a clone checked out at v1. Returns (clone, origin, v1_sha)."""
+    origin = tmp_path / "origin"
+    origin.mkdir()
+    subprocess.run(["git", "-C", str(origin), "init", "-q", "-b", "main"], check=True)
+    subprocess.run(["git", "-C", str(origin), "config", "user.email", "t@t"], check=True)
+    subprocess.run(["git", "-C", str(origin), "config", "user.name", "t"], check=True)
+    (origin / "openhost.toml").write_text(_CONSUMES.format(consumes=""))
+    _git(origin, "add", "-A")
+    _git(origin, "commit", "-qm", "v1 no consumes")
+    v1 = _git(origin, "rev-parse", "HEAD")
+    # v2 adds a new consume
+    (origin / "openhost.toml").write_text(
+        _CONSUMES.format(consumes=_consume_block("github.com/x/secrets", "secrets", '{ key = "API_KEY" }'))
+    )
+    _git(origin, "add", "-A")
+    _git(origin, "commit", "-qm", "v2 adds consume")
+
+    v2 = _git(origin, "rev-parse", "HEAD")
+    clone = tmp_path / "clone"
+    subprocess.run(["git", "clone", "-q", str(origin), str(clone)], check=True)
+    subprocess.run(["git", "-C", str(clone), "config", "user.email", "t@t"], check=True)
+    subprocess.run(["git", "-C", str(clone), "config", "user.name", "t"], check=True)
+    # The app is "running" v1: detach the working tree at v1. The (mocked) update
+    # pull will fast-forward it to v2, which the gate must then roll back.
+    _git(clone, "checkout", "-q", v1)
+    return clone, origin, v1, v2
+
+
+def _seed_running_app_at(cfg: Any, repo: Path, origin: Path) -> str:
+    app_id = new_app_id()
+    db = sqlite3.connect(cfg.db_path)
+    try:
+        db.execute(
+            "INSERT INTO apps (app_id, name, version, repo_path, repo_url, local_port, status) "
+            "VALUES (?, 'perm-app', '1.0', ?, ?, 20955, 'running')",
+            (app_id, str(repo), str(origin)),  # repo_url = origin so git_pull fetches v2
+        )
+        db.commit()
+    finally:
+        db.close()
+    return app_id
+
+
+def test_refused_update_rolls_back_working_tree(
+    cfg: Any, client: TestClient[Litestar], cookies: dict[str, str], tmp_path: Path
+) -> None:
+    clone, _origin, v1, v2 = _init_two_commit_repo(tmp_path)
+    app_id = _seed_running_app_at(cfg, clone, _origin)
+
+    # Simulate the update pull advancing the working tree to v2 (which declares a
+    # new, unapproved permission). Our gate must then refuse AND roll the tree
+    # back to v1, so a later plain reload can't deploy the unapproved version.
+    def _fake_pull(*_a: Any, **_k: Any) -> tuple[bool, None]:
+        _git(clone, "reset", "--hard", v2)
+        return True, None
+
+    with (
+        patch("compute_space.web.routes.api.apps.git_pull", side_effect=_fake_pull),
+        patch("compute_space.web.routes.api.apps._pin_refless_to_landed_branch", return_value=None),
+        patch("compute_space.web.routes.api.apps.stop_app_process") as stop,
+        patch("compute_space.web.routes.api.apps.Thread") as thread,
+    ):
+        # sanity: the pulled v2 really does declare a new consume
+        resp = client.post(f"/reload_app/{app_id}", json={"update": True}, cookies=cookies)
+
+    assert resp.status_code == 200
+    assert resp.json()["ok"] is False, "update declaring a new permission must be refused"
+    stop.assert_not_called()
+    thread.assert_not_called()
+    assert get_all_permissions_v2(consumer_app_id=app_id) == []
+    # The working tree must be rolled back to v1 — NOT left on the pulled v2 — so
+    # a subsequent plain (ungated) reload can't deploy the unapproved version.
+    assert _git(clone, "rev-parse", "HEAD") == v1
+    assert "consumes" not in (clone / "openhost.toml").read_text()

--- a/compute_space/src/compute_space/web/routes/api/apps.py
+++ b/compute_space/src/compute_space/web/routes/api/apps.py
@@ -30,11 +30,14 @@ from compute_space.core.apps import app_log_path
 from compute_space.core.apps import clone_with_github_fallback
 from compute_space.core.apps import git_pull
 from compute_space.core.apps import insert_and_deploy
+from compute_space.core.apps import manifest_ungranted_permissions_v2
 from compute_space.core.apps import move_clone_to_app_temp_dir
 from compute_space.core.apps import reload_app_background
 from compute_space.core.apps import remove_app_background
 from compute_space.core.apps import start_app_process
 from compute_space.core.apps import validate_manifest
+from compute_space.core.auth.permissions_v2 import get_all_permissions_v2
+from compute_space.core.auth.permissions_v2 import grant_permission_v2
 from compute_space.core.containers import BUILD_CACHE_CORRUPT_MARKER
 from compute_space.core.containers import archive_old_log
 from compute_space.core.containers import get_docker_logs
@@ -149,6 +152,24 @@ class AppStatusResponse:
 @attr.s(auto_attribs=True, frozen=True)
 class ReloadAppRequest:
     update: bool = False
+    # When True, the owner has reviewed the permissions the (updated) manifest
+    # newly declares and approves granting them as part of this reload. Without
+    # it, a reload whose manifest declares new, ungranted permissions is
+    # refused (see PermissionsRequiredResponse) — mirroring the explicit
+    # owner approval required at install time.
+    approve_new_permissions: bool = False
+
+
+@attr.s(auto_attribs=True, frozen=True)
+class PermissionsRequiredResponse:
+    """Returned by ``/reload_app`` when the manifest to be deployed declares
+    permissions the app does not already hold and the caller has not approved
+    them. The reload is NOT performed; the app keeps running its current
+    version until the owner re-submits with ``approve_new_permissions``."""
+
+    ok: bool
+    permissions_required: list[dict[str, Any]]
+    error: str
 
 
 @attr.s(auto_attribs=True, frozen=True)
@@ -529,13 +550,65 @@ async def stop_app(app_id: str, db: sqlite3.Connection) -> Response[OkResponse] 
     return Response(content=OkResponse(ok=True), status_code=200, media_type=MediaType.JSON)
 
 
+def _gate_new_permissions(
+    app_id: str,
+    repo_path: str,
+    approve_new_permissions: bool,
+) -> PermissionsRequiredResponse | None:
+    """Enforce explicit owner approval of permissions a reload would newly grant.
+
+    Reads the manifest that is about to be deployed (from ``repo_path`` on disk,
+    which already reflects any git pull) and diffs its declared permissions
+    against what the app already holds. If the manifest declares nothing new,
+    returns ``None`` (proceed). If it declares new permissions:
+
+    - ``approve_new_permissions=True``: grant them and return ``None`` (proceed),
+      mirroring the owner-approved grants at install time.
+    - otherwise: return a :class:`PermissionsRequiredResponse` so the caller can
+      refuse the reload until the owner approves.
+
+    A manifest that can't be parsed is treated as "nothing new" here; the reload
+    path will surface the parse error on its own.
+    """
+    if not repo_path or not os.path.isdir(repo_path):
+        return None
+    try:
+        manifest = parse_manifest(repo_path)
+    except ValueError:
+        return None
+
+    ungranted = manifest_ungranted_permissions_v2(manifest, get_all_permissions_v2(consumer_app_id=app_id))
+    if not ungranted:
+        return None
+
+    if approve_new_permissions:
+        for pg in ungranted:
+            grant_permission_v2(consumer_app_id=app_id, service_url=pg.service_url, grant_payload=pg.grant)
+        return None
+
+    shortname_by_service = {c.service: c.shortname for c in manifest.consumes_services_v2}
+    return PermissionsRequiredResponse(
+        ok=False,
+        permissions_required=[
+            {
+                "service_url": pg.service_url,
+                "grant": pg.grant,
+                "shortname": shortname_by_service.get(pg.service_url, ""),
+            }
+            for pg in ungranted
+        ],
+        error=("This update declares new service permissions that must be approved before it can be applied."),
+    )
+
+
 async def _reload_app_impl(
     app_id: str,
     update: bool,
     continue_oauth: bool,
+    approve_new_permissions: bool,
     db: sqlite3.Connection,
     config: Config,
-) -> Response[OkResponse] | Response[ErrorResponse] | Redirect:
+) -> Response[OkResponse] | Response[ErrorResponse] | Response[PermissionsRequiredResponse] | Redirect:
     """Shared body for the POST (user-initiated reload) and GET (OAuth callback)
     entry points to ``/reload_app/{app_id}``."""
     app_row, err = _resolve_app_or_error(app_id, db)
@@ -652,6 +725,18 @@ async def _reload_app_impl(
                 db.commit()
                 lf.write(f"Pinned upstream to {pinned}\n")
 
+    # Gate: if the manifest that's about to be deployed declares permissions the
+    # app doesn't already hold, refuse the reload until the owner approves them
+    # (the install flow requires the same explicit approval). Runs before the
+    # running container is touched, so a refused update leaves the app untouched.
+    perm_gate = await asyncio.to_thread(_gate_new_permissions, app_id, app_row["repo_path"], approve_new_permissions)
+    if perm_gate is not None:
+        with open(log_file, "a") as lf:
+            lf.write("Update requires approval of new service permissions; not reloading.\n")
+        if continue_oauth:
+            return Redirect(path=f"/app_detail/{app_name}")
+        return Response(content=perm_gate, status_code=200, media_type=MediaType.JSON)
+
     await asyncio.to_thread(stop_app_process, app_row)
     db.execute(
         "UPDATE apps SET status = 'building', container_id = NULL, error_message = NULL WHERE app_id = ?",
@@ -674,9 +759,16 @@ async def reload_app(
     db: sqlite3.Connection,
     config: Config,
     data: ReloadAppRequest = ReloadAppRequest(),  # noqa: B008 — Litestar resolves this at dependency-injection time
-) -> Response[OkResponse] | Response[ErrorResponse] | Redirect:
+) -> Response[OkResponse] | Response[ErrorResponse] | Response[PermissionsRequiredResponse] | Redirect:
     """User-initiated reload, optionally pulling latest code via ``update``."""
-    return await _reload_app_impl(app_id, update=data.update, continue_oauth=False, db=db, config=config)
+    return await _reload_app_impl(
+        app_id,
+        update=data.update,
+        continue_oauth=False,
+        approve_new_permissions=data.approve_new_permissions,
+        db=db,
+        config=config,
+    )
 
 
 @get("/reload_app/{app_id:str}", guards=[require_owner_auth])
@@ -685,7 +777,7 @@ async def reload_app_after_oauth(
     db: sqlite3.Connection,
     config: Config,
     continue_oauth_update: Annotated[bool, Parameter(query="continue_oauth_update", required=False)] = False,
-) -> Response[OkResponse] | Response[ErrorResponse] | Redirect:
+) -> Response[OkResponse] | Response[ErrorResponse] | Response[PermissionsRequiredResponse] | Redirect:
     """OAuth callback re-entry: the secrets app redirected the user back here
     after they granted GitHub access.  Resumes the update with ``continue_oauth=True``
     so we don't truncate the log file again or re-prompt for OAuth."""
@@ -695,7 +787,14 @@ async def reload_app_after_oauth(
         if not row:
             return Redirect(path="/dashboard")
         return Redirect(path=f"/app_detail/{row['name']}")
-    return await _reload_app_impl(app_id, update=True, continue_oauth=True, db=db, config=config)
+    return await _reload_app_impl(
+        app_id,
+        update=True,
+        continue_oauth=True,
+        approve_new_permissions=False,
+        db=db,
+        config=config,
+    )
 
 
 @post("/remove_app/{app_id:str}", status_code=202, guards=[require_owner_auth])

--- a/compute_space/src/compute_space/web/routes/api/apps.py
+++ b/compute_space/src/compute_space/web/routes/api/apps.py
@@ -725,17 +725,26 @@ async def _reload_app_impl(
                 db.commit()
                 lf.write(f"Pinned upstream to {pinned}\n")
 
-    # Gate: if the manifest that's about to be deployed declares permissions the
+    # Gate: when an update pulls a new manifest that declares permissions the
     # app doesn't already hold, refuse the reload until the owner approves them
     # (the install flow requires the same explicit approval). Runs before the
     # running container is touched, so a refused update leaves the app untouched.
-    perm_gate = await asyncio.to_thread(_gate_new_permissions, app_id, app_row["repo_path"], approve_new_permissions)
-    if perm_gate is not None:
-        with open(log_file, "a") as lf:
-            lf.write("Update requires approval of new service permissions; not reloading.\n")
-        if continue_oauth:
-            return Redirect(path=f"/app_detail/{app_name}")
-        return Response(content=perm_gate, status_code=200, media_type=MediaType.JSON)
+    #
+    # Only applies when code is actually being pulled (update / oauth re-entry).
+    # A plain reload deploys the manifest already on disk — the one the app is
+    # currently running — so it can't introduce new permissions, and gating it
+    # would wrongly re-prompt for permissions the owner deliberately declined at
+    # install and chose to keep running without.
+    if update or continue_oauth:
+        perm_gate = await asyncio.to_thread(
+            _gate_new_permissions, app_id, app_row["repo_path"], approve_new_permissions
+        )
+        if perm_gate is not None:
+            with open(log_file, "a") as lf:
+                lf.write("Update requires approval of new service permissions; not reloading.\n")
+            if continue_oauth:
+                return Redirect(path=f"/app_detail/{app_name}")
+            return Response(content=perm_gate, status_code=200, media_type=MediaType.JSON)
 
     await asyncio.to_thread(stop_app_process, app_row)
     db.execute(

--- a/compute_space/src/compute_space/web/routes/api/apps.py
+++ b/compute_space/src/compute_space/web/routes/api/apps.py
@@ -52,6 +52,7 @@ from compute_space.core.git_ops import get_head_sha
 from compute_space.core.git_ops import is_dirty
 from compute_space.core.git_ops import is_github_repo_url
 from compute_space.core.git_ops import parse_repo_url
+from compute_space.core.git_ops import reset_hard
 from compute_space.core.logging import logger
 from compute_space.core.manifest import parse_manifest
 from compute_space.core.oauth import OAuthAuthorizationRequired
@@ -646,6 +647,11 @@ async def _reload_app_impl(
         else:
             lf.write("continuing app reload after oauth\n")
 
+        # SHA the app is currently deployed at, captured before any pull so a
+        # refused update can roll the working tree back to it (keeping the
+        # on-disk repo in sync with the running version — see the gate below).
+        pre_pull_sha: str | None = None
+
         if update or continue_oauth:
             if not app_row["repo_path"] or not os.path.isdir(os.path.join(app_row["repo_path"], ".git")):
                 db.execute(
@@ -657,6 +663,11 @@ async def _reload_app_impl(
                 )
                 db.commit()
                 return Response(content=OkResponse(ok=True), status_code=200, media_type=MediaType.JSON)
+
+            try:
+                pre_pull_sha = await get_head_sha(Path(app_row["repo_path"]))
+            except Exception as e:  # noqa: BLE001 — best-effort; rollback just won't run
+                lf.write(f"Could not read pre-pull HEAD sha: {e}\n")
 
             repo_url = app_row["repo_url"] or ""
             pull_ok = False
@@ -740,6 +751,17 @@ async def _reload_app_impl(
             _gate_new_permissions, app_id, app_row["repo_path"], approve_new_permissions
         )
         if perm_gate is not None:
+            # Roll the working tree back to the version the app is running, so the
+            # pulled-but-refused code (which declares the unapproved permissions)
+            # does not linger on disk where a later plain reload — which is not
+            # gated, on the assumption the on-disk manifest matches the running
+            # one — would silently deploy it.
+            if pre_pull_sha:
+                try:
+                    await reset_hard(Path(app_row["repo_path"]), pre_pull_sha)
+                except Exception as e:  # noqa: BLE001
+                    with open(log_file, "a") as lf:
+                        lf.write(f"WARNING: failed to roll back refused update to {pre_pull_sha}: {e}\n")
             with open(log_file, "a") as lf:
                 lf.write("Update requires approval of new service permissions; not reloading.\n")
             if continue_oauth:

--- a/compute_space/src/compute_space/web/routes/pages/apps.py
+++ b/compute_space/src/compute_space/web/routes/pages/apps.py
@@ -1,4 +1,3 @@
-import json
 import sqlite3
 from pathlib import Path
 from urllib.parse import urlencode
@@ -11,6 +10,7 @@ from litestar.response import Template
 from compute_space.config import Config
 from compute_space.core.app_id import is_valid_app_name
 from compute_space.core.apps import deserialize_links
+from compute_space.core.apps import manifest_ungranted_permissions_v2
 from compute_space.core.auth.permissions_v2 import get_all_permissions_v2
 from compute_space.core.containers import get_docker_logs
 from compute_space.core.git_ops import UnsupportedRepoUrlError
@@ -60,28 +60,26 @@ async def app_detail(app_name: str, db: sqlite3.Connection, config: Config, next
     # User-facing links the app advertised in its manifest's [[links]].
     links = deserialize_links(app_row["links"])
 
-    # Permissions: granted + manifest-declared but not yet granted
-    granted_perms = [
-        {"service_url": p.service_url, "grant": p.grant, "scope": p.scope}
-        for p in get_all_permissions_v2(consumer_app_id=app_id)
-    ]
+    # Permissions: granted + manifest-declared but not yet granted. The
+    # ungranted diff uses the same shared helper the update/reload gate uses,
+    # so the "needs approval" set the owner sees here matches what an update
+    # would refuse to apply.
+    granted_records = get_all_permissions_v2(consumer_app_id=app_id)
+    granted_perms = [{"service_url": p.service_url, "grant": p.grant, "scope": p.scope} for p in granted_records]
     ungranted_perms: list[dict[str, object]] = []
     manifest_raw = app_row["manifest_raw"]
     if manifest_raw:
         try:
             manifest = parse_manifest_from_string(manifest_raw)
-            granted_set = {(p["service_url"], json.dumps(p["grant"], sort_keys=True)) for p in granted_perms}
-            for consume in manifest.consumes_services_v2:
-                for grant_payload in consume.grants:
-                    key = (consume.service, json.dumps(grant_payload, sort_keys=True))
-                    if key not in granted_set:
-                        ungranted_perms.append(
-                            {
-                                "service_url": consume.service,
-                                "grant": grant_payload,
-                                "shortname": consume.shortname,
-                            }
-                        )
+            shortname_by_service = {c.service: c.shortname for c in manifest.consumes_services_v2}
+            for pg in manifest_ungranted_permissions_v2(manifest, granted_records):
+                ungranted_perms.append(
+                    {
+                        "service_url": pg.service_url,
+                        "grant": pg.grant,
+                        "shortname": shortname_by_service.get(pg.service_url, ""),
+                    }
+                )
         except Exception:
             logger.opt(exception=True).warning("Failed to parse manifest for permission display (app %s)", app_id)
 

--- a/compute_space/src/compute_space/web/static/js/app-detail.js
+++ b/compute_space/src/compute_space/web/static/js/app-detail.js
@@ -108,6 +108,18 @@ function appAction(url, data, opts) {
   })
     .then(function(r) { return r.json().then(function(d) { return {ok: r.ok, data: d}; }); })
     .then(function(res) {
+      // An update whose manifest declares new service permissions is refused
+      // until the owner explicitly approves them (mirrors install-time
+      // approval). Prompt, and on confirmation re-issue the request with
+      // approve_new_permissions so the grants are written before the reload.
+      if (res.ok && res.data && res.data.permissions_required) {
+        if (clear) clear();
+        if (confirmNewPermissions(res.data.permissions_required)) {
+          var approved = Object.assign({}, data || {}, {approve_new_permissions: true});
+          appAction(url, approved, opts);
+        }
+        return;
+      }
       if (!res.ok || (res.data && res.data.error)) {
         var msg = (res.data && res.data.error) || 'Request failed';
         if (clear) clear(msg);
@@ -121,6 +133,20 @@ function appAction(url, data, opts) {
       if (clear) clear('Request failed');
       alert('Request failed');
     });
+}
+
+// Show the owner exactly which new permissions an update wants and get an
+// explicit yes/no. Returns true if the owner approved.
+function confirmNewPermissions(perms) {
+  var lines = perms.map(function(p) {
+    var label = p.shortname ? (p.shortname + ' (' + p.service_url + ')') : p.service_url;
+    return '\u2022 ' + label + ': ' + JSON.stringify(p.grant);
+  });
+  return confirm(
+    'This update requests new service permissions:\n\n' +
+    lines.join('\n') +
+    '\n\nApprove these and continue updating?'
+  );
 }
 
 // ─── Toast ───


### PR DESCRIPTION
Follow-up to #226. Previously, updating an app whose manifest newly declared service permissions took effect silently: reload re-synced the manifest columns but left the new permissions ungranted, surfacing only passively on the app detail page. Install has always required explicit owner approval of declared permissions; update did not.

This closes that asymmetry. _reload_app_impl now gates the reload on _gate_new_permissions: after any git pull, it diffs the to-be-deployed manifest's declared consumes_services_v2 grants against what the app already holds. If the manifest declares new permissions and the owner has not approved them, the reload is refused and the app keeps running its current version. When the owner approves (approve_new_permissions on the reload request), the grants are written and the reload proceeds, mirroring install-time approval.

Adds manifest_ungranted_permissions_v2() as the single source of truth for the ungranted-permission diff, shared by the app detail page and the reload gate so they can't drift. The Update and Reload button prompts the owner with the specific new permissions and re-submits with approval on confirm.

The gate runs before the running container is touched, so a refused update leaves the app fully untouched. Already-granted permissions and manifests declaring no new permissions proceed without a prompt. The installer-service and default-apps install paths are unaffected (they go through insert_and_deploy, not reload).

Tests: new test_reload_permissions.py covers the diff helper (empty/new/already-granted, key-order-insensitive matching, dedup), the gate (refuse without approval, grant and proceed with approval, ignore already-granted, ignore unparseable manifest), and the /reload_app route end-to-end (refused response leaves app running and grants nothing; approval grants and reloads; no-new-permissions proceeds).

Verified end-to-end on a provisioned instance: installed an app with no permissions, pushed an update adding a secrets grant, confirmed Update and Reload was refused with the new permission listed and the app stayed on the old version and running; then confirmed approval granted the permission and applied the new version; and that a subsequent update with the same (already-granted) permission proceeded without prompting.