### PR TITLE
Cap journald on-disk size to prevent host disk fill

### DIFF
--- a/ansible/local_setup.yml
+++ b/ansible/local_setup.yml
@@ -24,6 +24,7 @@
   tasks:
     - import_tasks: tasks/apt_packages.yml
     - import_tasks: tasks/containers.yml
+    - import_tasks: tasks/journald.yml
 
 - name: Dev environment
   hosts: localhost

--- a/ansible/prebake.yml
+++ b/ansible/prebake.yml
@@ -42,6 +42,7 @@
   tasks:
     - import_tasks: tasks/apt_packages.yml
     - import_tasks: tasks/containers.yml
+    - import_tasks: tasks/journald.yml
 
 - name: Dev environment
   hosts: all

--- a/ansible/setup.yml
+++ b/ansible/setup.yml
@@ -36,6 +36,7 @@
   tasks:
     - import_tasks: tasks/apt_packages.yml
     - import_tasks: tasks/containers.yml
+    - import_tasks: tasks/journald.yml
 
 - name: Dev environment
   hosts: all

--- a/ansible/tasks/journald.yml
+++ b/ansible/tasks/journald.yml
@@ -1,0 +1,41 @@
+---
+# Cap journald's on-disk size so the system journal can't fill the host disk.
+# Runs with become: yes.
+#
+# OpenHost forwards the router process's stderr (plus forwarded Caddy and
+# CoreDNS output) to journald.  journald's defaults let the journal grow to
+# ~10% of the filesystem (capped at 4 GB), which on long-lived hosts combined
+# with accumulated container images could fill the disk.  A drop-in is used
+# rather than editing /etc/systemd/journald.conf so distro/operator settings
+# are never clobbered.
+#
+# Kept byte-identical with the openhost_system_agent v6 migration
+# (v0006_journald_size_cap.py), which applies the same cap to existing hosts.
+# A test enforces this.
+
+- name: Ensure journald drop-in directory exists
+  file:
+    path: /etc/systemd/journald.conf.d
+    state: directory
+    mode: "0755"
+
+- name: Cap journald on-disk size
+  copy:
+    content: |
+      # Managed by OpenHost; do not edit by hand.
+      [Journal]
+      SystemMaxUse=500M
+    dest: /etc/systemd/journald.conf.d/10-openhost.conf
+    mode: "0644"
+  register: _journald_dropin
+
+- name: Restart journald to apply size cap
+  systemd:
+    name: systemd-journald
+    state: restarted
+  when: _journald_dropin.changed
+
+- name: Vacuum journal down to the new size cap
+  command: journalctl --vacuum-size=500M
+  when: _journald_dropin.changed
+  changed_when: true

--- a/docs/src/logs.md
+++ b/docs/src/logs.md
@@ -20,7 +20,7 @@ The router writes to two sinks simultaneously via loguru:
 - Written at DEBUG level and above.
 - Captured by systemd from the router process's stderr and stored in journald's binary database at `/var/log/journal/`.
 - Also contains output from Caddy and CoreDNS, because both are child processes of the router — their stdout is read line-by-line and re-emitted through the router's logger.
-- Persists across restarts and accumulates until journald's system-level limits are hit (not configured by OpenHost; system defaults apply — typically 10% of disk or 4 GB, whichever is smaller).
+- Persists across restarts and accumulates until journald's on-disk size cap is hit. OpenHost caps the total journal at 500 MB via a drop-in at `/etc/systemd/journald.conf.d/10-openhost.conf` (`SystemMaxUse=500M`) so the journal alone can't fill the host disk; older entries are discarded once the cap is reached.
 - Access via `journalctl -u openhost` or `journalctl -u openhost -f` to follow.
 
 ---
@@ -65,4 +65,4 @@ journalctl -u openhost-juicefs
 - App container stdout/stderr (now written to `container.log` via k8s-file)
 - The contents of `compute_space.log` (the file sink is separate from journald)
 
-Journald stores logs in a binary indexed format across multiple files. Queries are indexed by unit, priority, and time — they are not a linear scan — but total journal size still affects seek time. No per-unit size cap is configured by OpenHost; use `SystemMaxUse`, `SystemMaxFiles`, or `MaxRetentionSec` in `/etc/systemd/journald.conf` if the journal grows too large.
+Journald stores logs in a binary indexed format across multiple files. Queries are indexed by unit, priority, and time — they are not a linear scan — but total journal size still affects seek time. OpenHost caps the total on-disk journal at 500 MB via `SystemMaxUse` in a drop-in at `/etc/systemd/journald.conf.d/10-openhost.conf`. Operators who need a different limit can add `SystemMaxFiles` or `MaxRetentionSec`, or override `SystemMaxUse`, in a higher-numbered drop-in (e.g. `/etc/systemd/journald.conf.d/20-local.conf`).

--- a/openhost_system_agent/src/openhost_system_agent/migrations/registry.py
+++ b/openhost_system_agent/src/openhost_system_agent/migrations/registry.py
@@ -9,6 +9,7 @@ from openhost_system_agent.migrations.versions.v0003_remove_obsolete_hairpin_nat
 )
 from openhost_system_agent.migrations.versions.v0004_pixi_version import Migration0004PixiVersion
 from openhost_system_agent.migrations.versions.v0005_pixi_ownership_failsafe import Migration0005PixiOwnershipFailsafe
+from openhost_system_agent.migrations.versions.v0006_journald_size_cap import Migration0006JournaldSizeCap
 
 # Numbered migrations in apply order. Versions MUST start at 2 and be
 # contiguous. v1 is the baseline produced by ansible setup.yml.
@@ -17,6 +18,7 @@ REGISTRY: list[SystemMigration] = [
     Migration0003RemoveObsoleteHairpinNat(),
     Migration0004PixiVersion(),
     Migration0005PixiOwnershipFailsafe(),
+    Migration0006JournaldSizeCap(),
 ]
 
 

--- a/openhost_system_agent/src/openhost_system_agent/migrations/versions/v0006_journald_size_cap.py
+++ b/openhost_system_agent/src/openhost_system_agent/migrations/versions/v0006_journald_size_cap.py
@@ -1,0 +1,52 @@
+"""Cap journald's on-disk size so the system journal can't fill the disk.
+
+OpenHost forwards the router process's stderr (plus forwarded Caddy and CoreDNS
+output) to journald via systemd.  journald's own defaults let the journal grow
+to ~10% of the filesystem (capped at 4 GB), and OpenHost previously configured
+no limit — so on long-lived hosts the journal steadily grew and, combined with
+accumulated container images, could fill the disk and take the instance down.
+
+This migration installs a journald drop-in that caps total journal size at
+500 MB and requests it be applied immediately.  A drop-in under
+``journald.conf.d`` is used rather than editing ``/etc/systemd/journald.conf``
+so we never clobber operator or distro settings, and can cleanly manage just
+this one knob.
+
+Idempotent: writing the same drop-in and re-running ``journalctl --vacuum-size``
+is safe to repeat.  Kept byte-identical with the ansible task that provisions
+fresh hosts (``ansible/tasks/journald.yml``); a test enforces this.
+"""
+
+from __future__ import annotations
+
+import subprocess
+
+from openhost_system_agent.migrations.base import SystemMigration
+from openhost_system_agent.migrations.helpers import write_file
+
+# Drop-in path and contents.  Shared so the ansible task and the byte-identity
+# test reference the same source of truth.
+JOURNALD_DROPIN_PATH = "/etc/systemd/journald.conf.d/10-openhost.conf"
+
+# SystemMaxUse bounds the total size of the persistent journal.  500 MB is
+# ample for diagnosing router/Caddy/CoreDNS issues across many restarts while
+# leaving no path for the journal alone to fill a host disk.
+JOURNALD_MAX_USE = "500M"
+
+JOURNALD_DROPIN_CONTENT = f"# Managed by OpenHost; do not edit by hand.\n[Journal]\nSystemMaxUse={JOURNALD_MAX_USE}\n"
+
+
+class Migration0006JournaldSizeCap(SystemMigration):
+    version = 6
+
+    def up(self) -> None:
+        write_file(JOURNALD_DROPIN_PATH, JOURNALD_DROPIN_CONTENT, mode=0o644)
+        # Reload journald so the new SystemMaxUse takes effect without a reboot.
+        subprocess.run(["systemctl", "restart", "systemd-journald"], check=False)
+        # Retire journal beyond the new cap right away so a host that is
+        # already over 500 MB frees space now, not just at the next rotation.
+        subprocess.run(
+            ["journalctl", f"--vacuum-size={JOURNALD_MAX_USE}"],
+            capture_output=True,
+            check=False,
+        )

--- a/openhost_system_agent/src/openhost_system_agent/tests/test_migration_journald.py
+++ b/openhost_system_agent/src/openhost_system_agent/tests/test_migration_journald.py
@@ -1,0 +1,86 @@
+"""Tests for the v6 migration that caps journald's on-disk size.
+
+The migration writes a journald drop-in and asks journald to apply it, so we
+drive it through fakes to assert it writes the right file with the right mode,
+restarts journald, and vacuums the journal down to the cap.  A separate test
+enforces that the drop-in it writes stays byte-identical with the ansible task
+that provisions fresh hosts.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from openhost_system_agent.migrations.versions.v0006_journald_size_cap import JOURNALD_DROPIN_CONTENT
+from openhost_system_agent.migrations.versions.v0006_journald_size_cap import JOURNALD_DROPIN_PATH
+from openhost_system_agent.migrations.versions.v0006_journald_size_cap import JOURNALD_MAX_USE
+from openhost_system_agent.migrations.versions.v0006_journald_size_cap import Migration0006JournaldSizeCap
+
+_PREFIX = "openhost_system_agent.migrations.versions.v0006_journald_size_cap"
+
+
+def test_writes_dropin_and_applies(monkeypatch: pytest.MonkeyPatch) -> None:
+    written: dict[str, Any] = {}
+
+    def fake_write_file(path: str, content: str, *, mode: int = 0o600) -> None:
+        written["path"] = path
+        written["content"] = content
+        written["mode"] = mode
+
+    calls: list[list[str]] = []
+
+    def fake_run(cmd: list[str], **kwargs: Any) -> None:
+        calls.append(cmd)
+
+    monkeypatch.setattr(f"{_PREFIX}.write_file", fake_write_file)
+    monkeypatch.setattr(f"{_PREFIX}.subprocess.run", fake_run)
+
+    Migration0006JournaldSizeCap().up()
+
+    # World-readable drop-in at the expected path with the cap set.
+    assert written["path"] == JOURNALD_DROPIN_PATH
+    assert written["mode"] == 0o644
+    assert f"SystemMaxUse={JOURNALD_MAX_USE}" in written["content"]
+
+    # journald is restarted so the cap takes effect without a reboot.
+    assert ["systemctl", "restart", "systemd-journald"] in calls
+    # The journal is vacuumed down to the cap immediately.
+    vacuum = [c for c in calls if c and c[0] == "journalctl"]
+    assert vacuum == [["journalctl", f"--vacuum-size={JOURNALD_MAX_USE}"]]
+
+
+def test_dropin_targets_a_dropin_not_the_main_conf() -> None:
+    # A drop-in under journald.conf.d, not /etc/systemd/journald.conf, so we
+    # never clobber operator or distro settings.
+    assert JOURNALD_DROPIN_PATH.startswith("/etc/systemd/journald.conf.d/")
+    assert "[Journal]" in JOURNALD_DROPIN_CONTENT
+
+
+def test_matches_ansible_task_byte_for_byte() -> None:
+    # The migration-written drop-in and the ansible-copied drop-in must be
+    # identical so a host looks the same however it was set up.  The ansible
+    # task embeds the content inline in a `copy: content:` block, so extract
+    # and compare it here.
+    repo_root = Path(__file__).resolve().parents[4]
+    task = (repo_root / "ansible" / "tasks" / "journald.yml").read_text()
+
+    marker = "content: |\n"
+    start = task.index(marker) + len(marker)
+    # The literal block is indented 6 spaces under `content: |`.  Keep only the
+    # lines carrying that indent (the following `dest:`/`mode:` keys are indented
+    # 4 spaces and mark the end of the block), then strip the indent.
+    indent = " " * 6
+    block_lines: list[str] = []
+    for line in task[start:].splitlines():
+        if line.startswith(indent):
+            block_lines.append(line[len(indent) :])
+        elif line.strip() == "":
+            block_lines.append("")
+        else:
+            break
+    ansible_content = "\n".join(block_lines).rstrip("\n") + "\n"
+
+    assert ansible_content == JOURNALD_DROPIN_CONTENT


### PR DESCRIPTION
OpenHost forwards the router process stderr, plus forwarded Caddy and CoreDNS output, to journald via systemd. journald was left uncapped, so its defaults let the journal grow toward ~10 percent of the disk (up to 4 GB). On long-lived hosts this steadily grew and, combined with accumulated container images, could fill the disk and take the instance down.

This installs a journald drop-in setting SystemMaxUse=500M so the journal alone can never fill a host disk. A drop-in under journald.conf.d is used rather than editing journald.conf so operator and distro settings are never clobbered.

Applied on both provisioning paths:
- Fresh hosts: new ansible task ansible/tasks/journald.yml, wired into setup.yml, local_setup.yml, and prebake.yml. It writes the drop-in, restarts journald, and vacuums the journal to the cap.
- Existing hosts: new openhost_system_agent migration v0006, which writes the same drop-in, restarts systemd-journald, and runs journalctl --vacuum-size so hosts already over the cap free space immediately.

The drop-in content is kept byte-identical across both paths, enforced by a test.

Testing:
- Provisioned a fresh Hetzner instance from this branch via vm-manager. All four journald tasks ran and applied (changed), and the play finished with failed=0. Instance was torn down after.
- Added unit tests for the migration (file/mode written, journald restarted, vacuum invoked, drop-in path is a drop-in not the main conf) plus the byte-identity test. Full system-agent test suite passes.
- ruff check and format clean.

This is the disk-fill mitigation only. It does not change image pruning or the storage guard.