### PR TITLE
Federation: [federation] manifest section + zone /federation/connect page

### DIFF
--- a/compute_space/src/compute_space/core/manifest.py
+++ b/compute_space/src/compute_space/core/manifest.py
@@ -178,6 +178,10 @@ class AppManifest:
     # Convenience shorthand: equivalent to access_all_app_data + access_all_archive.
     access_all_data: bool = False
 
+    # [federation]
+    federation_url: str | None = None
+    federation_connect_path: str = "/federation/connect"
+
     # [services.v2]
     provides_services_v2: list[ServiceProvides] = attr.Factory(list)
 
@@ -371,6 +375,22 @@ def _parse_services_v2_consumes(data: dict[str, Any]) -> list[ServiceConsumes]:
     return perms
 
 
+def _parse_federation(data: dict[str, Any]) -> tuple[str | None, str]:
+    """Parse the optional [federation] section: (url, connect_path)."""
+    if "federation" not in data:
+        return None, "/federation/connect"
+    federation = data["federation"]
+    if not isinstance(federation, dict):
+        raise ValueError("[federation] must be a table")
+    url = federation.get("url")
+    if not url or not isinstance(url, str):
+        raise ValueError("[federation] requires a non-empty string 'url'")
+    connect_path = federation.get("connect_path", "/federation/connect")
+    if not isinstance(connect_path, str) or not connect_path.startswith("/"):
+        raise ValueError("[federation].connect_path must be a string starting with '/'")
+    return url, connect_path
+
+
 def parse_manifest_from_string(raw_text: str) -> AppManifest:
     """Parse an openhost.toml manifest from its string content."""
     data = tomllib.loads(raw_text)
@@ -409,6 +429,8 @@ def parse_manifest_from_string(raw_text: str) -> AppManifest:
             app_name,
         )
 
+    federation_url, federation_connect_path = _parse_federation(data)
+
     _compat_all_data = data_section.get("access_all_data", False)
     return AppManifest(
         name=app_name,
@@ -439,6 +461,8 @@ def parse_manifest_from_string(raw_text: str) -> AppManifest:
         access_all_data=_compat_all_data,
         access_all_app_data=data_section.get("access_all_app_data", False) or _compat_all_data,
         access_all_archive=data_section.get("access_all_archive", False) or _compat_all_data,
+        federation_url=federation_url,
+        federation_connect_path=federation_connect_path,
         provides_services_v2=_parse_services_v2(data),
         consumes_services_v2=_parse_services_v2_consumes(data),
         raw_toml=raw_text,

--- a/compute_space/src/compute_space/tests/test_federation_page.py
+++ b/compute_space/src/compute_space/tests/test_federation_page.py
@@ -1,0 +1,206 @@
+from __future__ import annotations
+
+import html
+import re
+import sqlite3
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Any
+from urllib.parse import parse_qs
+from urllib.parse import urlparse
+
+import pytest
+from litestar import Litestar
+from litestar.contrib.jinja import JinjaTemplateEngine
+from litestar.di import Provide
+from litestar.exceptions import NotAuthorizedException
+from litestar.template.config import TemplateConfig
+from litestar.testing import TestClient
+
+from compute_space.config import provide_config
+from compute_space.config import set_active_config
+from compute_space.db import provide_db
+from compute_space.db.connection import init_db
+from compute_space.web.app import _login_required_redirect
+from compute_space.web.app import _template_globals
+from compute_space.web.routes.pages.federation import federation_connect
+
+from ._litestar_helpers import auth_cookie
+from .conftest import _make_test_config
+
+SPEC_URL = "https://github.com/imbue-openhost/md-notes/blob/main/docs/federation.md"
+
+FEDERATED_MANIFEST = f"""\
+[app]
+name = "md-notes"
+version = "0.1.0"
+
+[runtime.container]
+image = "Dockerfile"
+port = 8080
+
+[federation]
+url = "{SPEC_URL}"
+"""
+
+PLAIN_MANIFEST = """\
+[app]
+name = "plain-app"
+version = "0.1.0"
+
+[runtime.container]
+image = "Dockerfile"
+port = 8080
+"""
+
+
+@pytest.fixture
+def cfg(tmp_path: Path) -> Iterator[Any]:
+    config = _make_test_config(tmp_path)
+    init_db(config.db_path)
+    yield config
+
+
+def _build_app(cfg: Any) -> Litestar:
+    web_dir = Path(__file__).resolve().parents[1] / "web"
+    template_config: TemplateConfig[JinjaTemplateEngine] = TemplateConfig(
+        directory=web_dir / "templates",
+        engine=JinjaTemplateEngine,
+    )
+
+    def _install_globals(app: Litestar) -> None:
+        engine = app.template_engine
+        if isinstance(engine, JinjaTemplateEngine):
+            engine.engine.globals.update(_template_globals(cfg, web_dir / "static"))
+
+    return Litestar(
+        route_handlers=[federation_connect],
+        template_config=template_config,
+        dependencies={
+            "config": Provide(provide_config, sync_to_thread=False),
+            "db": Provide(provide_db),
+        },
+        exception_handlers={NotAuthorizedException: _login_required_redirect},
+        on_startup=[_install_globals],
+        openapi_config=None,
+    )
+
+
+def _seed_app(db_path: str, name: str, local_port: int, manifest_raw: str | None) -> None:
+    conn = sqlite3.connect(db_path)
+    try:
+        conn.execute(
+            "INSERT INTO apps (app_id, name, version, repo_path, local_port, status, manifest_raw)"
+            " VALUES (?, ?, '0.1.0', ?, ?, 'running', ?)",
+            (f"{name}appid"[:12], name, f"/tmp/{name}", local_port, manifest_raw),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+INVITE_PARAMS = {
+    "spec": SPEC_URL,
+    "source": "https://md-notes.usera.example.com",
+    "vault": "my vault",
+    "secret": "s3cr3t",
+}
+
+
+def test_lists_matching_app_with_passthrough_query(cfg: Any) -> None:
+    set_active_config(cfg)
+    cookie = auth_cookie(cfg)
+    _seed_app(cfg.db_path, "notes", 19010, FEDERATED_MANIFEST)
+    _seed_app(cfg.db_path, "plain", 19011, PLAIN_MANIFEST)
+
+    with TestClient(app=_build_app(cfg)) as client:
+        resp = client.get("/redirect/federation/connect", params=INVITE_PARAMS, cookies=cookie)
+    assert resp.status_code == 200
+    assert "Connect with notes" in resp.text
+    # Inviter shown as a hostname, spec rendered as a link.
+    assert "md-notes.usera.example.com" in resp.text
+    assert SPEC_URL in resp.text
+    # Non-federated app is not offered.
+    assert "Connect with plain" not in resp.text
+
+    # The connect link points at the app subdomain + connect path, with the
+    # original query string passed through verbatim.
+    hrefs = [html.unescape(h) for h in re.findall(r'href="([^"]+)"', resp.text)]
+    connect_links = [h for h in hrefs if h.startswith(f"http://notes.{cfg.zone_domain}")]
+    assert len(connect_links) == 1
+    parsed = urlparse(connect_links[0])
+    assert parsed.path == "/federation/connect"
+    assert parse_qs(parsed.query) == {k: [v] for k, v in INVITE_PARAMS.items()}
+
+
+def test_custom_connect_path_is_used(cfg: Any) -> None:
+    set_active_config(cfg)
+    cookie = auth_cookie(cfg)
+    manifest = FEDERATED_MANIFEST + 'connect_path = "/fed/join"\n'
+    _seed_app(cfg.db_path, "notes", 19010, manifest)
+
+    with TestClient(app=_build_app(cfg)) as client:
+        resp = client.get("/redirect/federation/connect", params=INVITE_PARAMS, cookies=cookie)
+    assert resp.status_code == 200
+    assert f"http://notes.{cfg.zone_domain}/fed/join?" in html.unescape(resp.text)
+
+
+def test_no_matching_app_shows_message(cfg: Any) -> None:
+    set_active_config(cfg)
+    cookie = auth_cookie(cfg)
+    _seed_app(cfg.db_path, "plain", 19011, PLAIN_MANIFEST)
+
+    with TestClient(app=_build_app(cfg)) as client:
+        resp = client.get("/redirect/federation/connect", params=INVITE_PARAMS, cookies=cookie)
+    assert resp.status_code == 200
+    assert "No installed app serves this protocol" in resp.text
+    assert "Connect with" not in resp.text
+    # No catalog installed -> no catalog link.
+    assert "catalog" not in resp.text
+
+
+def test_no_matching_app_links_to_catalog_when_installed(cfg: Any) -> None:
+    set_active_config(cfg)
+    cookie = auth_cookie(cfg)
+    _seed_app(cfg.db_path, "catalog", 19012, None)
+
+    with TestClient(app=_build_app(cfg)) as client:
+        resp = client.get("/redirect/federation/connect", params=INVITE_PARAMS, cookies=cookie)
+    assert resp.status_code == 200
+    assert "No installed app serves this protocol" in resp.text
+    hrefs = [html.unescape(h) for h in re.findall(r'href="([^"]+)"', resp.text)]
+    catalog_links = [h for h in hrefs if h.startswith(f"http://catalog.{cfg.zone_domain}/")]
+    assert len(catalog_links) == 1
+    assert parse_qs(urlparse(catalog_links[0]).query) == {"federation_url": [SPEC_URL]}
+
+
+def test_missing_spec_is_rejected(cfg: Any) -> None:
+    set_active_config(cfg)
+    cookie = auth_cookie(cfg)
+
+    with TestClient(app=_build_app(cfg)) as client:
+        resp = client.get("/redirect/federation/connect", params={"source": "https://a.example.com"}, cookies=cookie)
+    assert resp.status_code == 400
+
+
+def test_unauthenticated_redirects_to_login(cfg: Any) -> None:
+    set_active_config(cfg)
+
+    with TestClient(app=_build_app(cfg)) as client:
+        resp = client.get("/redirect/federation/connect", params=INVITE_PARAMS, follow_redirects=False)
+    assert resp.status_code == 302
+    assert "/login" in resp.headers["location"]
+    assert "Federation invite" not in resp.text
+
+
+def test_non_http_spec_is_not_linkified(cfg: Any) -> None:
+    set_active_config(cfg)
+    cookie = auth_cookie(cfg)
+    _seed_app(cfg.db_path, "plain", 19011, PLAIN_MANIFEST)
+
+    params = dict(INVITE_PARAMS, spec="javascript:alert(1)")
+    with TestClient(app=_build_app(cfg)) as client:
+        resp = client.get("/redirect/federation/connect", params=params, cookies=cookie)
+    assert resp.status_code == 200
+    assert 'href="javascript:' not in resp.text
+    assert "javascript:alert(1)" in resp.text  # still shown as text

--- a/compute_space/src/compute_space/tests/test_manifest.py
+++ b/compute_space/src/compute_space/tests/test_manifest.py
@@ -798,3 +798,44 @@ class TestShmMb:
         toml = MINIMAL + 'shm_mb = "big"\n'
         with pytest.raises(ValueError, match="shm_mb"):
             parse_manifest_from_string(toml)
+
+
+class TestFederation:
+    """[federation] section."""
+
+    def test_absent_section_defaults(self):
+        manifest = parse_manifest_from_string(MINIMAL)
+        assert manifest.federation_url is None
+        assert manifest.federation_connect_path == "/federation/connect"
+
+    def test_url_and_connect_path_round_trip(self):
+        toml = MINIMAL + '\n[federation]\nurl = "https://example.com/spec.md"\nconnect_path = "/fed/join"\n'
+        manifest = parse_manifest_from_string(toml)
+        assert manifest.federation_url == "https://example.com/spec.md"
+        assert manifest.federation_connect_path == "/fed/join"
+
+    def test_connect_path_defaults_when_omitted(self):
+        toml = MINIMAL + '\n[federation]\nurl = "https://example.com/spec.md"\n'
+        manifest = parse_manifest_from_string(toml)
+        assert manifest.federation_url == "https://example.com/spec.md"
+        assert manifest.federation_connect_path == "/federation/connect"
+
+    def test_section_without_url_rejected(self):
+        toml = MINIMAL + '\n[federation]\nconnect_path = "/fed/join"\n'
+        with pytest.raises(ValueError, match=r"\[federation\] requires a non-empty string 'url'"):
+            parse_manifest_from_string(toml)
+
+    def test_empty_url_rejected(self):
+        toml = MINIMAL + '\n[federation]\nurl = ""\n'
+        with pytest.raises(ValueError, match=r"\[federation\] requires a non-empty string 'url'"):
+            parse_manifest_from_string(toml)
+
+    def test_connect_path_without_leading_slash_rejected(self):
+        toml = MINIMAL + '\n[federation]\nurl = "https://example.com/spec.md"\nconnect_path = "fed/join"\n'
+        with pytest.raises(ValueError, match="connect_path"):
+            parse_manifest_from_string(toml)
+
+    def test_non_string_connect_path_rejected(self):
+        toml = MINIMAL + '\n[federation]\nurl = "https://example.com/spec.md"\nconnect_path = 3\n'
+        with pytest.raises(ValueError, match="connect_path"):
+            parse_manifest_from_string(toml)

--- a/compute_space/src/compute_space/web/app.py
+++ b/compute_space/src/compute_space/web/app.py
@@ -42,6 +42,7 @@ from compute_space.web.routes.api.settings import api_settings_routes
 from compute_space.web.routes.api.system import system_routes
 from compute_space.web.routes.docs import docs_routes
 from compute_space.web.routes.pages.apps import pages_apps_routes
+from compute_space.web.routes.pages.federation import pages_federation_routes
 from compute_space.web.routes.pages.login import pages_login_routes
 from compute_space.web.routes.pages.permissions_v2 import pages_permissions_v2_routes
 from compute_space.web.routes.pages.settings import pages_settings_routes
@@ -207,6 +208,7 @@ def create_app(config: Config) -> ASGIApp:
             identity_routes,
             docs_routes,
             pages_apps_routes,
+            pages_federation_routes,
             pages_login_routes,
             pages_permissions_v2_routes,
             pages_settings_routes,

--- a/compute_space/src/compute_space/web/routes/pages/federation.py
+++ b/compute_space/src/compute_space/web/routes/pages/federation.py
@@ -1,0 +1,71 @@
+import sqlite3
+from typing import Any
+from urllib.parse import quote
+from urllib.parse import urlparse
+
+from litestar import Request
+from litestar import Router
+from litestar import get
+from litestar.response import Template
+
+from compute_space.config import Config
+from compute_space.core.logging import logger
+from compute_space.core.manifest import parse_manifest_from_string
+from compute_space.web.auth.auth import require_owner_auth
+from compute_space.web.routes.pages.apps import CATALOG_APP_NAME
+
+
+@get("/redirect/federation/connect", guards=[require_owner_auth])
+async def federation_connect(
+    request: Request[Any, Any, Any],
+    db: sqlite3.Connection,
+    config: Config,
+    spec: str,
+    source: str = "",
+) -> Template:
+    """Owner-facing page: route a federation invite to an installed app that serves ``spec``.
+
+    Lives under the zone's ``/redirect/`` namespace: the shared my.* redirect domain forwards
+    ``/redirect/...`` deep links verbatim, so published links can only ever land on pages under
+    this reserved, side-effect-free prefix — never on arbitrary zone or app pages.
+
+    GET-only and side-effect free: the page just lists matching apps; clicking through to an
+    app's own connect page is the confirmation, and any mutation happens there via an
+    authenticated POST.
+    """
+    proto = "https" if config.tls_enabled else "http"
+    # The full original query string is passed through verbatim so the app's connect page
+    # receives every invite parameter (source, secrets, etc.) without us enumerating them.
+    query = request.url.query
+
+    matching_apps: list[dict[str, str]] = []
+    for row in db.execute("SELECT name, manifest_raw FROM apps ORDER BY name").fetchall():
+        if not row["manifest_raw"]:
+            continue
+        try:
+            manifest = parse_manifest_from_string(row["manifest_raw"])
+        except Exception:
+            logger.opt(exception=True).warning("Skipping unparseable manifest for app %s", row["name"])
+            continue
+        if manifest.federation_url == spec:
+            connect_url = f"{proto}://{row['name']}.{config.zone_domain}{manifest.federation_connect_path}?{query}"
+            matching_apps.append({"name": row["name"], "connect_url": connect_url})
+
+    catalog_url = None
+    if not matching_apps:
+        catalog_installed = db.execute("SELECT 1 FROM apps WHERE name = ?", (CATALOG_APP_NAME,)).fetchone() is not None
+        if catalog_installed:
+            catalog_url = f"{proto}://{CATALOG_APP_NAME}.{config.zone_domain}/?federation_url={quote(spec, safe='')}"
+
+    return Template(
+        template_name="federation_connect.html",
+        context={
+            "spec": spec,
+            "source_host": urlparse(source).netloc or source,
+            "matching_apps": matching_apps,
+            "catalog_url": catalog_url,
+        },
+    )
+
+
+pages_federation_routes = Router(path="/", route_handlers=[federation_connect])

--- a/compute_space/src/compute_space/web/templates/federation_connect.html
+++ b/compute_space/src/compute_space/web/templates/federation_connect.html
@@ -1,0 +1,26 @@
+{% extends "layout.html" %}
+{% block title_suffix %} — Federation Invite{% endblock %}
+{% block content %}
+<h2>Federation invite</h2>
+
+<p>
+  {% if source_host %}<strong>{{ source_host }}</strong> has invited you{% else %}You have been invited{% endif %}
+  to connect using the protocol
+  {# Only linkify http(s) specs — the spec comes from the invite URL and could be any scheme. #}
+  {% if spec.startswith("http://") or spec.startswith("https://") %}<a href="{{ spec }}">{{ spec }}</a>{% else %}<code>{{ spec }}</code>{% endif %}.
+</p>
+
+{% if matching_apps %}
+<p>Choose an app to connect with. Nothing is changed until you confirm inside the app.</p>
+<ul>
+  {% for app in matching_apps %}
+  <li style="margin: 0.5em 0;"><a class="btn btn-primary" href="{{ app.connect_url }}">Connect with {{ app.name }}</a></li>
+  {% endfor %}
+</ul>
+{% else %}
+<p>No installed app serves this protocol.</p>
+{% if catalog_url %}
+<p><a class="btn btn-primary" href="{{ catalog_url }}">Find one in the catalog</a></p>
+{% endif %}
+{% endif %}
+{% endblock %}

--- a/docs/src/creating_an_app.md
+++ b/docs/src/creating_an_app.md
@@ -155,6 +155,10 @@ See [OAuth in Apps](./oauth.md) for an example - getting oauth tokens to externa
 
 For apps that should be available to multiple users and require more than trivial publicly routes or token-protected public routes, see [User Identity](./user_identity.md) for how to implement this with the OpenHost user identity provider.
 
+### Federation
+
+Apps can connect to the same app (or a compatible one) running on *someone else's* zone. An app declares the federation protocol it implements — identified by a spec URL — in the `[federation]` section of its manifest and serves its own connect page. The zone's `/redirect/federation/connect` page (reached via the shared my.* redirect domain, which only forwards `/redirect/...` links, verbatim) routes incoming invites to installed apps declaring the matching spec URL. See the `[federation]` section of the [manifest spec](manifest_spec.md) for details.
+
 
 ## Development / Debugging workflow
 

--- a/docs/src/manifest_spec.md
+++ b/docs/src/manifest_spec.md
@@ -73,6 +73,17 @@ User-facing links the app advertises for paths on its own URL that aren't the ba
 | `access_all_archive` | boolean | no | false | Mount all apps' archive parent directory. Permissive: silently skipped when JuiceFS is not configured. For backup tools. |
 | `access_all_data` | boolean | no | false | Convenience shorthand for `access_all_app_data = true` + `access_all_archive = true`. |
 
+### `[federation]` — optional
+
+Declares that the app implements a federation protocol, identified by the URL of its spec document. When the owner opens a federation invite, the zone's `/redirect/federation/connect` page finds installed apps whose `url` matches the invite's `spec` parameter and offers a click-through into each app's own connect page (at `connect_path`, with the invite's full query string passed along).
+
+The app's connect page must be side-effect free on GET: it may validate and display the invite, but any mutation (actually creating the connection) must happen only via an authenticated POST after the owner confirms.
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `url` | string | yes | — | URL of the federation spec the app implements (e.g. a spec document in the app's repo) |
+| `connect_path` | string | no | `/federation/connect` | Path on the app's URL serving its connect/confirm page. Must start with `/`. |
+
 
 ## Data Directory Structure
 


### PR DESCRIPTION
## What

Adds platform support for app federation — apps on different OpenHost zones connecting to each other on a declared protocol.

- **Manifest**: new optional `[federation]` section — `url` (the federation-spec URL the app implements, required) and `connect_path` (default `/federation/connect`, must start with `/`). Parsed onto `AppManifest.federation_url` / `federation_connect_path`; unknown to older routers, so federated apps still deploy there.
- **Zone page**: owner-guarded, GET-only, side-effect-free `GET /redirect/federation/connect?spec=...&...`. Matches `spec` against installed apps' manifests and renders "Connect with <app>" links into each matching app's own connect page, passing the full invite query string through verbatim. If nothing matches, links to the catalog filtered by `?federation_url=<spec>` (when the catalog app is installed). Non-http(s) `spec` values are shown as text, never linkified.
- **Docs**: `[federation]` in `manifest_spec.md`, a federation note in `creating_an_app.md`.

The page deliberately lives under the zone's `/redirect/` prefix: the shared my.* redirect domain forwards `/redirect/...` deep links **verbatim** (see the companion my-openhost-redirect PR), so a published link can only land inside this reserved, side-effect-free namespace — it can never be crafted to hit an arbitrary page in someone's space.

The invite flow this enables (see the md-notes reference implementation, `docs/federation.md` in imbue-openhost/md-notes): app A builds an invite URL on the shared `my.*` redirect domain (`https://my.../redirect/federation/connect?spec=...&source=...&secret=...`); the redirect page forwards it verbatim to the recipient's zone, this page routes it into a matching app, and the app performs the actual connection via an authenticated POST after owner confirmation.

Companion PRs: imbue-openhost/my-openhost-redirect#1 (forward only `/redirect/*`, verbatim), imbue-openhost/openhost-catalog#17 (search by `federation_url`), plus the md-notes implementation.

## Test plan

- New `TestFederation` manifest tests (7) and `test_federation_page.py` (7): matching/non-matching apps, verbatim query passthrough, custom connect_path, catalog fallback, missing `spec` → 400, unauthenticated → login redirect, `javascript:` spec not linkified.
- `pixi run -e dev pytest` (lightweight suite, no containers): 1002 passed, 60 skipped.
- Exercised end-to-end locally by md-notes' two-instance harness tests.

Note: repo-wide mypy currently fails on main in an unrelated file; #232 fixes that separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)