### PR TITLE
Install openhost-community-chat by default in new spaces

### DIFF
--- a/compute_space/src/compute_space/config.py
+++ b/compute_space/src/compute_space/config.py
@@ -279,6 +279,7 @@ class DefaultConfig(Config):
             "oauth_provider",
             "https://github.com/imbue-openhost/openhost-catalog",
             "https://github.com/imbue-openhost/openhost-backup",
+            "https://github.com/imbue-openhost/openhost-community-chat",
         ]
     )
 


### PR DESCRIPTION
Appends the openhost-community-chat public repo to the default_apps list in DefaultConfig so it is auto-deployed at /setup completion. Placed after oauth_provider and secrets so its SSO dependencies are installed first. The repo is public and has a valid openhost.toml, so the unauthenticated setup-time clone succeeds.