### PR TITLE
Constrain system logs to page content width

### DIFF
--- a/compute_space/src/compute_space/web/templates/system.html
+++ b/compute_space/src/compute_space/web/templates/system.html
@@ -14,7 +14,7 @@
 </table>
 
 <h2 class="section-title">Logs</h2>
-<pre class="log-output" id="cs-logs" style="max-height: 120em; white-space: pre-wrap; word-break: break-all; width: calc(100vw - 2em); position: relative; left: 50%; margin-left: calc(-50vw + 1em); box-sizing: border-box;"></pre>
+<pre class="log-output" id="cs-logs" style="max-height: 120em; white-space: pre-wrap; word-break: break-all;"></pre>
 
 <script id="page-config" type="application/json">
 {


### PR DESCRIPTION
The System Info logs pane used a full-viewport-width breakout that made it wider than every other element on the page. This removes the breakout so the logs match the width of the tables and headings, which are bounded by the body max-width.