### PR TITLE
Email design doc: multi-tenant-safe send/receive via central broker

### DIFF
--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -8,6 +8,7 @@
 - [Routing](./routing.md)
 - [User Identity](./user_identity.md)
 - [Persistent Data & Archive](./data.md)
+- [Email](./email.md)
 - [Logs](./logs.md)
 
 # Guides

--- a/docs/src/email.md
+++ b/docs/src/email.md
@@ -1,0 +1,228 @@
+# Email (Design)
+
+This document describes how OpenHost instances send and receive email
+for their zone (`user@<zone_domain>`), and why the design is shaped the
+way it is. It is a **design document** for a not-yet-built capability;
+it describes the intended architecture, not current behaviour.
+
+The guiding constraint is that **OpenHost instances are operated by
+untrusted users**. A single instance must never be able to damage email
+deliverability for any other instance, exhaust a shared resource, or
+send mail claiming to be a domain it does not own. Every decision below
+follows from that constraint.
+
+## Why email needs platform support
+
+Two facts make email different from a normal app:
+
+1. **Cloud providers block port 25.** Most hosts (Hetzner, GCP, and
+   others) block inbound *and* outbound TCP/25 to fight spam. An
+   instance therefore cannot deliver mail directly to a recipient's MX,
+   nor accept mail directly from a sender's MX. Some relay is
+   mandatory — this is not optional plumbing.
+
+2. **Deliverability is a shared, reputation-based resource.** Whether
+   mail lands in an inbox depends on the sending IP's reputation and on
+   SPF/DKIM/DMARC alignment. If every instance sent from its own cloud
+   IP, one abusive tenant would get that IP block-listed and, worse, a
+   shared address space would let one tenant poison the reputation of
+   all others.
+
+Both facts point to the same answer: mail flows through a **central,
+OpenHost-operated relay** that owns the sending reputation and enforces
+per-instance limits, rather than each instance talking to the world
+directly.
+
+## Architecture overview
+
+```
+                          ┌─────────────────────────────────────┐
+                          │        OpenHost Mail Broker          │
+                          │  (central, OpenHost-operated)        │
+   instance A ──submit──▶ │  · authenticates instance (Keycloak) │ ──▶ SES SMTP  ─▶ recipient MX
+   instance B ──submit──▶ │  · enforces From = own zone only     │      (outbound)
+                          │  · per-instance rate / volume caps   │
+                          │  · bounce / complaint suppression    │
+   instance A ◀─webhook── │  · abuse detection + auto-suspend    │ ◀── SES inbound (S3 + SNS)
+                          └─────────────────────────────────────┘
+```
+
+- **Sending** (outbound): the instance hands each message to the broker;
+  the broker relays it to the upstream email provider (AWS SES) and is
+  the single point where policy is enforced.
+- **Receiving** (inbound): the upstream provider accepts mail for the
+  zone, stores the raw message, and notifies the broker, which delivers
+  it into the instance's mailbox.
+- The **mailbox itself** (the SMTP/JMAP server the owner reads with a
+  webmail app) runs *on the instance*, so mail data stays on the
+  operator's own zone.
+
+The broker is the crux of the design: it is the trust boundary that
+makes multi-tenant email safe.
+
+## Sending mail
+
+### Path
+
+1. An app on the instance submits a message to a local submission
+   endpoint (standard SMTP on `localhost`, or the mailbox server's
+   outbound hook). The instance's mailbox server is configured as a
+   **smarthost client**: it does not deliver directly, it relays every
+   outbound message to the broker.
+2. The instance authenticates to the broker with a **per-instance
+   credential** and submits the message.
+3. The broker validates and relays the message to SES SMTP submission
+   (port 587, which cloud hosts allow), which delivers it to the
+   recipient's MX.
+
+The instance never holds AWS credentials. It only holds a broker
+credential that OpenHost can revoke at any time.
+
+### Instance authentication
+
+The broker authenticates each instance with **Keycloak client
+credentials**, mirroring the existing certificate-broker pattern: every
+instance is provisioned with its own confidential client in a shared
+realm, and the client credentials are injected at finalize time (see
+[Provisioning](#provisioning)). Revoking a single instance is a matter
+of disabling its client — no shared secret to rotate.
+
+### Abuse controls (the reason for the broker)
+
+Because the broker is the only way out, it is where all multi-tenant
+safety lives:
+
+- **From-domain enforcement.** The broker knows each instance's true
+  zone domain (from the authenticated identity, not from anything the
+  instance asserts). It **rejects any message whose envelope-from or
+  header-from is not within that instance's own zone.** An instance can
+  only ever send as `*@<its-own-zone>`. This is not enforceable on the
+  instance itself — only a party the tenant cannot bypass can enforce
+  it, which is exactly the broker.
+- **Per-instance rate and volume caps.** Each instance gets its own
+  send-rate and daily-volume budget. One tenant cannot consume the
+  shared SES quota at the expense of others.
+- **Reputation isolation.** The broker assigns each instance (or cohort
+  of instances) to a distinct SES **configuration set**, so bounce and
+  complaint reputation is tracked per tenant rather than pooled. A bad
+  actor's reputation damage is contained to their own configuration
+  set, and can be given dedicated IPs if needed.
+- **Suppression and bounce/complaint handling.** The broker consumes
+  SES bounce/complaint notifications, maintains a suppression list, and
+  refuses to send to addresses that have hard-bounced or complained —
+  centrally, so no instance can repeatedly hammer a bad address.
+- **Automatic suspension.** An instance whose bounce or complaint rate
+  crosses a threshold is automatically throttled or suspended, and the
+  event is surfaced to OpenHost operators. Suspension is per-instance
+  and does not affect anyone else.
+
+### DNS for deliverability
+
+Each instance is authoritative for its own zone (see
+[Routing](./routing.md)), so the records that make outbound mail
+deliverable are published **into the instance's own CoreDNS zone at
+provision time**, with no manual operator step:
+
+- **SPF** authorizing the broker/SES to send for the zone.
+- **DKIM** public keys so signed mail aligns.
+- **DMARC** policy for the zone.
+
+Because these are persistent zone records (unlike the transient
+ACME-challenge records), they are written as part of the zone's base
+configuration so they survive router restarts, and the ACME-challenge
+cleanup is scoped so that it never removes them.
+
+## Receiving mail
+
+Inbound port 25 is blocked, so the instance cannot accept mail directly.
+Instead:
+
+1. **MX points at the upstream provider.** The instance publishes an MX
+   record (in its own CoreDNS zone) directing mail for the zone to SES's
+   inbound endpoint.
+2. **SES receives and stores.** SES accepts the message and writes the
+   raw RFC822 to an OpenHost-owned S3 bucket, then publishes an SNS
+   notification.
+3. **The broker is notified and forwards to the instance.** SNS delivers
+   a signed notification; the broker (or a per-instance inbound webhook
+   fronted by the broker) **verifies the SNS signature**, fetches the
+   raw message from S3, and hands it to the destination instance.
+4. **The instance's mailbox server ingests it.** The message is
+   delivered into the instance's local mailbox (via LMTP/SMTP into the
+   mailbox server), where the owner can read it.
+
+Signature verification is mandatory: the inbound webhook is
+internet-reachable, so an unverified payload would let anyone inject
+mail. Only notifications with a valid AWS SNS signature from the
+expected topic are accepted.
+
+### Inbound abuse considerations
+
+Receiving is also multi-tenant-sensitive: untrusted users receiving
+unbounded mail is a storage- and content-abuse vector. The design
+applies **per-instance inbound quotas** (message rate and total
+mailbox storage) enforced before delivery, and routes inbound mail
+only to the instance that owns the destination zone.
+
+## The mailbox and reading mail
+
+The mailbox server (SMTP + JMAP) runs **on the instance** as an app so
+that mail contents live on the operator's own zone rather than in a
+central store. It stores mail in local per-app data so it survives
+rebuilds.
+
+Reading mail is done by a **webmail app** that talks to the mailbox
+server. The mailbox server exposes its JMAP interface as a
+[cross-app service](./cross_app_services.md); the webmail app *consumes*
+that service. A small proxy in front of the mailbox server:
+
+- validates the consuming app's permission grant,
+- strips any client-supplied credentials, and
+- injects the owner's mailbox credentials before forwarding.
+
+This is the same trust model as other cross-app services: the consuming
+app never sees mailbox credentials; it authenticates to the router with
+its app token, and the provider proxy vouches for it. Access to the
+mailbox is gated by **OpenHost owner authentication**, not by a mail
+password.
+
+## Provisioning
+
+Per-instance email configuration is injected at **finalize time**,
+alongside the existing certificate-broker configuration:
+
+- the instance's **broker credential** (Keycloak client id/secret),
+- the broker base URL,
+- and the zone's mail settings (mailbox domain, DKIM key material).
+
+At the same point, the SPF/DKIM/DMARC/MX records are written into the
+instance's CoreDNS zone. No manual AWS or DNS steps are required of the
+operator — the instance can send and receive as soon as it is claimed.
+
+## Trust and failure model
+
+- **An instance can only send as its own zone.** Enforced by the
+  broker, which derives the zone from the authenticated identity.
+- **An instance cannot damage others' deliverability.** Reputation is
+  isolated per configuration set; abuse triggers per-instance
+  suspension only.
+- **An instance holds no upstream (AWS) credentials.** It authenticates
+  to the broker with a per-instance, individually-revocable credential.
+- **Broker unavailability is fail-safe.** If the broker is unreachable,
+  outbound mail queues on the instance's mailbox server and retries;
+  inbound mail is retried by SNS. No mail is silently dropped.
+- **Mail data stays on the instance.** Message contents live in the
+  operator's own zone; the broker relays and enforces policy but is not
+  the mail store.
+
+## Summary
+
+| Concern            | Where it lives            | Why |
+|--------------------|---------------------------|-----|
+| Outbound relay     | Central broker → SES SMTP  | Port 25 blocked; reputation is shared |
+| From-domain safety | Central broker             | Only the broker can enforce it against an untrusted tenant |
+| Rate / abuse / suppression | Central broker      | Multi-tenant isolation |
+| Inbound receive    | SES → S3 → SNS → broker → instance | Port 25 blocked; signature-verified |
+| SPF/DKIM/DMARC/MX  | Instance CoreDNS zone (auto) | Instance owns its zone |
+| Mailbox store      | Instance (local app data)  | Mail data stays on the operator's zone |
+| Reading mail       | Webmail app via JMAP cross-app service | Consuming app never sees mail credentials |

--- a/docs/src/email.md
+++ b/docs/src/email.md
@@ -1,9 +1,9 @@
 # Email (Design)
 
 This document describes how OpenHost instances send and receive email
-for their zone (`user@<zone_domain>`), and why the design is shaped the
-way it is. It is a **design document** for a not-yet-built capability;
-it describes the intended architecture, not current behaviour.
+for their zone, and why the design is shaped the way it is. It is a
+**design document** for a not-yet-fully-built capability; it describes
+the intended architecture, not current behaviour.
 
 The guiding constraint is that **OpenHost instances are operated by
 untrusted users**. A single instance must never be able to damage email
@@ -18,8 +18,8 @@ Two facts make email different from a normal app:
 1. **Cloud providers block port 25.** Most hosts (Hetzner, GCP, and
    others) block inbound *and* outbound TCP/25 to fight spam. An
    instance therefore cannot deliver mail directly to a recipient's MX,
-   nor accept mail directly from a sender's MX. Some relay is
-   mandatory — this is not optional plumbing.
+   nor accept mail directly from a sender's MX. A relay is mandatory —
+   this is not optional plumbing.
 
 2. **Deliverability is a shared, reputation-based resource.** Whether
    mail lands in an inbox depends on the sending IP's reputation and on
@@ -28,201 +28,259 @@ Two facts make email different from a normal app:
    shared address space would let one tenant poison the reputation of
    all others.
 
-Both facts point to the same answer: mail flows through a **central,
-OpenHost-operated relay** that owns the sending reputation and enforces
-per-instance limits, rather than each instance talking to the world
-directly.
+Both facts point to the same answer: outbound mail flows through a
+**central, OpenHost-operated SES proxy** that owns the sending
+reputation and enforces per-instance limits, rather than each instance
+talking to the world directly.
+
+## The platform / app divide
+
+The design splits along a single principle: anything **trust-critical or
+multi-tenant-unsafe** is central or platform-level; anything
+**user-facing and iterated often** is an app.
+
+| Piece | Where | Why |
+|-------|-------|-----|
+| SES proxy (relay, spam/abuse mitigation, SES identity + verification) | **Central** (imbue infra, e.g. fly.io) | Holds AWS creds; shared reputation must be centrally governed |
+| Per-instance credential (Keycloak) | **Central-issued, instance-held** | Authenticates the instance and anchors From-domain enforcement |
+| DNS records (DKIM/SPF/DMARC/MX) | **Platform** (CoreDNS) | Only the platform can write the authoritative zone |
+| Provisioning (inject credential + mail config) | **Platform** | Part of instance finalize |
+| Mailbox server (SMTP/JMAP + storage) | **App** (default) | User-facing, swappable, iterate-often |
+| Webmail client | **App** (default) | Pure UX |
+
+The SES proxy is the crux: it is the trust boundary that makes
+multi-tenant email safe. The mailbox and webmail pieces are ordinary
+OpenHost apps shipped as defaults.
 
 ## Architecture overview
 
 ```
                           ┌─────────────────────────────────────┐
-                          │        OpenHost Mail Broker          │
-                          │  (central, OpenHost-operated)        │
-   instance A ──submit──▶ │  · authenticates instance (Keycloak) │ ──▶ SES SMTP  ─▶ recipient MX
-   instance B ──submit──▶ │  · enforces From = own zone only     │      (outbound)
-                          │  · per-instance rate / volume caps   │
-                          │  · bounce / complaint suppression    │
-   instance A ◀─webhook── │  · abuse detection + auto-suspend    │ ◀── SES inbound (S3 + SNS)
+                          │      OpenHost SES Proxy (central)     │
+                          │  · Keycloak-verifies each request     │
+   instance A ──submit──▶ │  · enforces From = own zone only      │ ──▶ AWS SES ─▶ recipient MX
+   instance B ──submit──▶ │  · per-instance rate / volume caps    │      (outbound)
+                          │  · spam / bounce / complaint handling │
+   instance A ◀─webhook── │  · abuse detection + auto-suspend     │ ◀── SES inbound (S3 + SNS)
+                          │  · creates + verifies SES identities  │
                           └─────────────────────────────────────┘
+        │                                                          ▲
+        ▼                                                          │
+  CoreDNS on the instance writes DKIM / SPF / DMARC / MX ──────────┘
+  (authoritative for the selfhost subzone; and for a BYO domain
+   via optional NS delegation)
+
+  On the instance: mailbox server (app) + webmail client (app)
 ```
 
-- **Sending** (outbound): the instance hands each message to the broker;
-  the broker relays it to the upstream email provider (AWS SES) and is
-  the single point where policy is enforced.
-- **Receiving** (inbound): the upstream provider accepts mail for the
-  zone, stores the raw message, and notifies the broker, which delivers
-  it into the instance's mailbox.
-- The **mailbox itself** (the SMTP/JMAP server the owner reads with a
-  webmail app) runs *on the instance*, so mail data stays on the
-  operator's own zone.
+## The SES proxy (central)
 
-The broker is the crux of the design: it is the trust boundary that
-makes multi-tenant email safe.
+The proxy runs on OpenHost-operated infrastructure (e.g. fly.io),
+**separate from any instance**. It is the direct analog of the existing
+certificate broker (`cert-api`): a central service holding privileged
+upstream credentials that instances talk to over an authenticated
+channel, never touching those credentials themselves.
 
-## Sending mail
+Its responsibilities:
 
-### Path
+- **Relay outbound mail to AWS SES.** Instances submit mail to the
+  proxy; the proxy relays it to SES SMTP submission (port 587, which
+  cloud hosts allow), which delivers to the recipient's MX.
+- **Spam and abuse mitigation** for the whole fleet (see
+  [Abuse controls](#abuse-controls)).
+- **Create and verify SES domain identities.** When a zone is
+  provisioned, the proxy calls SES to create the domain identity, gets
+  back the DKIM tokens, hands them to the instance's DNS layer to
+  publish, and polls SES until the domain is verified. SES will not send
+  on behalf of an unverified domain, so this loop is mandatory and is
+  the proxy's job — not the operator's.
+- **Handle inbound** via SES receiving (see [Receiving mail](#receiving-mail)).
 
-1. An app on the instance submits a message to a local submission
-   endpoint (standard SMTP on `localhost`, or the mailbox server's
-   outbound hook). The instance's mailbox server is configured as a
-   **smarthost client**: it does not deliver directly, it relays every
-   outbound message to the broker.
-2. The instance authenticates to the broker with a **per-instance
-   credential** and submits the message.
-3. The broker validates and relays the message to SES SMTP submission
-   (port 587, which cloud hosts allow), which delivers it to the
-   recipient's MX.
-
-The instance never holds AWS credentials. It only holds a broker
+The instance never holds AWS credentials. It only holds a Keycloak
 credential that OpenHost can revoke at any time.
 
-### Instance authentication
+### Request authentication (Keycloak, cert-api pattern)
 
-The broker authenticates each instance with **Keycloak client
-credentials**, mirroring the existing certificate-broker pattern: every
-instance is provisioned with its own confidential client in a shared
-realm, and the client credentials are injected at finalize time (see
-[Provisioning](#provisioning)). Revoking a single instance is a matter
-of disabling its client — no shared secret to rotate.
+Every request an instance makes to the proxy is authenticated with
+**Keycloak client credentials**, exactly mirroring the certificate
+broker: each instance is provisioned with its own confidential client in
+a shared realm, and the client credentials are injected at finalize time
+(see [Provisioning](#provisioning)).
 
-### Abuse controls (the reason for the broker)
+The instance's Keycloak identity encodes which zone it is, so the proxy
+learns the instance's true sending domain from the authenticated token
+— not from anything the instance asserts in the message. This is what
+anchors From-domain enforcement. Revoking a single instance is a matter
+of disabling its client; there is no shared secret to rotate.
 
-Because the broker is the only way out, it is where all multi-tenant
+### Abuse controls
+
+Because the proxy is the only way out, it is where all multi-tenant
 safety lives:
 
-- **From-domain enforcement.** The broker knows each instance's true
-  zone domain (from the authenticated identity, not from anything the
-  instance asserts). It **rejects any message whose envelope-from or
-  header-from is not within that instance's own zone.** An instance can
-  only ever send as `*@<its-own-zone>`. This is not enforceable on the
-  instance itself — only a party the tenant cannot bypass can enforce
-  it, which is exactly the broker.
-- **Per-instance rate and volume caps.** Each instance gets its own
-  send-rate and daily-volume budget. One tenant cannot consume the
-  shared SES quota at the expense of others.
-- **Reputation isolation.** The broker assigns each instance (or cohort
-  of instances) to a distinct SES **configuration set**, so bounce and
-  complaint reputation is tracked per tenant rather than pooled. A bad
-  actor's reputation damage is contained to their own configuration
-  set, and can be given dedicated IPs if needed.
-- **Suppression and bounce/complaint handling.** The broker consumes
-  SES bounce/complaint notifications, maintains a suppression list, and
-  refuses to send to addresses that have hard-bounced or complained —
-  centrally, so no instance can repeatedly hammer a bad address.
-- **Automatic suspension.** An instance whose bounce or complaint rate
-  crosses a threshold is automatically throttled or suspended, and the
-  event is surfaced to OpenHost operators. Suspension is per-instance
-  and does not affect anyone else.
+- **From-domain enforcement.** The proxy rejects any message whose
+  envelope-from or header-from is not within the instance's own
+  (Keycloak-attested) zone. An instance can only ever send as
+  `*@<its-own-zone>`. This cannot be enforced on the instance itself —
+  only a party the tenant cannot bypass can enforce it.
+- **Per-instance rate and volume caps**, so one tenant cannot consume
+  the shared SES quota at the expense of others.
+- **Reputation isolation.** Each instance (or cohort) is assigned a
+  distinct SES **configuration set**, so bounce/complaint reputation is
+  tracked per tenant and a bad actor's damage is contained; dedicated
+  IPs can be assigned where needed.
+- **Suppression and bounce/complaint handling**, maintained centrally so
+  no instance can repeatedly hammer a bad address.
+- **Automatic suspension** of an instance whose bounce/complaint rate
+  crosses a threshold — per-instance, without affecting anyone else.
 
-### DNS for deliverability
+## DNS records (CoreDNS)
 
-Each instance is authoritative for its own zone (see
-[Routing](./routing.md)), so the records that make outbound mail
-deliverable are published **into the instance's own CoreDNS zone at
-provision time**, with no manual operator step:
+Each instance is authoritative for its own zone via CoreDNS (see
+[Routing](./routing.md)). The email deliverability records are written
+into that zone **automatically** — there is a single mechanism, no
+per-provider connectors:
 
-- **SPF** authorizing the broker/SES to send for the zone.
-- **DKIM** public keys so signed mail aligns.
+- **SPF** authorizing SES to send for the zone.
+- **DKIM** public keys (the tokens the SES proxy obtained when creating
+  the domain identity) so signed mail aligns.
 - **DMARC** policy for the zone.
+- **MX** pointing at the SES inbound endpoint.
 
 Because these are persistent zone records (unlike the transient
 ACME-challenge records), they are written as part of the zone's base
 configuration so they survive router restarts, and the ACME-challenge
 cleanup is scoped so that it never removes them.
 
+### Bring-your-own domain (optional NS delegation)
+
+A `<name>.selfhost.imbue.com` address works out of the box because the
+parent zone already delegates each subzone to the instance's CoreDNS.
+
+To use a **custom domain** (e.g. `me@mydomain.com`), the user delegates a
+zone to the instance's CoreDNS with a single **NS record** at their
+registrar — the same delegation model selfhost already uses. Once
+delegated, CoreDNS is authoritative for that zone and OpenHost writes all
+the email records automatically; no manual DKIM/verification steps at the
+registrar.
+
+Recommendation: delegate a **subdomain** (e.g. `mail.mydomain.com`)
+rather than the apex, so OpenHost only becomes authoritative for the mail
+subzone and the user keeps their existing website/DNS untouched.
+Delegating the apex is possible for users who want OpenHost to serve all
+of their DNS, but it is a bigger commitment and makes the instance's
+CoreDNS load-bearing for the whole domain.
+
 ## Receiving mail
 
 Inbound port 25 is blocked, so the instance cannot accept mail directly.
 Instead:
 
-1. **MX points at the upstream provider.** The instance publishes an MX
-   record (in its own CoreDNS zone) directing mail for the zone to SES's
-   inbound endpoint.
-2. **SES receives and stores.** SES accepts the message and writes the
-   raw RFC822 to an OpenHost-owned S3 bucket, then publishes an SNS
+1. **MX points at SES.** The instance's CoreDNS publishes an MX record
+   directing mail for the zone to SES's inbound endpoint.
+2. **SES receives and stores.** SES accepts the message, writes the raw
+   RFC822 to an OpenHost-owned S3 bucket, and publishes an SNS
    notification.
-3. **The broker is notified and forwards to the instance.** SNS delivers
-   a signed notification; the broker (or a per-instance inbound webhook
-   fronted by the broker) **verifies the SNS signature**, fetches the
-   raw message from S3, and hands it to the destination instance.
-4. **The instance's mailbox server ingests it.** The message is
-   delivered into the instance's local mailbox (via LMTP/SMTP into the
-   mailbox server), where the owner can read it.
+3. **The proxy is notified and forwards to the instance.** SNS delivers a
+   signed notification; the proxy **verifies the SNS signature**, fetches
+   the raw message from S3, and hands it to the destination instance.
+4. **The instance's mailbox server ingests it** via LMTP/SMTP, where the
+   owner can read it.
 
 Signature verification is mandatory: the inbound webhook is
 internet-reachable, so an unverified payload would let anyone inject
-mail. Only notifications with a valid AWS SNS signature from the
-expected topic are accepted.
+mail. Only notifications with a valid AWS SNS signature from the expected
+topic are accepted.
 
-### Inbound abuse considerations
+Inbound is also multi-tenant-sensitive — untrusted users receiving
+unbounded mail is a storage/content-abuse vector — so the design applies
+**per-instance inbound quotas** (rate and total mailbox storage) and
+routes inbound mail only to the instance that owns the destination zone.
 
-Receiving is also multi-tenant-sensitive: untrusted users receiving
-unbounded mail is a storage- and content-abuse vector. The design
-applies **per-instance inbound quotas** (message rate and total
-mailbox storage) enforced before delivery, and routes inbound mail
-only to the instance that owns the destination zone.
+## The mailbox and webmail apps
 
-## The mailbox and reading mail
+The mailbox server (SMTP + JMAP with local storage) and the webmail
+client ship as **default OpenHost apps**. Keeping them as apps means mail
+data lives on the operator's own zone (not in a central store), and the
+implementation can iterate without a platform release.
 
-The mailbox server (SMTP + JMAP) runs **on the instance** as an app so
-that mail contents live on the operator's own zone rather than in a
-central store. It stores mail in local per-app data so it survives
-rebuilds.
+- The mailbox server relays outbound mail to the SES proxy (as a
+  smarthost client) and ingests inbound mail delivered by the proxy.
+- The mailbox server exposes its JMAP interface as a
+  [cross-app service](./cross_app_services.md); the webmail app
+  *consumes* that service.
 
-Reading mail is done by a **webmail app** that talks to the mailbox
-server. The mailbox server exposes its JMAP interface as a
-[cross-app service](./cross_app_services.md); the webmail app *consumes*
-that service. A small proxy in front of the mailbox server:
+## Access control — who can read the mail
 
-- validates the consuming app's permission grant,
-- strips any client-supplied credentials, and
-- injects the owner's mailbox credentials before forwarding.
+Isolation has three layers; keep them distinct.
 
-This is the same trust model as other cross-app services: the consuming
-app never sees mailbox credentials; it authenticates to the router with
-its app token, and the provider proxy vouches for it. Access to the
-mailbox is gated by **OpenHost owner authentication**, not by a mail
-password.
+1. **Between instances (structural).** Each instance is a separate VM
+   with its own mailbox server and its own storage, so one instance
+   physically cannot read another's mail. The proxy additionally routes
+   inbound mail only to the instance that owns the destination zone.
+   This is the same isolation that already separates every OpenHost zone
+   — nothing new is built for it.
+
+2. **Within an instance, single owner (the common case).** Access to the
+   webmail app and the mailbox is gated by **OpenHost owner
+   authentication**: the router only stamps `X-OpenHost-Is-Owner: true`
+   for the authenticated zone owner; everyone else is bounced to the zone
+   login. A small proxy in front of the mailbox server validates the
+   consuming app's permission grant, **strips any client-supplied
+   credentials, and injects the owner's mailbox credentials** before
+   forwarding. The webmail app never sees a mail password; the mail
+   account's own password is internal and never user-facing. Access is
+   governed entirely by OpenHost auth, not by knowledge of a mail
+   password.
+
+3. **Within an instance, multiple users (out of scope for now).** The
+   current owner-auth model is binary — owner or not-owner — so every
+   party who authenticates as the owner sees the same mailbox. Giving
+   several distinct users on one zone their own private mailboxes would
+   require mapping each authenticated OpenHost user to a specific mailbox
+   in the JMAP proxy, which depends on OpenHost's federated-identity work
+   and is not addressed here.
 
 ## Provisioning
 
 Per-instance email configuration is injected at **finalize time**,
 alongside the existing certificate-broker configuration:
 
-- the instance's **broker credential** (Keycloak client id/secret),
-- the broker base URL,
-- and the zone's mail settings (mailbox domain, DKIM key material).
+- the instance's **Keycloak credential** (client id/secret) for the SES
+  proxy,
+- the proxy's base URL,
+- and the zone's mail settings.
 
-At the same point, the SPF/DKIM/DMARC/MX records are written into the
-instance's CoreDNS zone. No manual AWS or DNS steps are required of the
-operator — the instance can send and receive as soon as it is claimed.
+At provision, the SES proxy creates the SES domain identity and the DKIM
+tokens are published into CoreDNS along with SPF/DMARC/MX; the proxy
+polls SES until the domain verifies. For a `selfhost` subdomain this is
+fully automatic. For a custom domain, the one manual step is the user's
+NS delegation; everything after that is automatic.
 
 ## Trust and failure model
 
-- **An instance can only send as its own zone.** Enforced by the
-  broker, which derives the zone from the authenticated identity.
-- **An instance cannot damage others' deliverability.** Reputation is
-  isolated per configuration set; abuse triggers per-instance
+- **An instance can only send as its own zone**, enforced by the proxy
+  from the Keycloak-attested identity.
+- **An instance cannot damage others' deliverability** — reputation is
+  isolated per SES configuration set; abuse triggers per-instance
   suspension only.
-- **An instance holds no upstream (AWS) credentials.** It authenticates
-  to the broker with a per-instance, individually-revocable credential.
-- **Broker unavailability is fail-safe.** If the broker is unreachable,
-  outbound mail queues on the instance's mailbox server and retries;
-  inbound mail is retried by SNS. No mail is silently dropped.
-- **Mail data stays on the instance.** Message contents live in the
-  operator's own zone; the broker relays and enforces policy but is not
-  the mail store.
+- **An instance holds no AWS credentials** — it authenticates to the
+  proxy with a per-instance, individually-revocable Keycloak credential.
+- **Proxy unavailability is fail-safe** — outbound mail queues on the
+  instance's mailbox server and retries; inbound mail is retried by SNS.
+- **Mail data stays on the instance** — the proxy relays and enforces
+  policy but is not the mail store.
 
 ## Summary
 
-| Concern            | Where it lives            | Why |
-|--------------------|---------------------------|-----|
-| Outbound relay     | Central broker → SES SMTP  | Port 25 blocked; reputation is shared |
-| From-domain safety | Central broker             | Only the broker can enforce it against an untrusted tenant |
-| Rate / abuse / suppression | Central broker      | Multi-tenant isolation |
-| Inbound receive    | SES → S3 → SNS → broker → instance | Port 25 blocked; signature-verified |
-| SPF/DKIM/DMARC/MX  | Instance CoreDNS zone (auto) | Instance owns its zone |
-| Mailbox store      | Instance (local app data)  | Mail data stays on the operator's zone |
-| Reading mail       | Webmail app via JMAP cross-app service | Consuming app never sees mail credentials |
+| Concern | Where it lives | Why |
+|---------|----------------|-----|
+| Outbound relay + spam/abuse | Central SES proxy (fly.io) → AWS SES | Port 25 blocked; reputation is shared |
+| Request auth | Keycloak (cert-api pattern) | Per-instance, revocable; anchors From-enforcement |
+| From-domain safety | Central SES proxy | Only the proxy can enforce it against an untrusted tenant |
+| SES identity + verification | Central SES proxy | SES won't send for an unverified domain |
+| DKIM/SPF/DMARC/MX | CoreDNS (auto) | Instance owns its zone |
+| Custom domains | Optional NS delegation → CoreDNS | Seamless BYO-domain via one record |
+| Inbound receive | SES → S3 → SNS → proxy → instance | Port 25 blocked; signature-verified |
+| Mailbox store + webmail | Default apps | Mail data stays on the operator's zone; iterate freely |
+| Read access (single owner) | OpenHost owner auth + JMAP proxy | App never sees mail credentials |


### PR DESCRIPTION
Adds docs/src/email.md describing how OpenHost instances would send and receive email for their zone, designed to be safe for untrusted multi-tenant users.

Outbound and inbound mail flow through a central OpenHost-operated broker in front of AWS SES. The broker is the trust boundary: instances authenticate with a per-instance Keycloak client credential (mirroring the cert broker), the broker enforces that an instance can only send as its own zone, applies per-instance rate/volume caps, isolates reputation via SES configuration sets, and handles suppression and auto-suspension. Instances never hold AWS credentials.

Sending: instance mailbox server relays as a smarthost client to the broker, which relays to SES SMTP. Receiving: SES to S3 to SNS to a signature-verified webhook fronted by the broker, delivered into the instance's local mailbox. SPF/DKIM/DMARC/MX are auto-published into the instance's own CoreDNS zone at finalize. The mailbox lives on the instance so mail data stays on the operator's zone; a webmail app reads it over a JMAP cross-app service.

Docs only. Added to SUMMARY.md.