### PR TITLE
Support git submodules in app deploy and update

### DIFF
--- a/compute_space/src/compute_space/core/apps.py
+++ b/compute_space/src/compute_space/core/apps.py
@@ -190,6 +190,18 @@ def inject_github_token_in_url(url: str, token: str) -> str:
     return url
 
 
+def github_token_git_config(token: str | None) -> list[str]:
+    """Ephemeral ``git -c`` args that authenticate GitHub HTTPS fetches.
+
+    Rides in GIT_CONFIG_PARAMETERS, which git propagates to child processes —
+    including recursive submodule clones/fetches — so private submodules
+    authenticate without the token ever being written to a git config file.
+    """
+    if not token:
+        return []
+    return ["-c", f"url.https://{token}@github.com/.insteadOf=https://github.com/"]
+
+
 async def clone_and_read_manifest(
     repo_url: str, github_token: str | None = None
 ) -> tuple[AppManifest | None, str | None, str | None]:
@@ -229,14 +241,23 @@ async def clone_and_read_manifest(
     tmp_parent = tempfile.mkdtemp(prefix="openhost-clone-")
     clone_dir = os.path.join(tmp_parent, "repo")
     try:
-        clone_cmd = ["git", "clone", "--recurse-submodules", "--shallow-submodules"]
+        clone_cmd = [
+            "git",
+            *github_token_git_config(github_token),
+            "clone",
+            "--recurse-submodules",
+            "--shallow-submodules",
+        ]
         if ref:
             clone_cmd.extend(["--branch", ref])
         clone_cmd.extend([clone_url, clone_dir])
         result = await asyncio.to_thread(subprocess.run, clone_cmd, capture_output=True, text=True, timeout=120)
         if result.returncode != 0:
             rmtree_with_sudo_fallback(tmp_parent, raise_on_failure=False)
-            return None, None, f"Git clone failed: {result.stderr.strip()}"
+            stderr = result.stderr.strip()
+            if github_token:
+                stderr = stderr.replace(github_token, "***")
+            return None, None, f"Git clone failed: {stderr}"
         # If we cloned with a token, reset the remote URL so the token isn't persisted
         if github_token and clone_url != base_url:
             await asyncio.to_thread(
@@ -246,6 +267,17 @@ async def clone_and_read_manifest(
                 capture_output=True,
                 timeout=10,
             )
+            # Relative .gitmodules URLs resolved against the token-bearing clone
+            # URL, so the recorded submodule URLs may embed the token; re-sync
+            # them against the now-clean origin.
+            if os.path.exists(os.path.join(clone_dir, ".gitmodules")):
+                await asyncio.to_thread(
+                    subprocess.run,
+                    ["git", "submodule", "sync", "--recursive"],
+                    cwd=clone_dir,
+                    capture_output=True,
+                    timeout=30,
+                )
         try:
             manifest = parse_manifest(clone_dir)
         except ValueError as e:
@@ -794,7 +826,11 @@ def git_pull(
 ) -> tuple[bool, str | None]:
     """Try to git pull. Returns (ok, error_msg)."""
 
+    def _redact(msg: str) -> str:
+        return msg.replace(github_token, "***") if github_token else msg
+
     def _log(msg: str) -> None:
+        msg = _redact(msg)
         logger.info("%s: %s", app_name, msg)
         if log_file:
             with open(log_file, "a") as f:
@@ -846,16 +882,41 @@ def git_pull(
         except Exception:
             pass
 
-    def _run(cmd: list[str]) -> tuple[bool, str | None]:
+    def _run(cmd: list[str], timeout: int = 60) -> tuple[bool, str | None]:
         _log("$ " + " ".join(cmd))
-        result = subprocess.run(cmd, cwd=repo_path, capture_output=True, text=True, timeout=60)
+        result = subprocess.run(cmd, cwd=repo_path, capture_output=True, text=True, timeout=timeout)
         if result.stdout.strip():
             _log(result.stdout.strip())
         if result.stderr.strip():
             _log(result.stderr.strip())
         if result.returncode != 0:
-            return False, result.stderr.strip() or result.stdout.strip() or f"{' '.join(cmd)} failed"
+            err = result.stderr.strip() or result.stdout.strip() or f"{' '.join(cmd)} failed"
+            return False, _redact(err)
         return True, None
+
+    def _restore_origin() -> None:
+        if github_token and original_url:
+            subprocess.run(
+                ["git", "remote", "set-url", "origin", original_url],
+                cwd=repo_path,
+                capture_output=True,
+                timeout=10,
+            )
+
+    def _update_submodules() -> tuple[bool, str | None]:
+        if not os.path.exists(os.path.join(repo_path, ".gitmodules")):
+            return True, None
+        # Sync recorded submodule URLs against the clean origin URL (relative
+        # .gitmodules paths resolve against it), so the token never lands in a
+        # config file; auth rides only in the ephemeral insteadOf config.
+        _restore_origin()
+        ok, err = _run(["git", "submodule", "sync", "--recursive"])
+        if not ok:
+            return False, err
+        return _run(
+            ["git", *github_token_git_config(github_token), "submodule", "update", "--init", "--recursive"],
+            timeout=300,
+        )
 
     try:
         if not ref:
@@ -866,7 +927,10 @@ def git_pull(
                 return False, default_err
         if not ref:
             # Couldn't determine a default branch; pull the current one.
-            return _run(["git", "pull"])
+            ok, err = _run(["git", "pull"])
+            if not ok:
+                return False, err
+            return _update_submodules()
 
         # Fetch the pinned ref and hard-reset the working tree to it.
         # TODO: this duplicates the branch-vs-tag checkout in
@@ -894,8 +958,12 @@ def git_pull(
             == 0
         )
         if is_branch:
-            return _run(["git", "checkout", "-fB", ref, f"origin/{ref}"])
-        return _run(["git", "checkout", "-f", "FETCH_HEAD"])
+            ok, err = _run(["git", "checkout", "-fB", ref, f"origin/{ref}"])
+        else:
+            ok, err = _run(["git", "checkout", "-f", "FETCH_HEAD"])
+        if not ok:
+            return False, err
+        return _update_submodules()
     except Exception as e:
         _log(f"git update failed: {e}")
         return False, str(e)

--- a/compute_space/src/compute_space/tests/test_app_submodules.py
+++ b/compute_space/src/compute_space/tests/test_app_submodules.py
@@ -1,0 +1,139 @@
+"""Tests for git submodule support in app deploy and update.
+
+Covers the initial clone (``clone_and_read_manifest`` recursing into
+submodules) and the Update & Reload path (``git_pull`` materializing bumped
+submodule pointers and initializing submodules added upstream) — without
+which a submodule-based app would deploy fine but silently rebuild from
+stale submodule content on every update.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from compute_space.core.apps import clone_and_read_manifest
+from compute_space.core.apps import git_pull
+from compute_space.core.apps import github_token_git_config
+
+MANIFEST = '[app]\nname = "myapp"\nversion = "0.1.0"\n[runtime.container]\nimage = "Dockerfile"\nport = 8080\n'
+
+
+def _git(cwd: Path, *args: str) -> None:
+    subprocess.run(
+        ["git", *args],
+        cwd=cwd,
+        check=True,
+        capture_output=True,
+        env={
+            **os.environ,
+            "GIT_AUTHOR_NAME": "t",
+            "GIT_AUTHOR_EMAIL": "t@t",
+            "GIT_COMMITTER_NAME": "t",
+            "GIT_COMMITTER_EMAIL": "t@t",
+        },
+    )
+
+
+@pytest.fixture(autouse=True)
+def _allow_file_submodules(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Modern git refuses file-protocol submodules by default; allow them for
+    the local fixture repos (real deploys use https)."""
+    monkeypatch.setenv("GIT_CONFIG_COUNT", "1")
+    monkeypatch.setenv("GIT_CONFIG_KEY_0", "protocol.file.allow")
+    monkeypatch.setenv("GIT_CONFIG_VALUE_0", "always")
+
+
+def _make_submodule_origin(tmp_path: Path) -> tuple[Path, Path]:
+    """A superproject (with openhost.toml) containing one submodule at sub/."""
+    sub_origin = tmp_path / "sub_origin"
+    sub_origin.mkdir()
+    _git(sub_origin, "init", "-b", "main")
+    (sub_origin / "sub.txt").write_text("v1")
+    _git(sub_origin, "add", ".")
+    _git(sub_origin, "commit", "-m", "sub v1")
+
+    origin = tmp_path / "origin"
+    origin.mkdir()
+    _git(origin, "init", "-b", "main")
+    (origin / "openhost.toml").write_text(MANIFEST)
+    _git(origin, "add", ".")
+    _git(origin, "commit", "-m", "init")
+    _git(origin, "submodule", "add", f"file://{sub_origin}", "sub")
+    _git(origin, "commit", "-m", "add submodule")
+    return origin, sub_origin
+
+
+def _bump_submodule(origin: Path, sub_origin: Path, content: str) -> None:
+    """Commit new content in the submodule origin and point the superproject
+    at it."""
+    (sub_origin / "sub.txt").write_text(content)
+    _git(sub_origin, "commit", "-am", f"sub {content}")
+    _git(origin / "sub", "pull", "origin", "main")
+    _git(origin, "add", "sub")
+    _git(origin, "commit", "-m", f"bump sub to {content}")
+
+
+def test_clone_recurses_submodules(tmp_path: Path) -> None:
+    """Deploy-time clone materializes submodule content."""
+    origin, _ = _make_submodule_origin(tmp_path)
+
+    manifest, clone_dir, error = asyncio.run(clone_and_read_manifest(f"file://{origin}"))
+    assert error is None, error
+    assert manifest is not None and manifest.name == "myapp"
+    assert clone_dir is not None
+    assert (Path(clone_dir) / "sub" / "sub.txt").read_text() == "v1"
+
+
+def test_git_pull_updates_submodule_pointer(tmp_path: Path) -> None:
+    """Update & Reload checks out the submodule commit the superproject now
+    pins, so the rebuild sees the new content."""
+    origin, sub_origin = _make_submodule_origin(tmp_path)
+    clone = tmp_path / "clone"
+    _git(tmp_path, "clone", "--recurse-submodules", f"file://{origin}", str(clone))
+    assert (clone / "sub" / "sub.txt").read_text() == "v1"
+
+    _bump_submodule(origin, sub_origin, "v2")
+
+    ok, err = git_pull(str(clone), "myapp", repo_url=f"file://{origin}@main")
+    assert ok, err
+    assert (clone / "sub" / "sub.txt").read_text() == "v2"
+
+
+def test_git_pull_inits_submodule_added_upstream(tmp_path: Path) -> None:
+    """A submodule introduced after install is cloned on the next update."""
+    origin = tmp_path / "origin"
+    origin.mkdir()
+    _git(origin, "init", "-b", "main")
+    (origin / "openhost.toml").write_text(MANIFEST)
+    _git(origin, "add", ".")
+    _git(origin, "commit", "-m", "init")
+
+    clone = tmp_path / "clone"
+    _git(tmp_path, "clone", f"file://{origin}", str(clone))
+
+    sub_origin = tmp_path / "sub_origin"
+    sub_origin.mkdir()
+    _git(sub_origin, "init", "-b", "main")
+    (sub_origin / "sub.txt").write_text("new")
+    _git(sub_origin, "add", ".")
+    _git(sub_origin, "commit", "-m", "sub")
+    _git(origin, "submodule", "add", f"file://{sub_origin}", "sub")
+    _git(origin, "commit", "-m", "add submodule")
+
+    ok, err = git_pull(str(clone), "myapp", repo_url=f"file://{origin}@main")
+    assert ok, err
+    assert (clone / "sub" / "sub.txt").read_text() == "new"
+
+
+def test_github_token_git_config() -> None:
+    """The token rides only in ephemeral -c config, formatted for insteadOf."""
+    assert github_token_git_config(None) == []
+    assert github_token_git_config("tok123") == [
+        "-c",
+        "url.https://tok123@github.com/.insteadOf=https://github.com/",
+    ]

--- a/openhost_app_test_harness/src/openhost_test_harness/stack.py
+++ b/openhost_app_test_harness/src/openhost_test_harness/stack.py
@@ -91,18 +91,11 @@ def _normalize_service_url(url: str) -> str:
     return url.removeprefix("https://").removeprefix("http://").rstrip("/")
 
 
-def _snapshot_working_tree(app_dir: Path, dest: Path) -> None:
-    """Copy ``app_dir``'s git working tree to ``dest``: tracked + untracked files,
-    minus gitignored ones and ``.git`` itself.
-
-    The router clones git repos at HEAD, which would silently deploy stale code while
-    you iterate; deploying a snapshot makes the app under test reflect uncommitted
-    changes, while gitignored build artefacts (.venv, node_modules, ...) stay out of
-    the build context.
-    """
+def _copy_git_listed_files(src_dir: Path, dest_dir: Path) -> None:
+    """Copy ``src_dir``'s tracked + untracked-unignored files into ``dest_dir``."""
     listing = subprocess.run(
         ["git", "ls-files", "--cached", "--others", "--exclude-standard", "-z"],
-        cwd=app_dir,
+        cwd=src_dir,
         capture_output=True,
         check=True,
     )
@@ -110,12 +103,36 @@ def _snapshot_working_tree(app_dir: Path, dest: Path) -> None:
         if not raw:
             continue
         rel = raw.decode()
-        src = app_dir / rel
+        src = src_dir / rel
         if not src.is_file():  # staged deletions still appear in ls-files
             continue
-        target = dest / rel
+        target = dest_dir / rel
         target.parent.mkdir(parents=True, exist_ok=True)
         shutil.copy2(src, target)
+
+
+def _snapshot_working_tree(app_dir: Path, dest: Path) -> None:
+    """Copy ``app_dir``'s git working tree to ``dest``: tracked + untracked files,
+    minus gitignored ones and ``.git`` itself. Submodule working trees are included
+    (``git ls-files`` lists a submodule as a single gitlink, not its files).
+
+    The router clones git repos at HEAD, which would silently deploy stale code while
+    you iterate; deploying a snapshot makes the app under test reflect uncommitted
+    changes, while gitignored build artefacts (.venv, node_modules, ...) stay out of
+    the build context.
+    """
+    _copy_git_listed_files(app_dir, dest)
+    submodules = subprocess.run(
+        ["git", "submodule", "foreach", "--quiet", "--recursive", "echo $displaypath"],
+        cwd=app_dir,
+        capture_output=True,
+        check=True,
+        text=True,
+    )
+    for sub_rel in submodules.stdout.splitlines():
+        sub_rel = sub_rel.strip()
+        if sub_rel:
+            _copy_git_listed_files(app_dir / sub_rel, dest / sub_rel)
 
 
 def _warn_if_linux_gateway_missing() -> None:

--- a/openhost_app_test_harness/src/openhost_test_harness/tests/test_snapshot_working_tree.py
+++ b/openhost_app_test_harness/src/openhost_test_harness/tests/test_snapshot_working_tree.py
@@ -1,0 +1,84 @@
+"""Unit tests for the working-tree snapshot used to deploy the app under test."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from openhost_test_harness.stack import _snapshot_working_tree
+
+
+def _git(cwd: Path, *args: str) -> None:
+    subprocess.run(
+        ["git", *args],
+        cwd=cwd,
+        check=True,
+        capture_output=True,
+        env={
+            **os.environ,
+            "GIT_AUTHOR_NAME": "t",
+            "GIT_AUTHOR_EMAIL": "t@t",
+            "GIT_COMMITTER_NAME": "t",
+            "GIT_COMMITTER_EMAIL": "t@t",
+        },
+    )
+
+
+@pytest.fixture(autouse=True)
+def _allow_file_submodules(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("GIT_CONFIG_COUNT", "1")
+    monkeypatch.setenv("GIT_CONFIG_KEY_0", "protocol.file.allow")
+    monkeypatch.setenv("GIT_CONFIG_VALUE_0", "always")
+
+
+def test_snapshot_includes_tracked_untracked_and_skips_ignored(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init", "-b", "main")
+    (repo / "tracked.txt").write_text("tracked")
+    (repo / ".gitignore").write_text("ignored.txt\n")
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-m", "init")
+    (repo / "untracked.txt").write_text("untracked")
+    (repo / "ignored.txt").write_text("ignored")
+
+    dest = tmp_path / "dest"
+    _snapshot_working_tree(repo, dest)
+
+    assert (dest / "tracked.txt").read_text() == "tracked"
+    assert (dest / "untracked.txt").read_text() == "untracked"
+    assert not (dest / "ignored.txt").exists()
+    assert not (dest / ".git").exists()
+
+
+def test_snapshot_includes_submodule_working_tree(tmp_path: Path) -> None:
+    """git ls-files lists a submodule as a bare gitlink, so its files need their
+    own pass — without it a submodule-based app deploys with the directory empty."""
+    sub_origin = tmp_path / "sub_origin"
+    sub_origin.mkdir()
+    _git(sub_origin, "init", "-b", "main")
+    (sub_origin / "sub.txt").write_text("sub content")
+    _git(sub_origin, "add", ".")
+    _git(sub_origin, "commit", "-m", "sub")
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init", "-b", "main")
+    (repo / "app.txt").write_text("app")
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-m", "init")
+    _git(repo, "submodule", "add", f"file://{sub_origin}", "vendor/sub")
+    _git(repo, "commit", "-m", "add submodule")
+    # Uncommitted submodule edits ride along too (same rationale as the superproject).
+    (repo / "vendor/sub/local-edit.txt").write_text("edit")
+
+    dest = tmp_path / "dest"
+    _snapshot_working_tree(repo, dest)
+
+    assert (dest / "app.txt").read_text() == "app"
+    assert (dest / "vendor/sub/sub.txt").read_text() == "sub content"
+    assert (dest / "vendor/sub/local-edit.txt").read_text() == "edit"
+    assert not (dest / "vendor/sub/.git").exists()


### PR DESCRIPTION
## Why

The upcoming `openhost-minds` app pins its workspace-template code as a (private) git submodule. Today that half-works in a dangerous way:

- **Deploy** clones with `--recurse-submodules`, but the GitHub OAuth token is injected only into the top-level clone URL, so private submodules fail to clone.
- **Update & Reload** (`git_pull`) never touches submodules, so a bumped submodule pointer is fetched into the superproject but never materialized in the working tree — the app "updates" and then rebuilds from the old submodule content with no error.

## What

- `git_pull` now finishes every successful pull/checkout with `git submodule sync --recursive` + `git submodule update --init --recursive` (300s timeout for large submodules; no-op when there is no `.gitmodules`). Newly-added submodules get initialized; bumped pointers get checked out.
- Private-submodule auth uses ephemeral config: `git -c url.https://<token>@github.com/.insteadOf=https://github.com/` on the clone / submodule-update commands. Git exports `-c` config via `GIT_CONFIG_PARAMETERS` to child processes, so recursive submodule fetches inherit it — and the token is never written to any config file.
- Token hygiene: submodule URL sync runs against the restored (clean) origin URL, so relative `.gitmodules` URLs that resolved against a token-bearing origin get scrubbed; on the deploy path the same scrub runs post-clone. `git_pull` logs and returned error strings now redact the token (git error output can echo tokenized URLs).

## Tests

New `test_app_submodules.py` (local file:// fixture repos, same style as `test_set_app_remote.py`): deploy-time clone materializes submodule content; update checks out a bumped submodule pointer; update initializes a submodule added after install; token config formatting. Full compute_space suite (minus podman integration tests): 817 passed, 8 skipped.

Known limitation: relative `.gitmodules` URLs are recommended for private submodules that live in the same org/host as the superproject; absolute private URLs on hosts other than github.com won't authenticate (unchanged from today's top-level behavior).

🤖 Generated with [Claude Code](https://claude.com/claude-code)