### PR TITLE
Propagate WebSocket close codes/reasons through the app proxy

### DIFF
--- a/compute_space/src/compute_space/tests/test_websocket_proxy.py
+++ b/compute_space/src/compute_space/tests/test_websocket_proxy.py
@@ -1,0 +1,122 @@
+import asyncio
+from typing import Any
+from typing import cast
+
+from litestar import WebSocket
+from litestar.datastructures import Headers
+from websockets.asyncio.server import ServerConnection
+from websockets.asyncio.server import serve
+
+from compute_space.core.updates import initialize_shutdown_event
+from compute_space.web.helpers.proxy import proxy_websocket_request
+
+
+def _init_shutdown_event() -> None:
+    """The proxy races its pumps against wait_for_shutdown(), which is an instant no-op unless the
+    app-startup event is wired — without this every proxied session tears down immediately."""
+    initialize_shutdown_event(asyncio.Event())
+
+
+class FakeClientWebSocket:
+    """Stand-in for the litestar client-side WebSocket: records what the proxy sends/closes."""
+
+    def __init__(self) -> None:
+        self.scope = {
+            "type": "websocket",
+            "raw_path": b"/ws",
+            "query_string": b"",
+        }
+        self.headers = Headers({})
+        self.accepted = False
+        self.received: list[bytes | str] = []
+        self.closed: tuple[int, str] | None = None
+        self._inbound: asyncio.Queue[dict[str, Any]] = asyncio.Queue()
+
+    async def accept(self, subprotocols: str | None = None) -> None:
+        self.accepted = True
+
+    async def receive(self) -> dict[str, Any]:
+        return await self._inbound.get()
+
+    def queue_disconnect(self, code: int) -> None:
+        self._inbound.put_nowait({"type": "websocket.disconnect", "code": code})
+
+    async def send_bytes(self, data: bytes) -> None:
+        self.received.append(data)
+
+    async def send_text(self, data: str) -> None:
+        self.received.append(data)
+
+    async def close(self, code: int = 1000, reason: str | None = None) -> None:
+        self.closed = (code, reason or "")
+
+
+def test_backend_close_code_and_reason_reach_client() -> None:
+    async def run() -> None:
+        _init_shutdown_event()
+
+        async def handler(ws: ServerConnection) -> None:
+            await ws.send(b"hello")
+            await ws.close(code=4404, reason="Document deleted")
+
+        async with serve(handler, "127.0.0.1", 0) as server:
+            port = server.sockets[0].getsockname()[1]
+            client = FakeClientWebSocket()
+            await proxy_websocket_request(cast(WebSocket[Any, Any, Any], client), port)
+            assert client.accepted
+            assert client.received == [b"hello"]
+            assert client.closed == (4404, "Document deleted")
+
+    asyncio.run(run())
+
+
+def test_backend_abnormal_close_maps_to_1011() -> None:
+    async def run() -> None:
+        _init_shutdown_event()
+
+        async def handler(ws: ServerConnection) -> None:
+            # Kill the TCP connection without a close frame -> abnormal closure (1006).
+            transport = ws.transport
+            assert transport is not None
+            transport.abort()
+
+        async with serve(handler, "127.0.0.1", 0) as server:
+            port = server.sockets[0].getsockname()[1]
+            client = FakeClientWebSocket()
+            await proxy_websocket_request(cast(WebSocket[Any, Any, Any], client), port)
+            assert client.closed is not None
+            assert client.closed[0] == 1011
+
+    asyncio.run(run())
+
+
+def test_client_close_code_reaches_backend() -> None:
+    async def run() -> None:
+        _init_shutdown_event()
+        backend_saw: list[int | None] = []
+        connected = asyncio.Event()
+        recorded = asyncio.Event()
+
+        async def handler(ws: ServerConnection) -> None:
+            connected.set()
+            await ws.wait_closed()
+            backend_saw.append(ws.close_code)
+            recorded.set()
+
+        async with serve(handler, "127.0.0.1", 0) as server:
+            port = server.sockets[0].getsockname()[1]
+            client = FakeClientWebSocket()
+
+            async def disconnect_after_connect() -> None:
+                await connected.wait()
+                client.queue_disconnect(code=4001)
+
+            await asyncio.gather(
+                proxy_websocket_request(cast(WebSocket[Any, Any, Any], client), port),
+                disconnect_after_connect(),
+            )
+            # The proxy can return before the backend handler observes the close.
+            await asyncio.wait_for(recorded.wait(), timeout=5)
+            assert backend_saw == [4001]
+
+    asyncio.run(run())

--- a/compute_space/src/compute_space/web/helpers/proxy.py
+++ b/compute_space/src/compute_space/web/helpers/proxy.py
@@ -9,6 +9,7 @@ import asyncio
 from collections.abc import AsyncIterator
 from collections.abc import Iterable
 from collections.abc import Set
+from contextlib import suppress
 from typing import Any
 from typing import cast
 
@@ -260,6 +261,10 @@ async def proxy_http_request(
         raise
 
 
+# Close codes reserved for reporting only (RFC 6455 §7.4.1) — never valid in a close frame we send.
+_UNSENDABLE_CLOSE_CODES = frozenset({1005, 1006, 1015})
+
+
 _WS_REQUEST_EXCLUDED_HEADERS = frozenset(
     {
         # per-hop headers (these get read as we receive the incoming request, and automatically set on the outgoing)
@@ -331,6 +336,11 @@ async def proxy_websocket_request(
                             "WebSocketReceiveEvent | WebSocketDisconnectEvent", await connection.receive()
                         )
                         if msg["type"] == "websocket.disconnect":
+                            # Mirror the client's close code to the backend; otherwise the
+                            # context-manager close reports a generic 1000.
+                            if msg["code"] not in _UNSENDABLE_CLOSE_CODES:
+                                with suppress(Exception):
+                                    await backend.close(code=msg["code"])
                             return
                         if msg["bytes"] is not None:
                             await backend.send(msg["bytes"])
@@ -357,6 +367,14 @@ async def proxy_websocket_request(
                 # Drain any stored exceptions so cancelled tasks don't trigger
                 # "Task exception was never retrieved" warnings at GC.
                 await asyncio.gather(*tasks, return_exceptions=True)
+
+            # If the backend closed the connection, mirror its close code/reason to the client.
+            # Returning with the client socket still open would make the ASGI server close it
+            # with a generic 1011, hiding application-level close codes from clients.
+            if backend.close_code is not None:
+                code = 1011 if backend.close_code in _UNSENDABLE_CLOSE_CODES else backend.close_code
+                with suppress(Exception):  # the client may already be gone
+                    await connection.close(code=code, reason=backend.close_reason or "")
     except (OSError, TimeoutError, WebSocketException):
         logger.exception(f"WebSocket backend connection failed: {target_url}")
         await connection.close(code=1011)


### PR DESCRIPTION
## Problem

When a backend app closes a proxied WebSocket, `proxy_websocket_request` returns with the client socket still open, so the ASGI server closes it with a generic **1011** — the app's close code and reason never reach the client. Verified in-browser: an app closing with `4404 "Document deleted"` shows up client-side as `1011 ""`.

This breaks protocols that put meaning in close codes. Concretely, md-notes wants to close editors' CRDT sockets with "document deleted" so remote clients stop auto-reconnecting (imbue-openhost/md-notes#52 currently works around this with an in-band message).

## Fix

In `proxy_websocket_request`:

- **backend → client**: after the pump tasks settle, if the backend closed the connection, mirror its `close_code`/`close_reason` to the client instead of returning with the socket open. The report-only codes 1005/1006/1015 (RFC 6455 §7.4.1) can't be sent on the wire and map to 1011, matching the existing error path.
- **client → backend**: mirror the client's disconnect code to the backend instead of always closing with the context manager's default 1000.

Behavior is unchanged when the backend never closed (shutdown-race teardown, connect failures).

## Tests

New `test_websocket_proxy.py` runs the proxy against a real `websockets` server with a fake Litestar client socket:

- backend close `4404 "Document deleted"` → client sees `4404 "Document deleted"`
- backend TCP abort (abnormal 1006) → client sees 1011
- client disconnect with 4001 → backend sees 4001

The tests wire up `initialize_shutdown_event` — without it `wait_for_shutdown()` is an instant no-op and the proxy tears down every session immediately, which only bites in test envs.

Full lightweight suite: 997 passed, 60 skipped. ruff/mypy clean (run manually; my local pixi predates the repo's lockfile v7, so the pixi-run pre-commit hooks regenerate pixi.lock and self-report as failed — no code issues).

🤖 Generated with [Claude Code](https://claude.com/claude-code)