### PR TITLE
Email: one-NS-record custom domain + mailbox relay-config endpoint

### DIFF
--- a/ansible/templates/config.toml.j2
+++ b/ansible/templates/config.toml.j2
@@ -52,4 +52,13 @@ email_inbound_mx_host = "{{ email_inbound_mx_host | default('inbound-smtp.us-wes
 {% if email_dmarc_rua is defined %}
 email_dmarc_rua = "{{ email_dmarc_rua }}"
 {% endif %}
+{% if email_smtp_relay_host is defined %}
+# SMTP smarthost the instance's mailbox server (Stalwart) relays outbound mail
+# through: the openhost-email-proxy's submission listener.  user is the zone,
+# password is the per-instance HMAC credential the provisioner derived.
+email_smtp_relay_host = "{{ email_smtp_relay_host }}"
+email_smtp_relay_port = {{ email_smtp_relay_port | default(587) }}
+email_smtp_relay_user = "{{ email_smtp_relay_user }}"
+email_smtp_relay_password = "{{ email_smtp_relay_password }}"
+{% endif %}
 {% endif %}

--- a/ansible/templates/config.toml.j2
+++ b/ansible/templates/config.toml.j2
@@ -37,3 +37,19 @@ cert_api_keycloak_issuer_url = "{{ cert_api_keycloak_issuer_url }}"
 cert_api_keycloak_client_id = "{{ cert_api_keycloak_client_id }}"
 cert_api_keycloak_client_secret = "{{ cert_api_keycloak_client_secret }}"
 {% endif %}
+{% if email_enabled is defined and email_enabled %}
+# Opt-in: publish email DNS records (SPF/DKIM/DMARC/MX) into this instance's
+# CoreDNS zone and relay outbound mail through the openhost-email-proxy.  Auth is
+# Keycloak client-credentials (the same per-instance confidential client used for
+# cert_api); client_secret is the only sensitive value.  The proxy creates the
+# SES domain identity and returns the DKIM records this instance publishes.
+email_enabled = true
+email_proxy_base_url = "{{ email_proxy_base_url }}"
+email_keycloak_issuer_url = "{{ email_keycloak_issuer_url }}"
+email_keycloak_client_id = "{{ email_keycloak_client_id }}"
+email_keycloak_client_secret = "{{ email_keycloak_client_secret }}"
+email_inbound_mx_host = "{{ email_inbound_mx_host | default('inbound-smtp.us-west-2.amazonaws.com') }}"
+{% if email_dmarc_rua is defined %}
+email_dmarc_rua = "{{ email_dmarc_rua }}"
+{% endif %}
+{% endif %}

--- a/ansible/templates/config.toml.j2
+++ b/ansible/templates/config.toml.j2
@@ -52,6 +52,12 @@ email_inbound_mx_host = "{{ email_inbound_mx_host | default('inbound-smtp.us-wes
 {% if email_dmarc_rua is defined %}
 email_dmarc_rua = "{{ email_dmarc_rua }}"
 {% endif %}
+{% if email_custom_domain is defined and email_custom_domain %}
+# Owner's custom mail domain, delegated to this instance's CoreDNS with a single
+# NS record (name -> ns.<zone>).  The instance serves it as a second authoritative
+# zone and publishes the same SPF/DKIM/DMARC/MX records into it.
+email_custom_domain = "{{ email_custom_domain }}"
+{% endif %}
 {% if email_smtp_relay_host is defined %}
 # SMTP smarthost the instance's mailbox server (Stalwart) relays outbound mail
 # through: the openhost-email-proxy's submission listener.  user is the zone,

--- a/compute_space/src/compute_space/config.py
+++ b/compute_space/src/compute_space/config.py
@@ -126,11 +126,16 @@ class Config:
     # SMTP smarthost the mailbox app (Stalwart) relays outbound through — the
     # email proxy's submission listener.  user is the zone; password is the
     # per-instance HMAC credential (the only sensitive value).  Surfaced to the
-    # mailbox app so it can configure its outbound relay.
+    # mailbox app on request via /api/email/relay-config (NOT injected into every
+    # app's environment) so the relay password stays scoped to the mailbox app.
     email_smtp_relay_host: str | None
     email_smtp_relay_port: int | None
     email_smtp_relay_user: str | None
     email_smtp_relay_password: str | None
+    # App name(s) allowed to fetch the SMTP relay config from
+    # /api/email/relay-config.  Only the mailbox app needs the relay password, so
+    # the endpoint is scoped to these names (defaults to the built-in mailbox app).
+    email_mailbox_app_names: list[str]
 
     ## coredns (only really needed if acquiring TLS certs via DNS-01, or if using NS dns records)
     coredns_enabled: bool
@@ -407,6 +412,7 @@ class DefaultConfig(Config):
     email_smtp_relay_port: int | None = None
     email_smtp_relay_user: str | None = None
     email_smtp_relay_password: str | None = None
+    email_mailbox_app_names: list[str] = attr.Factory(lambda: ["stalwart-email-server"])
 
     start_caddy: bool = True
 

--- a/compute_space/src/compute_space/config.py
+++ b/compute_space/src/compute_space/config.py
@@ -1,4 +1,5 @@
 import os
+import re
 import tomllib
 from pathlib import Path
 from typing import Any
@@ -20,6 +21,23 @@ CERT_PROVIDER_CERT_API = "cert_api"
 def _lowercase(s: str) -> str:
     # mypy can't handle str.lower apparently
     return s.lower()
+
+
+# A DNS label: 1-63 chars, alphanumeric plus internal hyphens.  A well-formed
+# domain is one or more such labels joined by single dots (no empty labels, so no
+# leading/trailing/double dots).  Deliberately conservative — used to reject a
+# malformed email_custom_domain at config load.
+_DOMAIN_LABEL_RE = re.compile(r"^(?!-)[a-z0-9-]{1,63}(?<!-)$")
+
+
+def _is_well_formed_domain(domain: str) -> bool:
+    domain = domain.strip().lower().rstrip(".")
+    if not domain or len(domain) > 253:
+        return False
+    labels = domain.split(".")
+    if len(labels) < 2:
+        return False
+    return all(_DOMAIN_LABEL_RE.match(label) for label in labels)
 
 
 @attr.s(auto_attribs=True, frozen=True)
@@ -80,6 +98,14 @@ class Config:
     email_inbound_mx_host: str | None
     # Optional DMARC aggregate-report address published in the _dmarc record.
     email_dmarc_rua: str | None
+    # Optional custom mail domain the owner delegated to this instance's CoreDNS
+    # with a single NS record (e.g. "mail.mydomain.com").  When set, the instance
+    # serves it as a second authoritative zone and publishes the same
+    # SPF/DKIM/DMARC/MX records into it, so the owner can send/receive as that
+    # domain in addition to the built-in <zone> subdomain.  The NS delegation to
+    # this instance is itself the proof of control; the SES identity's DKIM
+    # verification is the second proof.
+    email_custom_domain: str | None
     # SMTP smarthost the mailbox app (Stalwart) relays outbound through — the
     # email proxy's submission listener.  user is the zone; password is the
     # per-instance HMAC credential (the only sensitive value).  Surfaced to the
@@ -165,10 +191,37 @@ class Config:
             ):
                 if not getattr(self, name):
                     raise ValueError(f"{name} must be set in config when email_enabled is True")
+        # Validate the custom mail domain shape (if set) regardless of
+        # email_enabled, so a typo surfaces at config load rather than at the
+        # first boot that turns email on.
+        custom = self.email_custom_domain_normalized
+        if custom is not None:
+            if not _is_well_formed_domain(custom):
+                raise ValueError(f"email_custom_domain {self.email_custom_domain!r} is not a well-formed domain")
+            # The custom domain must be distinct from the built-in zone (which is
+            # already served); overlapping would double-declare the same names.
+            zone = self.zone_domain_no_port.strip().lower().rstrip(".")
+            if custom == zone or custom.endswith("." + zone) or zone.endswith("." + custom):
+                raise ValueError(
+                    f"email_custom_domain {custom!r} overlaps the instance zone {zone!r}; "
+                    "the built-in zone already handles that name"
+                )
 
     @property
     def zone_domain_no_port(self) -> str:
         return self.zone_domain.split(":")[0]
+
+    @property
+    def email_custom_domain_normalized(self) -> str | None:
+        """The custom mail domain lowercased and stripped of any trailing dot.
+
+        Returns None when no custom domain is configured (or it is blank after
+        normalization), so callers can treat "unset" and "blank" identically.
+        """
+        if not self.email_custom_domain:
+            return None
+        normalized = self.email_custom_domain.strip().lower().rstrip(".")
+        return normalized or None
 
     def evolve(self, **kwargs: Any) -> Self:
         return attr.evolve(self, **kwargs)
@@ -243,6 +296,29 @@ class Config:
         return self.openhost_data_path / "zonefile"
 
     @property
+    def coredns_custom_zonefile_path(self) -> Path:
+        """Zone file for the delegated custom mail domain (second authoritative zone)."""
+        return self.openhost_data_path / "zonefile.custom"
+
+    def custom_domain_delegation_record(self) -> dict[str, str] | None:
+        """The single NS record the owner must add at their registrar to delegate
+        their custom mail domain to this instance, or None if none is configured.
+
+        Returns a dict describing the record (name / type / value) so a UI or the
+        CLI can show the owner exactly what to paste. The nameserver host lives
+        under the instance's own zone (``ns.<zone>``), which already resolves to
+        the instance's public IP, so this one record is all that is required.
+        """
+        custom = self.email_custom_domain_normalized
+        if custom is None:
+            return None
+        return {
+            "name": custom,
+            "type": "NS",
+            "value": f"ns.{self.zone_domain_no_port}",
+        }
+
+    @property
     def caddyfile_path(self) -> Path:
         return self.openhost_data_path / "Caddyfile"
 
@@ -310,6 +386,7 @@ class DefaultConfig(Config):
     email_keycloak_client_secret: str | None = None
     email_inbound_mx_host: str | None = None
     email_dmarc_rua: str | None = None
+    email_custom_domain: str | None = None
     email_smtp_relay_host: str | None = None
     email_smtp_relay_port: int | None = None
     email_smtp_relay_user: str | None = None

--- a/compute_space/src/compute_space/config.py
+++ b/compute_space/src/compute_space/config.py
@@ -64,7 +64,10 @@ class Config:
     # __attrs_post_init__).  Provisioning injects these per instance, mirroring
     # the cert_api Keycloak fields.
     email_enabled: bool
-    # openhost-email-proxy base URL, e.g. "https://openhost-email-proxy.fly.dev".
+    # Base URL of the email API (the imbue-hosted-spaces frontend, the
+    # authenticated public door), e.g. "https://openhost.imbue.com".  The instance
+    # calls the frontend's /api/email/* endpoints; the frontend authenticates this
+    # instance and proxies to the private email backend over 6PN.
     email_proxy_base_url: str | None
     # Keycloak client-credentials for the email proxy.  Reuses the same per-instance
     # confidential client as cert_api when present, but kept as distinct fields so

--- a/compute_space/src/compute_space/config.py
+++ b/compute_space/src/compute_space/config.py
@@ -41,6 +41,23 @@ def _is_well_formed_domain(domain: str) -> bool:
 
 
 @attr.s(auto_attribs=True, frozen=True)
+class DelegationRecord:
+    """A single DNS record the owner must add at their registrar.
+
+    Used to tell the owner exactly what to paste to delegate a custom mail domain
+    to this instance (see Config.custom_domain_delegation_record).
+    """
+
+    name: str
+    record_type: str
+    value: str
+
+    def as_display_line(self) -> str:
+        """A registrar-style one-liner, e.g. 'mail.mydomain.com  NS  ns.<zone>'."""
+        return f"{self.name}   {self.record_type}   {self.value}"
+
+
+@attr.s(auto_attribs=True, frozen=True)
 class Config:
     ## Server
     # zone_domain is where the compute space is hosted, eg `host.example.com`
@@ -300,23 +317,22 @@ class Config:
         """Zone file for the delegated custom mail domain (second authoritative zone)."""
         return self.openhost_data_path / "zonefile.custom"
 
-    def custom_domain_delegation_record(self) -> dict[str, str] | None:
+    def custom_domain_delegation_record(self) -> DelegationRecord | None:
         """The single NS record the owner must add at their registrar to delegate
         their custom mail domain to this instance, or None if none is configured.
 
-        Returns a dict describing the record (name / type / value) so a UI or the
-        CLI can show the owner exactly what to paste. The nameserver host lives
-        under the instance's own zone (``ns.<zone>``), which already resolves to
-        the instance's public IP, so this one record is all that is required.
+        The nameserver host lives under the instance's own zone (``ns.<zone>``),
+        which already resolves to the instance's public IP, so this one record is
+        all that is required.
         """
         custom = self.email_custom_domain_normalized
         if custom is None:
             return None
-        return {
-            "name": custom,
-            "type": "NS",
-            "value": f"ns.{self.zone_domain_no_port}",
-        }
+        return DelegationRecord(
+            name=custom,
+            record_type="NS",
+            value=f"ns.{self.zone_domain_no_port}",
+        )
 
     @property
     def caddyfile_path(self) -> Path:

--- a/compute_space/src/compute_space/config.py
+++ b/compute_space/src/compute_space/config.py
@@ -80,6 +80,14 @@ class Config:
     email_inbound_mx_host: str | None
     # Optional DMARC aggregate-report address published in the _dmarc record.
     email_dmarc_rua: str | None
+    # SMTP smarthost the mailbox app (Stalwart) relays outbound through — the
+    # email proxy's submission listener.  user is the zone; password is the
+    # per-instance HMAC credential (the only sensitive value).  Surfaced to the
+    # mailbox app so it can configure its outbound relay.
+    email_smtp_relay_host: str | None
+    email_smtp_relay_port: int | None
+    email_smtp_relay_user: str | None
+    email_smtp_relay_password: str | None
 
     ## coredns (only really needed if acquiring TLS certs via DNS-01, or if using NS dns records)
     coredns_enabled: bool
@@ -302,6 +310,10 @@ class DefaultConfig(Config):
     email_keycloak_client_secret: str | None = None
     email_inbound_mx_host: str | None = None
     email_dmarc_rua: str | None = None
+    email_smtp_relay_host: str | None = None
+    email_smtp_relay_port: int | None = None
+    email_smtp_relay_user: str | None = None
+    email_smtp_relay_password: str | None = None
 
     start_caddy: bool = True
 

--- a/compute_space/src/compute_space/config.py
+++ b/compute_space/src/compute_space/config.py
@@ -57,6 +57,27 @@ class Config:
     #   per-instance client secret (the only sensitive value — treat like the ACME account key)
     cert_api_keycloak_client_secret: str | None
 
+    ## Email
+    # When True, the instance publishes email DNS records (SPF/DKIM/DMARC/MX) into
+    # its CoreDNS zone and can relay outbound mail through the email proxy.  All
+    # the email_* fields below must be set when this is True (validated in
+    # __attrs_post_init__).  Provisioning injects these per instance, mirroring
+    # the cert_api Keycloak fields.
+    email_enabled: bool
+    # openhost-email-proxy base URL, e.g. "https://openhost-email-proxy.fly.dev".
+    email_proxy_base_url: str | None
+    # Keycloak client-credentials for the email proxy.  Reuses the same per-instance
+    # confidential client as cert_api when present, but kept as distinct fields so
+    # email can be enabled independently.  Issuer is the openhost-customers realm.
+    email_keycloak_issuer_url: str | None
+    email_keycloak_client_id: str | None
+    email_keycloak_client_secret: str | None
+    # The SES-managed inbound MX host for the region, e.g.
+    # "inbound-smtp.us-west-2.amazonaws.com".
+    email_inbound_mx_host: str | None
+    # Optional DMARC aggregate-report address published in the _dmarc record.
+    email_dmarc_rua: str | None
+
     ## coredns (only really needed if acquiring TLS certs via DNS-01, or if using NS dns records)
     coredns_enabled: bool
     public_ip: str | None
@@ -113,6 +134,18 @@ class Config:
             ):
                 if not getattr(self, name):
                     raise ValueError(f"{name} must be set in config to use the cert_api provider")
+        if self.email_enabled:
+            # Enabling email requires the proxy URL, the per-instance Keycloak
+            # client-credentials, and the inbound MX host; none have a usable default.
+            for name in (
+                "email_proxy_base_url",
+                "email_keycloak_issuer_url",
+                "email_keycloak_client_id",
+                "email_keycloak_client_secret",
+                "email_inbound_mx_host",
+            ):
+                if not getattr(self, name):
+                    raise ValueError(f"{name} must be set in config when email_enabled is True")
 
     @property
     def zone_domain_no_port(self) -> str:
@@ -249,6 +282,15 @@ class DefaultConfig(Config):
     cert_api_keycloak_issuer_url: str | None = None
     cert_api_keycloak_client_id: str | None = None
     cert_api_keycloak_client_secret: str | None = None
+
+    # Email — disabled by default. All fields injected by provisioning when enabled.
+    email_enabled: bool = False
+    email_proxy_base_url: str | None = None
+    email_keycloak_issuer_url: str | None = None
+    email_keycloak_client_id: str | None = None
+    email_keycloak_client_secret: str | None = None
+    email_inbound_mx_host: str | None = None
+    email_dmarc_rua: str | None = None
 
     start_caddy: bool = True
 

--- a/compute_space/src/compute_space/core/dns.py
+++ b/compute_space/src/compute_space/core/dns.py
@@ -98,6 +98,8 @@ def start_coredns(
     zonefile_path: Path,
     container_gateway_ip: str | None = CONTAINER_GATEWAY_IP,
     coredns_bin: str = "coredns",
+    custom_zone_domain: str | None = None,
+    custom_zonefile_path: Path | None = None,
 ) -> subprocess.Popen[bytes]:
     """Write CoreDNS config + zone file, start CoreDNS, return the process.
 
@@ -107,9 +109,17 @@ def start_coredns(
     reach sibling apps' public HTTPS URLs through Caddy (NAT hairpin), with a
     catch-all forward for everything else.  Pass ``None`` to disable (e.g. in
     environments without the gateway interface).
+
+    When ``custom_zone_domain`` is set (the owner's delegated custom mail domain),
+    an additional authoritative zone is served for it from ``custom_zonefile_path``.
+    The email records for the custom zone are appended later by
+    ``apply_email_records`` (same as the primary zone), once the SES identity's
+    DKIM tokens are known.
     """
 
     bind_serial = int(time.time())
+    if custom_zone_domain and custom_zonefile_path is None:
+        raise ValueError("custom_zonefile_path is required when custom_zone_domain is set")
 
     # Only emit the container-facing view when the gateway IP is actually
     # bindable (the openhost0 dummy interface exists in production but not in
@@ -130,6 +140,8 @@ def start_coredns(
         container_gateway_ip=container_gateway_ip,
         container_zone_file_path=container_zonefile_path,
         upstream_dns=" ".join(_host_upstream_resolvers()),
+        custom_zone_domain=custom_zone_domain,
+        custom_zone_file_path=custom_zonefile_path,
     )
     with open(corefile_path, "w") as f:
         f.write(corefile)
@@ -152,6 +164,18 @@ def start_coredns(
         )
         with open(container_zonefile_path, "w") as f:
             f.write(container_content)
+
+    if custom_zone_domain:
+        assert custom_zonefile_path is not None  # guarded at entry
+        custom_content = _jinja_env.get_template("zonefile_custom").render(
+            custom_zone_domain=custom_zone_domain,
+            zone_domain=zone_domain,
+            public_ip=public_ip,
+            serial=bind_serial,
+        )
+        with open(custom_zonefile_path, "w") as f:
+            f.write(custom_content)
+        logger.info(f"Serving delegated custom mail domain {custom_zone_domain}")
 
     logger.info(f"Starting CoreDNS for {zone_domain}")
     proc = subprocess.Popen(

--- a/compute_space/src/compute_space/core/dns.py
+++ b/compute_space/src/compute_space/core/dns.py
@@ -198,6 +198,80 @@ class TxtRecord:
     record_value: str
 
 
+@attr.s(auto_attribs=True, frozen=True)
+class DkimCname:
+    """One DKIM CNAME record SES requires the zone to publish.
+
+    ``name`` and ``target`` are absolute (SES returns fully-qualified names), so
+    both are written as FQDNs (trailing dot) into the zone file.
+    """
+
+    name: str
+    target: str
+
+
+def render_email_records(
+    zone_domain: str,
+    *,
+    mail_from_host: str,
+    dkim_cnames: list[DkimCname],
+    dmarc_rua: str | None = None,
+) -> str:
+    """Render the persistent email DNS records for a zone as zone-file lines.
+
+    Produces SPF (apex TXT authorizing SES), a DMARC policy (_dmarc TXT), the MX
+    record (pointing at the SES-managed inbound host), and the DKIM CNAMEs SES
+    requires. These are deterministic given the inputs, so they can be re-applied
+    idempotently on every boot (the zone file is regenerated from template at
+    start_coredns time).
+    """
+    lines: list[str] = ["; --- openhost email records (managed) ---"]
+    # SPF: authorize Amazon SES to send for this domain.
+    lines.append('@   IN TXT  "v=spf1 include:amazonses.com ~all"')
+    # DMARC: a conservative default policy. rua is optional aggregate-report addr.
+    dmarc = "v=DMARC1; p=quarantine"
+    if dmarc_rua:
+        dmarc += f"; rua=mailto:{dmarc_rua}"
+    lines.append(f'_dmarc   IN TXT  "{dmarc}"')
+    # MX: inbound mail for the zone goes to the SES-managed inbound host.
+    lines.append(f"@   IN MX   10 {mail_from_host.rstrip('.')}.")
+    # DKIM: SES CNAMEs (absolute names).
+    for c in dkim_cnames:
+        lines.append(f"{c.name.rstrip('.')}.   IN CNAME  {c.target.rstrip('.')}.")
+    lines.append("; --- end openhost email records ---")
+    return "\n".join(lines) + "\n"
+
+
+def apply_email_records(
+    zone_file_path: Path,
+    zone_domain: str,
+    *,
+    mail_from_host: str,
+    dkim_cnames: list[DkimCname],
+    dmarc_rua: str | None = None,
+) -> None:
+    """Append the persistent email records to the zone file and bump the serial.
+
+    Intended to be called once after ``start_coredns`` on each boot, since the
+    zone file is regenerated from template there. Appending (rather than
+    templating) keeps the DKIM tokens — which are only known after the SES
+    identity is created at provision time — out of the boot-time template.
+    """
+    block = render_email_records(
+        zone_domain,
+        mail_from_host=mail_from_host,
+        dkim_cnames=dkim_cnames,
+        dmarc_rua=dmarc_rua,
+    )
+    with open(zone_file_path) as f:
+        content = f.read()
+    content = _bump_serial(content)
+    content = content.rstrip("\n") + "\n" + block
+    with open(zone_file_path, "w") as f:
+        f.write(content)
+    logger.info(f"Applied {len(dkim_cnames)} DKIM CNAME(s) + SPF/DMARC/MX to {zone_file_path}")
+
+
 def append_txt_records(zone_file_path: Path, records: list[TxtRecord]) -> None:
     """Append TXT record(s) to the zone file and bump the SOA serial.
 
@@ -216,12 +290,37 @@ def append_txt_records(zone_file_path: Path, records: list[TxtRecord]) -> None:
     logger.info(f"Appended {len(records)} TXT record(s)")
 
 
+# ACME DNS-01 challenge TXT records are always published at this owner name
+# (relative to the zone $ORIGIN, or as the absolute FQDN). clear_txt scopes its
+# removal to these so it never deletes persistent email TXT records (SPF at the
+# apex, DMARC at _dmarc) that share the "IN TXT" shape.
+_ACME_CHALLENGE_LABEL = "_acme-challenge"
+
+
+def _is_acme_challenge_txt(line: str) -> bool:
+    """True iff ``line`` is an ACME-challenge TXT record.
+
+    Matches the owner name this module writes challenges under, whether relative
+    (``_acme-challenge``) or absolute (``_acme-challenge.<zone>.``). Only lines
+    that are TXT records AND owned by that name are considered challenges.
+    """
+    if "IN TXT" not in line:
+        return False
+    owner = line.split(None, 1)[0] if line.split() else ""
+    return owner == _ACME_CHALLENGE_LABEL or owner.startswith(_ACME_CHALLENGE_LABEL + ".")
+
+
 def clear_txt(zone_file_path: Path) -> None:
-    """Remove all TXT records from the zone file and bump the SOA serial."""
+    """Remove ACME-challenge TXT records from the zone file and bump the SOA serial.
+
+    Only ``_acme-challenge`` TXT records are removed; persistent email records
+    (SPF at the apex, DMARC at ``_dmarc``, DKIM CNAMEs) are left intact so a cert
+    renewal never disturbs mail deliverability.
+    """
     with open(zone_file_path) as f:
         content = f.read()
-    lines = [line for line in content.splitlines() if "IN TXT" not in line]
+    lines = [line for line in content.splitlines() if not _is_acme_challenge_txt(line)]
     content = _bump_serial("\n".join(lines) + "\n")
     with open(zone_file_path, "w") as f:
         f.write(content)
-    logger.info(f"Cleared TXT records from {zone_file_path}")
+    logger.info(f"Cleared ACME-challenge TXT records from {zone_file_path}")

--- a/compute_space/src/compute_space/core/email/provision.py
+++ b/compute_space/src/compute_space/core/email/provision.py
@@ -1,0 +1,68 @@
+"""Provision the instance's email DNS records at startup.
+
+When email is enabled, this:
+  1. authenticates to the email proxy with the instance's Keycloak client,
+  2. asks the proxy to create/ensure the SES domain identity and return the
+     DKIM CNAME records SES requires,
+  3. writes those DKIM records plus SPF/DMARC/MX into the CoreDNS zone.
+
+Runs after start_coredns on each boot (the zone file is regenerated from
+template there, so the email records must be re-applied every time). Best-effort:
+a proxy or SES hiccup logs and returns rather than blocking router startup —
+mail is not load-bearing for the instance coming up.
+"""
+
+from __future__ import annotations
+
+from compute_space.config import Config
+from compute_space.core.dns import DkimCname
+from compute_space.core.dns import apply_email_records
+from compute_space.core.email.proxy_client import EmailProxyClient
+from compute_space.core.email.proxy_client import EmailProxyError
+from compute_space.core.logging import logger
+from compute_space.core.tls.keycloak import KeycloakClientCredentials
+from compute_space.core.tls.keycloak import KeycloakTokenProvider
+
+
+def provision_email_records(config: Config) -> None:
+    """Create the SES identity and publish email DNS records for this zone.
+
+    No-op when email is disabled. Validated config guarantees the email_* fields
+    are populated when email_enabled is True (Config.__attrs_post_init__).
+    """
+    if not config.email_enabled:
+        return
+    assert config.email_proxy_base_url is not None
+    assert config.email_keycloak_issuer_url is not None
+    assert config.email_keycloak_client_id is not None
+    assert config.email_keycloak_client_secret is not None
+    assert config.email_inbound_mx_host is not None
+
+    credentials = KeycloakClientCredentials(
+        issuer_url=config.email_keycloak_issuer_url,
+        client_id=config.email_keycloak_client_id,
+        client_secret=config.email_keycloak_client_secret,
+    )
+    try:
+        with KeycloakTokenProvider.create(credentials) as token_provider:
+            with EmailProxyClient.create(config.email_proxy_base_url, token_provider) as client:
+                result = client.ensure_identity()
+    except EmailProxyError as e:
+        logger.warning(f"Email provisioning skipped: could not reach email proxy: {e}")
+        return
+    except Exception as e:  # noqa: BLE001
+        logger.warning(f"Email provisioning skipped: {e}")
+        return
+
+    dkim_cnames = [DkimCname(name=r.name, target=r.value) for r in result.dkim_records]
+    apply_email_records(
+        config.coredns_zonefile_path,
+        config.zone_domain_no_port,
+        mail_from_host=config.email_inbound_mx_host,
+        dkim_cnames=dkim_cnames,
+        dmarc_rua=config.email_dmarc_rua,
+    )
+    logger.info(
+        f"Published email DNS records for {config.zone_domain_no_port} "
+        f"({len(dkim_cnames)} DKIM CNAME(s); identity verified={result.verified})"
+    )

--- a/compute_space/src/compute_space/core/email/provision.py
+++ b/compute_space/src/compute_space/core/email/provision.py
@@ -67,6 +67,14 @@ def provision_email_records(config: Config) -> None:
                 # Delegated custom mail domain (optional, one NS record).
                 custom_domain = config.email_custom_domain_normalized
                 if custom_domain is not None:
+                    delegation = config.custom_domain_delegation_record()
+                    if delegation is not None:
+                        logger.info(
+                            "Custom mail domain %s: ensure this single NS record is set at the "
+                            "registrar to delegate it to this instance:  %s",
+                            custom_domain,
+                            delegation.as_display_line(),
+                        )
                     _provision_zone(
                         config,
                         client,

--- a/compute_space/src/compute_space/core/email/provision.py
+++ b/compute_space/src/compute_space/core/email/provision.py
@@ -6,6 +6,11 @@ When email is enabled, this:
      DKIM CNAME records SES requires,
   3. writes those DKIM records plus SPF/DMARC/MX into the CoreDNS zone.
 
+This runs for the instance's built-in zone, and — when the owner has delegated a
+custom mail domain (email_custom_domain) to this instance with an NS record —
+also for that custom zone, so a single NS record is all it takes to send/receive
+as the custom domain.
+
 Runs after start_coredns on each boot (the zone file is regenerated from
 template there, so the email records must be re-applied every time). Best-effort:
 a proxy or SES hiccup logs and returns rather than blocking router startup —
@@ -13,6 +18,8 @@ mail is not load-bearing for the instance coming up.
 """
 
 from __future__ import annotations
+
+from pathlib import Path
 
 from compute_space.config import Config
 from compute_space.core.dns import DkimCname
@@ -25,10 +32,12 @@ from compute_space.core.tls.keycloak import KeycloakTokenProvider
 
 
 def provision_email_records(config: Config) -> None:
-    """Create the SES identity and publish email DNS records for this zone.
+    """Create the SES identity/identities and publish email DNS records.
 
-    No-op when email is disabled. Validated config guarantees the email_* fields
-    are populated when email_enabled is True (Config.__attrs_post_init__).
+    Provisions the instance's built-in zone, and the delegated custom mail domain
+    when one is configured. No-op when email is disabled. Validated config
+    guarantees the email_* fields are populated when email_enabled is True
+    (Config.__attrs_post_init__).
     """
     if not config.email_enabled:
         return
@@ -46,7 +55,25 @@ def provision_email_records(config: Config) -> None:
     try:
         with KeycloakTokenProvider.create(credentials) as token_provider:
             with EmailProxyClient.create(config.email_proxy_base_url, token_provider) as client:
-                result = client.ensure_identity()
+                # Built-in zone: the proxy defaults to the caller's zone when no
+                # domain is passed.
+                _provision_zone(
+                    config,
+                    client,
+                    domain=config.zone_domain_no_port,
+                    zone_file_path=config.coredns_zonefile_path,
+                    request_domain=None,
+                )
+                # Delegated custom mail domain (optional, one NS record).
+                custom_domain = config.email_custom_domain_normalized
+                if custom_domain is not None:
+                    _provision_zone(
+                        config,
+                        client,
+                        domain=custom_domain,
+                        zone_file_path=config.coredns_custom_zonefile_path,
+                        request_domain=custom_domain,
+                    )
     except EmailProxyError as e:
         logger.warning(f"Email provisioning skipped: could not reach email proxy: {e}")
         return
@@ -54,15 +81,31 @@ def provision_email_records(config: Config) -> None:
         logger.warning(f"Email provisioning skipped: {e}")
         return
 
+
+def _provision_zone(
+    config: Config,
+    client: EmailProxyClient,
+    *,
+    domain: str,
+    zone_file_path: Path,
+    request_domain: str | None,
+) -> None:
+    """Ensure the SES identity for ``domain`` and write its records into ``zone_file_path``.
+
+    ``request_domain`` is what we ask the proxy for: None means "the caller's own
+    zone" (the proxy scopes it), while a concrete value is the delegated custom
+    domain the proxy must be authorized to create an identity for.
+    """
+    result = client.ensure_identity(request_domain)
     dkim_cnames = [DkimCname(name=r.name, target=r.value) for r in result.dkim_records]
     apply_email_records(
-        config.coredns_zonefile_path,
-        config.zone_domain_no_port,
-        mail_from_host=config.email_inbound_mx_host,
+        zone_file_path,
+        domain,
+        mail_from_host=config.email_inbound_mx_host,  # type: ignore[arg-type]  # asserted non-None by caller
         dkim_cnames=dkim_cnames,
         dmarc_rua=config.email_dmarc_rua,
     )
     logger.info(
-        f"Published email DNS records for {config.zone_domain_no_port} "
+        f"Published email DNS records for {domain} "
         f"({len(dkim_cnames)} DKIM CNAME(s); identity verified={result.verified})"
     )

--- a/compute_space/src/compute_space/core/email/provision.py
+++ b/compute_space/src/compute_space/core/email/provision.py
@@ -70,10 +70,8 @@ def provision_email_records(config: Config) -> None:
                     delegation = config.custom_domain_delegation_record()
                     if delegation is not None:
                         logger.info(
-                            "Custom mail domain %s: ensure this single NS record is set at the "
-                            "registrar to delegate it to this instance:  %s",
-                            custom_domain,
-                            delegation.as_display_line(),
+                            f"Custom mail domain {custom_domain}: ensure this single NS record is set "
+                            f"at the registrar to delegate it to this instance:  {delegation.as_display_line()}"
                         )
                     _provision_zone(
                         config,

--- a/compute_space/src/compute_space/core/email/proxy_client.py
+++ b/compute_space/src/compute_space/core/email/proxy_client.py
@@ -40,9 +40,7 @@ class EmailProxyClient:
     http_client: httpx.Client
 
     @classmethod
-    def create(
-        cls, base_url: str, token_provider: TokenProvider, timeout: float = 30.0
-    ) -> EmailProxyClient:
+    def create(cls, base_url: str, token_provider: TokenProvider, timeout: float = 30.0) -> EmailProxyClient:
         return cls(
             base_url=base_url.rstrip("/"),
             token_provider=token_provider,
@@ -69,9 +67,7 @@ class EmailProxyClient:
         subdomain) and return its DKIM records + verification status."""
         body = {"domain": domain} if domain else {}
         try:
-            resp = self.http_client.post(
-                f"{self.base_url}/v1/identity", json=body, headers=self._auth_headers()
-            )
+            resp = self.http_client.post(f"{self.base_url}/v1/identity", json=body, headers=self._auth_headers())
         except httpx.HTTPError as e:
             raise EmailProxyError(f"email proxy unreachable: {e}") from e
         return _parse_identity(resp)
@@ -79,9 +75,7 @@ class EmailProxyClient:
     def identity_status(self, domain: str | None = None) -> IdentityResult:
         params = {"domain": domain} if domain else {}
         try:
-            resp = self.http_client.get(
-                f"{self.base_url}/v1/identity", params=params, headers=self._auth_headers()
-            )
+            resp = self.http_client.get(f"{self.base_url}/v1/identity", params=params, headers=self._auth_headers())
         except httpx.HTTPError as e:
             raise EmailProxyError(f"email proxy unreachable: {e}") from e
         return _parse_identity(resp)
@@ -91,9 +85,7 @@ def _parse_identity(resp: httpx.Response) -> IdentityResult:
     if resp.status_code != 200:
         raise EmailProxyError(f"email proxy returned HTTP {resp.status_code}: {resp.text}")
     body = resp.json()
-    records = tuple(
-        DkimRecord(name=r["name"], value=r["value"]) for r in body.get("dkim_records", [])
-    )
+    records = tuple(DkimRecord(name=r["name"], value=r["value"]) for r in body.get("dkim_records", []))
     return IdentityResult(
         domain=body["domain"],
         verified=bool(body.get("verified")),

--- a/compute_space/src/compute_space/core/email/proxy_client.py
+++ b/compute_space/src/compute_space/core/email/proxy_client.py
@@ -1,8 +1,11 @@
-"""HTTP client for the openhost-email-proxy.
+"""HTTP client for the email API.
 
-Mirrors the cert_api client shape: a small httpx wrapper that presents a
-Keycloak bearer (fetched via the shared KeycloakTokenProvider) and calls the
-proxy's identity endpoint. The instance uses this at startup to create its SES
+The instance calls the imbue-hosted-spaces frontend (the authenticated public
+door), NOT the private email backend directly — the backend is only reachable
+over Fly's 6PN network. The frontend validates this instance's Keycloak token,
+derives its zone, and proxies to the private backend. This client presents a
+Keycloak bearer (via the shared KeycloakTokenProvider) and calls the frontend's
+``/api/email/*`` endpoints; the instance uses it at startup to create its SES
 domain identity and learn the DKIM CNAME records to publish in CoreDNS.
 """
 
@@ -67,23 +70,27 @@ class EmailProxyClient:
         subdomain) and return its DKIM records + verification status."""
         body = {"domain": domain} if domain else {}
         try:
-            resp = self.http_client.post(f"{self.base_url}/v1/identity", json=body, headers=self._auth_headers())
+            resp = self.http_client.post(
+                f"{self.base_url}/api/email/identity", json=body, headers=self._auth_headers()
+            )
         except httpx.HTTPError as e:
-            raise EmailProxyError(f"email proxy unreachable: {e}") from e
+            raise EmailProxyError(f"email API unreachable: {e}") from e
         return _parse_identity(resp)
 
     def identity_status(self, domain: str | None = None) -> IdentityResult:
         params = {"domain": domain} if domain else {}
         try:
-            resp = self.http_client.get(f"{self.base_url}/v1/identity", params=params, headers=self._auth_headers())
+            resp = self.http_client.get(
+                f"{self.base_url}/api/email/identity", params=params, headers=self._auth_headers()
+            )
         except httpx.HTTPError as e:
-            raise EmailProxyError(f"email proxy unreachable: {e}") from e
+            raise EmailProxyError(f"email API unreachable: {e}") from e
         return _parse_identity(resp)
 
 
 def _parse_identity(resp: httpx.Response) -> IdentityResult:
     if resp.status_code != 200:
-        raise EmailProxyError(f"email proxy returned HTTP {resp.status_code}: {resp.text}")
+        raise EmailProxyError(f"email API returned HTTP {resp.status_code}: {resp.text}")
     body = resp.json()
     records = tuple(DkimRecord(name=r["name"], value=r["value"]) for r in body.get("dkim_records", []))
     return IdentityResult(

--- a/compute_space/src/compute_space/core/email/proxy_client.py
+++ b/compute_space/src/compute_space/core/email/proxy_client.py
@@ -1,0 +1,101 @@
+"""HTTP client for the openhost-email-proxy.
+
+Mirrors the cert_api client shape: a small httpx wrapper that presents a
+Keycloak bearer (fetched via the shared KeycloakTokenProvider) and calls the
+proxy's identity endpoint. The instance uses this at startup to create its SES
+domain identity and learn the DKIM CNAME records to publish in CoreDNS.
+"""
+
+from __future__ import annotations
+
+from types import TracebackType
+
+import attr
+import httpx
+
+from compute_space.core.tls.keycloak import TokenProvider
+
+
+@attr.s(auto_attribs=True, frozen=True)
+class DkimRecord:
+    name: str
+    value: str
+
+
+@attr.s(auto_attribs=True, frozen=True)
+class IdentityResult:
+    domain: str
+    verified: bool
+    dkim_records: tuple[DkimRecord, ...]
+
+
+class EmailProxyError(RuntimeError):
+    """The email proxy returned an error or was unreachable."""
+
+
+@attr.s(auto_attribs=True)
+class EmailProxyClient:
+    base_url: str
+    token_provider: TokenProvider
+    http_client: httpx.Client
+
+    @classmethod
+    def create(
+        cls, base_url: str, token_provider: TokenProvider, timeout: float = 30.0
+    ) -> EmailProxyClient:
+        return cls(
+            base_url=base_url.rstrip("/"),
+            token_provider=token_provider,
+            http_client=httpx.Client(timeout=timeout),
+        )
+
+    def __enter__(self) -> EmailProxyClient:
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
+    ) -> None:
+        self.http_client.close()
+
+    def _auth_headers(self) -> dict[str, str]:
+        # Fetch fresh per call so the token refreshes transparently.
+        return {"Authorization": f"Bearer {self.token_provider.get_token()}"}
+
+    def ensure_identity(self, domain: str | None = None) -> IdentityResult:
+        """Create the SES domain identity for the instance's zone (or a delegated
+        subdomain) and return its DKIM records + verification status."""
+        body = {"domain": domain} if domain else {}
+        try:
+            resp = self.http_client.post(
+                f"{self.base_url}/v1/identity", json=body, headers=self._auth_headers()
+            )
+        except httpx.HTTPError as e:
+            raise EmailProxyError(f"email proxy unreachable: {e}") from e
+        return _parse_identity(resp)
+
+    def identity_status(self, domain: str | None = None) -> IdentityResult:
+        params = {"domain": domain} if domain else {}
+        try:
+            resp = self.http_client.get(
+                f"{self.base_url}/v1/identity", params=params, headers=self._auth_headers()
+            )
+        except httpx.HTTPError as e:
+            raise EmailProxyError(f"email proxy unreachable: {e}") from e
+        return _parse_identity(resp)
+
+
+def _parse_identity(resp: httpx.Response) -> IdentityResult:
+    if resp.status_code != 200:
+        raise EmailProxyError(f"email proxy returned HTTP {resp.status_code}: {resp.text}")
+    body = resp.json()
+    records = tuple(
+        DkimRecord(name=r["name"], value=r["value"]) for r in body.get("dkim_records", [])
+    )
+    return IdentityResult(
+        domain=body["domain"],
+        verified=bool(body.get("verified")),
+        dkim_records=records,
+    )

--- a/compute_space/src/compute_space/core/templates/Corefile
+++ b/compute_space/src/compute_space/core/templates/Corefile
@@ -6,6 +6,19 @@
     log
     errors
 }
+{% if custom_zone_domain %}
+# Delegated custom mail domain (e.g. mail.mydomain.com).  Served as a second
+# authoritative zone so the owner can use their own domain for email after
+# delegating it to this instance's CoreDNS with a single NS record.
+{{ custom_zone_domain }}:53 {
+    bind {{ bind_ip }}
+    file {{ custom_zone_file_path }} {
+        reload 2s
+    }
+    log
+    errors
+}
+{% endif %}
 {% if container_gateway_ip %}
 # Container-facing view.  Pasta app containers point their resolver here (see
 # core/containers.py --dns).  It answers the zone wildcard with the gateway IP

--- a/compute_space/src/compute_space/core/templates/zonefile_custom
+++ b/compute_space/src/compute_space/core/templates/zonefile_custom
@@ -1,0 +1,16 @@
+$ORIGIN {{ custom_zone_domain }}.
+$TTL 60
+@   IN SOA  ns.{{ zone_domain }}. admin.{{ custom_zone_domain }}. (
+    {{ serial }}   ; serial
+    3600  ; refresh
+    600   ; retry
+    86400 ; expire
+    60    ; minimum
+)
+; This instance is the authoritative nameserver for the delegated custom zone.
+; The NS host lives under the instance's primary zone (ns.{{ zone_domain }}),
+; which resolves to the instance's public IP, so the single NS record the owner
+; adds at their registrar is all that is needed for delegation.
+@   IN NS   ns.{{ zone_domain }}.
+@   IN A    {{ public_ip }}
+*   IN A    {{ public_ip }}

--- a/compute_space/src/compute_space/tests/test_dns.py
+++ b/compute_space/src/compute_space/tests/test_dns.py
@@ -95,7 +95,7 @@ def test_append_txt_records_writes_absolute_fqdn_names_verbatim(tmp_path: Path) 
     assert "app.example.com.app.example.com" not in content
 
 
-def test_clear_txt_removes_records(tmp_path: Path) -> None:
+def test_clear_txt_removes_acme_records(tmp_path: Path) -> None:
     zonefile = tmp_path / "zonefile"
     _write_zonefile(zonefile)
     append_txt_records(zonefile, [TxtRecord(record_name="_acme-challenge.app.example.com.", record_value="v")])
@@ -103,6 +103,60 @@ def test_clear_txt_removes_records(tmp_path: Path) -> None:
     clear_txt(zonefile)
 
     assert "IN TXT" not in zonefile.read_text()
+
+
+def test_clear_txt_preserves_email_txt_records(tmp_path: Path) -> None:
+    # clear_txt runs on every cert renewal; it must remove ACME challenges but
+    # NOT the persistent SPF/DMARC TXT records, or mail would break on renewal.
+    from compute_space.core.dns import DkimCname
+    from compute_space.core.dns import apply_email_records
+
+    zonefile = tmp_path / "zonefile"
+    _write_zonefile(zonefile)
+    apply_email_records(
+        zonefile,
+        "app.example.com",
+        mail_from_host="inbound-smtp.us-west-2.amazonaws.com",
+        dkim_cnames=[DkimCname(name="tok1._domainkey.app.example.com", target="tok1.dkim.amazonses.com")],
+        dmarc_rua="dmarc@app.example.com",
+    )
+    append_txt_records(zonefile, [TxtRecord(record_name="_acme-challenge", record_value="challenge")])
+
+    clear_txt(zonefile)
+
+    content = zonefile.read_text()
+    # ACME challenge gone...
+    assert "challenge" not in content
+    # ...but SPF, DMARC, MX, DKIM survive.
+    assert "v=spf1 include:amazonses.com" in content
+    assert "v=DMARC1" in content
+    assert "IN MX" in content
+    assert "tok1._domainkey.app.example.com.   IN CNAME  tok1.dkim.amazonses.com." in content
+
+
+def test_apply_email_records_bumps_serial_and_is_appendable(tmp_path: Path) -> None:
+    from compute_space.core.dns import DkimCname
+    from compute_space.core.dns import apply_email_records
+
+    zonefile = tmp_path / "zonefile"
+    _write_zonefile(zonefile, serial=100)
+    apply_email_records(
+        zonefile,
+        "app.example.com",
+        mail_from_host="inbound-smtp.us-west-2.amazonaws.com",
+        dkim_cnames=[
+            DkimCname(name="a._domainkey.app.example.com", target="a.dkim.amazonses.com"),
+            DkimCname(name="b._domainkey.app.example.com", target="b.dkim.amazonses.com"),
+        ],
+    )
+    content = zonefile.read_text()
+    assert "101   ; serial" in content
+    assert '@   IN TXT  "v=spf1 include:amazonses.com ~all"' in content
+    assert "@   IN MX   10 inbound-smtp.us-west-2.amazonaws.com." in content
+    assert "a._domainkey.app.example.com.   IN CNAME  a.dkim.amazonses.com." in content
+    assert "b._domainkey.app.example.com.   IN CNAME  b.dkim.amazonses.com." in content
+    # Default DMARC has no rua when none provided.
+    assert '_dmarc   IN TXT  "v=DMARC1; p=quarantine"' in content
 
 
 class _FakeProc:

--- a/compute_space/src/compute_space/tests/test_dns.py
+++ b/compute_space/src/compute_space/tests/test_dns.py
@@ -210,6 +210,66 @@ def test_container_dns_view_skipped_when_gateway_not_bindable(tmp_path: Path, mo
     assert not (tmp_path / "zonefile.container").exists()
 
 
+def test_custom_zone_served_as_second_authoritative_zone(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    # When a delegated custom mail domain is configured, CoreDNS serves it as a
+    # second authoritative zone with its own zone file (SOA/NS/A -> instance IP).
+    monkeypatch.setattr(dns_mod, "_coredns_bind_ip", lambda ip: "10.0.0.5")
+    _stub_popen(monkeypatch)
+
+    corefile = tmp_path / "Corefile"
+    zonefile = tmp_path / "zonefile"
+    custom_zonefile = tmp_path / "zonefile.custom"
+    dns_mod.start_coredns(
+        "app.example.com",
+        "203.0.113.10",
+        corefile,
+        zonefile,
+        container_gateway_ip=None,
+        custom_zone_domain="mail.mydomain.com",
+        custom_zonefile_path=custom_zonefile,
+    )
+
+    cf = corefile.read_text()
+    # Both zones are declared as authoritative server blocks, bound to the same IP.
+    assert "app.example.com:53 {" in cf
+    assert "mail.mydomain.com:53 {" in cf
+
+    assert custom_zonefile.exists()
+    cz = custom_zonefile.read_text()
+    assert "$ORIGIN mail.mydomain.com." in cz
+    # NS host lives under the instance's own zone (so one NS record delegates it).
+    assert "@   IN NS   ns.app.example.com." in cz
+    # A/wildcard point at the instance public IP.
+    assert "@   IN A    203.0.113.10" in cz
+    assert "*   IN A    203.0.113.10" in cz
+
+
+def test_custom_zone_not_served_when_unset(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(dns_mod, "_coredns_bind_ip", lambda ip: "10.0.0.5")
+    _stub_popen(monkeypatch)
+
+    corefile = tmp_path / "Corefile"
+    dns_mod.start_coredns(
+        "app.example.com", "203.0.113.10", corefile, tmp_path / "zonefile", container_gateway_ip=None
+    )
+
+    assert "mail.mydomain.com" not in corefile.read_text()
+    assert not (tmp_path / "zonefile.custom").exists()
+
+
+def test_custom_zone_requires_zonefile_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    _stub_popen(monkeypatch)
+    with pytest.raises(ValueError, match="custom_zonefile_path is required"):
+        dns_mod.start_coredns(
+            "app.example.com",
+            "203.0.113.10",
+            tmp_path / "Corefile",
+            tmp_path / "zonefile",
+            container_gateway_ip=None,
+            custom_zone_domain="mail.mydomain.com",
+        )
+
+
 def test_host_upstream_resolvers_filters_loopback_and_gateway(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     resolv = tmp_path / "resolv.conf"
     resolv.write_text(

--- a/compute_space/src/compute_space/tests/test_dns.py
+++ b/compute_space/src/compute_space/tests/test_dns.py
@@ -6,8 +6,10 @@ from pathlib import Path
 import pytest
 
 import compute_space.core.dns as dns_mod
+from compute_space.core.dns import DkimCname
 from compute_space.core.dns import TxtRecord
 from compute_space.core.dns import append_txt_records
+from compute_space.core.dns import apply_email_records
 from compute_space.core.dns import clear_txt
 
 
@@ -108,9 +110,6 @@ def test_clear_txt_removes_acme_records(tmp_path: Path) -> None:
 def test_clear_txt_preserves_email_txt_records(tmp_path: Path) -> None:
     # clear_txt runs on every cert renewal; it must remove ACME challenges but
     # NOT the persistent SPF/DMARC TXT records, or mail would break on renewal.
-    from compute_space.core.dns import DkimCname
-    from compute_space.core.dns import apply_email_records
-
     zonefile = tmp_path / "zonefile"
     _write_zonefile(zonefile)
     apply_email_records(
@@ -135,9 +134,6 @@ def test_clear_txt_preserves_email_txt_records(tmp_path: Path) -> None:
 
 
 def test_apply_email_records_bumps_serial_and_is_appendable(tmp_path: Path) -> None:
-    from compute_space.core.dns import DkimCname
-    from compute_space.core.dns import apply_email_records
-
     zonefile = tmp_path / "zonefile"
     _write_zonefile(zonefile, serial=100)
     apply_email_records(

--- a/compute_space/src/compute_space/tests/test_email_config.py
+++ b/compute_space/src/compute_space/tests/test_email_config.py
@@ -13,6 +13,7 @@ import pytest
 import typed_settings
 
 from compute_space.config import DefaultConfig
+from compute_space.web.routes.api.system import custom_email_domain
 
 
 def _full_email_kwargs() -> dict[str, object]:
@@ -109,7 +110,11 @@ def test_custom_domain_blank_treated_as_unset() -> None:
 def test_custom_domain_delegation_record() -> None:
     cfg = DefaultConfig(zone_domain="alice.selfhost.imbue.com:8443").evolve(email_custom_domain="mail.mydomain.com")
     rec = cfg.custom_domain_delegation_record()
-    assert rec == {"name": "mail.mydomain.com", "type": "NS", "value": "ns.alice.selfhost.imbue.com"}
+    assert rec is not None
+    assert rec.name == "mail.mydomain.com"
+    assert rec.record_type == "NS"
+    assert rec.value == "ns.alice.selfhost.imbue.com"
+    assert rec.as_display_line() == "mail.mydomain.com   NS   ns.alice.selfhost.imbue.com"
 
 
 def test_custom_domain_rejects_malformed() -> None:
@@ -138,3 +143,25 @@ def test_custom_domain_round_trips_through_toml() -> None:
         email_custom_domain="mail.mydomain.com",
     )
     assert 'email_custom_domain = "mail.mydomain.com"' in cfg.to_toml_str()
+
+
+def test_custom_email_domain_route_returns_record_when_set() -> None:
+    # The owner-facing route surfaces the exact NS record to paste at the registrar.
+
+    cfg = DefaultConfig(zone_domain="alice.selfhost.imbue.com").evolve(email_custom_domain="mail.mydomain.com")
+    resp = custom_email_domain.fn(cfg)  # type: ignore[attr-defined]
+    assert resp.configured is True
+    assert resp.domain == "mail.mydomain.com"
+    assert resp.record_name == "mail.mydomain.com"
+    assert resp.record_type == "NS"
+    assert resp.record_value == "ns.alice.selfhost.imbue.com"
+    assert resp.display_line == "mail.mydomain.com   NS   ns.alice.selfhost.imbue.com"
+
+
+def test_custom_email_domain_route_reports_unconfigured() -> None:
+
+    cfg = DefaultConfig(zone_domain="alice.selfhost.imbue.com")  # no custom domain
+    resp = custom_email_domain.fn(cfg)  # type: ignore[attr-defined]
+    assert resp.configured is False
+    assert resp.domain is None
+    assert resp.display_line is None

--- a/compute_space/src/compute_space/tests/test_email_config.py
+++ b/compute_space/src/compute_space/tests/test_email_config.py
@@ -87,3 +87,54 @@ def test_email_smtp_relay_fields_round_trip() -> None:
     assert "email_smtp_relay_port = 587" in rendered
     assert 'email_smtp_relay_user = "x.example.com"' in rendered
     assert 'email_smtp_relay_password = "hmac-pw"' in rendered
+
+
+def test_custom_domain_none_by_default() -> None:
+    cfg = DefaultConfig(zone_domain="x.example.com")
+    assert cfg.email_custom_domain is None
+    assert cfg.email_custom_domain_normalized is None
+    assert cfg.custom_domain_delegation_record() is None
+
+
+def test_custom_domain_normalized_lowercases_and_strips_dot() -> None:
+    cfg = DefaultConfig(zone_domain="x.example.com").evolve(email_custom_domain="Mail.MyDomain.Com.")
+    assert cfg.email_custom_domain_normalized == "mail.mydomain.com"
+
+
+def test_custom_domain_blank_treated_as_unset() -> None:
+    cfg = DefaultConfig(zone_domain="x.example.com").evolve(email_custom_domain="   ")
+    assert cfg.email_custom_domain_normalized is None
+
+
+def test_custom_domain_delegation_record() -> None:
+    cfg = DefaultConfig(zone_domain="alice.selfhost.imbue.com:8443").evolve(email_custom_domain="mail.mydomain.com")
+    rec = cfg.custom_domain_delegation_record()
+    assert rec == {"name": "mail.mydomain.com", "type": "NS", "value": "ns.alice.selfhost.imbue.com"}
+
+
+def test_custom_domain_rejects_malformed() -> None:
+    with pytest.raises(ValueError, match="not a well-formed domain"):
+        DefaultConfig(zone_domain="x.example.com").evolve(email_custom_domain="not a domain")
+
+
+def test_custom_domain_rejects_overlap_with_zone() -> None:
+    # The built-in zone already handles its own name and subdomains; a custom
+    # domain that overlaps would double-declare records.
+    with pytest.raises(ValueError, match="overlaps the instance zone"):
+        DefaultConfig(zone_domain="alice.example.com").evolve(email_custom_domain="mail.alice.example.com")
+    with pytest.raises(ValueError, match="overlaps the instance zone"):
+        DefaultConfig(zone_domain="alice.example.com").evolve(email_custom_domain="alice.example.com")
+
+
+def test_custom_domain_validated_even_when_email_disabled() -> None:
+    # A typo should surface at config load, not silently wait until email is on.
+    with pytest.raises(ValueError, match="not a well-formed domain"):
+        DefaultConfig(zone_domain="x.example.com").evolve(email_custom_domain="bad_domain!")
+
+
+def test_custom_domain_round_trips_through_toml() -> None:
+    cfg = DefaultConfig(zone_domain="x.example.com").evolve(
+        **_full_email_kwargs(),
+        email_custom_domain="mail.mydomain.com",
+    )
+    assert 'email_custom_domain = "mail.mydomain.com"' in cfg.to_toml_str()

--- a/compute_space/src/compute_space/tests/test_email_config.py
+++ b/compute_space/src/compute_space/tests/test_email_config.py
@@ -72,3 +72,18 @@ def test_email_config_round_trips_through_toml() -> None:
     assert 'email_proxy_base_url = "https://openhost-email-proxy.fly.dev"' in rendered
     assert 'email_keycloak_client_id = "instance-alice"' in rendered
     assert 'email_inbound_mx_host = "inbound-smtp.us-west-2.amazonaws.com"' in rendered
+
+
+def test_email_smtp_relay_fields_round_trip() -> None:
+    cfg = DefaultConfig(zone_domain="x.example.com").evolve(
+        **_full_email_kwargs(),
+        email_smtp_relay_host="openhost-email-proxy.internal",
+        email_smtp_relay_port=587,
+        email_smtp_relay_user="x.example.com",
+        email_smtp_relay_password="hmac-pw",
+    )
+    rendered = cfg.to_toml_str()
+    assert 'email_smtp_relay_host = "openhost-email-proxy.internal"' in rendered
+    assert "email_smtp_relay_port = 587" in rendered
+    assert 'email_smtp_relay_user = "x.example.com"' in rendered
+    assert 'email_smtp_relay_password = "hmac-pw"' in rendered

--- a/compute_space/src/compute_space/tests/test_email_config.py
+++ b/compute_space/src/compute_space/tests/test_email_config.py
@@ -1,0 +1,74 @@
+"""Config tests for the additive, opt-in email feature.
+
+Email is disabled by default; enabling it requires the proxy URL, per-instance
+Keycloak client-credentials, and the inbound MX host. Old configs (written
+before these fields existed) must keep loading unchanged.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import typed_settings
+
+from compute_space.config import DefaultConfig
+
+
+def _full_email_kwargs() -> dict[str, object]:
+    return dict(
+        email_enabled=True,
+        email_proxy_base_url="https://openhost-email-proxy.fly.dev",
+        email_keycloak_issuer_url="https://keycloak.example.com/realms/openhost-customers",
+        email_keycloak_client_id="instance-alice",
+        email_keycloak_client_secret="s3cr3t",
+        email_inbound_mx_host="inbound-smtp.us-west-2.amazonaws.com",
+    )
+
+
+def test_email_disabled_by_default() -> None:
+    cfg = DefaultConfig(zone_domain="x.example.com")
+    assert cfg.email_enabled is False
+    assert cfg.email_proxy_base_url is None
+    assert cfg.email_keycloak_client_secret is None
+    assert cfg.email_inbound_mx_host is None
+
+
+def test_email_enabled_requires_all_fields() -> None:
+    cfg = DefaultConfig(zone_domain="x.example.com")
+    with pytest.raises(ValueError, match="email_proxy_base_url must be set"):
+        cfg.evolve(email_enabled=True)
+    # Missing just the MX host still fails.
+    partial = {k: v for k, v in _full_email_kwargs().items() if k != "email_inbound_mx_host"}
+    with pytest.raises(ValueError, match="email_inbound_mx_host must be set"):
+        cfg.evolve(**partial)
+
+
+def test_email_enabled_with_all_fields_ok() -> None:
+    cfg = DefaultConfig(zone_domain="x.example.com").evolve(**_full_email_kwargs())
+    assert cfg.email_enabled is True
+    assert cfg.email_inbound_mx_host == "inbound-smtp.us-west-2.amazonaws.com"
+
+
+def test_legacy_config_without_email_fields_still_loads(tmp_path: Path) -> None:
+    # A config exactly as ansible wrote it before the email feature existed.
+    config_path = tmp_path / "config.toml"
+    config_path.write_text(
+        "[openhost]\n"
+        'zone_domain = "legacy.example.com"\n'
+        "tls_enabled = true\n"
+        "acquire_tls_cert_if_missing = true\n"
+        'acme_account_key_path = "/secrets/certbot_private_key.json"\n'
+        "coredns_enabled = true\n"
+    )
+    cfg = typed_settings.load(DefaultConfig, appname="openhost", config_files=[str(config_path)])
+    assert cfg.email_enabled is False
+
+
+def test_email_config_round_trips_through_toml() -> None:
+    cfg = DefaultConfig(zone_domain="x.example.com").evolve(**_full_email_kwargs())
+    rendered = cfg.to_toml_str()
+    assert "email_enabled = true" in rendered
+    assert 'email_proxy_base_url = "https://openhost-email-proxy.fly.dev"' in rendered
+    assert 'email_keycloak_client_id = "instance-alice"' in rendered
+    assert 'email_inbound_mx_host = "inbound-smtp.us-west-2.amazonaws.com"' in rendered

--- a/compute_space/src/compute_space/tests/test_email_config.py
+++ b/compute_space/src/compute_space/tests/test_email_config.py
@@ -11,7 +11,9 @@ from pathlib import Path
 
 import pytest
 import typed_settings
+from litestar.exceptions import NotAuthorizedException
 
+import compute_space.web.routes.api.system as sys_mod
 from compute_space.config import DefaultConfig
 from compute_space.web.routes.api.system import custom_email_domain
 
@@ -159,9 +161,60 @@ def test_custom_email_domain_route_returns_record_when_set() -> None:
 
 
 def test_custom_email_domain_route_reports_unconfigured() -> None:
-
     cfg = DefaultConfig(zone_domain="alice.selfhost.imbue.com")  # no custom domain
     resp = custom_email_domain.fn(cfg)  # type: ignore[attr-defined]
     assert resp.configured is False
     assert resp.domain is None
     assert resp.display_line is None
+
+
+def test_mailbox_app_names_default() -> None:
+    cfg = DefaultConfig(zone_domain="alice.selfhost.imbue.com")
+    assert cfg.email_mailbox_app_names == ["stalwart-email-server"]
+
+
+class _FakeDB:
+    def __init__(self, app_name: str | None) -> None:
+        self._app_name = app_name
+
+    def execute(self, *_args: object) -> _FakeDB:
+        return self
+
+    def fetchone(self) -> dict[str, str] | None:
+        return {"name": self._app_name} if self._app_name is not None else None
+
+
+def test_relay_config_rejects_non_mailbox_app(monkeypatch) -> None:
+
+    monkeypatch.setattr(sys_mod, "verify_app_auth", lambda request: "app-123")
+    cfg = DefaultConfig(zone_domain="alice.selfhost.imbue.com").evolve(**_full_email_kwargs())
+    # A different app (not in email_mailbox_app_names) must be refused.
+    with pytest.raises(NotAuthorizedException):
+        sys_mod.email_relay_config.fn(object(), _FakeDB("some-other-app"), cfg)  # type: ignore[attr-defined]
+
+
+def test_relay_config_returns_creds_to_mailbox_app(monkeypatch) -> None:
+    monkeypatch.setattr(sys_mod, "verify_app_auth", lambda request: "app-mail")
+    cfg = DefaultConfig(zone_domain="alice.selfhost.imbue.com").evolve(
+        **_full_email_kwargs(),
+        email_smtp_relay_host="openhost-email-proxy.internal",
+        email_smtp_relay_port=587,
+        email_smtp_relay_user="alice.selfhost.imbue.com",
+        email_smtp_relay_password="hmac-pw",
+        email_custom_domain="mail.mydomain.com",
+    )
+    resp = sys_mod.email_relay_config.fn(object(), _FakeDB("stalwart-email-server"), cfg)  # type: ignore[attr-defined]
+    body = resp.content
+    assert body.configured is True
+    assert body.smtp_relay_host == "openhost-email-proxy.internal"
+    assert body.smtp_relay_password == "hmac-pw"
+    assert body.zone_domain == "alice.selfhost.imbue.com"
+    assert body.custom_domain == "mail.mydomain.com"
+
+
+def test_relay_config_reports_unconfigured_when_email_off(monkeypatch) -> None:
+    monkeypatch.setattr(sys_mod, "verify_app_auth", lambda request: "app-mail")
+    cfg = DefaultConfig(zone_domain="alice.selfhost.imbue.com")  # email disabled
+    resp = sys_mod.email_relay_config.fn(object(), _FakeDB("stalwart-email-server"), cfg)  # type: ignore[attr-defined]
+    assert resp.content.configured is False
+    assert resp.content.smtp_relay_password is None

--- a/compute_space/src/compute_space/tests/test_email_provision.py
+++ b/compute_space/src/compute_space/tests/test_email_provision.py
@@ -128,6 +128,81 @@ def test_provision_email_records_writes_zone(tmp_path: Path, monkeypatch: pytest
     assert "tok._domainkey.alice.example.com.   IN CNAME  tok.dkim.amazonses.com." in content
 
 
+def test_provision_email_records_provisions_custom_domain(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    # With a delegated custom mail domain configured, both the built-in zone and
+    # the custom zone get an SES identity + published records, and the proxy is
+    # asked specifically for the custom domain (request_domain != None).
+    zonefile = tmp_path / "zonefile"
+    custom_zonefile = tmp_path / "zonefile.custom"
+    _write_zonefile(zonefile)
+    custom_zonefile.write_text(
+        "$ORIGIN mail.mydomain.com.\n"
+        "$TTL 60\n"
+        "@   IN SOA  ns.alice.example.com. admin.mail.mydomain.com. (\n"
+        "    100   ; serial\n"
+        "    3600  ; refresh\n"
+        "    600   ; retry\n"
+        "    86400 ; expire\n"
+        "    60    ; minimum\n"
+        ")\n"
+        "@   IN NS   ns.alice.example.com.\n"
+        "@   IN A    203.0.113.10\n"
+    )
+
+    cfg = DefaultConfig(zone_domain="alice.example.com").evolve(
+        email_enabled=True,
+        email_proxy_base_url="https://proxy.test",
+        email_keycloak_issuer_url="https://kc.test/realms/openhost-customers",
+        email_keycloak_client_id="instance-alice",
+        email_keycloak_client_secret="s3cr3t",
+        email_inbound_mx_host="inbound-smtp.us-west-2.amazonaws.com",
+        email_custom_domain="mail.mydomain.com",
+    )
+    monkeypatch.setattr(type(cfg), "coredns_zonefile_path", property(lambda self: zonefile))
+    monkeypatch.setattr(type(cfg), "coredns_custom_zonefile_path", property(lambda self: custom_zonefile))
+
+    requested: list[str | None] = []
+
+    class _FakeClient:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return None
+
+        def ensure_identity(self, domain=None):
+            requested.append(domain)
+            target = domain or "alice.example.com"
+            return IdentityResult(
+                domain=target,
+                verified=False,
+                dkim_records=(DkimRecord(name=f"tok._domainkey.{target}", value="tok.dkim.amazonses.com"),),
+            )
+
+    class _FakeTokenProvider:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return None
+
+    monkeypatch.setattr(prov.KeycloakTokenProvider, "create", classmethod(lambda cls, creds: _FakeTokenProvider()))
+    monkeypatch.setattr(prov.EmailProxyClient, "create", classmethod(lambda cls, url, tp: _FakeClient()))
+
+    provision_email_records(cfg)
+
+    # Built-in zone asked for with no explicit domain; custom zone asked for by name.
+    assert requested == [None, "mail.mydomain.com"]
+
+    # Built-in zone got its records.
+    assert "tok._domainkey.alice.example.com.   IN CNAME  tok.dkim.amazonses.com." in zonefile.read_text()
+    # Custom zone got its own records (SPF/DMARC/MX/DKIM under the custom origin).
+    custom_content = custom_zonefile.read_text()
+    assert "v=spf1 include:amazonses.com" in custom_content
+    assert "@   IN MX   10 inbound-smtp.us-west-2.amazonaws.com." in custom_content
+    assert "tok._domainkey.mail.mydomain.com.   IN CNAME  tok.dkim.amazonses.com." in custom_content
+
+
 def test_provision_email_records_noop_when_disabled(tmp_path: Path):
     zonefile = tmp_path / "zonefile"
     _write_zonefile(zonefile)

--- a/compute_space/src/compute_space/tests/test_email_provision.py
+++ b/compute_space/src/compute_space/tests/test_email_provision.py
@@ -1,0 +1,181 @@
+"""Tests for email provisioning: proxy client parsing + zone-record publishing."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import httpx
+import pytest
+
+from compute_space.config import DefaultConfig
+from compute_space.core.email.provision import provision_email_records
+from compute_space.core.email.proxy_client import EmailProxyClient
+from compute_space.core.email.proxy_client import EmailProxyError
+from compute_space.core.tls.keycloak import StaticTokenProvider
+
+
+def _write_zonefile(path: Path, serial: int = 100) -> None:
+    path.write_text(
+        "$ORIGIN alice.example.com.\n"
+        "$TTL 60\n"
+        "@   IN SOA  ns.alice.example.com. admin.alice.example.com. (\n"
+        f"    {serial}   ; serial\n"
+        "    3600  ; refresh\n"
+        "    600   ; retry\n"
+        "    86400 ; expire\n"
+        "    60    ; minimum\n"
+        ")\n"
+        "@   IN NS   ns.alice.example.com.\n"
+        "@   IN A    127.0.0.1\n"
+    )
+
+
+def _client_with_handler(handler) -> EmailProxyClient:
+    transport = httpx.MockTransport(handler)
+    return EmailProxyClient(
+        base_url="https://proxy.test",
+        token_provider=StaticTokenProvider(token="test-token"),
+        http_client=httpx.Client(transport=transport),
+    )
+
+
+def test_proxy_client_parses_identity_and_sends_bearer():
+    seen = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen["auth"] = request.headers.get("Authorization")
+        seen["path"] = request.url.path
+        return httpx.Response(
+            200,
+            json={
+                "domain": "alice.example.com",
+                "verified": False,
+                "dkim_records": [
+                    {"name": "a._domainkey.alice.example.com", "value": "a.dkim.amazonses.com"},
+                    {"name": "b._domainkey.alice.example.com", "value": "b.dkim.amazonses.com"},
+                ],
+            },
+        )
+
+    client = _client_with_handler(handler)
+    result = client.ensure_identity()
+    assert seen["auth"] == "Bearer test-token"
+    assert seen["path"] == "/v1/identity"
+    assert result.domain == "alice.example.com"
+    assert len(result.dkim_records) == 2
+    assert result.dkim_records[0].name == "a._domainkey.alice.example.com"
+
+
+def test_proxy_client_raises_on_error_status():
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(502, text="upstream boom")
+
+    client = _client_with_handler(handler)
+    with pytest.raises(EmailProxyError, match="HTTP 502"):
+        client.ensure_identity()
+
+
+def test_provision_email_records_writes_zone(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    zonefile = tmp_path / "zonefile"
+    _write_zonefile(zonefile)
+
+    cfg = DefaultConfig(zone_domain="alice.example.com").evolve(
+        email_enabled=True,
+        email_proxy_base_url="https://proxy.test",
+        email_keycloak_issuer_url="https://kc.test/realms/openhost-customers",
+        email_keycloak_client_id="instance-alice",
+        email_keycloak_client_secret="s3cr3t",
+        email_inbound_mx_host="inbound-smtp.us-west-2.amazonaws.com",
+    )
+    # Point the config's zonefile path at our temp file.
+    monkeypatch.setattr(
+        type(cfg), "coredns_zonefile_path", property(lambda self: zonefile)
+    )
+
+    # Stub the proxy client construction to return a fake identity.
+    import compute_space.core.email.provision as prov
+
+    class _FakeClient:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return None
+
+        def ensure_identity(self, domain=None):
+            from compute_space.core.email.proxy_client import DkimRecord, IdentityResult
+
+            return IdentityResult(
+                domain="alice.example.com",
+                verified=False,
+                dkim_records=(DkimRecord(name="tok._domainkey.alice.example.com", value="tok.dkim.amazonses.com"),),
+            )
+
+    class _FakeTokenProvider:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return None
+
+    monkeypatch.setattr(prov.KeycloakTokenProvider, "create", classmethod(lambda cls, creds: _FakeTokenProvider()))
+    monkeypatch.setattr(prov.EmailProxyClient, "create", classmethod(lambda cls, url, tp: _FakeClient()))
+
+    provision_email_records(cfg)
+
+    content = zonefile.read_text()
+    assert "v=spf1 include:amazonses.com" in content
+    assert "v=DMARC1" in content
+    assert "@   IN MX   10 inbound-smtp.us-west-2.amazonaws.com." in content
+    assert "tok._domainkey.alice.example.com.   IN CNAME  tok.dkim.amazonses.com." in content
+
+
+def test_provision_email_records_noop_when_disabled(tmp_path: Path):
+    zonefile = tmp_path / "zonefile"
+    _write_zonefile(zonefile)
+    before = zonefile.read_text()
+    cfg = DefaultConfig(zone_domain="alice.example.com")  # email disabled
+    provision_email_records(cfg)
+    assert zonefile.read_text() == before
+
+
+def test_provision_email_records_survives_proxy_outage(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    zonefile = tmp_path / "zonefile"
+    _write_zonefile(zonefile)
+    before = zonefile.read_text()
+
+    cfg = DefaultConfig(zone_domain="alice.example.com").evolve(
+        email_enabled=True,
+        email_proxy_base_url="https://proxy.test",
+        email_keycloak_issuer_url="https://kc.test/realms/openhost-customers",
+        email_keycloak_client_id="instance-alice",
+        email_keycloak_client_secret="s3cr3t",
+        email_inbound_mx_host="inbound-smtp.us-west-2.amazonaws.com",
+    )
+    monkeypatch.setattr(type(cfg), "coredns_zonefile_path", property(lambda self: zonefile))
+
+    import compute_space.core.email.provision as prov
+
+    class _FakeTokenProvider:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return None
+
+    class _FailingClient:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return None
+
+        def ensure_identity(self, domain=None):
+            raise EmailProxyError("proxy down")
+
+    monkeypatch.setattr(prov.KeycloakTokenProvider, "create", classmethod(lambda cls, creds: _FakeTokenProvider()))
+    monkeypatch.setattr(prov.EmailProxyClient, "create", classmethod(lambda cls, url, tp: _FailingClient()))
+
+    # Must not raise, and must not modify the zone (fail-open).
+    provision_email_records(cfg)
+    assert zonefile.read_text() == before

--- a/compute_space/src/compute_space/tests/test_email_provision.py
+++ b/compute_space/src/compute_space/tests/test_email_provision.py
@@ -63,7 +63,7 @@ def test_proxy_client_parses_identity_and_sends_bearer():
     client = _client_with_handler(handler)
     result = client.ensure_identity()
     assert seen["auth"] == "Bearer test-token"
-    assert seen["path"] == "/v1/identity"
+    assert seen["path"] == "/api/email/identity"
     assert result.domain == "alice.example.com"
     assert len(result.dkim_records) == 2
     assert result.dkim_records[0].name == "a._domainkey.alice.example.com"

--- a/compute_space/src/compute_space/tests/test_email_provision.py
+++ b/compute_space/src/compute_space/tests/test_email_provision.py
@@ -7,10 +7,13 @@ from pathlib import Path
 import httpx
 import pytest
 
+import compute_space.core.email.provision as prov
 from compute_space.config import DefaultConfig
 from compute_space.core.email.provision import provision_email_records
+from compute_space.core.email.proxy_client import DkimRecord
 from compute_space.core.email.proxy_client import EmailProxyClient
 from compute_space.core.email.proxy_client import EmailProxyError
+from compute_space.core.email.proxy_client import IdentityResult
 from compute_space.core.tls.keycloak import StaticTokenProvider
 
 
@@ -88,12 +91,9 @@ def test_provision_email_records_writes_zone(tmp_path: Path, monkeypatch: pytest
         email_inbound_mx_host="inbound-smtp.us-west-2.amazonaws.com",
     )
     # Point the config's zonefile path at our temp file.
-    monkeypatch.setattr(
-        type(cfg), "coredns_zonefile_path", property(lambda self: zonefile)
-    )
+    monkeypatch.setattr(type(cfg), "coredns_zonefile_path", property(lambda self: zonefile))
 
     # Stub the proxy client construction to return a fake identity.
-    import compute_space.core.email.provision as prov
 
     class _FakeClient:
         def __enter__(self):
@@ -103,8 +103,6 @@ def test_provision_email_records_writes_zone(tmp_path: Path, monkeypatch: pytest
             return None
 
         def ensure_identity(self, domain=None):
-            from compute_space.core.email.proxy_client import DkimRecord, IdentityResult
-
             return IdentityResult(
                 domain="alice.example.com",
                 verified=False,
@@ -153,8 +151,6 @@ def test_provision_email_records_survives_proxy_outage(tmp_path: Path, monkeypat
         email_inbound_mx_host="inbound-smtp.us-west-2.amazonaws.com",
     )
     monkeypatch.setattr(type(cfg), "coredns_zonefile_path", property(lambda self: zonefile))
-
-    import compute_space.core.email.provision as prov
 
     class _FakeTokenProvider:
         def __enter__(self):

--- a/compute_space/src/compute_space/web/routes/api/system.py
+++ b/compute_space/src/compute_space/web/routes/api/system.py
@@ -116,6 +116,22 @@ class DropCacheOk:
 
 
 @attr.s(auto_attribs=True, frozen=True)
+class CustomEmailDomainResponse:
+    """Owner-facing view of the custom mail domain and the single NS record to add.
+
+    ``configured`` is False when no custom mail domain is set on this instance, in
+    which case the record fields are None.
+    """
+
+    configured: bool
+    domain: str | None
+    record_name: str | None
+    record_type: str | None
+    record_value: str | None
+    display_line: str | None
+
+
+@attr.s(auto_attribs=True, frozen=True)
 class VersionInfo:
     """Git info for the running openhost checkout. ``branch`` is None when HEAD is detached.
     ``sha`` is empty when the install isn't a git checkout (e.g. tarball deploys)."""
@@ -336,6 +352,34 @@ async def api_diagnostics(
     return Response(content=diagnostics, status_code=200, media_type=MediaType.JSON, headers=headers)
 
 
+@get("/api/email/custom-domain", guards=[require_owner_auth], sync_to_thread=False)
+def custom_email_domain(config: Config) -> CustomEmailDomainResponse:
+    """Return the owner's custom mail domain and the single NS record to delegate it.
+
+    The owner sets this once at their registrar; the instance's nameserver host
+    (ns.<zone>) already resolves to the instance IP, so this one record is all
+    that is required for the custom domain to work.
+    """
+    record = config.custom_domain_delegation_record()
+    if record is None:
+        return CustomEmailDomainResponse(
+            configured=False,
+            domain=None,
+            record_name=None,
+            record_type=None,
+            record_value=None,
+            display_line=None,
+        )
+    return CustomEmailDomainResponse(
+        configured=True,
+        domain=config.email_custom_domain_normalized,
+        record_name=record.name,
+        record_type=record.record_type,
+        record_value=record.value,
+        display_line=record.as_display_line(),
+    )
+
+
 @post("/restart_router", status_code=200, guards=[require_owner_auth], sync_to_thread=False)
 def restart_router() -> OkResponse:
     """Restart the router systemd service to pick up code changes."""
@@ -368,6 +412,7 @@ system_routes = Router(
         drop_docker_cache,
         api_version,
         api_diagnostics,
+        custom_email_domain,
         restart_router,
     ],
 )

--- a/compute_space/src/compute_space/web/routes/api/system.py
+++ b/compute_space/src/compute_space/web/routes/api/system.py
@@ -6,14 +6,17 @@ import subprocess
 from datetime import UTC
 from datetime import datetime
 from datetime import timedelta
+from typing import Any
 
 import attr
 from litestar import MediaType
+from litestar import Request
 from litestar import Response
 from litestar import Router
 from litestar import delete
 from litestar import get
 from litestar import post
+from litestar.exceptions import NotAuthorizedException
 
 from compute_space import OPENHOST_PROJECT_DIR
 from compute_space.config import Config
@@ -32,7 +35,9 @@ from compute_space.core.storage import is_guard_paused
 from compute_space.core.storage import set_guard_paused
 from compute_space.core.storage import storage_status
 from compute_space.core.updates import is_shutdown_pending
+from compute_space.web.auth.auth import require_app_auth
 from compute_space.web.auth.auth import require_owner_auth
+from compute_space.web.auth.auth import verify_app_auth
 
 DEFAULT_TOKEN_EXPIRY_HOURS: float = 8.0
 
@@ -113,6 +118,24 @@ class SshStatusResponse:
 class DropCacheOk:
     ok: bool  # always True
     output: str
+
+
+@attr.s(auto_attribs=True, frozen=True)
+class EmailRelayConfigResponse:
+    """SMTP smarthost relay config the mailbox app uses to send outbound mail.
+
+    Returned only to the mailbox app (scoped by app name); the relay password is a
+    per-instance secret and is deliberately NOT injected into every app's env.
+    ``configured`` is False when email/relay isn't set up on this instance.
+    """
+
+    configured: bool
+    smtp_relay_host: str | None
+    smtp_relay_port: int | None
+    smtp_relay_user: str | None
+    smtp_relay_password: str | None
+    zone_domain: str | None
+    custom_domain: str | None
 
 
 @attr.s(auto_attribs=True, frozen=True)
@@ -352,6 +375,49 @@ async def api_diagnostics(
     return Response(content=diagnostics, status_code=200, media_type=MediaType.JSON, headers=headers)
 
 
+@get("/api/email/relay-config", guards=[require_app_auth], sync_to_thread=False)
+def email_relay_config(
+    request: Request[Any, Any, Any], db: sqlite3.Connection, config: Config
+) -> Response[EmailRelayConfigResponse]:
+    """Return the SMTP smarthost relay config for the mailbox app.
+
+    Scoped: the request must be authenticated as an app (OPENHOST_APP_TOKEN), and
+    that app must be one of ``config.email_mailbox_app_names``. This keeps the
+    per-instance relay password out of every other app's environment — only the
+    mailbox app can fetch it, and only over the loopback router URL.
+    """
+    app_id = verify_app_auth(request)
+    row = db.execute("SELECT name FROM apps WHERE app_id = ?", (app_id,)).fetchone()
+    app_name = row["name"] if row is not None else None
+    if app_name not in config.email_mailbox_app_names:
+        raise NotAuthorizedException(detail="app is not authorized to fetch email relay config")
+    if not config.email_enabled or not config.email_smtp_relay_host:
+        return Response(
+            content=EmailRelayConfigResponse(
+                configured=False,
+                smtp_relay_host=None,
+                smtp_relay_port=None,
+                smtp_relay_user=None,
+                smtp_relay_password=None,
+                zone_domain=None,
+                custom_domain=None,
+            ),
+            media_type=MediaType.JSON,
+        )
+    return Response(
+        content=EmailRelayConfigResponse(
+            configured=True,
+            smtp_relay_host=config.email_smtp_relay_host,
+            smtp_relay_port=config.email_smtp_relay_port,
+            smtp_relay_user=config.email_smtp_relay_user,
+            smtp_relay_password=config.email_smtp_relay_password,
+            zone_domain=config.zone_domain_no_port,
+            custom_domain=config.email_custom_domain_normalized,
+        ),
+        media_type=MediaType.JSON,
+    )
+
+
 @get("/api/email/custom-domain", guards=[require_owner_auth], sync_to_thread=False)
 def custom_email_domain(config: Config) -> CustomEmailDomainResponse:
     """Return the owner's custom mail domain and the single NS record to delegate it.
@@ -412,6 +478,7 @@ system_routes = Router(
         drop_docker_cache,
         api_version,
         api_diagnostics,
+        email_relay_config,
         custom_email_domain,
         restart_router,
     ],

--- a/compute_space/src/compute_space/web/start.py
+++ b/compute_space/src/compute_space/web/start.py
@@ -129,6 +129,10 @@ def main() -> None:
                 config.coredns_corefile_path,
                 config.coredns_zonefile_path,
                 coredns_bin=_ensure_coredns_binary(config),
+                custom_zone_domain=config.email_custom_domain_normalized,
+                custom_zonefile_path=(
+                    config.coredns_custom_zonefile_path if config.email_custom_domain_normalized else None
+                ),
             )
         )
 

--- a/compute_space/src/compute_space/web/start.py
+++ b/compute_space/src/compute_space/web/start.py
@@ -19,6 +19,7 @@ from compute_space.core.auth.keys import load_keys
 from compute_space.core.caddy import CaddyProcess
 from compute_space.core.caddy import start_caddy
 from compute_space.core.dns import start_coredns
+from compute_space.core.email.provision import provision_email_records
 from compute_space.core.logging import logger
 from compute_space.core.logging import setup_file_logging
 from compute_space.core.pinned_binary import get_pinned_binary
@@ -133,6 +134,13 @@ def main() -> None:
 
     if config.tls_enabled:
         _ensure_tls_cert(config)
+
+    # Publish email DNS records (SPF/DKIM/DMARC/MX) into the CoreDNS zone, after
+    # TLS acquisition so the initial DNS-01 challenge writes/clears don't race the
+    # email records.  No-op unless email is enabled.  Requires CoreDNS (the zone
+    # file it writes into is served by CoreDNS).
+    if config.email_enabled and config.coredns_enabled:
+        provision_email_records(config)
 
     # Caddy reverse proxy. mainly for TLS termination, but also some other features
     caddy: CaddyProcess | None = None

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -8,6 +8,7 @@
 - [Routing](./routing.md)
 - [User Identity](./user_identity.md)
 - [Persistent Data & Archive](./data.md)
+- [Email](./email.md)
 - [Logs](./logs.md)
 
 # Guides

--- a/docs/src/email.md
+++ b/docs/src/email.md
@@ -35,9 +35,27 @@ Two facts make email different from a normal app:
    all others.
 
 Both facts point to the same answer: outbound mail flows through a
-**central, OpenHost-operated SES proxy** that owns the sending
+**central, OpenHost-operated SES relay** that owns the sending
 reputation and enforces per-instance limits, rather than each instance
 talking to the world directly.
+
+The relay is split into two pieces, following the same pattern the
+platform uses for its other managed backends (DNS provisioning, vm-manager):
+
+- a **private backend** (`openhost-email-proxy`) that holds the AWS SES
+  credentials and does the SES work. It has **no public listener** — it
+  is reachable only over the operator network (Fly 6PN), so an instance
+  cannot call it directly.
+- the **imbue-hosted-spaces frontend** as the **authenticated public
+  door**. Instances call the frontend's `/api/email/*` endpoints with
+  their Keycloak token; the frontend verifies the token, derives the
+  instance's zone, and proxies to the private backend over 6PN, passing
+  the zone as a trusted `X-OpenHost-Zone` header. The backend enforces
+  From-domain scope and rate limits against that zone.
+
+This keeps the authentication boundary in one place (the frontend, which
+already fronts vm-manager the same way) and keeps the SES-credential-holding
+backend off the public internet entirely.
 
 ## The platform / app divide
 
@@ -47,82 +65,86 @@ multi-tenant-unsafe** is central or platform-level; anything
 
 | Piece | Where | Why |
 |-------|-------|-----|
-| SES proxy (relay, spam/abuse mitigation, SES identity + verification) | **Central** (imbue infra, e.g. fly.io) | Holds AWS creds; shared reputation must be centrally governed |
-| Per-instance credential (Keycloak) | **Central-issued, instance-held** | Authenticates the instance and anchors From-domain enforcement |
+| Email backend (SES relay, spam/abuse, SES identity + verification) | **Central, private** (Fly 6PN; holds AWS creds) | Shared reputation must be centrally governed; keep creds off the public internet |
+| Auth boundary (verify instance token, proxy to backend) | **Central** (imbue-hosted-spaces frontend) | One authenticated public door, mirroring how it fronts vm-manager |
+| Per-instance credential (Keycloak) | **Central-issued, instance-held** | Authenticates the instance and anchors From-enforcement |
 | DNS records (DKIM/SPF/DMARC/MX) | **Platform** (CoreDNS) | Only the platform can write the authoritative zone |
 | Provisioning (inject credential + mail config) | **Platform** | Part of instance finalize |
 | Mailbox server (SMTP/JMAP + storage) | **App** (default) | User-facing, swappable, iterate-often |
 | Webmail client | **App** (default) | Pure UX |
 
-The SES proxy is the crux: it is the trust boundary that makes
-multi-tenant email safe. The mailbox and webmail pieces are ordinary
-OpenHost apps shipped as defaults.
+The frontend + private backend together are the trust boundary that
+makes multi-tenant email safe. The mailbox and webmail pieces are
+ordinary OpenHost apps shipped as defaults.
 
 ## Architecture overview
 
 ```
-                          ┌─────────────────────────────────────┐
-                          │      OpenHost SES Proxy (central)     │
-                          │  · Keycloak-verifies each request     │
-   instance A ──submit──▶ │  · enforces From = own zone only      │ ──▶ AWS SES ─▶ recipient MX
-   instance B ──submit──▶ │  · per-instance rate / volume caps    │      (outbound)
-                          │  · spam / bounce / complaint handling │
-   instance A ◀─webhook── │  · abuse detection + auto-suspend     │ ◀── SES inbound (S3 + SNS)
-                          │  · creates + verifies SES identities  │
-                          └─────────────────────────────────────┘
-        │                                                          ▲
-        ▼                                                          │
-  CoreDNS on the instance writes DKIM / SPF / DMARC / MX ──────────┘
+                       ┌──────────────────────────┐        ┌──────────────────────────────┐
+   instance ──token──▶ │  imbue-hosted-spaces      │        │  email backend (PRIVATE, 6PN) │
+   (Keycloak,          │  frontend (public door)   │ ─6PN─▶ │  · From = zone only           │ ──▶ AWS SES ─▶ MX
+    calls /api/email)  │  · verifies instance token │        │  · per-instance rate caps     │     (outbound)
+                       │  · derives zone            │        │  · spam / bounce / complaint  │
+                       │  · sets X-OpenHost-Zone    │ ◀────  │  · SES identity + verify      │ ◀── SES inbound (S3+SNS)
+                       └──────────────────────────┘        └──────────────────────────────┘
+        │
+        ▼
+  CoreDNS on the instance writes DKIM / SPF / DMARC / MX
   (authoritative for the selfhost subzone; and for a BYO domain
    via optional NS delegation)
 
   On the instance: mailbox server (app) + webmail client (app)
 ```
 
-## The SES proxy (central)
+## The email relay (frontend + private backend)
 
-The proxy runs on OpenHost-operated infrastructure (e.g. fly.io),
-**separate from any instance**. It is the direct analog of the existing
-certificate broker (`cert-api`): a central service holding privileged
-upstream credentials that instances talk to over an authenticated
-channel, never touching those credentials themselves.
+The relay runs on OpenHost-operated infrastructure (Fly), **separate
+from any instance**, split into an authenticated frontend door and a
+private backend.
 
-Its responsibilities:
+**The private backend** holds the AWS SES credentials and does the SES
+work. It has no public listener (reachable only over Fly 6PN), so it is
+never exposed to the internet and cannot be called by an instance
+directly. Its responsibilities:
 
-- **Relay outbound mail to AWS SES.** Instances submit mail to the
-  proxy; the proxy relays it to SES SMTP submission (port 587, which
-  cloud hosts allow), which delivers to the recipient's MX.
+- **Relay outbound mail to AWS SES**, which delivers to the recipient's MX.
 - **Spam and abuse mitigation** for the whole fleet (see
   [Abuse controls](#abuse-controls)).
 - **Create and verify SES domain identities.** When a zone is
-  provisioned, the proxy calls SES to create the domain identity, gets
-  back the DKIM tokens, hands them to the instance's DNS layer to
-  publish, and polls SES until the domain is verified. SES will not send
-  on behalf of an unverified domain, so this loop is mandatory and is
-  the proxy's job — not the operator's.
+  provisioned, the backend calls SES to create the domain identity, gets
+  back the DKIM tokens, returns them so the instance can publish them in
+  CoreDNS, and SES verifies once they resolve. SES will not send on
+  behalf of an unverified domain, so this is mandatory — and automatic,
+  not an operator step.
 - **Handle inbound** via SES receiving (see [Receiving mail](#receiving-mail)).
 
 The instance never holds AWS credentials. It only holds a Keycloak
 credential that OpenHost can revoke at any time.
 
-### Request authentication (Keycloak, cert-api pattern)
+### Request authentication (frontend, Keycloak, cert-api pattern)
 
-Every request an instance makes to the proxy is authenticated with
-**Keycloak client credentials**, exactly mirroring the certificate
-broker: each instance is provisioned with its own confidential client in
-a shared realm, and the client credentials are injected at finalize time
-(see [Provisioning](#provisioning)).
+The **frontend** (imbue-hosted-spaces) is the authentication boundary —
+the same role it already plays in front of vm-manager. An instance calls
+the frontend's `/api/email/*` endpoints with a **Keycloak
+client-credentials** token: each instance is provisioned with its own
+confidential client in the `openhost-customers` realm (aud
+`openhost-email`, a `subdomain` claim = the instance's zone), injected at
+finalize time (see [Provisioning](#provisioning)), exactly mirroring the
+cert-api pattern.
 
-The instance's Keycloak identity encodes which zone it is, so the proxy
-learns the instance's true sending domain from the authenticated token
-— not from anything the instance asserts in the message. This is what
-anchors From-domain enforcement. Revoking a single instance is a matter
-of disabling its client; there is no shared secret to rotate.
+The frontend verifies the token locally against the realm's JWKS, reads
+the `subdomain` claim, and proxies to the private backend over 6PN with a
+trusted `X-OpenHost-Zone` header. The backend derives the sending domain
+from that header — not from anything the instance asserts in the message
+— which is what anchors From-domain enforcement. The header is
+trustworthy only because the backend is unreachable except from the
+frontend over the private network. Revoking a single instance is a matter
+of disabling its Keycloak client; there is no shared secret to rotate.
 
 ### Abuse controls
 
-Because the proxy is the only way out, it is where all multi-tenant
-safety lives:
+Because the backend is the only way out and the frontend is the only way
+in, that pair is where all multi-tenant safety lives:
 
 - **From-domain enforcement.** The proxy rejects any message whose
   envelope-from or header-from is not within the instance's own

--- a/docs/src/email.md
+++ b/docs/src/email.md
@@ -188,22 +188,40 @@ ACME-challenge records), they are written as part of the zone's base
 configuration so they survive router restarts, and the ACME-challenge
 cleanup is scoped so that it never removes them.
 
-### Bring-your-own domain (optional NS delegation)
+### Bring-your-own domain (one NS record)
 
 A `<name>.selfhost.imbue.com` address works out of the box because the
 parent zone already delegates each subzone to the instance's CoreDNS.
 
-To use a **custom domain** (e.g. `me@mydomain.com`), the user delegates a
-zone to the instance's CoreDNS with a single **NS record** at their
-registrar — the same delegation model selfhost already uses. Once
-delegated, CoreDNS is authoritative for that zone and OpenHost writes all
-the email records automatically; no manual DKIM/verification steps at the
-registrar.
+To use a **custom domain** (e.g. `me@mydomain.com`), the owner sets
+`email_custom_domain` on the instance and adds a **single NS record** at
+their registrar delegating that (sub)zone to the instance's CoreDNS — the
+same delegation model selfhost already uses. The exact record is surfaced
+by `Config.custom_domain_delegation_record()`:
+
+```
+mail.mydomain.com.   NS   ns.<zone>.
+```
+
+The nameserver host (`ns.<zone>`) already resolves to the instance's public
+IP within its built-in zone, so this one record is all that is required —
+there is nothing else to copy from the registrar side.
+
+Once set, the instance serves the custom domain as a **second authoritative
+zone** (`start_coredns` renders an extra CoreDNS server block + a
+`zonefile.custom`), and `provision_email_records` creates a second SES
+identity for it and publishes the same SPF/DKIM/DMARC/MX records into that
+zone. Sending from the custom domain is authorized end-to-end because (a)
+the NS delegation to *this* instance is proof the owner controls the
+domain, and (b) SES verifies the identity via the published DKIM records
+before it will send. The email proxy is told the instance's authorized
+custom domain by the frontend (never by the instance itself), so the
+multi-tenant From-domain boundary is preserved.
 
 Recommendation: delegate a **subdomain** (e.g. `mail.mydomain.com`)
 rather than the apex, so OpenHost only becomes authoritative for the mail
-subzone and the user keeps their existing website/DNS untouched.
-Delegating the apex is possible for users who want OpenHost to serve all
+subzone and the owner keeps their existing website/DNS untouched.
+Delegating the apex is possible for owners who want OpenHost to serve all
 of their DNS, but it is a bigger commitment and makes the instance's
 CoreDNS load-bearing for the whole domain.
 

--- a/docs/src/email.md
+++ b/docs/src/email.md
@@ -54,6 +54,14 @@ mailbox server relays outbound mail through the central SES proxy as an
   instance; the proxy re-derives + constant-time compares, learning the
   authorized zone from that one check. Rotating `relay_secret` rotates
   every instance credential.
+- The relay credentials reach the mailbox app through a **scoped router
+  endpoint**, not the app environment. The mailbox app fetches
+  `GET /api/email/relay-config` at `OPENHOST_ROUTER_URL` using its
+  `OPENHOST_APP_TOKEN`; the router returns the SMTP host/port/user/password
+  (plus zone + custom domain) **only** to an app whose name is in
+  `email_mailbox_app_names`. This keeps the per-instance relay password out
+  of every other (untrusted) app's environment — only the mailbox app can
+  read it.
 
 This keeps the SES-credential-holding proxy off the public internet
 (reached over Fly 6PN), gives instances a real inbox+outbox instead of a

--- a/docs/src/email.md
+++ b/docs/src/email.md
@@ -1,0 +1,352 @@
+# Email (Design)
+
+This document describes how OpenHost instances send and receive email
+for their zone, and why the design is shaped the way it is.
+
+The platform-side pieces described here (the CoreDNS email records and the
+provisioning that talks to the proxy) are implemented in this repo and gated
+behind `email_enabled` in the instance config (off by default). The central
+relay is a separate service,
+[`openhost-email-proxy`](https://github.com/imbue-openhost/openhost-email-proxy),
+deployed on fly.io. See [Production readiness](#production-readiness) for what
+remains before turning this on for real tenants.
+
+The guiding constraint is that **OpenHost instances are operated by
+untrusted users**. A single instance must never be able to damage email
+deliverability for any other instance, exhaust a shared resource, or
+send mail claiming to be a domain it does not own. Every decision below
+follows from that constraint.
+
+## Why email needs platform support
+
+Two facts make email different from a normal app:
+
+1. **Cloud providers block port 25.** Most hosts (Hetzner, GCP, and
+   others) block inbound *and* outbound TCP/25 to fight spam. An
+   instance therefore cannot deliver mail directly to a recipient's MX,
+   nor accept mail directly from a sender's MX. A relay is mandatory —
+   this is not optional plumbing.
+
+2. **Deliverability is a shared, reputation-based resource.** Whether
+   mail lands in an inbox depends on the sending IP's reputation and on
+   SPF/DKIM/DMARC alignment. If every instance sent from its own cloud
+   IP, one abusive tenant would get that IP block-listed and, worse, a
+   shared address space would let one tenant poison the reputation of
+   all others.
+
+Both facts point to the same answer: outbound mail flows through a
+**central, OpenHost-operated SES proxy** that owns the sending
+reputation and enforces per-instance limits, rather than each instance
+talking to the world directly.
+
+## The platform / app divide
+
+The design splits along a single principle: anything **trust-critical or
+multi-tenant-unsafe** is central or platform-level; anything
+**user-facing and iterated often** is an app.
+
+| Piece | Where | Why |
+|-------|-------|-----|
+| SES proxy (relay, spam/abuse mitigation, SES identity + verification) | **Central** (imbue infra, e.g. fly.io) | Holds AWS creds; shared reputation must be centrally governed |
+| Per-instance credential (Keycloak) | **Central-issued, instance-held** | Authenticates the instance and anchors From-domain enforcement |
+| DNS records (DKIM/SPF/DMARC/MX) | **Platform** (CoreDNS) | Only the platform can write the authoritative zone |
+| Provisioning (inject credential + mail config) | **Platform** | Part of instance finalize |
+| Mailbox server (SMTP/JMAP + storage) | **App** (default) | User-facing, swappable, iterate-often |
+| Webmail client | **App** (default) | Pure UX |
+
+The SES proxy is the crux: it is the trust boundary that makes
+multi-tenant email safe. The mailbox and webmail pieces are ordinary
+OpenHost apps shipped as defaults.
+
+## Architecture overview
+
+```
+                          ┌─────────────────────────────────────┐
+                          │      OpenHost SES Proxy (central)     │
+                          │  · Keycloak-verifies each request     │
+   instance A ──submit──▶ │  · enforces From = own zone only      │ ──▶ AWS SES ─▶ recipient MX
+   instance B ──submit──▶ │  · per-instance rate / volume caps    │      (outbound)
+                          │  · spam / bounce / complaint handling │
+   instance A ◀─webhook── │  · abuse detection + auto-suspend     │ ◀── SES inbound (S3 + SNS)
+                          │  · creates + verifies SES identities  │
+                          └─────────────────────────────────────┘
+        │                                                          ▲
+        ▼                                                          │
+  CoreDNS on the instance writes DKIM / SPF / DMARC / MX ──────────┘
+  (authoritative for the selfhost subzone; and for a BYO domain
+   via optional NS delegation)
+
+  On the instance: mailbox server (app) + webmail client (app)
+```
+
+## The SES proxy (central)
+
+The proxy runs on OpenHost-operated infrastructure (e.g. fly.io),
+**separate from any instance**. It is the direct analog of the existing
+certificate broker (`cert-api`): a central service holding privileged
+upstream credentials that instances talk to over an authenticated
+channel, never touching those credentials themselves.
+
+Its responsibilities:
+
+- **Relay outbound mail to AWS SES.** Instances submit mail to the
+  proxy; the proxy relays it to SES SMTP submission (port 587, which
+  cloud hosts allow), which delivers to the recipient's MX.
+- **Spam and abuse mitigation** for the whole fleet (see
+  [Abuse controls](#abuse-controls)).
+- **Create and verify SES domain identities.** When a zone is
+  provisioned, the proxy calls SES to create the domain identity, gets
+  back the DKIM tokens, hands them to the instance's DNS layer to
+  publish, and polls SES until the domain is verified. SES will not send
+  on behalf of an unverified domain, so this loop is mandatory and is
+  the proxy's job — not the operator's.
+- **Handle inbound** via SES receiving (see [Receiving mail](#receiving-mail)).
+
+The instance never holds AWS credentials. It only holds a Keycloak
+credential that OpenHost can revoke at any time.
+
+### Request authentication (Keycloak, cert-api pattern)
+
+Every request an instance makes to the proxy is authenticated with
+**Keycloak client credentials**, exactly mirroring the certificate
+broker: each instance is provisioned with its own confidential client in
+a shared realm, and the client credentials are injected at finalize time
+(see [Provisioning](#provisioning)).
+
+The instance's Keycloak identity encodes which zone it is, so the proxy
+learns the instance's true sending domain from the authenticated token
+— not from anything the instance asserts in the message. This is what
+anchors From-domain enforcement. Revoking a single instance is a matter
+of disabling its client; there is no shared secret to rotate.
+
+### Abuse controls
+
+Because the proxy is the only way out, it is where all multi-tenant
+safety lives:
+
+- **From-domain enforcement.** The proxy rejects any message whose
+  envelope-from or header-from is not within the instance's own
+  (Keycloak-attested) zone. An instance can only ever send as
+  `*@<its-own-zone>`. This cannot be enforced on the instance itself —
+  only a party the tenant cannot bypass can enforce it.
+- **Per-instance rate and volume caps**, so one tenant cannot consume
+  the shared SES quota at the expense of others.
+- **Reputation isolation.** Each instance (or cohort) is assigned a
+  distinct SES **configuration set**, so bounce/complaint reputation is
+  tracked per tenant and a bad actor's damage is contained; dedicated
+  IPs can be assigned where needed.
+- **Suppression and bounce/complaint handling**, maintained centrally so
+  no instance can repeatedly hammer a bad address.
+- **Automatic suspension** of an instance whose bounce/complaint rate
+  crosses a threshold — per-instance, without affecting anyone else.
+
+## DNS records (CoreDNS)
+
+Each instance is authoritative for its own zone via CoreDNS (see
+[Routing](./routing.md)). The email deliverability records are written
+into that zone **automatically** — there is a single mechanism, no
+per-provider connectors:
+
+- **SPF** authorizing SES to send for the zone.
+- **DKIM** public keys (the tokens the SES proxy obtained when creating
+  the domain identity) so signed mail aligns.
+- **DMARC** policy for the zone.
+- **MX** pointing at the SES inbound endpoint.
+
+Because these are persistent zone records (unlike the transient
+ACME-challenge records), they are written as part of the zone's base
+configuration so they survive router restarts, and the ACME-challenge
+cleanup is scoped so that it never removes them.
+
+### Bring-your-own domain (optional NS delegation)
+
+A `<name>.selfhost.imbue.com` address works out of the box because the
+parent zone already delegates each subzone to the instance's CoreDNS.
+
+To use a **custom domain** (e.g. `me@mydomain.com`), the user delegates a
+zone to the instance's CoreDNS with a single **NS record** at their
+registrar — the same delegation model selfhost already uses. Once
+delegated, CoreDNS is authoritative for that zone and OpenHost writes all
+the email records automatically; no manual DKIM/verification steps at the
+registrar.
+
+Recommendation: delegate a **subdomain** (e.g. `mail.mydomain.com`)
+rather than the apex, so OpenHost only becomes authoritative for the mail
+subzone and the user keeps their existing website/DNS untouched.
+Delegating the apex is possible for users who want OpenHost to serve all
+of their DNS, but it is a bigger commitment and makes the instance's
+CoreDNS load-bearing for the whole domain.
+
+## Receiving mail
+
+Inbound port 25 is blocked, so the instance cannot accept mail directly.
+Instead:
+
+1. **MX points at SES.** The instance's CoreDNS publishes an MX record
+   directing mail for the zone to SES's inbound endpoint.
+2. **SES receives and stores.** SES accepts the message, writes the raw
+   RFC822 to an OpenHost-owned S3 bucket, and publishes an SNS
+   notification.
+3. **The proxy is notified and forwards to the instance.** SNS delivers a
+   signed notification; the proxy **verifies the SNS signature**, fetches
+   the raw message from S3, and hands it to the destination instance.
+4. **The instance's mailbox server ingests it** via LMTP/SMTP, where the
+   owner can read it.
+
+Signature verification is mandatory: the inbound webhook is
+internet-reachable, so an unverified payload would let anyone inject
+mail. Only notifications with a valid AWS SNS signature from the expected
+topic are accepted.
+
+Inbound is also multi-tenant-sensitive — untrusted users receiving
+unbounded mail is a storage/content-abuse vector — so the design applies
+**per-instance inbound quotas** (rate and total mailbox storage) and
+routes inbound mail only to the instance that owns the destination zone.
+
+## The mailbox and webmail apps
+
+The mailbox server (SMTP + JMAP with local storage) and the webmail
+client ship as **default OpenHost apps**. Keeping them as apps means mail
+data lives on the operator's own zone (not in a central store), and the
+implementation can iterate without a platform release.
+
+- The mailbox server relays outbound mail to the SES proxy (as a
+  smarthost client) and ingests inbound mail delivered by the proxy.
+- The mailbox server exposes its JMAP interface as a
+  [cross-app service](./cross_app_services.md); the webmail app
+  *consumes* that service.
+
+## Access control — who can read the mail
+
+Isolation has three layers; keep them distinct.
+
+1. **Between instances (structural).** Each instance is a separate VM
+   with its own mailbox server and its own storage, so one instance
+   physically cannot read another's mail. The proxy additionally routes
+   inbound mail only to the instance that owns the destination zone.
+   This is the same isolation that already separates every OpenHost zone
+   — nothing new is built for it.
+
+2. **Within an instance, single owner (the common case).** Access to the
+   webmail app and the mailbox is gated by **OpenHost owner
+   authentication**: the router only stamps `X-OpenHost-Is-Owner: true`
+   for the authenticated zone owner; everyone else is bounced to the zone
+   login. A small proxy in front of the mailbox server validates the
+   consuming app's permission grant, **strips any client-supplied
+   credentials, and injects the owner's mailbox credentials** before
+   forwarding. The webmail app never sees a mail password; the mail
+   account's own password is internal and never user-facing. Access is
+   governed entirely by OpenHost auth, not by knowledge of a mail
+   password.
+
+3. **Within an instance, multiple users (out of scope for now).** The
+   current owner-auth model is binary — owner or not-owner — so every
+   party who authenticates as the owner sees the same mailbox. Giving
+   several distinct users on one zone their own private mailboxes would
+   require mapping each authenticated OpenHost user to a specific mailbox
+   in the JMAP proxy, which depends on OpenHost's federated-identity work
+   and is not addressed here.
+
+## Provisioning
+
+Per-instance email configuration is injected at **finalize time**,
+alongside the existing certificate-broker configuration:
+
+- the instance's **Keycloak credential** (client id/secret) for the SES
+  proxy,
+- the proxy's base URL,
+- and the zone's mail settings.
+
+At provision, the SES proxy creates the SES domain identity and the DKIM
+tokens are published into CoreDNS along with SPF/DMARC/MX; the proxy
+polls SES until the domain verifies. For a `selfhost` subdomain this is
+fully automatic. For a custom domain, the one manual step is the user's
+NS delegation; everything after that is automatic.
+
+## Trust and failure model
+
+- **An instance can only send as its own zone**, enforced by the proxy
+  from the Keycloak-attested identity.
+- **An instance cannot damage others' deliverability** — reputation is
+  isolated per SES configuration set; abuse triggers per-instance
+  suspension only.
+- **An instance holds no AWS credentials** — it authenticates to the
+  proxy with a per-instance, individually-revocable Keycloak credential.
+- **Proxy unavailability is fail-safe** — outbound mail queues on the
+  instance's mailbox server and retries; inbound mail is retried by SNS.
+- **Mail data stays on the instance** — the proxy relays and enforces
+  policy but is not the mail store.
+
+## Summary
+
+| Concern | Where it lives | Why |
+|---------|----------------|-----|
+| Outbound relay + spam/abuse | Central SES proxy (fly.io) → AWS SES | Port 25 blocked; reputation is shared |
+| Request auth | Keycloak (cert-api pattern) | Per-instance, revocable; anchors From-enforcement |
+| From-domain safety | Central SES proxy | Only the proxy can enforce it against an untrusted tenant |
+| SES identity + verification | Central SES proxy | SES won't send for an unverified domain |
+| DKIM/SPF/DMARC/MX | CoreDNS (auto) | Instance owns its zone |
+| Custom domains | Optional NS delegation → CoreDNS | Seamless BYO-domain via one record |
+| Inbound receive | SES → S3 → SNS → proxy → instance | Port 25 blocked; signature-verified |
+| Mailbox store + webmail | Default apps | Mail data stays on the operator's zone; iterate freely |
+| Read access (single owner) | OpenHost owner auth + JMAP proxy | App never sees mail credentials |
+
+## What is implemented today
+
+- **Platform (this repo):** `email_*` config (opt-in, off by default),
+  CoreDNS publishing of SPF/DKIM/DMARC/MX (`core/dns.py:apply_email_records`),
+  a `clear_txt` fix that no longer wipes email TXT records on cert renewal, the
+  proxy client + startup provisioning (`core/email/`), and finalize-time config
+  injection (`ansible/templates/config.toml.j2`).
+- **Proxy (`openhost-email-proxy`):** outbound send with Keycloak auth +
+  From-domain enforcement + per-instance rate/volume caps, SES identity
+  create/verify, and the signature-verified SNS inbound webhook with S3 fetch
+  and per-zone routing to the destination instance.
+
+Verified end-to-end on a fresh instance: it auto-published its DNS records, SES
+auto-verified the domain from those records, and the instance sent DKIM-signed
+mail through the proxy to a real external inbox. From-domain enforcement,
+audience/issuer checks, rate limiting, and SNS signature rejection are covered
+by tests.
+
+## Production readiness
+
+Before enabling email for real tenants, the following must be done. These are
+deliberately **not** in scope of the initial implementation (they are
+operational / infrastructure decisions or depend on other teams):
+
+1. **AWS SES production access.** The account is in the SES sandbox, which only
+   sends to verified recipients and caps volume. Request production access for
+   the production AWS account/region before any real sending.
+2. **A dedicated production AWS account.** Testing used a personal-scope account
+   with inline IAM keys. Production should use a dedicated imbue AWS account, an
+   IAM role/policy scoped to exactly the SES + S3 + SNS actions the proxy needs,
+   and credentials delivered as fly secrets (never committed).
+3. **Real per-instance Keycloak provisioning.** vm-manager must create the
+   per-instance confidential client in `openhost-customers`, attach the
+   `openhost-email` client scope (subdomain claim + `openhost-email` audience),
+   set the service-account `subdomain` attribute, and inject the client
+   credentials at finalize (the same step it will do for cert-api). Testing used
+   a throwaway Keycloak and a manual provisioning script; production points
+   `email_keycloak_issuer_url` at the real `keycloak.imbue.com` realm.
+4. **Inbound infrastructure (SES receiving).** Create the S3 receiving bucket,
+   the SNS topic subscribed to the proxy's `/v1/inbound`, and the SES receipt
+   rule set that stores mail to S3 + notifies SNS. The proxy's inbound dispatch
+   + signature verification are implemented and tested, but the AWS receipt
+   pipeline itself must be stood up (and is only needed if inbound is desired;
+   outbound works without it).
+5. **Instance-side inbound endpoint + mailbox app.** The proxy forwards inbound
+   mail to `https://<zone>/_email/inbound`; that endpoint (and the mailbox
+   server + webmail default apps that consume it) is a separate piece of work.
+6. **Proxy scaling / shared rate-limit store.** The proxy runs a single fly
+   machine because the rate-limiter is in-process. Multi-machine HA needs a
+   shared counter store (e.g. Redis/DynamoDB). Same constraint as cert-api.
+7. **SES configuration sets per tenant.** Reputation isolation via per-tenant
+   configuration sets (and dedicated IPs where warranted) plus bounce/complaint
+   SNS handling and a suppression list should be provisioned before scale.
+8. **DMARC policy + reporting.** The default published policy is
+   `p=quarantine`; decide the production policy and a `rua` aggregate-report
+   address per zone (config supports `email_dmarc_rua`).
+9. **Canonical proxy URL + config defaults.** Point `email_proxy_base_url` and
+   `email_inbound_mx_host` at the production proxy and SES region; consider a
+   default once the production proxy has a stable DNS name.

--- a/docs/src/email.md
+++ b/docs/src/email.md
@@ -39,23 +39,31 @@ Both facts point to the same answer: outbound mail flows through a
 reputation and enforces per-instance limits, rather than each instance
 talking to the world directly.
 
-The relay is split into two pieces, following the same pattern the
-platform uses for its other managed backends (DNS provisioning, vm-manager):
+Each instance runs a real mailbox server (**Stalwart**) and webmail
+client (**Bulwark**) as default apps, giving a real inbox + outbox. The
+mailbox server relays outbound mail through the central SES proxy as an
+**SMTP smarthost**:
 
-- a **private backend** (`openhost-email-proxy`) that holds the AWS SES
-  credentials and does the SES work. It has **no public listener** — it
-  is reachable only over the operator network (Fly 6PN), so an instance
-  cannot call it directly.
-- the **imbue-hosted-spaces frontend** as the **authenticated public
-  door**. Instances call the frontend's `/api/email/*` endpoints with
-  their Keycloak token; the frontend verifies the token, derives the
-  instance's zone, and proxies to the private backend over 6PN, passing
-  the zone as a trusted `X-OpenHost-Zone` header. The backend enforces
-  From-domain scope and rate limits against that zone.
+- the **email proxy** (`openhost-email-proxy`) runs an **SMTP submission
+  relay** that holds the AWS SES credentials. Instances' Stalwart relays
+  outbound to it over SMTP submission (AUTH), and it enforces From-domain
+  scope + per-instance rate limits, then forwards to SES.
+- **Per-instance SMTP auth is a stateless HMAC credential**: username =
+  the instance's zone FQDN, password = `HMAC-SHA256(relay_secret, zone)`.
+  vm-manager derives the same password at provision and hands it to the
+  instance; the proxy re-derives + constant-time compares, learning the
+  authorized zone from that one check. Rotating `relay_secret` rotates
+  every instance credential.
 
-This keeps the authentication boundary in one place (the frontend, which
-already fronts vm-manager the same way) and keeps the SES-credential-holding
-backend off the public internet entirely.
+This keeps the SES-credential-holding proxy off the public internet
+(reached over Fly 6PN), gives instances a real inbox+outbox instead of a
+send-only shim, and keeps the central multi-tenant safety guarantees
+(From enforcement, rate limits, abuse controls) in one place.
+
+> The SES **domain-identity creation** (to obtain DKIM tokens at
+> provision) still uses a small HTTP call authenticated by the
+> per-instance Keycloak client via the imbue-hosted-spaces frontend; only
+> the high-volume *send* path moved to SMTP.
 
 ## The platform / app divide
 


### PR DESCRIPTION
Builds on the email foundation branch (andrew/email-dns-records).

Lets an owner use their own mail domain by adding a single NS record delegating it to the instance's CoreDNS.

- email_custom_domain config; the instance serves it as a second authoritative CoreDNS zone (extra Corefile block + zonefile.custom whose NS host is ns.<zone>, so one delegation record suffices) and provisions a second SES identity + SPF/DKIM/DMARC/MX for it.
- custom_domain_delegation_record() + GET /api/email/custom-domain surface the exact NS record to the owner.
- Scoped GET /api/email/relay-config (option b): the mailbox app fetches its SMTP smarthost relay credentials with its app token; the relay password is returned only to the mailbox app (email_mailbox_app_names), never injected into every app's environment.
- docs + tests.