### PR TITLE
Fix pre-existing mypy error in oauth_provider schemathesis test

### DIFF
--- a/apps/oauth_provider/src/oauth_provider/tests/test_schemathesis.py
+++ b/apps/oauth_provider/src/oauth_provider/tests/test_schemathesis.py
@@ -3,13 +3,17 @@ from typing import Any
 
 from schemathesis import Case
 from schemathesis.checks import CHECKS
+from schemathesis.checks import CheckFunction
 from schemathesis.checks import load_all_checks
 from schemathesis.openapi import from_path
 
 SPEC_PATH = Path(__file__).resolve().parents[5] / "services" / "oauth" / "openapi.yaml"
 
 load_all_checks()
-positive_data_acceptance = CHECKS.get_one("positive_data_acceptance")
+_check = CHECKS.get_one("positive_data_acceptance")
+# The registry can also hold check classes; excluded_checks accepts functions only.
+assert not isinstance(_check, type)
+positive_data_acceptance: CheckFunction = _check
 
 schema = from_path(str(SPEC_PATH))
 


### PR DESCRIPTION
Repo-wide `mypy` currently fails on `apps/oauth_provider/.../test_schemathesis.py` (`CHECKS.get_one` returns an optional). Narrows the result with an assert. Split out from #231 so it can be reviewed/landed independently; #231's CI needs this to pass repo-wide mypy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)