### PR TITLE
Add periodic dangling-image pruner thread

### DIFF
--- a/compute_space/src/compute_space/config.py
+++ b/compute_space/src/compute_space/config.py
@@ -75,6 +75,11 @@ class Config:
     # How often (seconds) to prune dangling container images (0 = disabled).
     image_prune_interval_seconds: int
 
+    # Age (seconds) above which a tagged OpenHost app image with no matching app
+    # in the DB is treated as orphaned and pruned (0 = never prune orphaned
+    # tagged images).
+    image_orphan_max_age_seconds: int
+
     ## Ports
     port_range_start: int
     port_range_end: int
@@ -270,6 +275,15 @@ class DefaultConfig(Config):
     # keeps them from filling the disk.  Only dangling images are removed, so
     # stopped apps never need rebuilding.  Defaults to every 6 hours.
     image_prune_interval_seconds: int = 6 * 60 * 60
+
+    # Age (seconds) above which a tagged ``openhost-{name}:latest`` image whose
+    # app no longer exists in the DB (in any status) is pruned by the periodic
+    # sweep.  App removal already deletes the app's image, so this only reclaims
+    # tagged images orphaned by a removal that failed or predated that logic.
+    # The age guard ensures an image built for an app whose DB row is not yet
+    # committed (mid-deploy) is never reaped.  0 disables orphan pruning.
+    # Defaults to 7 days.
+    image_orphan_max_age_seconds: int = 7 * 24 * 60 * 60
 
     # Fail-safe default: require a claim token at /setup. Callers that want
     # the open-setup behavior (local-dev loopback) must set this False.

--- a/compute_space/src/compute_space/config.py
+++ b/compute_space/src/compute_space/config.py
@@ -72,6 +72,9 @@ class Config:
     # Minimum free disk space in MB (0 = no enforcement)
     storage_min_free_mb: int
 
+    # How often (seconds) to prune dangling container images (0 = disabled).
+    image_prune_interval_seconds: int
+
     ## Ports
     port_range_start: int
     port_range_end: int
@@ -260,6 +263,13 @@ class DefaultConfig(Config):
 
     # Minimum free disk space in MB (0 = no enforcement)
     storage_min_free_mb: int = 0
+
+    # How often (seconds) the periodic pruner removes dangling container images
+    # (0 = disabled).  Rebuilds re-tag ``openhost-{app}:latest`` and orphan the
+    # previous image, so untagged layers accumulate; pruning them on a schedule
+    # keeps them from filling the disk.  Only dangling images are removed, so
+    # stopped apps never need rebuilding.  Defaults to every 6 hours.
+    image_prune_interval_seconds: int = 6 * 60 * 60
 
     # Fail-safe default: require a claim token at /setup. Callers that want
     # the open-setup behavior (local-dev loopback) must set this False.

--- a/compute_space/src/compute_space/core/containers.py
+++ b/compute_space/src/compute_space/core/containers.py
@@ -489,6 +489,28 @@ def drop_docker_build_cache() -> str:
     return output
 
 
+def prune_dangling_images() -> str:
+    """Remove only dangling (untagged) images via ``podman image prune``.
+
+    Unlike ``drop_docker_build_cache``, this omits ``--all``, so it removes
+    only the untagged image layers left behind when an app is rebuilt (each
+    rebuild re-tags ``openhost-{app}:latest``, orphaning the previous image).
+    Tagged images for stopped apps are kept, so nothing has to be rebuilt on
+    next start.  This makes it safe to run unconditionally on a schedule.
+
+    Returns podman's combined output.  Raises ``RuntimeError`` on failure so
+    the caller can log it; the periodic thread swallows that so a transient
+    podman error never kills the loop.
+    """
+    cmd = ["podman", "image", "prune", "--force"]
+    logger.info("Pruning dangling container images: %s", " ".join(cmd))
+    result = subprocess.run(cmd, capture_output=True, text=True, timeout=120)
+    output = (result.stdout + result.stderr).strip()
+    if result.returncode != 0:
+        raise RuntimeError(output or "podman image prune failed")
+    return output
+
+
 def is_container_running(container_id: str) -> bool:
     """Return True iff podman reports the container's ``State.Status`` as ``running``.
 

--- a/compute_space/src/compute_space/core/containers.py
+++ b/compute_space/src/compute_space/core/containers.py
@@ -27,6 +27,8 @@ import subprocess
 from datetime import UTC
 from datetime import datetime
 
+import attr
+
 from compute_space.core.logging import logger
 from compute_space.core.manifest import AppManifest
 from compute_space.core.manifest import PortMapping
@@ -509,6 +511,96 @@ def prune_dangling_images() -> str:
     if result.returncode != 0:
         raise RuntimeError(output or "podman image prune failed")
     return output
+
+
+# An OpenHost app image is always tagged ``openhost-{app_name}:latest`` (see
+# ``build_image``).  podman reports the tag fully qualified, e.g.
+# ``localhost/openhost-{app_name}:latest``.  This matches that form and pulls
+# out the app name.  App names are DNS-label-like (see core.app_id), so the
+# capture group is deliberately permissive and validated by the caller against
+# the apps DB rather than by a strict name regex here.
+_OPENHOST_IMAGE_TAG_RE = re.compile(r"^(?:localhost/)?openhost-(?P<app_name>.+):latest$")
+
+
+def parse_openhost_image_app_name(tag: str) -> str | None:
+    """Return the app name for an ``openhost-{name}:latest`` tag, else None.
+
+    Only OpenHost app images are matched; any other repo tag (base images an
+    app FROMs, unrelated tags) returns None so it is never a prune candidate.
+    """
+    match = _OPENHOST_IMAGE_TAG_RE.match(tag)
+    return match.group("app_name") if match else None
+
+
+@attr.s(auto_attribs=True, frozen=True)
+class OpenHostImage:
+    """A tagged OpenHost app image as reported by ``podman images``."""
+
+    image_id: str
+    app_name: str
+    created_epoch: int  # unix seconds
+
+
+def list_openhost_images() -> list[OpenHostImage]:
+    """List tagged OpenHost app images (``openhost-{name}:latest``).
+
+    Parses ``podman images --format json``.  Only images whose tag matches the
+    OpenHost app scheme are returned; dangling (untagged) images and unrelated
+    repos are skipped.  Returns an empty list when podman is unavailable or its
+    output can't be parsed, so a transient error degrades to "prune nothing"
+    rather than raising.
+    """
+    try:
+        result = subprocess.run(
+            ["podman", "images", "--format", "json"],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        if result.returncode != 0:
+            logger.warning("podman images failed (exit %d): %s", result.returncode, result.stderr.strip())
+            return []
+        rows = json.loads(result.stdout) or []
+    except Exception as e:
+        logger.warning("Could not list podman images: %s", e)
+        return []
+
+    images: list[OpenHostImage] = []
+    for row in rows:
+        image_id = row.get("Id")
+        # podman may report "Created" as unix seconds (int) and/or "CreatedAt"
+        # as a string; prefer the numeric field.
+        created = row.get("Created")
+        if not isinstance(created, int):
+            continue
+        # A single image id can carry several tags (Names/RepoTags).  Match any
+        # that is an OpenHost app tag; one physical image mapping to two app
+        # names is not expected, but handle each tag independently.
+        names = row.get("Names") or row.get("RepoTags") or []
+        if not isinstance(names, list):
+            continue
+        for name in names:
+            if not isinstance(name, str):
+                continue
+            app_name = parse_openhost_image_app_name(name)
+            if app_name is not None and isinstance(image_id, str):
+                images.append(OpenHostImage(image_id=image_id, app_name=app_name, created_epoch=created))
+    return images
+
+
+def remove_image_by_id(image_id: str) -> bool:
+    """Force-remove an image by id.  Returns True on success, False otherwise.
+
+    Uses ``podman rmi --force`` by id (not tag) so it targets exactly the image
+    we decided to prune, even if the tag moved in the meantime.  ``--force``
+    covers the (unexpected) case of a lingering container reference; a failure
+    is logged and swallowed so one bad removal can't abort a sweep.
+    """
+    result = subprocess.run(["podman", "rmi", "--force", image_id], capture_output=True, text=True, timeout=30)
+    if result.returncode != 0:
+        logger.warning("Failed to remove image %s: %s", image_id, (result.stdout + result.stderr).strip())
+        return False
+    return True
 
 
 def is_container_running(container_id: str) -> bool:

--- a/compute_space/src/compute_space/core/image_pruner.py
+++ b/compute_space/src/compute_space/core/image_pruner.py
@@ -1,4 +1,4 @@
-"""Periodic dangling-image pruner.
+"""Periodic image pruner.
 
 Every app rebuild re-tags ``openhost-{app}:latest`` and orphans the previous
 image, so untagged (dangling) layers accumulate over time.  Nothing prunes
@@ -6,22 +6,35 @@ them automatically today: the ``/api/drop-docker-cache`` endpoint exists but
 runs only on explicit operator action, so on long-lived hosts these dangling
 images pile up and can fill the disk.
 
-This module runs a lightweight daemon thread that periodically prunes *only*
-dangling images (``podman image prune`` without ``--all``), independent of disk
-pressure.  Tagged images for stopped apps are kept, so nothing has to be
-rebuilt on next start — which is what makes an unconditional periodic prune
-safe.  The interval is configured by ``image_prune_interval_seconds`` (0
-disables the thread).
+This module runs a lightweight daemon thread that periodically:
+
+1. Prunes *only* dangling images (``podman image prune`` without ``--all``),
+   independent of disk pressure.  Tagged images for stopped apps are kept, so
+   nothing has to be rebuilt on next start — which is what makes an
+   unconditional periodic prune safe.
+2. Sweeps *orphaned tagged* app images: ``openhost-{name}:latest`` images whose
+   app no longer exists in the DB (in any status) and which are older than
+   ``image_orphan_max_age_seconds``.  App removal already deletes the app's
+   image, so this only reclaims tagged images left by a removal that failed or
+   predated that logic — the case a dangling-only prune can never catch
+   (raised in review).  The age guard prevents reaping an image built for an
+   app whose DB row is not yet committed (mid-deploy).
+
+The interval is configured by ``image_prune_interval_seconds`` (0 disables the
+thread); orphan pruning by ``image_orphan_max_age_seconds`` (0 disables it).
 """
 
 from __future__ import annotations
 
 import os
+import sqlite3
 import threading
 import time
 
 from compute_space.config import Config
+from compute_space.core.containers import list_openhost_images
 from compute_space.core.containers import prune_dangling_images
+from compute_space.core.containers import remove_image_by_id
 from compute_space.core.logging import logger
 
 # Guard so the thread is started at most once per config (mirrors the storage
@@ -39,8 +52,70 @@ def prune_interval_seconds(config: Config) -> int | None:
     return interval
 
 
-def _run_prune_once() -> None:
-    """Prune dangling images once, logging (never raising) on failure."""
+def orphan_max_age_seconds(config: Config) -> int | None:
+    """Return the orphaned-image max age in seconds, or None if disabled."""
+    max_age = int(config.image_orphan_max_age_seconds)
+    if max_age <= 0:
+        return None
+    return max_age
+
+
+def _current_app_names(config: Config) -> set[str]:
+    """Return every app name currently in the DB, in any status.
+
+    Includes apps in every status (running, stopped, error, etc.) so an image
+    for a merely-stopped or errored app is never treated as orphaned.
+    """
+    db = sqlite3.connect(config.db_path)
+    try:
+        rows = db.execute("SELECT name FROM apps").fetchall()
+    finally:
+        db.close()
+    return {row[0] for row in rows if row[0] is not None}
+
+
+def sweep_orphaned_images(config: Config, now_epoch: float) -> list[str]:
+    """Remove orphaned tagged app images older than the configured threshold.
+
+    An image ``openhost-{name}:latest`` is orphaned when ``{name}`` is not the
+    name of any current app in the DB.  Only images older than
+    ``image_orphan_max_age_seconds`` are removed, so an image whose app row is
+    still being committed (mid-deploy) is left alone.  Returns the list of
+    removed image ids.  Never raises — failures are logged so the loop survives.
+    """
+    max_age = orphan_max_age_seconds(config)
+    if max_age is None:
+        return []
+
+    try:
+        app_names = _current_app_names(config)
+    except Exception:
+        logger.exception("Orphaned-image sweep: could not read apps DB; skipping")
+        return []
+
+    removed: list[str] = []
+    # Query the DB once; images list once.  Both are small.
+    for image in list_openhost_images():
+        if image.app_name in app_names:
+            continue  # image belongs to a live app (any status) — keep.
+        age = now_epoch - image.created_epoch
+        if age < max_age:
+            # Too new to be sure it's an orphan (e.g. a deploy mid-flight whose
+            # DB row hasn't landed yet).  Leave it for a future sweep.
+            continue
+        logger.info(
+            "Removing orphaned image %s (app '%s' no longer exists, age %.0fs)",
+            image.image_id,
+            image.app_name,
+            age,
+        )
+        if remove_image_by_id(image.image_id):
+            removed.append(image.image_id)
+    return removed
+
+
+def _run_prune_once(config: Config) -> None:
+    """Run one prune cycle (dangling prune + orphan sweep), never raising."""
     try:
         output = prune_dangling_images()
         if output:
@@ -48,13 +123,20 @@ def _run_prune_once() -> None:
     except Exception:
         logger.exception("Periodic image prune failed")
 
+    try:
+        removed = sweep_orphaned_images(config, time.time())
+        if removed:
+            logger.info("Orphaned-image sweep removed %d image(s)", len(removed))
+    except Exception:
+        logger.exception("Orphaned-image sweep failed")
 
-def _image_pruner_loop(interval: int) -> None:
+
+def _image_pruner_loop(config: Config, interval: int) -> None:
     # Sleep first so we don't prune during the startup rush (when a deploy may
     # be mid-build and its intermediate layers are legitimately "dangling").
     while True:
         time.sleep(interval)
-        _run_prune_once()
+        _run_prune_once(config)
 
 
 def start_image_pruner(config: Config) -> None:
@@ -71,4 +153,4 @@ def start_image_pruner(config: Config) -> None:
             return
         _pruner_db_paths.add(db_key)
     logger.info("Starting periodic image pruner (every %ds)", interval)
-    threading.Thread(target=_image_pruner_loop, args=(interval,), daemon=True).start()
+    threading.Thread(target=_image_pruner_loop, args=(config, interval), daemon=True).start()

--- a/compute_space/src/compute_space/core/image_pruner.py
+++ b/compute_space/src/compute_space/core/image_pruner.py
@@ -1,0 +1,74 @@
+"""Periodic dangling-image pruner.
+
+Every app rebuild re-tags ``openhost-{app}:latest`` and orphans the previous
+image, so untagged (dangling) layers accumulate over time.  Nothing prunes
+them automatically today: the ``/api/drop-docker-cache`` endpoint exists but
+runs only on explicit operator action, so on long-lived hosts these dangling
+images pile up and can fill the disk.
+
+This module runs a lightweight daemon thread that periodically prunes *only*
+dangling images (``podman image prune`` without ``--all``), independent of disk
+pressure.  Tagged images for stopped apps are kept, so nothing has to be
+rebuilt on next start — which is what makes an unconditional periodic prune
+safe.  The interval is configured by ``image_prune_interval_seconds`` (0
+disables the thread).
+"""
+
+from __future__ import annotations
+
+import os
+import threading
+import time
+
+from compute_space.config import Config
+from compute_space.core.containers import prune_dangling_images
+from compute_space.core.logging import logger
+
+# Guard so the thread is started at most once per config (mirrors the storage
+# guard).  Keyed by db_path because that is the stable per-instance identifier
+# already used by the storage guard, and tests can clear it between runs.
+_pruner_lock = threading.Lock()
+_pruner_db_paths: set[str] = set()
+
+
+def prune_interval_seconds(config: Config) -> int | None:
+    """Return the configured prune interval in seconds, or None if disabled."""
+    interval = int(config.image_prune_interval_seconds)
+    if interval <= 0:
+        return None
+    return interval
+
+
+def _run_prune_once() -> None:
+    """Prune dangling images once, logging (never raising) on failure."""
+    try:
+        output = prune_dangling_images()
+        if output:
+            logger.info("Periodic image prune: %s", output)
+    except Exception:
+        logger.exception("Periodic image prune failed")
+
+
+def _image_pruner_loop(interval: int) -> None:
+    # Sleep first so we don't prune during the startup rush (when a deploy may
+    # be mid-build and its intermediate layers are legitimately "dangling").
+    while True:
+        time.sleep(interval)
+        _run_prune_once()
+
+
+def start_image_pruner(config: Config) -> None:
+    """Start the periodic image-pruner daemon thread (once per db_path).
+
+    Only starts if ``image_prune_interval_seconds`` is configured (> 0).
+    """
+    interval = prune_interval_seconds(config)
+    if interval is None:
+        return
+    db_key = os.path.abspath(config.db_path)
+    with _pruner_lock:
+        if db_key in _pruner_db_paths:
+            return
+        _pruner_db_paths.add(db_key)
+    logger.info("Starting periodic image pruner (every %ds)", interval)
+    threading.Thread(target=_image_pruner_loop, args=(interval,), daemon=True).start()

--- a/compute_space/src/compute_space/tests/test_image_pruner.py
+++ b/compute_space/src/compute_space/tests/test_image_pruner.py
@@ -1,0 +1,126 @@
+"""Tests for the periodic dangling-image pruner.
+
+The pruner runs a daemon thread that periodically prunes only dangling images
+(``podman image prune`` without ``--all``).  These tests drive the pieces
+directly: the prune command shape, thread start/idempotency/disable, and that
+the loop swallows failures so a transient podman error can't kill it.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from typing import Any
+
+import pytest
+
+import compute_space.core.image_pruner as image_pruner
+from compute_space.core.containers import prune_dangling_images
+from compute_space.tests.conftest import _make_test_config
+
+
+def test_prune_dangling_images_omits_all_flag(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: dict[str, Any] = {}
+
+    def fake_run(cmd: list[str], **kwargs: Any) -> subprocess.CompletedProcess[str]:
+        calls["cmd"] = cmd
+        calls["timeout"] = kwargs.get("timeout")
+        return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="Total reclaimed space: 5MB\n", stderr="")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    output = prune_dangling_images()
+
+    assert output == "Total reclaimed space: 5MB"
+    # Dangling-only: no --all (which would also remove tagged stopped-app images).
+    assert calls["cmd"] == ["podman", "image", "prune", "--force"]
+    assert "--all" not in calls["cmd"]
+    assert calls["timeout"] == 120
+
+
+def test_prune_dangling_images_raises_on_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fake_run(cmd: list[str], **kwargs: Any) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(args=cmd, returncode=1, stdout="", stderr="podman broke")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    with pytest.raises(RuntimeError, match="podman broke"):
+        prune_dangling_images()
+
+
+def test_run_prune_once_swallows_errors(monkeypatch: pytest.MonkeyPatch) -> None:
+    def boom() -> str:
+        raise RuntimeError("podman broke")
+
+    monkeypatch.setattr(image_pruner, "prune_dangling_images", boom)
+    # Must not raise — the loop relies on this so one bad prune can't kill it.
+    image_pruner._run_prune_once()
+
+
+def test_start_image_pruner_noop_when_disabled(tmp_path: Any, monkeypatch: pytest.MonkeyPatch) -> None:
+    config = _make_test_config(tmp_path, image_prune_interval_seconds=0)
+    image_pruner._pruner_db_paths.clear()
+
+    started: list[bool] = []
+
+    class FakeThread:
+        def __init__(self, target: Any, args: Any, daemon: bool) -> None:
+            started.append(True)
+
+        def start(self) -> None:
+            pass
+
+    monkeypatch.setattr(image_pruner.threading, "Thread", FakeThread)
+
+    image_pruner.start_image_pruner(config)
+    assert started == []
+
+
+def test_start_image_pruner_starts_and_is_idempotent(tmp_path: Any, monkeypatch: pytest.MonkeyPatch) -> None:
+    config = _make_test_config(tmp_path, image_prune_interval_seconds=3600)
+    image_pruner._pruner_db_paths.clear()
+
+    started: list[Any] = []
+
+    class FakeThread:
+        def __init__(self, target: Any, args: Any, daemon: bool) -> None:
+            self.target = target
+            self.args = args
+            self.daemon = daemon
+
+        def start(self) -> None:
+            started.append(self)
+
+    monkeypatch.setattr(image_pruner.threading, "Thread", FakeThread)
+
+    image_pruner.start_image_pruner(config)
+    image_pruner.start_image_pruner(config)  # idempotent per db_path
+
+    assert len(started) == 1
+    assert started[0].daemon is True
+    assert started[0].args == (3600,)
+
+
+def test_loop_sleeps_before_first_prune(monkeypatch: pytest.MonkeyPatch) -> None:
+    # The loop must sleep the interval before its first prune (so a mid-build
+    # deploy's intermediate layers aren't pruned during the startup rush), then
+    # prune each cycle.  Stop it after two iterations via a sleep that raises.
+    sleeps: list[int] = []
+    prunes: list[bool] = []
+
+    class _Stop(Exception):
+        pass
+
+    def fake_sleep(seconds: int) -> None:
+        sleeps.append(seconds)
+        if len(sleeps) >= 2:
+            raise _Stop
+
+    monkeypatch.setattr(image_pruner.time, "sleep", fake_sleep)
+    monkeypatch.setattr(image_pruner, "_run_prune_once", lambda: prunes.append(True))
+
+    with pytest.raises(_Stop):
+        image_pruner._image_pruner_loop(1800)
+
+    # Slept before the first prune, and pruned once between the two sleeps.
+    assert sleeps == [1800, 1800]
+    assert prunes == [True]

--- a/compute_space/src/compute_space/tests/test_image_pruner.py
+++ b/compute_space/src/compute_space/tests/test_image_pruner.py
@@ -1,21 +1,36 @@
-"""Tests for the periodic dangling-image pruner.
+"""Tests for the periodic image pruner.
 
-The pruner runs a daemon thread that periodically prunes only dangling images
-(``podman image prune`` without ``--all``).  These tests drive the pieces
-directly: the prune command shape, thread start/idempotency/disable, and that
-the loop swallows failures so a transient podman error can't kill it.
+Covers two behaviours:
+- The dangling-only prune (``podman image prune`` without ``--all``).
+- The orphaned tagged-image sweep: ``openhost-{name}:latest`` images whose app
+  is gone from the DB and which are older than the configured age threshold.
+
+Plus thread wiring (start/idempotency/disable) and that the loop swallows
+failures so a transient podman/DB error can't kill it.
 """
 
 from __future__ import annotations
 
+import json
+import sqlite3
 import subprocess
+from pathlib import Path
 from typing import Any
 
 import pytest
 
 import compute_space.core.image_pruner as image_pruner
+from compute_space.core.app_id import new_app_id
+from compute_space.core.containers import OpenHostImage
+from compute_space.core.containers import list_openhost_images
+from compute_space.core.containers import parse_openhost_image_app_name
 from compute_space.core.containers import prune_dangling_images
+from compute_space.db.connection import init_db
 from compute_space.tests.conftest import _make_test_config
+
+# --------------------------------------------------------------------------
+# Dangling-only prune
+# --------------------------------------------------------------------------
 
 
 def test_prune_dangling_images_omits_all_flag(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -47,13 +62,243 @@ def test_prune_dangling_images_raises_on_error(monkeypatch: pytest.MonkeyPatch) 
         prune_dangling_images()
 
 
-def test_run_prune_once_swallows_errors(monkeypatch: pytest.MonkeyPatch) -> None:
-    def boom() -> str:
+# --------------------------------------------------------------------------
+# Tag parsing
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "tag,expected",
+    [
+        ("openhost-notes:latest", "notes"),
+        ("localhost/openhost-notes:latest", "notes"),
+        ("openhost-my-cool-app:latest", "my-cool-app"),  # interior hyphens
+        ("localhost/openhost-a1:latest", "a1"),
+        # Non-OpenHost repos and shapes must not match.
+        ("docker.io/library/python:3.12", None),
+        ("openhost-notes:v2", None),  # only :latest is an OpenHost app tag
+        ("notopenhost-notes:latest", None),
+        ("python:latest", None),
+        ("<none>:<none>", None),
+    ],
+)
+def test_parse_openhost_image_app_name(tag: str, expected: str | None) -> None:
+    assert parse_openhost_image_app_name(tag) == expected
+
+
+# --------------------------------------------------------------------------
+# list_openhost_images
+# --------------------------------------------------------------------------
+
+
+def _fake_images_run(rows: list[dict[str, Any]], returncode: int = 0) -> Any:
+    def fake_run(cmd: list[str], **kwargs: Any) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(args=cmd, returncode=returncode, stdout=json.dumps(rows), stderr="")
+
+    return fake_run
+
+
+def test_list_openhost_images_filters_and_parses(monkeypatch: pytest.MonkeyPatch) -> None:
+    rows = [
+        {"Id": "id-notes", "Names": ["localhost/openhost-notes:latest"], "Created": 1000},
+        {"Id": "id-base", "Names": ["docker.io/library/python:3.12"], "Created": 900},  # not ours
+        {"Id": "id-blog", "Names": ["openhost-blog:latest"], "Created": 2000},
+        {"Id": "id-dangling", "Names": [], "Created": 500},  # dangling — skipped
+    ]
+    monkeypatch.setattr(subprocess, "run", _fake_images_run(rows))
+
+    images = list_openhost_images()
+
+    assert {(i.app_name, i.image_id, i.created_epoch) for i in images} == {
+        ("notes", "id-notes", 1000),
+        ("blog", "id-blog", 2000),
+    }
+
+
+def test_list_openhost_images_skips_rows_without_int_created(monkeypatch: pytest.MonkeyPatch) -> None:
+    rows = [
+        {"Id": "id-x", "Names": ["openhost-x:latest"], "Created": "2024-01-01"},  # str, not int
+        {"Id": "id-y", "Names": ["openhost-y:latest"]},  # no Created
+        {"Id": "id-z", "Names": ["openhost-z:latest"], "Created": 1234},
+    ]
+    monkeypatch.setattr(subprocess, "run", _fake_images_run(rows))
+
+    images = list_openhost_images()
+    assert [(i.app_name, i.created_epoch) for i in images] == [("z", 1234)]
+
+
+def test_list_openhost_images_falls_back_to_repotags(monkeypatch: pytest.MonkeyPatch) -> None:
+    rows = [{"Id": "id-r", "RepoTags": ["openhost-repo:latest"], "Created": 42}]
+    monkeypatch.setattr(subprocess, "run", _fake_images_run(rows))
+    images = list_openhost_images()
+    assert [(i.app_name, i.image_id) for i in images] == [("repo", "id-r")]
+
+
+def test_list_openhost_images_empty_on_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(subprocess, "run", _fake_images_run([], returncode=1))
+    assert list_openhost_images() == []
+
+
+def test_list_openhost_images_empty_on_bad_json(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fake_run(cmd: list[str], **kwargs: Any) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="not json", stderr="")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    assert list_openhost_images() == []
+
+
+# --------------------------------------------------------------------------
+# Orphaned-image sweep
+# --------------------------------------------------------------------------
+
+
+def _insert_app(db_path: str, name: str, status: str = "running") -> None:
+    db = sqlite3.connect(db_path)
+    try:
+        db.execute(
+            "INSERT INTO apps (app_id, name, version, repo_path, local_port, container_id, status, error_message) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            (new_app_id(), name, "1", f"/tmp/{name}", _free_port(db), None, status, None),
+        )
+        db.commit()
+    finally:
+        db.close()
+
+
+_PORT_COUNTER = [9100]
+
+
+def _free_port(_db: sqlite3.Connection) -> int:
+    _PORT_COUNTER[0] += 1
+    return _PORT_COUNTER[0]
+
+
+@pytest.fixture
+def cfg(tmp_path: Path) -> Any:
+    cfg = _make_test_config(tmp_path, image_orphan_max_age_seconds=7 * 24 * 3600)
+    init_db(cfg.db_path)
+    return cfg
+
+
+def test_sweep_removes_orphan_older_than_threshold(cfg: Any, monkeypatch: pytest.MonkeyPatch) -> None:
+    _insert_app(cfg.db_path, "liveapp")
+    now = 1_000_000.0
+    old = int(now - 8 * 24 * 3600)  # 8 days old — past the 7-day threshold
+    images = [
+        OpenHostImage(image_id="id-live", app_name="liveapp", created_epoch=old),  # kept: app exists
+        OpenHostImage(image_id="id-orphan", app_name="goneapp", created_epoch=old),  # removed
+    ]
+    removed: list[str] = []
+    monkeypatch.setattr(image_pruner, "list_openhost_images", lambda: images)
+    monkeypatch.setattr(image_pruner, "remove_image_by_id", lambda i: removed.append(i) or True)
+
+    result = image_pruner.sweep_orphaned_images(cfg, now)
+
+    assert result == ["id-orphan"]
+    assert removed == ["id-orphan"]
+
+
+def test_sweep_keeps_orphan_younger_than_threshold(cfg: Any, monkeypatch: pytest.MonkeyPatch) -> None:
+    now = 1_000_000.0
+    recent = int(now - 1 * 24 * 3600)  # 1 day old — within the age guard
+    images = [OpenHostImage(image_id="id-recent-orphan", app_name="goneapp", created_epoch=recent)]
+    removed: list[str] = []
+    monkeypatch.setattr(image_pruner, "list_openhost_images", lambda: images)
+    monkeypatch.setattr(image_pruner, "remove_image_by_id", lambda i: removed.append(i) or True)
+
+    # No app in DB, but the image is too new: must NOT be removed (protects
+    # mid-deploy images whose DB row hasn't committed yet).
+    result = image_pruner.sweep_orphaned_images(cfg, now)
+
+    assert result == []
+    assert removed == []
+
+
+def test_sweep_keeps_images_for_stopped_and_errored_apps(cfg: Any, monkeypatch: pytest.MonkeyPatch) -> None:
+    _insert_app(cfg.db_path, "stoppedapp", status="stopped")
+    _insert_app(cfg.db_path, "erroredapp", status="error")
+    now = 1_000_000.0
+    old = int(now - 30 * 24 * 3600)  # very old, but apps still exist
+    images = [
+        OpenHostImage(image_id="id-stopped", app_name="stoppedapp", created_epoch=old),
+        OpenHostImage(image_id="id-errored", app_name="erroredapp", created_epoch=old),
+    ]
+    removed: list[str] = []
+    monkeypatch.setattr(image_pruner, "list_openhost_images", lambda: images)
+    monkeypatch.setattr(image_pruner, "remove_image_by_id", lambda i: removed.append(i) or True)
+
+    result = image_pruner.sweep_orphaned_images(cfg, now)
+
+    # Images for apps in ANY status are kept, however old.
+    assert result == []
+    assert removed == []
+
+
+def test_sweep_disabled_when_max_age_zero(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    cfg = _make_test_config(tmp_path, image_orphan_max_age_seconds=0)
+    init_db(cfg.db_path)
+    called: list[bool] = []
+    monkeypatch.setattr(image_pruner, "list_openhost_images", lambda: called.append(True) or [])
+
+    result = image_pruner.sweep_orphaned_images(cfg, 1_000_000.0)
+
+    assert result == []
+    # Short-circuits before even listing images.
+    assert called == []
+
+
+def test_sweep_survives_db_error(cfg: Any, monkeypatch: pytest.MonkeyPatch) -> None:
+    def boom(_config: Any) -> set[str]:
+        raise sqlite3.OperationalError("db locked")
+
+    monkeypatch.setattr(image_pruner, "_current_app_names", boom)
+    # Should not raise, and should remove nothing when it can't read the DB.
+    assert image_pruner.sweep_orphaned_images(cfg, 1_000_000.0) == []
+
+
+def test_sweep_continues_after_a_failed_removal(cfg: Any, monkeypatch: pytest.MonkeyPatch) -> None:
+    now = 1_000_000.0
+    old = int(now - 10 * 24 * 3600)
+    images = [
+        OpenHostImage(image_id="id-fail", app_name="gone1", created_epoch=old),
+        OpenHostImage(image_id="id-ok", app_name="gone2", created_epoch=old),
+    ]
+    monkeypatch.setattr(image_pruner, "list_openhost_images", lambda: images)
+    # First removal fails, second succeeds.
+    monkeypatch.setattr(image_pruner, "remove_image_by_id", lambda i: i == "id-ok")
+
+    result = image_pruner.sweep_orphaned_images(cfg, now)
+
+    # Only the successful removal is reported; the failed one didn't abort the sweep.
+    assert result == ["id-ok"]
+
+
+# --------------------------------------------------------------------------
+# Loop / thread wiring
+# --------------------------------------------------------------------------
+
+
+def test_run_prune_once_swallows_prune_and_sweep_errors(cfg: Any, monkeypatch: pytest.MonkeyPatch) -> None:
+    def boom_prune() -> str:
         raise RuntimeError("podman broke")
 
-    monkeypatch.setattr(image_pruner, "prune_dangling_images", boom)
-    # Must not raise — the loop relies on this so one bad prune can't kill it.
-    image_pruner._run_prune_once()
+    def boom_sweep(_config: Any, _now: float) -> list[str]:
+        raise RuntimeError("sweep broke")
+
+    monkeypatch.setattr(image_pruner, "prune_dangling_images", boom_prune)
+    monkeypatch.setattr(image_pruner, "sweep_orphaned_images", boom_sweep)
+    # Must not raise — the loop relies on this so one bad cycle can't kill it.
+    image_pruner._run_prune_once(cfg)
+
+
+def test_run_prune_once_runs_both_prune_and_sweep(cfg: Any, monkeypatch: pytest.MonkeyPatch) -> None:
+    order: list[str] = []
+    monkeypatch.setattr(image_pruner, "prune_dangling_images", lambda: order.append("prune") or "")
+    monkeypatch.setattr(image_pruner, "sweep_orphaned_images", lambda c, n: order.append("sweep") or [])
+
+    image_pruner._run_prune_once(cfg)
+
+    assert order == ["prune", "sweep"]
 
 
 def test_start_image_pruner_noop_when_disabled(tmp_path: Any, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -97,15 +342,16 @@ def test_start_image_pruner_starts_and_is_idempotent(tmp_path: Any, monkeypatch:
 
     assert len(started) == 1
     assert started[0].daemon is True
-    assert started[0].args == (3600,)
+    # Thread receives (config, interval).
+    assert started[0].args == (config, 3600)
 
 
-def test_loop_sleeps_before_first_prune(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_loop_sleeps_before_first_prune(cfg: Any, monkeypatch: pytest.MonkeyPatch) -> None:
     # The loop must sleep the interval before its first prune (so a mid-build
     # deploy's intermediate layers aren't pruned during the startup rush), then
     # prune each cycle.  Stop it after two iterations via a sleep that raises.
     sleeps: list[int] = []
-    prunes: list[bool] = []
+    prunes: list[Any] = []
 
     class _Stop(Exception):
         pass
@@ -116,11 +362,11 @@ def test_loop_sleeps_before_first_prune(monkeypatch: pytest.MonkeyPatch) -> None
             raise _Stop
 
     monkeypatch.setattr(image_pruner.time, "sleep", fake_sleep)
-    monkeypatch.setattr(image_pruner, "_run_prune_once", lambda: prunes.append(True))
+    monkeypatch.setattr(image_pruner, "_run_prune_once", lambda c: prunes.append(c))
 
     with pytest.raises(_Stop):
-        image_pruner._image_pruner_loop(1800)
+        image_pruner._image_pruner_loop(cfg, 1800)
 
     # Slept before the first prune, and pruned once between the two sleeps.
     assert sleeps == [1800, 1800]
-    assert prunes == [True]
+    assert prunes == [cfg]

--- a/compute_space/src/compute_space/web/app.py
+++ b/compute_space/src/compute_space/web/app.py
@@ -24,6 +24,7 @@ from compute_space.config import provide_config
 from compute_space.core import archive_backend
 from compute_space.core.auth.auth import read_owner_username
 from compute_space.core.auth.identity import load_identity_keys
+from compute_space.core.image_pruner import start_image_pruner
 from compute_space.core.logging import logger
 from compute_space.core.startup import check_app_status
 from compute_space.core.startup import retry_pending_default_apps
@@ -117,6 +118,7 @@ def _full_app_bootstrap(config: Config) -> None:
     check_app_status(config)
     load_identity_keys(config.persistent_data_dir)
     start_storage_guard(config)
+    start_image_pruner(config)
     retry_pending_default_apps(config)
 
 


### PR DESCRIPTION
Every app rebuild re-tags openhost-{app}:latest and orphans the previous image, so untagged (dangling) image layers accumulate over time. Nothing prunes them automatically today: the /api/drop-docker-cache endpoint exists but runs only on explicit operator action, so on long-lived hosts these dangling images pile up and can fill the disk.

This adds a lightweight daemon thread that periodically prunes only dangling images, independent of disk pressure. It runs podman image prune --force (note: no --all), so tagged images for stopped apps are kept and nothing has to be rebuilt on next start. That is what makes an unconditional periodic prune safe.

Details:
- New core/image_pruner.py with the daemon thread, started once per instance from the app bootstrap, mirroring the existing storage guard (idempotent per db_path).
- New containers.prune_dangling_images() helper alongside the existing drop_docker_build_cache(); the difference is the omitted --all flag.
- Config field image_prune_interval_seconds (default 6h; 0 disables). The loop sleeps the interval before its first prune so a mid-build deploy's intermediate layers aren't pruned during the startup rush.
- Prune failures are logged and swallowed so a transient podman error can't kill the loop.

Testing:
- New unit tests for the prune command shape (asserts no --all), the raise-on-error path, the loop swallowing failures, thread start/idempotency/disable, and that the loop sleeps before the first prune. All pass.
- Full compute_space suite green except pre-existing environmental failures (integration and settings_host_prep) that also fail on clean main without the full runtime env.
- ruff check and format clean.
- Vet: opus API plus three agentic runs, all clean.

This is one of two disk-fill mitigation PRs. The other caps journald on-disk size. This PR does not change the storage guard's stop-apps behavior.