### PR TITLE
Add /_email/inbound router endpoint to deliver inbound mail to the mailbox app

### DIFF
--- a/ansible/templates/config.toml.j2
+++ b/ansible/templates/config.toml.j2
@@ -58,13 +58,10 @@ email_dmarc_rua = "{{ email_dmarc_rua }}"
 # zone and publishes the same SPF/DKIM/DMARC/MX records into it.
 email_custom_domain = "{{ email_custom_domain }}"
 {% endif %}
-{% if email_smtp_relay_host is defined %}
-# SMTP smarthost the instance's mailbox server (Stalwart) relays outbound mail
-# through: the openhost-email-proxy's submission listener.  user is the zone,
-# password is the per-instance HMAC credential the provisioner derived.
-email_smtp_relay_host = "{{ email_smtp_relay_host }}"
-email_smtp_relay_port = {{ email_smtp_relay_port | default(587) }}
-email_smtp_relay_user = "{{ email_smtp_relay_user }}"
-email_smtp_relay_password = "{{ email_smtp_relay_password }}"
-{% endif %}
+# NOTE: the SMTP smarthost host/port + per-instance relay credential are NOT
+# stored here. The router fetches them at runtime from the frontend
+# (GET /api/email/relay-config), which has the backend derive
+# HMAC(RELAY_SECRET, zone). So nothing email-specific is baked into this config,
+# enabling email needs no secret injection, and rotating RELAY_SECRET requires no
+# re-provisioning.
 {% endif %}

--- a/compute_space/src/compute_space/config.py
+++ b/compute_space/src/compute_space/config.py
@@ -123,18 +123,13 @@ class Config:
     # this instance is itself the proof of control; the SES identity's DKIM
     # verification is the second proof.
     email_custom_domain: str | None
-    # SMTP smarthost the mailbox app (Stalwart) relays outbound through — the
-    # email proxy's submission listener.  user is the zone; password is the
-    # per-instance HMAC credential (the only sensitive value).  Surfaced to the
-    # mailbox app on request via /api/email/relay-config (NOT injected into every
-    # app's environment) so the relay password stays scoped to the mailbox app.
-    email_smtp_relay_host: str | None
-    email_smtp_relay_port: int | None
-    email_smtp_relay_user: str | None
-    email_smtp_relay_password: str | None
     # App name(s) allowed to fetch the SMTP relay config from
-    # /api/email/relay-config.  Only the mailbox app needs the relay password, so
-    # the endpoint is scoped to these names (defaults to the built-in mailbox app).
+    # /api/email/relay-config.  The relay host/port + per-instance credential are
+    # NOT stored on the instance: the router fetches them at runtime from the
+    # frontend (which has the backend derive HMAC(RELAY_SECRET, zone)), so nothing
+    # email-specific is baked into instance config and rotating RELAY_SECRET needs
+    # no re-provisioning.  The endpoint is scoped to these mailbox app names so the
+    # credential only reaches the mailbox app.
     email_mailbox_app_names: list[str]
 
     ## coredns (only really needed if acquiring TLS certs via DNS-01, or if using NS dns records)
@@ -408,10 +403,6 @@ class DefaultConfig(Config):
     email_inbound_mx_host: str | None = None
     email_dmarc_rua: str | None = None
     email_custom_domain: str | None = None
-    email_smtp_relay_host: str | None = None
-    email_smtp_relay_port: int | None = None
-    email_smtp_relay_user: str | None = None
-    email_smtp_relay_password: str | None = None
     email_mailbox_app_names: list[str] = attr.Factory(lambda: ["stalwart-email-server"])
 
     start_caddy: bool = True

--- a/compute_space/src/compute_space/core/email/relay_credential.py
+++ b/compute_space/src/compute_space/core/email/relay_credential.py
@@ -1,0 +1,133 @@
+"""Fetch this instance's SMTP relay credential from the frontend at runtime.
+
+The relay credential (host/port + username/password) is deliberately NOT baked
+into the instance's config. Instead the router fetches it from the email frontend
+(imbue-hosted-spaces) using the same per-instance Keycloak client the instance
+already holds for cert-api/email, and the frontend has the backend derive
+``HMAC(RELAY_SECRET, zone)``. This means:
+
+  * nothing email-specific (no relay password) is stored in per-instance config,
+    so enabling email needs no secret injection and upgrades never touch it;
+  * rotating ``RELAY_SECRET`` (which lives only on the backend) rotates every
+    instance's credential automatically — the instance just refetches.
+
+The result is cached in-process with a short TTL so the mailbox app's
+relay-config calls and the inbound-auth check don't hit the frontend on every
+request, while still picking up a rotated secret within the TTL.
+"""
+
+from __future__ import annotations
+
+import hmac
+import threading
+import time
+
+import attr
+import httpx
+
+from compute_space.config import Config
+from compute_space.core.logging import logger
+from compute_space.core.tls.keycloak import KeycloakClientCredentials
+from compute_space.core.tls.keycloak import KeycloakTokenProvider
+
+# How long a fetched credential is trusted before we refetch. Short enough that a
+# rotated RELAY_SECRET propagates quickly; long enough to avoid per-request calls.
+_CACHE_TTL_SECONDS = 300.0
+
+
+@attr.s(auto_attribs=True, frozen=True)
+class RelayCredential:
+    """The SMTP smarthost config the mailbox app needs to relay outbound mail."""
+
+    smtp_relay_host: str
+    smtp_relay_port: int
+    smtp_relay_user: str
+    smtp_relay_password: str
+    zone_domain: str
+    custom_domain: str | None
+
+
+class RelayCredentialError(RuntimeError):
+    pass
+
+
+@attr.s(auto_attribs=True)
+class RelayCredentialProvider:
+    """Fetches + caches this instance's relay credential from the frontend."""
+
+    config: Config
+    monotonic: object = time.monotonic
+    _cached: RelayCredential | None = attr.ib(default=None, init=False)
+    _expires_at: float = attr.ib(default=0.0, init=False)
+    _lock: threading.Lock = attr.ib(factory=threading.Lock, init=False)
+
+    def get(self) -> RelayCredential | None:
+        """Return the current relay credential, or None when email isn't configured.
+
+        Raises RelayCredentialError only on an unexpected fetch failure while email
+        IS configured (so callers can distinguish "off" from "temporarily broken").
+        """
+        if not self.config.email_enabled:
+            return None
+        with self._lock:
+            now = self.monotonic()  # type: ignore[operator]
+            if self._cached is not None and now < self._expires_at:
+                return self._cached
+            cred = self._fetch()
+            self._cached = cred
+            self._expires_at = now + _CACHE_TTL_SECONDS
+            return cred
+
+    def _fetch(self) -> RelayCredential:
+        cfg = self.config
+        assert cfg.email_proxy_base_url is not None
+        assert cfg.email_keycloak_issuer_url is not None
+        assert cfg.email_keycloak_client_id is not None
+        assert cfg.email_keycloak_client_secret is not None
+        credentials = KeycloakClientCredentials(
+            issuer_url=cfg.email_keycloak_issuer_url,
+            client_id=cfg.email_keycloak_client_id,
+            client_secret=cfg.email_keycloak_client_secret,
+        )
+        url = f"{cfg.email_proxy_base_url.rstrip('/')}/api/email/relay-config"
+        try:
+            with KeycloakTokenProvider.create(credentials) as tokens:
+                token = tokens.get_token()
+                with httpx.Client(timeout=30.0) as client:
+                    resp = client.get(url, headers={"Authorization": f"Bearer {token}"})
+        except httpx.HTTPError as e:
+            raise RelayCredentialError(f"relay-config fetch failed: {e}") from e
+        if resp.status_code != 200:
+            raise RelayCredentialError(f"relay-config returned HTTP {resp.status_code}")
+        body = resp.json()
+        if not body.get("configured"):
+            raise RelayCredentialError("frontend reports relay not configured")
+        try:
+            return RelayCredential(
+                smtp_relay_host=body["smtp_relay_host"],
+                smtp_relay_port=int(body["smtp_relay_port"]),
+                smtp_relay_user=body["smtp_relay_user"],
+                smtp_relay_password=body["smtp_relay_password"],
+                zone_domain=body.get("zone_domain") or cfg.zone_domain_no_port,
+                custom_domain=cfg.email_custom_domain_normalized,
+            )
+        except (KeyError, TypeError, ValueError) as e:
+            raise RelayCredentialError(f"relay-config response malformed: {e}") from e
+
+    def verify_inbound_token(self, token: str) -> bool:
+        """Constant-time check that ``token`` matches this instance's relay password.
+
+        Used to authenticate the proxy's inbound forward. Returns False on any
+        fetch problem rather than raising, so a transient frontend blip fails
+        closed (rejects inbound) instead of 500-ing.
+        """
+        if not token:
+            return False
+        try:
+            cred = self.get()
+        except RelayCredentialError as e:
+            logger.warning(f"inbound auth: could not resolve relay credential: {e}")
+            return False
+        if cred is None:
+            return False
+        return hmac.compare_digest(token, cred.smtp_relay_password)

--- a/compute_space/src/compute_space/tests/test_email_config.py
+++ b/compute_space/src/compute_space/tests/test_email_config.py
@@ -15,6 +15,7 @@ from litestar.exceptions import NotAuthorizedException
 
 import compute_space.web.routes.api.system as sys_mod
 from compute_space.config import DefaultConfig
+from compute_space.core.email.relay_credential import RelayCredential
 from compute_space.web.routes.api.system import custom_email_domain
 
 
@@ -77,19 +78,13 @@ def test_email_config_round_trips_through_toml() -> None:
     assert 'email_inbound_mx_host = "inbound-smtp.us-west-2.amazonaws.com"' in rendered
 
 
-def test_email_smtp_relay_fields_round_trip() -> None:
-    cfg = DefaultConfig(zone_domain="x.example.com").evolve(
-        **_full_email_kwargs(),
-        email_smtp_relay_host="openhost-email-proxy.internal",
-        email_smtp_relay_port=587,
-        email_smtp_relay_user="x.example.com",
-        email_smtp_relay_password="hmac-pw",
-    )
+def test_email_config_has_no_baked_in_relay_secret() -> None:
+    # The relay host/port/user/password are fetched at runtime from the frontend,
+    # never rendered into the instance config.
+    cfg = DefaultConfig(zone_domain="x.example.com").evolve(**_full_email_kwargs())
     rendered = cfg.to_toml_str()
-    assert 'email_smtp_relay_host = "openhost-email-proxy.internal"' in rendered
-    assert "email_smtp_relay_port = 587" in rendered
-    assert 'email_smtp_relay_user = "x.example.com"' in rendered
-    assert 'email_smtp_relay_password = "hmac-pw"' in rendered
+    assert "email_smtp_relay_password" not in rendered
+    assert "email_smtp_relay_host" not in rendered
 
 
 def test_custom_domain_none_by_default() -> None:
@@ -197,16 +192,28 @@ def test_relay_config_returns_creds_to_mailbox_app(monkeypatch) -> None:
     monkeypatch.setattr(sys_mod, "verify_app_auth", lambda request: "app-mail")
     cfg = DefaultConfig(zone_domain="alice.selfhost.imbue.com").evolve(
         **_full_email_kwargs(),
-        email_smtp_relay_host="openhost-email-proxy.internal",
-        email_smtp_relay_port=587,
-        email_smtp_relay_user="alice.selfhost.imbue.com",
-        email_smtp_relay_password="hmac-pw",
         email_custom_domain="mail.mydomain.com",
     )
+    # The router fetches the credential at runtime from the frontend; stub the
+    # provider so we don't need a live frontend.
+    cred = RelayCredential(
+        smtp_relay_host="openhost-email-proxy.fly.dev",
+        smtp_relay_port=465,
+        smtp_relay_user="alice.selfhost.imbue.com",
+        smtp_relay_password="hmac-pw",
+        zone_domain="alice.selfhost.imbue.com",
+        custom_domain="mail.mydomain.com",
+    )
+
+    class _StubProvider:
+        def get(self) -> RelayCredential:
+            return cred
+
+    monkeypatch.setattr(sys_mod, "get_relay_credential_provider", lambda config: _StubProvider())
     resp = sys_mod.email_relay_config.fn(object(), _FakeDB("stalwart-email-server"), cfg)  # type: ignore[attr-defined]
     body = resp.content
     assert body.configured is True
-    assert body.smtp_relay_host == "openhost-email-proxy.internal"
+    assert body.smtp_relay_host == "openhost-email-proxy.fly.dev"
     assert body.smtp_relay_password == "hmac-pw"
     assert body.zone_domain == "alice.selfhost.imbue.com"
     assert body.custom_domain == "mail.mydomain.com"

--- a/compute_space/src/compute_space/tests/test_email_dns_config_edge.py
+++ b/compute_space/src/compute_space/tests/test_email_dns_config_edge.py
@@ -1,0 +1,225 @@
+"""Edge cases for email DNS record rendering + custom-domain config validation."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from compute_space.config import DefaultConfig
+from compute_space.core.dns import DkimCname
+from compute_space.core.dns import apply_email_records
+from compute_space.core.dns import render_email_records
+
+_EMAIL_KW = dict(
+    email_enabled=True,
+    email_proxy_base_url="https://frontend.example",
+    email_keycloak_issuer_url="https://kc.example/realms/openhost-customers",
+    email_keycloak_client_id="instance-x",
+    email_keycloak_client_secret="secret",
+    email_inbound_mx_host="inbound-smtp.us-west-2.amazonaws.com",
+)
+
+
+# ─────────────────────── render_email_records ───────────────────────
+
+
+def test_render_includes_spf_dmarc_mx():
+    out = render_email_records("z.example", mail_from_host="inbound-smtp.us-west-2.amazonaws.com", dkim_cnames=[])
+    assert '@   IN TXT  "v=spf1 include:amazonses.com ~all"' in out
+    assert '_dmarc   IN TXT  "v=DMARC1; p=quarantine"' in out
+    assert "@   IN MX   10 inbound-smtp.us-west-2.amazonaws.com." in out
+
+
+def test_render_dmarc_rua_appended():
+    out = render_email_records("z.example", mail_from_host="mx.aws", dkim_cnames=[], dmarc_rua="dmarc@z.example")
+    assert "rua=mailto:dmarc@z.example" in out
+
+
+def test_render_no_dkim_still_valid():
+    out = render_email_records("z.example", mail_from_host="mx.aws", dkim_cnames=[])
+    assert "IN CNAME" not in out
+    assert out.strip().endswith("; --- end openhost email records ---")
+
+
+def test_render_multiple_dkim_cnames():
+    cnames = [DkimCname(name=f"t{i}._domainkey.z.example", target=f"t{i}.dkim.amazonses.com") for i in range(3)]
+    out = render_email_records("z.example", mail_from_host="mx.aws", dkim_cnames=cnames)
+    assert out.count("IN CNAME") == 3
+
+
+def test_render_dkim_names_get_trailing_dot():
+    c = [DkimCname(name="tok._domainkey.z.example", target="tok.dkim.amazonses.com")]
+    out = render_email_records("z.example", mail_from_host="mx.aws", dkim_cnames=c)
+    assert "tok._domainkey.z.example.   IN CNAME  tok.dkim.amazonses.com." in out
+
+
+def test_render_dkim_names_already_dotted_not_doubled():
+    c = [DkimCname(name="tok._domainkey.z.example.", target="tok.dkim.amazonses.com.")]
+    out = render_email_records("z.example", mail_from_host="mx.aws", dkim_cnames=c)
+    assert "tok._domainkey.z.example.   IN CNAME  tok.dkim.amazonses.com." in out
+    assert ".." not in out.replace("; ---", "")  # no double dots in records
+
+
+def test_render_mx_host_trailing_dot_not_doubled():
+    out = render_email_records("z.example", mail_from_host="mx.aws.", dkim_cnames=[])
+    assert "@   IN MX   10 mx.aws." in out
+    assert "mx.aws.." not in out
+
+
+def _zone_file(serial: int = 2020010100) -> str:
+    return (
+        "$ORIGIN z.example.\n"
+        "$TTL 60\n"
+        "@   IN SOA  ns.z.example. admin.z.example. (\n"
+        f"    {serial}   ; serial\n"
+        "    3600  ; refresh\n"
+        "    600   ; retry\n"
+        "    86400 ; expire\n"
+        "    60    ; minimum\n"
+        ")\n"
+        "@   IN NS   ns.z.example.\n"
+        "@   IN A    127.0.0.1\n"
+    )
+
+
+def test_apply_email_records_appends_and_bumps_serial(tmp_path: Path):
+    zone = tmp_path / "zone.db"
+    zone.write_text(_zone_file())
+    apply_email_records(
+        zone,
+        "z.example",
+        mail_from_host="mx.aws",
+        dkim_cnames=[DkimCname(name="t._domainkey.z.example", target="t.dkim.amazonses.com")],
+    )
+    content = zone.read_text()
+    assert "v=spf1 include:amazonses.com" in content
+    assert "IN CNAME" in content
+    # serial bumped from 2020010100
+    assert "2020010100   ; serial" not in content
+
+
+def test_apply_email_records_idempotent_serial_progresses(tmp_path: Path):
+    zone = tmp_path / "zone.db"
+    zone.write_text(_zone_file())
+    apply_email_records(zone, "z.example", mail_from_host="mx", dkim_cnames=[])
+    apply_email_records(zone, "z.example", mail_from_host="mx", dkim_cnames=[])
+    second = zone.read_text()
+    # applied twice -> two record blocks, serial advanced again
+    assert second.count("openhost email records (managed)") == 2
+
+
+# ─────────────────────── custom-domain validation ───────────────────────
+
+
+def test_custom_domain_normalized_lower_and_strip():
+    cfg = DefaultConfig(zone_domain="alice.selfhost.imbue.com").evolve(
+        **_EMAIL_KW, email_custom_domain="  Mail.MyDomain.COM.  "
+    )
+    assert cfg.email_custom_domain_normalized == "mail.mydomain.com"
+
+
+def test_custom_domain_blank_is_none():
+    cfg = DefaultConfig(zone_domain="alice.selfhost.imbue.com").evolve(**_EMAIL_KW, email_custom_domain="   ")
+    assert cfg.email_custom_domain_normalized is None
+
+
+def test_custom_domain_unset_is_none():
+    cfg = DefaultConfig(zone_domain="alice.selfhost.imbue.com").evolve(**_EMAIL_KW)
+    assert cfg.email_custom_domain_normalized is None
+
+
+@pytest.mark.parametrize("bad", [".mail.mydomain.com", "mail..mydomain.com", "mail.my..domain.com"])
+def test_custom_domain_malformed_rejected(bad):
+    with pytest.raises(ValueError):
+        DefaultConfig(zone_domain="alice.selfhost.imbue.com").evolve(**_EMAIL_KW, email_custom_domain=bad)
+
+
+def test_custom_domain_trailing_dots_normalized_not_rejected():
+    # Trailing dots are stripped by normalization, so a trailing-dot FQDN is fine.
+    cfg = DefaultConfig(zone_domain="alice.selfhost.imbue.com").evolve(
+        **_EMAIL_KW, email_custom_domain="mail.mydomain.com.."
+    )
+    assert cfg.email_custom_domain_normalized == "mail.mydomain.com"
+
+
+def test_custom_domain_equal_to_zone_rejected():
+    with pytest.raises(ValueError):
+        DefaultConfig(zone_domain="alice.selfhost.imbue.com").evolve(
+            **_EMAIL_KW, email_custom_domain="alice.selfhost.imbue.com"
+        )
+
+
+def test_custom_domain_subdomain_of_zone_rejected():
+    with pytest.raises(ValueError):
+        DefaultConfig(zone_domain="alice.selfhost.imbue.com").evolve(
+            **_EMAIL_KW, email_custom_domain="mail.alice.selfhost.imbue.com"
+        )
+
+
+def test_custom_domain_parent_of_zone_rejected():
+    # zone is a subdomain of the custom domain -> also overlaps
+    with pytest.raises(ValueError):
+        DefaultConfig(zone_domain="alice.selfhost.imbue.com").evolve(
+            **_EMAIL_KW, email_custom_domain="selfhost.imbue.com"
+        )
+
+
+def test_custom_domain_distinct_ok():
+    cfg = DefaultConfig(zone_domain="alice.selfhost.imbue.com").evolve(
+        **_EMAIL_KW, email_custom_domain="mail.mydomain.com"
+    )
+    assert cfg.email_custom_domain_normalized == "mail.mydomain.com"
+
+
+# ─────────────────────── delegation record ───────────────────────
+
+
+def test_delegation_record_shape():
+    cfg = DefaultConfig(zone_domain="alice.selfhost.imbue.com").evolve(
+        **_EMAIL_KW, email_custom_domain="mail.mydomain.com"
+    )
+    rec = cfg.custom_domain_delegation_record()
+    assert rec is not None
+    assert rec.name == "mail.mydomain.com"
+    assert rec.record_type == "NS"
+    assert rec.value == "ns.alice.selfhost.imbue.com"
+
+
+def test_delegation_record_none_without_custom_domain():
+    cfg = DefaultConfig(zone_domain="alice.selfhost.imbue.com").evolve(**_EMAIL_KW)
+    assert cfg.custom_domain_delegation_record() is None
+
+
+def test_delegation_record_strips_zone_port():
+    cfg = DefaultConfig(zone_domain="alice.selfhost.imbue.com:8443").evolve(
+        **_EMAIL_KW, email_custom_domain="mail.mydomain.com"
+    )
+    rec = cfg.custom_domain_delegation_record()
+    assert rec.value == "ns.alice.selfhost.imbue.com"  # no :8443
+
+
+# ─────────────────────── email_enabled validation ───────────────────────
+
+
+@pytest.mark.parametrize(
+    "missing",
+    [
+        "email_proxy_base_url",
+        "email_keycloak_issuer_url",
+        "email_keycloak_client_id",
+        "email_keycloak_client_secret",
+        "email_inbound_mx_host",
+    ],
+)
+def test_email_enabled_requires_all_fields(missing):
+    kw = dict(_EMAIL_KW)
+    kw[missing] = None
+    with pytest.raises(ValueError):
+        DefaultConfig(zone_domain="alice.selfhost.imbue.com").evolve(**kw)
+
+
+def test_email_disabled_needs_no_fields():
+    # No exception when email is off, even with all email_* unset.
+    cfg = DefaultConfig(zone_domain="alice.selfhost.imbue.com")
+    assert cfg.email_enabled is False

--- a/compute_space/src/compute_space/tests/test_email_edge_cases.py
+++ b/compute_space/src/compute_space/tests/test_email_edge_cases.py
@@ -1,0 +1,238 @@
+"""Edge-case suite for the openhost email router endpoint + relay credential provider."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+from unittest import mock
+
+import httpx
+import pytest
+from litestar import Litestar
+from litestar.di import Provide
+from litestar.response.base import ASGIResponse
+from litestar.testing import TestClient
+
+from compute_space.config import provide_config
+from compute_space.core.email import relay_credential as rc
+from compute_space.core.email.relay_credential import RelayCredential
+from compute_space.core.email.relay_credential import RelayCredentialProvider
+from compute_space.db import provide_db
+from compute_space.db.connection import init_db
+from compute_space.tests.conftest import _make_test_config
+from compute_space.web.routes.api.system import system_routes
+
+RELAY_PW = "d" * 64
+_VERIFY = "compute_space.core.email.relay_credential.RelayCredentialProvider.verify_inbound_token"
+_EMAIL_KW = dict(
+    email_enabled=True,
+    email_mailbox_app_names=["stalwart-email-server"],
+    email_proxy_base_url="https://frontend.example",
+    email_keycloak_issuer_url="https://kc.example/realms/openhost-customers",
+    email_keycloak_client_id="instance-x",
+    email_keycloak_client_secret="secret",
+    email_inbound_mx_host="inbound-smtp.us-west-2.amazonaws.com",
+)
+
+
+@pytest.fixture()
+def client(tmp_path: Path) -> Any:
+    config = _make_test_config(tmp_path, **_EMAIL_KW)
+    init_db(config.db_path)
+    app = Litestar(
+        route_handlers=[system_routes],
+        dependencies={"config": Provide(provide_config, sync_to_thread=False), "db": Provide(provide_db)},
+    )
+    with TestClient(app=app) as c:
+        yield c
+
+
+# ─────────────────────── /_email/inbound auth header parsing ───────────────────────
+
+
+@pytest.mark.parametrize(
+    "header,should_pass",
+    [
+        (f"Bearer {RELAY_PW}", True),
+        (f"bearer {RELAY_PW}", False),  # scheme is case-sensitive in the endpoint (startswith 'Bearer ')
+        (RELAY_PW, False),  # no scheme
+        (f"Bearer  {RELAY_PW}", False),  # double space -> token mismatch
+        ("Bearer ", False),  # empty token
+        ("", False),  # no header
+        (f"Basic {RELAY_PW}", False),  # wrong scheme
+        (f"Bearer {RELAY_PW}extra", False),  # wrong token
+    ],
+)
+def test_inbound_auth_header_shapes(client, header, should_pass):
+    # verify_inbound_token accepts exactly RELAY_PW; the endpoint's own header
+    # parsing must extract the token correctly for that to matter.
+    with (
+        mock.patch(_VERIFY, lambda self, t: t == RELAY_PW),
+        mock.patch("compute_space.web.routes.api.system.find_app_by_name", return_value=mock.Mock(local_port=1)),
+        mock.patch("compute_space.web.routes.api.system.proxy_http_request", new=_ok_proxy()),
+    ):
+        headers = {"Authorization": header} if header else {}
+        resp = client.post("/_email/inbound", content=b"x", headers=headers)
+    if should_pass:
+        assert resp.status_code == 200
+    else:
+        assert resp.status_code == 401
+
+
+def _ok_proxy():
+    async def _p(request, target_port, **kw):
+        return ASGIResponse(body=b"{}", status_code=200)
+
+    return _p
+
+
+def test_inbound_picks_first_deployed_mailbox_app(tmp_path):
+    config = _make_test_config(
+        tmp_path, **{**_EMAIL_KW, "email_mailbox_app_names": ["missing-app", "stalwart-email-server"]}
+    )
+    init_db(config.db_path)
+    app = Litestar(
+        route_handlers=[system_routes],
+        dependencies={"config": Provide(provide_config, sync_to_thread=False), "db": Provide(provide_db)},
+    )
+
+    def fake_find(name):
+        return None if name == "missing-app" else mock.Mock(local_port=4242)
+
+    seen = {}
+
+    async def fake_proxy(request, target_port, **kw):
+        seen["port"] = target_port
+        return ASGIResponse(body=b"{}", status_code=200)
+
+    with (
+        TestClient(app=app) as c,
+        mock.patch(_VERIFY, lambda self, t: True),
+        mock.patch("compute_space.web.routes.api.system.find_app_by_name", side_effect=fake_find),
+        mock.patch("compute_space.web.routes.api.system.proxy_http_request", side_effect=fake_proxy),
+    ):
+        resp = c.post("/_email/inbound", content=b"x", headers={"Authorization": f"Bearer {RELAY_PW}"})
+    assert resp.status_code == 200
+    assert seen["port"] == 4242  # skipped the missing app, used the deployed one
+
+
+def test_inbound_get_405_or_404(client):
+    # GET on a POST-only route -> 405 (litestar) ; ensure it's not accidentally allowed.
+    resp = client.get("/_email/inbound", headers={"Authorization": f"Bearer {RELAY_PW}"})
+    assert resp.status_code in (404, 405)
+
+
+# ─────────────────────── RelayCredentialProvider edge cases ───────────────────────
+
+
+def _provider(tmp_path, clock):
+    config = _make_test_config(tmp_path, zone_domain="alice.selfhost.imbue.com", **_EMAIL_KW)
+    return RelayCredentialProvider(config=config, monotonic=lambda: clock[0])
+
+
+_CRED = RelayCredential(
+    smtp_relay_host="h",
+    smtp_relay_port=465,
+    smtp_relay_user="u",
+    smtp_relay_password="pw",
+    zone_domain="z",
+    custom_domain=None,
+)
+
+
+def test_provider_caches_within_ttl(tmp_path):
+    clock = [0.0]
+    p = _provider(tmp_path, clock)
+    with mock.patch.object(RelayCredentialProvider, "_fetch", return_value=_CRED) as f:
+        p.get()
+        p.get()
+        assert f.call_count == 1
+        clock[0] += rc._CACHE_TTL_SECONDS - 1
+        p.get()
+        assert f.call_count == 1  # still within TTL
+
+
+def test_provider_refetches_after_ttl(tmp_path):
+    clock = [0.0]
+    p = _provider(tmp_path, clock)
+    with mock.patch.object(RelayCredentialProvider, "_fetch", return_value=_CRED) as f:
+        p.get()
+        clock[0] += rc._CACHE_TTL_SECONDS + 0.1
+        p.get()
+        assert f.call_count == 2
+
+
+def test_provider_disabled_returns_none_no_fetch(tmp_path):
+    config = _make_test_config(tmp_path)  # email disabled
+    p = RelayCredentialProvider(config=config)
+    with mock.patch.object(RelayCredentialProvider, "_fetch") as f:
+        assert p.get() is None
+        f.assert_not_called()
+
+
+def test_provider_fetch_http_error_raises(tmp_path):
+    p = _provider(tmp_path, [0.0])
+    with mock.patch("httpx.Client") as C:
+        C.return_value.__enter__.return_value.get.side_effect = httpx.ConnectError("down")
+        with mock.patch("compute_space.core.email.relay_credential.KeycloakTokenProvider"):
+            with pytest.raises(rc.RelayCredentialError):
+                p._fetch()
+
+
+def test_provider_fetch_non_200_raises(tmp_path):
+    p = _provider(tmp_path, [0.0])
+    resp = mock.Mock(status_code=503)
+    with (
+        mock.patch("compute_space.core.email.relay_credential.KeycloakTokenProvider"),
+        mock.patch("httpx.Client") as C,
+    ):
+        C.return_value.__enter__.return_value.get.return_value = resp
+        with pytest.raises(rc.RelayCredentialError):
+            p._fetch()
+
+
+def test_provider_fetch_unconfigured_body_raises(tmp_path):
+    p = _provider(tmp_path, [0.0])
+    resp = mock.Mock(status_code=200)
+    resp.json.return_value = {"configured": False}
+    with (
+        mock.patch("compute_space.core.email.relay_credential.KeycloakTokenProvider"),
+        mock.patch("httpx.Client") as C,
+    ):
+        C.return_value.__enter__.return_value.get.return_value = resp
+        with pytest.raises(rc.RelayCredentialError):
+            p._fetch()
+
+
+def test_provider_fetch_malformed_body_raises(tmp_path):
+    p = _provider(tmp_path, [0.0])
+    resp = mock.Mock(status_code=200)
+    resp.json.return_value = {"configured": True}  # missing required fields
+    with (
+        mock.patch("compute_space.core.email.relay_credential.KeycloakTokenProvider"),
+        mock.patch("httpx.Client") as C,
+    ):
+        C.return_value.__enter__.return_value.get.return_value = resp
+        with pytest.raises(rc.RelayCredentialError):
+            p._fetch()
+
+
+def test_verify_inbound_token_matches(tmp_path):
+    p = _provider(tmp_path, [0.0])
+    with mock.patch.object(RelayCredentialProvider, "_fetch", return_value=_CRED):
+        assert p.verify_inbound_token("pw") is True
+        assert p.verify_inbound_token("PW") is False
+        assert p.verify_inbound_token("") is False
+        assert p.verify_inbound_token("pw ") is False  # exact match only
+
+
+def test_verify_inbound_token_fails_closed_on_error(tmp_path):
+    p = _provider(tmp_path, [0.0])
+    with mock.patch.object(RelayCredentialProvider, "_fetch", side_effect=rc.RelayCredentialError("x")):
+        assert p.verify_inbound_token("pw") is False
+
+
+def test_verify_inbound_token_disabled_false(tmp_path):
+    config = _make_test_config(tmp_path)
+    p = RelayCredentialProvider(config=config)
+    assert p.verify_inbound_token("anything") is False

--- a/compute_space/src/compute_space/tests/test_email_inbound_route.py
+++ b/compute_space/src/compute_space/tests/test_email_inbound_route.py
@@ -1,0 +1,115 @@
+"""Tests for the router's /_email/inbound endpoint.
+
+The email proxy POSTs received mail here (via the imbue-hosted-spaces public
+door). The router authenticates the hop with the per-instance SMTP relay
+password (HMAC of the zone) it already holds, then forwards to the mailbox app's
+own /_email/inbound on its loopback port. These tests cover the auth gate
+(unconfigured, missing/bad/good token), the no-mailbox-app case, and that a good
+request forwards to the resolved app port.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+from unittest import mock
+
+import pytest
+from litestar import Litestar
+from litestar.di import Provide
+from litestar.response.base import ASGIResponse
+from litestar.testing import TestClient
+
+from compute_space.config import provide_config
+from compute_space.db import provide_db
+from compute_space.db.connection import init_db
+from compute_space.tests.conftest import _make_test_config
+from compute_space.web.routes.api.system import system_routes
+
+RELAY_PW = "a" * 64  # stand-in HMAC-SHA256 hex
+
+
+@pytest.fixture()
+def client(tmp_path: Path) -> Any:
+    config = _make_test_config(
+        tmp_path,
+        email_enabled=True,
+        email_smtp_relay_password=RELAY_PW,
+        email_mailbox_app_names=["stalwart-email-server"],
+        email_proxy_base_url="https://frontend.example",
+        email_keycloak_issuer_url="https://kc.example/realms/openhost-customers",
+        email_keycloak_client_id="instance-x",
+        email_keycloak_client_secret="secret",
+        email_inbound_mx_host="inbound-smtp.us-west-2.amazonaws.com",
+    )
+    init_db(config.db_path)
+    app = Litestar(
+        route_handlers=[system_routes],
+        dependencies={
+            "config": Provide(provide_config, sync_to_thread=False),
+            "db": Provide(provide_db),
+        },
+    )
+    with TestClient(app=app) as c:
+        yield c
+
+
+def _auth(token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}"}
+
+
+def test_missing_token_401(client: TestClient) -> None:
+    resp = client.post("/_email/inbound", content=b"raw")
+    assert resp.status_code == 401
+
+
+def test_bad_token_401(client: TestClient) -> None:
+    resp = client.post("/_email/inbound", content=b"raw", headers=_auth("b" * 64))
+    assert resp.status_code == 401
+
+
+def test_good_token_no_mailbox_app_503(client: TestClient) -> None:
+    # find_app_by_name returns None (no app deployed) -> 503.
+    with mock.patch(
+        "compute_space.web.routes.api.system.find_app_by_name", return_value=None
+    ):
+        resp = client.post("/_email/inbound", content=b"raw", headers=_auth(RELAY_PW))
+    assert resp.status_code == 503
+
+
+def test_good_token_forwards_to_mailbox_app(client: TestClient) -> None:
+    fake_app = mock.Mock(local_port=19042)
+
+    async def fake_proxy(request: Any, target_port: int, **kwargs: Any) -> ASGIResponse:
+        assert target_port == 19042
+        assert kwargs["override_path"] == "/_email/inbound"
+        return ASGIResponse(body=b'{"delivered":true}', status_code=200)
+
+    with (
+        mock.patch(
+            "compute_space.web.routes.api.system.find_app_by_name", return_value=fake_app
+        ),
+        mock.patch(
+            "compute_space.web.routes.api.system.proxy_http_request", side_effect=fake_proxy
+        ) as proxied,
+    ):
+        resp = client.post("/_email/inbound", content=b"raw rfc822", headers=_auth(RELAY_PW))
+
+    assert resp.status_code == 200
+    assert proxied.called
+
+
+def test_unconfigured_instance_401(tmp_path: Path) -> None:
+    # email disabled -> 401 (does not leak that it's unconfigured vs bad creds).
+    config = _make_test_config(tmp_path, email_enabled=False)
+    init_db(config.db_path)
+    app = Litestar(
+        route_handlers=[system_routes],
+        dependencies={
+            "config": Provide(provide_config, sync_to_thread=False),
+            "db": Provide(provide_db),
+        },
+    )
+    with TestClient(app=app) as c:
+        resp = c.post("/_email/inbound", content=b"raw", headers=_auth(RELAY_PW))
+    assert resp.status_code == 401

--- a/compute_space/src/compute_space/tests/test_email_inbound_route.py
+++ b/compute_space/src/compute_space/tests/test_email_inbound_route.py
@@ -28,13 +28,16 @@ from compute_space.web.routes.api.system import system_routes
 
 RELAY_PW = "a" * 64  # stand-in HMAC-SHA256 hex
 
+# Inbound auth now verifies the token against the runtime-fetched relay credential
+# (no secret in config). Patch the provider's verify to accept exactly RELAY_PW.
+_VERIFY = "compute_space.core.email.relay_credential.RelayCredentialProvider.verify_inbound_token"
+
 
 @pytest.fixture()
 def client(tmp_path: Path) -> Any:
     config = _make_test_config(
         tmp_path,
         email_enabled=True,
-        email_smtp_relay_password=RELAY_PW,
         email_mailbox_app_names=["stalwart-email-server"],
         email_proxy_base_url="https://frontend.example",
         email_keycloak_issuer_url="https://kc.example/realms/openhost-customers",
@@ -59,19 +62,22 @@ def _auth(token: str) -> dict[str, str]:
 
 
 def test_missing_token_401(client: TestClient) -> None:
-    resp = client.post("/_email/inbound", content=b"raw")
+    with mock.patch(_VERIFY, lambda self, t: t == RELAY_PW):
+        resp = client.post("/_email/inbound", content=b"raw")
     assert resp.status_code == 401
 
 
 def test_bad_token_401(client: TestClient) -> None:
-    resp = client.post("/_email/inbound", content=b"raw", headers=_auth("b" * 64))
+    with mock.patch(_VERIFY, lambda self, t: t == RELAY_PW):
+        resp = client.post("/_email/inbound", content=b"raw", headers=_auth("b" * 64))
     assert resp.status_code == 401
 
 
 def test_good_token_no_mailbox_app_503(client: TestClient) -> None:
     # find_app_by_name returns None (no app deployed) -> 503.
-    with mock.patch(
-        "compute_space.web.routes.api.system.find_app_by_name", return_value=None
+    with (
+        mock.patch(_VERIFY, lambda self, t: t == RELAY_PW),
+        mock.patch("compute_space.web.routes.api.system.find_app_by_name", return_value=None),
     ):
         resp = client.post("/_email/inbound", content=b"raw", headers=_auth(RELAY_PW))
     assert resp.status_code == 503
@@ -86,9 +92,8 @@ def test_good_token_forwards_to_mailbox_app(client: TestClient) -> None:
         return ASGIResponse(body=b'{"delivered":true}', status_code=200)
 
     with (
-        mock.patch(
-            "compute_space.web.routes.api.system.find_app_by_name", return_value=fake_app
-        ),
+        mock.patch(_VERIFY, lambda self, t: t == RELAY_PW),
+        mock.patch("compute_space.web.routes.api.system.find_app_by_name", return_value=fake_app),
         mock.patch(
             "compute_space.web.routes.api.system.proxy_http_request", side_effect=fake_proxy
         ) as proxied,

--- a/compute_space/src/compute_space/tests/test_relay_credential.py
+++ b/compute_space/src/compute_space/tests/test_relay_credential.py
@@ -1,0 +1,78 @@
+"""Tests for the runtime relay-credential provider (fetch + cache + verify)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest import mock
+
+from compute_space.core.email import relay_credential as rc
+from compute_space.core.email.relay_credential import RelayCredentialProvider
+from compute_space.tests.conftest import _make_test_config
+
+_EMAIL_KW = dict(
+    email_enabled=True,
+    email_proxy_base_url="https://frontend.example",
+    email_keycloak_issuer_url="https://kc.example/realms/openhost-customers",
+    email_keycloak_client_id="instance-x",
+    email_keycloak_client_secret="secret",
+    email_inbound_mx_host="inbound-smtp.us-west-2.amazonaws.com",
+)
+
+
+def _provider(tmp_path: Path, clock: list[float]) -> RelayCredentialProvider:
+    config = _make_test_config(tmp_path, zone_domain="alice.selfhost.imbue.com", **_EMAIL_KW)
+    return RelayCredentialProvider(config=config, monotonic=lambda: clock[0])
+
+
+def _fetch_body(pw: str = "hmac-pw") -> dict:
+    return {
+        "configured": True,
+        "smtp_relay_host": "openhost-email-proxy.fly.dev",
+        "smtp_relay_port": 465,
+        "smtp_relay_user": "alice.selfhost.imbue.com",
+        "smtp_relay_password": pw,
+        "zone_domain": "alice.selfhost.imbue.com",
+    }
+
+
+def test_disabled_returns_none(tmp_path: Path) -> None:
+    config = _make_test_config(tmp_path)  # email disabled
+    assert RelayCredentialProvider(config=config).get() is None
+
+
+def test_fetch_and_cache(tmp_path: Path) -> None:
+    clock = [0.0]
+    provider = _provider(tmp_path, clock)
+    with mock.patch.object(RelayCredentialProvider, "_fetch") as fetch:
+        fetch.return_value = rc.RelayCredential(
+            smtp_relay_host="h", smtp_relay_port=465, smtp_relay_user="u",
+            smtp_relay_password="pw", zone_domain="z", custom_domain=None,
+        )
+        c1 = provider.get()
+        c2 = provider.get()  # within TTL -> cached, no second fetch
+        assert c1 is c2
+        assert fetch.call_count == 1
+        # advance past TTL -> refetch
+        clock[0] += rc._CACHE_TTL_SECONDS + 1
+        provider.get()
+        assert fetch.call_count == 2
+
+
+def test_verify_inbound_token_constant_time_match(tmp_path: Path) -> None:
+    provider = _provider(tmp_path, [0.0])
+    cred = rc.RelayCredential(
+        smtp_relay_host="h", smtp_relay_port=465, smtp_relay_user="u",
+        smtp_relay_password="the-pw", zone_domain="z", custom_domain=None,
+    )
+    with mock.patch.object(RelayCredentialProvider, "_fetch", return_value=cred):
+        assert provider.verify_inbound_token("the-pw") is True
+        assert provider.verify_inbound_token("wrong") is False
+        assert provider.verify_inbound_token("") is False
+
+
+def test_verify_fails_closed_on_fetch_error(tmp_path: Path) -> None:
+    provider = _provider(tmp_path, [0.0])
+    with mock.patch.object(
+        RelayCredentialProvider, "_fetch", side_effect=rc.RelayCredentialError("boom")
+    ):
+        assert provider.verify_inbound_token("anything") is False

--- a/compute_space/src/compute_space/web/routes/api/system.py
+++ b/compute_space/src/compute_space/web/routes/api/system.py
@@ -1,4 +1,6 @@
 import hashlib
+import hmac
+import json
 import os
 import secrets
 import sqlite3
@@ -17,9 +19,11 @@ from litestar import delete
 from litestar import get
 from litestar import post
 from litestar.exceptions import NotAuthorizedException
+from litestar.response.base import ASGIResponse
 
 from compute_space import OPENHOST_PROJECT_DIR
 from compute_space.config import Config
+from compute_space.core.apps import find_app_by_name
 from compute_space.core.auth.security_audit import ListeningPort
 from compute_space.core.auth.security_audit import external_ports
 from compute_space.core.auth.security_audit import is_sshd_active
@@ -31,6 +35,7 @@ from compute_space.core.git_ops import get_branch_name
 from compute_space.core.git_ops import get_head_sha
 from compute_space.core.git_ops import is_dirty
 from compute_space.core.logging import get_log_path
+from compute_space.core.logging import logger
 from compute_space.core.storage import is_guard_paused
 from compute_space.core.storage import set_guard_paused
 from compute_space.core.storage import storage_status
@@ -38,8 +43,18 @@ from compute_space.core.updates import is_shutdown_pending
 from compute_space.web.auth.auth import require_app_auth
 from compute_space.web.auth.auth import require_owner_auth
 from compute_space.web.auth.auth import verify_app_auth
+from compute_space.web.helpers.proxy import proxy_http_request
 
 DEFAULT_TOKEN_EXPIRY_HOURS: float = 8.0
+
+
+def _asgi_json_error(error: str, message: str, status: int) -> ASGIResponse:
+    """JSON error as an already-encoded ASGIResponse (for handlers returning ASGIResponse)."""
+    return ASGIResponse(
+        body=json.dumps({"error": error, "message": message}).encode(),
+        status_code=status,
+        media_type=MediaType.JSON,
+    )
 
 
 # ─── attrs models ──────────────────────────────────────────────────────────
@@ -446,6 +461,47 @@ def custom_email_domain(config: Config) -> CustomEmailDomainResponse:
     )
 
 
+@post("/_email/inbound")
+async def email_inbound(request: Request[Any, Any, Any], config: Config) -> ASGIResponse:
+    """Receive an inbound message from the email proxy and hand it to the mailbox app.
+
+    The email proxy (openhost-email-proxy), after verifying the AWS SNS signature
+    and fetching the raw RFC822 from S3, POSTs it here (via the imbue-hosted-spaces
+    public door). We authenticate that hop with the per-instance credential the
+    instance already holds — the SMTP relay password, which is
+    HMAC-SHA256(RELAY_SECRET, zone) — presented as ``Authorization: Bearer <pw>``,
+    then forward the request to the mailbox app's own ``/_email/inbound`` on its
+    loopback port. The mailbox app performs the actual mailbox delivery.
+
+    Auth is constant-time. An unconfigured instance and a bad credential both
+    return 401 so we don't leak whether email is enabled here.
+    """
+    header = request.headers.get("Authorization", "")
+    token = header[7:] if header.startswith("Bearer ") else ""
+    expected = config.email_smtp_relay_password or ""
+    ok = bool(config.email_enabled and expected and token and hmac.compare_digest(token, expected))
+    if not ok:
+        return _asgi_json_error("unauthorized", "invalid inbound credential", 401)
+
+    # Deliver to the first configured mailbox app that is deployed.
+    target_port: int | None = None
+    for name in config.email_mailbox_app_names:
+        app = find_app_by_name(name)
+        if app is not None:
+            target_port = app.local_port
+            break
+    if target_port is None:
+        logger.warning("Inbound mail received but no mailbox app is deployed; dropping")
+        return _asgi_json_error("no_mailbox_app", "no mailbox app deployed", 503)
+
+    return await proxy_http_request(
+        request,
+        target_port=target_port,
+        override_path="/_email/inbound",
+        read_timeout=30,
+    )
+
+
 @post("/restart_router", status_code=200, guards=[require_owner_auth], sync_to_thread=False)
 def restart_router() -> OkResponse:
     """Restart the router systemd service to pick up code changes."""
@@ -480,6 +536,7 @@ system_routes = Router(
         api_diagnostics,
         email_relay_config,
         custom_email_domain,
+        email_inbound,
         restart_router,
     ],
 )

--- a/compute_space/src/compute_space/web/routes/api/system.py
+++ b/compute_space/src/compute_space/web/routes/api/system.py
@@ -1,10 +1,10 @@
 import hashlib
-import hmac
 import json
 import os
 import secrets
 import sqlite3
 import subprocess
+import threading
 from datetime import UTC
 from datetime import datetime
 from datetime import timedelta
@@ -31,6 +31,8 @@ from compute_space.core.auth.security_audit import list_listening_ports
 from compute_space.core.containers import drop_docker_build_cache
 from compute_space.core.diagnostics import PlatformDiagnostics
 from compute_space.core.diagnostics import collect_platform_diagnostics
+from compute_space.core.email.relay_credential import RelayCredentialError
+from compute_space.core.email.relay_credential import RelayCredentialProvider
 from compute_space.core.git_ops import get_branch_name
 from compute_space.core.git_ops import get_head_sha
 from compute_space.core.git_ops import is_dirty
@@ -55,6 +57,23 @@ def _asgi_json_error(error: str, message: str, status: int) -> ASGIResponse:
         status_code=status,
         media_type=MediaType.JSON,
     )
+
+
+# Process-wide relay-credential provider (caches the frontend-fetched credential
+# with a short TTL). One per config identity so tests with distinct configs don't
+# bleed into each other.
+_relay_providers: dict[int, RelayCredentialProvider] = {}
+_relay_providers_lock = threading.Lock()
+
+
+def get_relay_credential_provider(config: Config) -> RelayCredentialProvider:
+    key = id(config)
+    with _relay_providers_lock:
+        provider = _relay_providers.get(key)
+        if provider is None:
+            provider = RelayCredentialProvider(config=config)
+            _relay_providers[key] = provider
+        return provider
 
 
 # ─── attrs models ──────────────────────────────────────────────────────────
@@ -390,44 +409,53 @@ async def api_diagnostics(
     return Response(content=diagnostics, status_code=200, media_type=MediaType.JSON, headers=headers)
 
 
-@get("/api/email/relay-config", guards=[require_app_auth], sync_to_thread=False)
+@get("/api/email/relay-config", guards=[require_app_auth], sync_to_thread=True)
 def email_relay_config(
     request: Request[Any, Any, Any], db: sqlite3.Connection, config: Config
 ) -> Response[EmailRelayConfigResponse]:
     """Return the SMTP smarthost relay config for the mailbox app.
 
     Scoped: the request must be authenticated as an app (OPENHOST_APP_TOKEN), and
-    that app must be one of ``config.email_mailbox_app_names``. This keeps the
-    per-instance relay password out of every other app's environment — only the
-    mailbox app can fetch it, and only over the loopback router URL.
+    that app must be one of ``config.email_mailbox_app_names``. The relay host/port
+    + per-instance credential are fetched at runtime from the frontend (never baked
+    into this instance's config), then handed only to the mailbox app.
     """
     app_id = verify_app_auth(request)
     row = db.execute("SELECT name FROM apps WHERE app_id = ?", (app_id,)).fetchone()
     app_name = row["name"] if row is not None else None
     if app_name not in config.email_mailbox_app_names:
         raise NotAuthorizedException(detail="app is not authorized to fetch email relay config")
-    if not config.email_enabled or not config.email_smtp_relay_host:
-        return Response(
-            content=EmailRelayConfigResponse(
-                configured=False,
-                smtp_relay_host=None,
-                smtp_relay_port=None,
-                smtp_relay_user=None,
-                smtp_relay_password=None,
-                zone_domain=None,
-                custom_domain=None,
-            ),
-            media_type=MediaType.JSON,
-        )
+
+    unconfigured = Response(
+        content=EmailRelayConfigResponse(
+            configured=False,
+            smtp_relay_host=None,
+            smtp_relay_port=None,
+            smtp_relay_user=None,
+            smtp_relay_password=None,
+            zone_domain=None,
+            custom_domain=None,
+        ),
+        media_type=MediaType.JSON,
+    )
+    if not config.email_enabled:
+        return unconfigured
+    try:
+        cred = get_relay_credential_provider(config).get()
+    except RelayCredentialError as e:
+        logger.warning(f"relay-config: could not fetch credential from frontend: {e}")
+        return unconfigured
+    if cred is None:
+        return unconfigured
     return Response(
         content=EmailRelayConfigResponse(
             configured=True,
-            smtp_relay_host=config.email_smtp_relay_host,
-            smtp_relay_port=config.email_smtp_relay_port,
-            smtp_relay_user=config.email_smtp_relay_user,
-            smtp_relay_password=config.email_smtp_relay_password,
-            zone_domain=config.zone_domain_no_port,
-            custom_domain=config.email_custom_domain_normalized,
+            smtp_relay_host=cred.smtp_relay_host,
+            smtp_relay_port=cred.smtp_relay_port,
+            smtp_relay_user=cred.smtp_relay_user,
+            smtp_relay_password=cred.smtp_relay_password,
+            zone_domain=cred.zone_domain,
+            custom_domain=cred.custom_domain,
         ),
         media_type=MediaType.JSON,
     )
@@ -478,9 +506,10 @@ async def email_inbound(request: Request[Any, Any, Any], config: Config) -> ASGI
     """
     header = request.headers.get("Authorization", "")
     token = header[7:] if header.startswith("Bearer ") else ""
-    expected = config.email_smtp_relay_password or ""
-    ok = bool(config.email_enabled and expected and token and hmac.compare_digest(token, expected))
-    if not ok:
+    # Verify against this instance's relay password, resolved at runtime from the
+    # frontend (HMAC(RELAY_SECRET, zone)); no secret is stored in config. Fails
+    # closed (401) on a fetch blip so we never accept unauthenticated inbound.
+    if not config.email_enabled or not get_relay_credential_provider(config).verify_inbound_token(token):
         return _asgi_json_error("unauthorized", "invalid inbound credential", 401)
 
     # Deliver to the first configured mailbox app that is deployed.


### PR DESCRIPTION
Stacked on andrew/email-custom-domain-and-apps (PR #243).

The email proxy POSTs received mail (raw RFC822, after SNS signature verification and S3 fetch) to https://<zone>/_email/inbound via the imbue-hosted-spaces public door. This router endpoint authenticates that hop in constant time against the per-instance SMTP relay password the instance already holds (Authorization: Bearer = HMAC-SHA256(RELAY_SECRET, zone)), then forwards the request to the first deployed mailbox app (email_mailbox_app_names) on its loopback port at /_email/inbound, which performs actual mailbox delivery. Unconfigured and bad-credential both return 401 (no leak); no mailbox app deployed returns 503. Adds route tests covering auth, no-app, and successful forward.