### PR TITLE
ansible: reclaim pixi ownership before git/pixi, so re-ansible unbricks

### DIFF
--- a/ansible/deploy.yml
+++ b/ansible/deploy.yml
@@ -8,5 +8,6 @@
   hosts: all
   user: host
   tasks:
+    - import_tasks: tasks/reclaim_pixi.yml
     - import_tasks: tasks/sync_code.yml
     - import_tasks: tasks/restart_openhost_service.yml

--- a/ansible/files/openhost-reclaim-pixi
+++ b/ansible/files/openhost-reclaim-pixi
@@ -1,28 +1,9 @@
 #!/bin/sh
-# Reclaim ownership of the host's OpenHost trees for the host user. Managed by
-# OpenHost; keep in sync with RECLAIM_SCRIPT in the openhost_system_agent
-# baseline migration (v0002_baseline.py).
-#
-# The openhost service runs as the unprivileged host user: it runs `git` and
-# `pixi run` against /home/host/openhost (repo + its .pixi env) and against
-# /home/host/.pixi (pixi binary + caches). The root-run update walk (migrations,
-# git checkout/clean, and in older versions pixi install) can leave root-owned
-# files in those trees, after which the host service's pixi run fails with
-# EACCES and git ops fail on root-owned objects, so it won't start. Run as root
-# (e.g. from a systemd ExecStartPre with the '+' prefix), this hands those trees
-# back to host so the service self-heals on boot. A standalone script (not an
-# inline ExecStartPre snippet) so no $VAR reaches systemd, which would
-# substitute it before /bin/sh runs. Idempotent; missing paths are skipped.
-#
-# Best-effort by design: the whole reclaim is bounded by a single `timeout` and
-# its failure is swallowed (`|| :`). A systemd ExecStartPre with the `-` prefix
-# ignores this script's exit code, but that does NOT exempt it from
-# TimeoutStartSec, which applies cumulatively across ExecStartPre commands. A
-# chown hung on a slow/stuck disk would otherwise blow the start window and
-# block the very service this failsafe protects. One overall bound (not a
-# per-path bound that could sum past the window) well under systemd's default
-# 90s start timeout guarantees we never do that.
-#
+# Reclaim ownership of the host's OpenHost trees for the host user, so files a
+# root-run update left behind can't brick the host-user service. Run as root
+# before the host `git`/`pixi run`. Managed by OpenHost; keep byte-identical
+# with RECLAIM_SCRIPT in the openhost_system_agent baseline (v0002_baseline.py).
+# Best-effort: one overall timeout, failure swallowed, so it can't block startup.
 # shellcheck disable=SC2016  # $dir is expanded by the inner `sh -c`, not here.
 timeout 80 sh -c '
 for dir in /home/host/openhost /home/host/.pixi; do

--- a/ansible/prebake.yml
+++ b/ansible/prebake.yml
@@ -58,6 +58,7 @@
   vars:
     ansible_python_interpreter: /usr/bin/python3
   tasks:
+    - import_tasks: tasks/reclaim_pixi.yml
     - import_tasks: tasks/sync_code.yml
     - import_tasks: tasks/pixi.yml
     - import_tasks: tasks/coredns.yml

--- a/ansible/readme.md
+++ b/ansible/readme.md
@@ -78,6 +78,13 @@ copying secrets back off the instance. specifically, on a re-run:
 - **`config.toml`** is left untouched if it exists, so the cert creds, domain,
   and other settings baked in at first setup are preserved.
 - the **claim token** is left untouched if it exists.
+- **root-owned pixi/repo trees are reclaimed up front.** if a bad self-update
+  left root-owned files in `/home/host/openhost` or `/home/host/.pixi` (which
+  bricks the service — the host-user `pixi run` fails with EACCES), the run
+  chowns them back to `host` *before* the `git`/`pixi install` steps that would
+  otherwise choke on them. so a plain re-run recovers a bricked instance with no
+  manual `chown`. this is what an existing user runs to fix the update button
+  after upgrading from a pre-failsafe (pre-2026-07-08) checkout.
 
 on a **first** deploy the host has no cert credential yet, so the run honors the
 `cert_provider` flag: cert_api bakes the keycloak secret into `config.toml`,

--- a/ansible/setup.yml
+++ b/ansible/setup.yml
@@ -52,6 +52,7 @@
   vars:
     ansible_python_interpreter: /usr/bin/python3
   tasks:
+    - import_tasks: tasks/reclaim_pixi.yml
     - import_tasks: tasks/sync_code.yml
     - import_tasks: tasks/pixi.yml
     - import_tasks: tasks/coredns.yml

--- a/ansible/tasks/install_openhost_units.yml
+++ b/ansible/tasks/install_openhost_units.yml
@@ -44,20 +44,9 @@
     state: link
     force: yes
 
-# The openhost.service ExecStartPre reclaims ownership of the pixi trees as
-# root before the host-user ExecStart runs `pixi run`. It lives at a fixed
-# system path so the unit references it without any $VAR that systemd would
-# substitute, and so it works even when the pixi env is broken.
-- name: Install pixi-ownership reclaim script
-  become: yes
-  become_user: root
-  copy:
-    src: files/openhost-reclaim-pixi
-    dest: /usr/local/bin/openhost-reclaim-pixi
-    owner: root
-    group: root
-    mode: "0755"
-
+# The reclaim script the unit's ExecStartPre invokes (see tasks/reclaim_pixi.yml,
+# imported earlier) is installed there — up front, before the host-user git/pixi
+# steps — so it is already in place by the time this unit references it.
 - name: Install openhost systemd service
   become: yes
   become_user: root

--- a/ansible/tasks/reclaim_pixi.yml
+++ b/ansible/tasks/reclaim_pixi.yml
@@ -1,0 +1,35 @@
+---
+# Reclaim ownership of the host's OpenHost trees for the host user, BEFORE any
+# host-user git or pixi step runs.
+#
+# A root-run update walk (system migrations, git checkout/clean, and in older
+# versions a root-run `pixi install`) can leave root-owned files in
+# /home/host/openhost (repo + its .pixi env) and /home/host/.pixi (pixi binary +
+# caches). After that, sync_code's `git` and pixi.yml's `pixi install` — both run
+# as the unprivileged host user — fail with EACCES ("Permission denied (os error
+# 13)"), and the play aborts long before install_openhost_units.yml installs the
+# reclaim failsafe. So the unit's ExecStartPre reclaim never gets a chance to run:
+# re-ansible alone couldn't recover a bricked instance without a manual chown.
+#
+# Running the reclaim script here, up front, closes that gap — a plain re-run of
+# ansible recovers a bricked instance with no manual steps. The script is
+# installed too, so this also works on hosts provisioned before the failsafe
+# existed (pre-2026-07-08), where /usr/local/bin/openhost-reclaim-pixi is absent.
+# Idempotent: the script skips missing paths, so it is a no-op on a first deploy
+# (where /home/host/openhost and /home/host/.pixi don't exist yet).
+
+- name: Install pixi-ownership reclaim script
+  become: yes
+  become_user: root
+  copy:
+    src: files/openhost-reclaim-pixi
+    dest: /usr/local/bin/openhost-reclaim-pixi
+    owner: root
+    group: root
+    mode: "0755"
+
+- name: Reclaim ownership of the OpenHost trees for the host user
+  become: yes
+  become_user: root
+  command: /usr/local/bin/openhost-reclaim-pixi
+  changed_when: false

--- a/ansible/tasks/reclaim_pixi.yml
+++ b/ansible/tasks/reclaim_pixi.yml
@@ -1,22 +1,10 @@
 ---
-# Reclaim ownership of the host's OpenHost trees for the host user, BEFORE any
-# host-user git or pixi step runs.
-#
-# A root-run update walk (system migrations, git checkout/clean, and in older
-# versions a root-run `pixi install`) can leave root-owned files in
-# /home/host/openhost (repo + its .pixi env) and /home/host/.pixi (pixi binary +
-# caches). After that, sync_code's `git` and pixi.yml's `pixi install` — both run
-# as the unprivileged host user — fail with EACCES ("Permission denied (os error
-# 13)"), and the play aborts long before install_openhost_units.yml installs the
-# reclaim failsafe. So the unit's ExecStartPre reclaim never gets a chance to run:
-# re-ansible alone couldn't recover a bricked instance without a manual chown.
-#
-# Running the reclaim script here, up front, closes that gap — a plain re-run of
-# ansible recovers a bricked instance with no manual steps. The script is
-# installed too, so this also works on hosts provisioned before the failsafe
-# existed (pre-2026-07-08), where /usr/local/bin/openhost-reclaim-pixi is absent.
-# Idempotent: the script skips missing paths, so it is a no-op on a first deploy
-# (where /home/host/openhost and /home/host/.pixi don't exist yet).
+# Reclaim root-owned files in the OpenHost trees before any host-user git/pixi
+# step. A bad root-run self-update can leave them root-owned, after which
+# sync_code's `git` and pixi.yml's `pixi install` fail with EACCES and the play
+# aborts before install_openhost_units.yml installs the reclaim failsafe. Running
+# it here lets a plain re-ansible recover a bricked host. Installs the script too,
+# for hosts predating the failsafe; idempotent (skips missing paths).
 
 - name: Install pixi-ownership reclaim script
   become: yes

--- a/openhost_system_agent/src/openhost_system_agent/migrations/versions/v0002_baseline.py
+++ b/openhost_system_agent/src/openhost_system_agent/migrations/versions/v0002_baseline.py
@@ -30,30 +30,11 @@ RECLAIM_SCRIPT_PATH = "/usr/local/bin/openhost-reclaim-pixi"
 # Kept byte-identical with ansible/files/openhost-reclaim-pixi (a test enforces
 # this).
 RECLAIM_SCRIPT = """#!/bin/sh
-# Reclaim ownership of the host's OpenHost trees for the host user. Managed by
-# OpenHost; keep in sync with RECLAIM_SCRIPT in the openhost_system_agent
-# baseline migration (v0002_baseline.py).
-#
-# The openhost service runs as the unprivileged host user: it runs `git` and
-# `pixi run` against /home/host/openhost (repo + its .pixi env) and against
-# /home/host/.pixi (pixi binary + caches). The root-run update walk (migrations,
-# git checkout/clean, and in older versions pixi install) can leave root-owned
-# files in those trees, after which the host service's pixi run fails with
-# EACCES and git ops fail on root-owned objects, so it won't start. Run as root
-# (e.g. from a systemd ExecStartPre with the '+' prefix), this hands those trees
-# back to host so the service self-heals on boot. A standalone script (not an
-# inline ExecStartPre snippet) so no $VAR reaches systemd, which would
-# substitute it before /bin/sh runs. Idempotent; missing paths are skipped.
-#
-# Best-effort by design: the whole reclaim is bounded by a single `timeout` and
-# its failure is swallowed (`|| :`). A systemd ExecStartPre with the `-` prefix
-# ignores this script's exit code, but that does NOT exempt it from
-# TimeoutStartSec, which applies cumulatively across ExecStartPre commands. A
-# chown hung on a slow/stuck disk would otherwise blow the start window and
-# block the very service this failsafe protects. One overall bound (not a
-# per-path bound that could sum past the window) well under systemd's default
-# 90s start timeout guarantees we never do that.
-#
+# Reclaim ownership of the host's OpenHost trees for the host user, so files a
+# root-run update left behind can't brick the host-user service. Run as root
+# before the host `git`/`pixi run`. Managed by OpenHost; keep byte-identical
+# with RECLAIM_SCRIPT in the openhost_system_agent baseline (v0002_baseline.py).
+# Best-effort: one overall timeout, failure swallowed, so it can't block startup.
 # shellcheck disable=SC2016  # $dir is expanded by the inner `sh -c`, not here.
 timeout 80 sh -c '
 for dir in /home/host/openhost /home/host/.pixi; do


### PR DESCRIPTION
## Problem
An instance whose in-dashboard self-update ran `pixi install` **as root** (pre-2026-06-24) is left with root-owned files in `/home/host/openhost` and `/home/host/.pixi`. The host-user `pixi run` then fails with `Permission denied (os error 13)` and the service won't start — the site is bricked.

The reclaim failsafe (`openhost-reclaim-pixi` script + unit `ExecStartPre`, landed 2026-07-08) only runs at service **start**. On a bricked host, re-running ansible never gets there: `sync_code`'s `git` and `pixi.yml`'s `pixi install` both run as the host user and hit the same EACCES, aborting the play **before** `install_openhost_units.yml` installs the failsafe. Recovery required a manual `chown`.

## Fix
Install + run the reclaim script **up front**, before any host-user git/pixi step, in every play that runs them (`setup.yml`, `prebake.yml`, `deploy.yml`), via a new shared `tasks/reclaim_pixi.yml`. The script install moves out of `install_openhost_units.yml` into that shared task (single source; still in place before the unit's `ExecStartPre` references it). Now a plain re-ansible recovers a bricked instance with **no manual steps**.

## Verification (live instance)
- Bricked to the exact pre-failsafe state: old unit (no `ExecStartPre`), reclaim script removed, `/home/host/openhost/.pixi` root-owned → site down (`HTTP 000`), journal shows `pixi: failed to acquire install lock ... Permission denied (os error 13)`.
- Re-ran `setup.yml` as a plain user — **no cert vars, no local ACME key, no manual chown**: reclaim ran first → `pixi install` succeeded → `Copy ACME account key` **skipped** (cert-creds preservation, merged in #228) → `failed=0` → site back to **HTTP 200**, failsafe reinstalled, trees owned by host, system version 5.
- `deploy.yml` fast-re-deploy path also recovers a brick.
- `test_service_unit.py` + `test_reclaim.py` pass (10 tests), incl. the byte-identical parity guard between `ansible/files/openhost-reclaim-pixi` and the migration's `RECLAIM_SCRIPT`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)