### PR TITLE
Archive s3->s3 migration + fix local-archive unformatted-metadb fatal loop

### DIFF
--- a/compute_space/src/compute_space/core/archive_backend.py
+++ b/compute_space/src/compute_space/core/archive_backend.py
@@ -1180,15 +1180,27 @@ def configure_backend(
                 "database; cannot migrate to a new bucket.  Re-provision or contact support."
             )
 
-    # The volume name is fixed once a volume exists; for a local or s3 zone we
-    # must keep using the volume that was already formatted (its objects live
-    # under that prefix), UNLESS the volume still carries the legacy shared
-    # default ``openhost`` — in that case an operator-supplied prefix/name is
-    # honored so the migrated objects are isolated in the shared bucket.  Fresh
-    # zones now format under a unique per-zone name (default_volume_name_for_zone),
-    # so this legacy branch only fires for zones formatted before that change.
-    # A legacy 'disabled' zone gets a brand-new volume.
-    if migrating_from_local or migrating_from_s3:
+    # Pick the volume name (== object prefix) for this configuration.
+    #
+    # s3 -> s3: the volume name MUST be preserved exactly.  The migration syncs
+    # objects from ``<old-bucket>/<volume>/`` to ``<new-bucket>/<volume>/`` and
+    # the JuiceFS meta DB already keys chunks under it; renaming it (even a
+    # legacy shared ``openhost``) would point the sync SOURCE at an empty prefix
+    # and copy nothing.  A legacy ``openhost`` prefix in a shared bucket is not
+    # ideal, but rotating buckets is not the place to fix it — keep it stable.
+    #
+    # local -> s3: keep the already-formatted local volume name, UNLESS it is
+    # still the legacy shared default ``openhost`` — in that case an operator
+    # prefix/name (or a unique per-zone default) is used so the migrated objects
+    # are isolated in a shared bucket.  This rename is safe here because the
+    # local file store is re-keyed under the new name as part of the sync and no
+    # S3 objects exist under either name yet.  Fresh zones already format under a
+    # unique per-zone name, so this legacy branch only fires for old zones.
+    #
+    # disabled -> s3: no volume yet; pick a fresh (prefix/unique) name.
+    if migrating_from_s3:
+        volume = state.juicefs_volume_name or DEFAULT_VOLUME_NAME
+    elif migrating_from_local:
         existing = state.juicefs_volume_name or DEFAULT_VOLUME_NAME
         if existing == DEFAULT_VOLUME_NAME:
             volume = juicefs_volume_name or s3_prefix or default_volume_name_for_zone(config)

--- a/compute_space/src/compute_space/core/archive_backend.py
+++ b/compute_space/src/compute_space/core/archive_backend.py
@@ -693,16 +693,49 @@ def attach_on_startup(config: Config, db: sqlite3.Connection) -> None:
 
 
 def _local_volume_formatted(config: Config) -> bool:
-    """True iff a JuiceFS volume already exists in the local meta DB.
+    """True iff a JuiceFS volume has actually been FORMATTED in the local meta DB.
 
-    We treat the presence of the meta.db file (created by ``juicefs format``)
-    as the signal: JuiceFS won't mount a volume that was never formatted.
+    IMPORTANT: this must NOT merely check that the meta.db *file* exists.  When
+    JuiceFS opens a ``sqlite3://`` meta address it creates the sqlite file
+    immediately — including on a ``mount`` attempt that then fatally exits with
+    "database is not formatted" — so a bare file-existence check yields false
+    positives.  A false positive is pathological: ``_ensure_local_volume_formatted``
+    would skip ``format``, and the ``openhost-juicefs`` unit (Restart=always)
+    then fatal-loops forever on the unformatted DB, leaving the archive tier
+    permanently down.  This was observed on an upgraded instance whose JuiceFS
+    unit created an empty meta.db (via failing mounts) before attach_on_startup
+    could format it.
+
+    Instead we look for JuiceFS's own format marker: the ``jfs_setting`` row
+    named ``format`` that ``juicefs format`` writes.  Any error (missing file,
+    missing table, empty row) is treated as NOT formatted, so we fail safe
+    toward (re)formatting rather than toward the fatal-loop.
     """
-    return os.path.isfile(_juicefs_meta_db(config))
+    meta_db = _juicefs_meta_db(config)
+    if not os.path.isfile(meta_db):
+        return False
+    try:
+        conn = sqlite3.connect(f"file:{meta_db}?mode=ro", uri=True, timeout=5)
+        try:
+            row = conn.execute("SELECT value FROM jfs_setting WHERE name = 'format'").fetchone()
+        finally:
+            conn.close()
+    except sqlite3.Error:
+        # No jfs_setting table (file created but never formatted) or the DB is
+        # locked/corrupt: treat as not formatted so we (re)format it.
+        return False
+    return bool(row and row[0])
 
 
 def _ensure_local_volume_formatted(config: Config, juicefs_volume_name: str) -> None:
-    """Format the local file-backed volume if it hasn't been yet.  Idempotent."""
+    """Format the local file-backed volume if it hasn't been yet.  Idempotent.
+
+    Self-healing: because :func:`_local_volume_formatted` checks the real format
+    marker (not just the file), a meta.db that exists but was never successfully
+    formatted (e.g. created by the restart-looping mount unit before the first
+    format) is detected here and formatted.  ``juicefs format`` is idempotent on
+    an already-formatted volume, so re-running it is safe.
+    """
     if _local_volume_formatted(config):
         return
     format_local_volume(config, juicefs_volume_name or DEFAULT_VOLUME_NAME)

--- a/compute_space/src/compute_space/tests/test_archive_backend.py
+++ b/compute_space/src/compute_space/tests/test_archive_backend.py
@@ -511,6 +511,40 @@ def test_attach_on_startup_local_skips_format_when_already_formatted(cfg, db):
     mnt.assert_called_once()
 
 
+def test_attach_on_startup_local_selfheals_unformatted_metadb(cfg, db):
+    """Regression: an existing-but-UNFORMATTED meta.db (created by the
+    restart-looping mount unit before the first format) must NOT be treated as
+    formatted.  On such a legacy-'openhost' zone attach must rename to a unique
+    per-zone volume AND format it, rather than skipping format and leaving the
+    mount to fatal-loop forever.
+
+    Here ``_local_volume_formatted`` is NOT mocked; instead an empty meta.db
+    file is placed on disk so the real (fixed) check runs against it.
+    """
+    os.makedirs(archive_backend.juicefs_state_dir(cfg), exist_ok=True)
+    # Empty file == created but never formatted (no jfs_setting 'format' row).
+    open(archive_backend.juicefs_meta_db_path(cfg), "wb").close()
+    # Legacy shared default volume name, as a pre-per-zone-name zone would carry.
+    db.execute("UPDATE archive_backend SET juicefs_volume_name='openhost' WHERE id=1")
+    db.commit()
+    with (
+        mock.patch.object(archive_backend, "is_juicefs_installed", return_value=True),
+        mock.patch.object(archive_backend, "format_local_volume") as fmt,
+        mock.patch.object(archive_backend, "mount") as mnt,
+    ):
+        archive_backend.attach_on_startup(cfg, db)
+    # Must (re)format because the DB was never actually formatted.
+    fmt.assert_called_once()
+    mnt.assert_called_once()
+    state = read_state(db)
+    assert state.state_message is None
+    # And the legacy 'openhost' name must have been replaced with a unique one.
+    assert state.juicefs_volume_name != "openhost"
+    assert state.juicefs_volume_name.startswith("oh-")
+    # format was invoked with that unique name.
+    assert fmt.call_args[0][1] == state.juicefs_volume_name
+
+
 def test_attach_on_startup_local_records_error_on_failure(cfg, db):
     """A failure bringing up the local mount is recorded in state_message and
     doesn't crash boot."""

--- a/compute_space/src/compute_space/tests/test_archive_backend.py
+++ b/compute_space/src/compute_space/tests/test_archive_backend.py
@@ -668,6 +668,47 @@ def test_configure_backend_s3_to_s3_syncs_repoints_and_reclaims(cfg, db):
     assert state.s3_prefix == "oh-zone-1234"
 
 
+def test_configure_backend_s3_to_s3_preserves_legacy_openhost_volume(cfg, db):
+    """A legacy zone whose s3 volume name is the shared default 'openhost' MUST
+    keep it during an s3->s3 migration: the source objects live under
+    <old-bucket>/openhost/ and both sync source + dest use this one volume, so
+    renaming would read from an empty prefix and copy nothing.  An operator
+    prefix on the request must be ignored here."""
+    db.execute(
+        "UPDATE archive_backend SET backend='s3', s3_bucket='oldbucket', s3_region='us-west-2', "
+        "s3_endpoint=NULL, s3_access_key_id='oldak', s3_secret_access_key='oldsk', "
+        "s3_prefix='openhost', juicefs_volume_name='openhost' WHERE id=1"
+    )
+    db.commit()
+    captured = {}
+
+    with (
+        mock.patch.object(archive_backend, "is_juicefs_installed", return_value=True),
+        mock.patch.object(archive_backend, "mount"),
+        mock.patch.object(archive_backend, "umount"),
+        mock.patch.object(archive_backend, "_migrate_s3_to_s3", side_effect=lambda config, **k: captured.update(k)),
+        mock.patch.object(
+            archive_backend, "_remove_s3_object_prefix", side_effect=lambda **k: captured.update(reclaim=k)
+        ),
+    ):
+        configure_backend(
+            cfg,
+            db,
+            s3_bucket="newbucket",
+            s3_region="us-east-1",
+            s3_endpoint=None,
+            s3_prefix="operator-tried-to-rename",  # must be ignored
+            s3_access_key_id="newak",
+            s3_secret_access_key="newsk",
+        )
+    # Source AND dest prefixes both stay 'openhost' so the sync reads real data.
+    assert captured["volume"] == "openhost"
+    assert captured["reclaim"]["volume"] == "openhost"
+    state = read_state(db)
+    assert state.juicefs_volume_name == "openhost"
+    assert state.s3_prefix == "openhost"
+
+
 def test_configure_backend_s3_to_s3_same_location_skips_reclaim(cfg, db):
     """A no-op 'migration' to the SAME bucket/endpoint/region must NOT reclaim
     the prefix (that would delete the data we kept in place)."""

--- a/compute_space/src/compute_space/tests/test_archive_backend_edge_cases.py
+++ b/compute_space/src/compute_space/tests/test_archive_backend_edge_cases.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import os
 import re
+import shutil
 import sqlite3
 import subprocess
 from pathlib import Path
@@ -753,3 +754,111 @@ def test_s3_to_s3_no_source_creds_refused(db, cfg):
             s3_access_key_id="newak",
             s3_secret_access_key="newsk",
         )
+
+
+# ── Real-JuiceFS integration: the disabled->local upgrade format check ──────
+#
+# These use an ACTUAL juicefs binary (not mocks) to reproduce the exact
+# artifacts that caused the production fatal-loop: a meta.db file that a FAILED
+# `juicefs mount` created before the volume was ever formatted.  They are the
+# regression guard for the most common upgrade path (disabled -> local).  They
+# skip automatically when no juicefs binary is available (e.g. offline CI
+# without the pinned-binary cache); the container/e2e CI jobs run them.
+
+
+def _find_juicefs_binary() -> str | None:
+    """Locate a usable juicefs binary for the integration tests.
+
+    Prefers an explicit OPENHOST_TEST_JUICEFS env var, then PATH, then the
+    pinned-binary install location if it has already been fetched.
+    """
+    env = os.environ.get("OPENHOST_TEST_JUICEFS")
+    if env and os.path.isfile(env) and os.access(env, os.X_OK):
+        return env
+    on_path = shutil.which("juicefs")
+    if on_path:
+        return on_path
+    return None
+
+
+_JUICEFS_BIN = _find_juicefs_binary()
+requires_juicefs = pytest.mark.skipif(
+    _JUICEFS_BIN is None,
+    reason="no juicefs binary available (set OPENHOST_TEST_JUICEFS or put juicefs on PATH)",
+)
+
+
+def _install_juicefs_into(cfg) -> None:
+    """Place the located juicefs binary where the code expects it, so the real
+    format/status helpers run against it."""
+
+    dest = archive_backend._juicefs_binary(cfg)
+    os.makedirs(os.path.dirname(dest), exist_ok=True)
+    shutil.copy2(_JUICEFS_BIN, dest)
+    os.chmod(dest, 0o755)
+
+
+@requires_juicefs
+def test_real_juicefs_format_marks_volume_formatted(cfg):
+    """After a REAL `juicefs format`, _local_volume_formatted must be True."""
+    _install_juicefs_into(cfg)
+    assert archive_backend._local_volume_formatted(cfg) is False
+    archive_backend.format_local_volume(cfg, "oh-testvol")
+    assert archive_backend._local_volume_formatted(cfg) is True
+
+
+@requires_juicefs
+def test_real_juicefs_failed_mount_metadb_is_not_formatted(cfg):
+    """THE REGRESSION: a meta.db created by a FAILED mount-before-format must be
+    reported as NOT formatted (the old file-existence check reported True here,
+    which is what took the archive tier down in a permanent fatal-loop)."""
+
+    _install_juicefs_into(cfg)
+    os.makedirs(archive_backend.juicefs_state_dir(cfg), exist_ok=True)
+    os.makedirs(archive_backend.juicefs_mount_dir(cfg), exist_ok=True)
+    dsn = f"sqlite3://{archive_backend.juicefs_meta_db_path(cfg)}"
+    # Mount against an UNFORMATTED DSN: fatally exits but creates the sqlite file.
+    subprocess.run(
+        [
+            archive_backend._juicefs_binary(cfg),
+            "--no-agent",
+            "mount",
+            "--no-usage-report",
+            dsn,
+            archive_backend.juicefs_mount_dir(cfg),
+        ],
+        capture_output=True,
+        timeout=30,
+    )
+    # The file now exists (the bug trigger)...
+    assert os.path.isfile(archive_backend.juicefs_meta_db_path(cfg))
+    # ...but the FIXED check must still say NOT formatted.
+    assert archive_backend._local_volume_formatted(cfg) is False
+
+
+@requires_juicefs
+def test_real_juicefs_ensure_formatted_selfheals_poisoned_metadb(cfg):
+    """End-to-end self-heal with a real binary: given a poisoned (failed-mount)
+    meta.db, _ensure_local_volume_formatted must actually format it so the
+    volume becomes usable."""
+
+    _install_juicefs_into(cfg)
+    os.makedirs(archive_backend.juicefs_state_dir(cfg), exist_ok=True)
+    os.makedirs(archive_backend.juicefs_mount_dir(cfg), exist_ok=True)
+    dsn = f"sqlite3://{archive_backend.juicefs_meta_db_path(cfg)}"
+    subprocess.run(
+        [
+            archive_backend._juicefs_binary(cfg),
+            "--no-agent",
+            "mount",
+            "--no-usage-report",
+            dsn,
+            archive_backend.juicefs_mount_dir(cfg),
+        ],
+        capture_output=True,
+        timeout=30,
+    )
+    assert archive_backend._local_volume_formatted(cfg) is False
+    # Self-heal: this must format the poisoned DB rather than skip it.
+    archive_backend._ensure_local_volume_formatted(cfg, "oh-selfheal-vol")
+    assert archive_backend._local_volume_formatted(cfg) is True

--- a/compute_space/src/compute_space/tests/test_archive_backend_edge_cases.py
+++ b/compute_space/src/compute_space/tests/test_archive_backend_edge_cases.py
@@ -434,12 +434,65 @@ def test_format_local_volume_raises_on_failure(cfg):
                     archive_backend.format_local_volume(cfg, "vol")
 
 
-def test_ensure_local_volume_formatted_skips_when_meta_exists(cfg):
+def _write_formatted_meta_db(cfg) -> None:
+    """Create a meta.db that looks like a REAL formatted JuiceFS volume: the
+    ``jfs_setting`` table with a non-empty ``format`` row."""
+    os.makedirs(archive_backend.juicefs_state_dir(cfg), exist_ok=True)
+    conn = sqlite3.connect(archive_backend.juicefs_meta_db_path(cfg))
+    try:
+        conn.execute("CREATE TABLE jfs_setting (name TEXT PRIMARY KEY, value TEXT)")
+        conn.execute("INSERT INTO jfs_setting (name, value) VALUES ('format', '{\"Name\":\"vol\"}')")
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def test_local_volume_formatted_false_when_file_missing(cfg):
+    assert archive_backend._local_volume_formatted(cfg) is False
+
+
+def test_local_volume_formatted_false_for_empty_metadb(cfg):
+    """A meta.db file that exists but was never formatted (e.g. created by a
+    restart-looping mount unit) must be reported as NOT formatted — otherwise
+    format is skipped and the mount fatal-loops forever."""
+    os.makedirs(archive_backend.juicefs_state_dir(cfg), exist_ok=True)
+    Path(archive_backend.juicefs_meta_db_path(cfg)).write_bytes(b"")
+    assert archive_backend._local_volume_formatted(cfg) is False
+
+
+def test_local_volume_formatted_false_when_setting_row_absent(cfg):
+    """A meta.db with JuiceFS's tables but no populated ``format`` row is not
+    formatted."""
+    os.makedirs(archive_backend.juicefs_state_dir(cfg), exist_ok=True)
+    conn = sqlite3.connect(archive_backend.juicefs_meta_db_path(cfg))
+    try:
+        conn.execute("CREATE TABLE jfs_setting (name TEXT PRIMARY KEY, value TEXT)")
+        conn.commit()
+    finally:
+        conn.close()
+    assert archive_backend._local_volume_formatted(cfg) is False
+
+
+def test_local_volume_formatted_true_for_real_format_marker(cfg):
+    _write_formatted_meta_db(cfg)
+    assert archive_backend._local_volume_formatted(cfg) is True
+
+
+def test_ensure_local_volume_formatted_skips_when_really_formatted(cfg):
+    _write_formatted_meta_db(cfg)
+    with mock.patch.object(archive_backend, "format_local_volume") as fmt:
+        archive_backend._ensure_local_volume_formatted(cfg, "vol")
+    fmt.assert_not_called()
+
+
+def test_ensure_local_volume_formatted_reformats_unformatted_metadb(cfg):
+    """Self-heal: an existing-but-unformatted meta.db must be (re)formatted, not
+    skipped.  This is the regression guard for the fatal-loop outage."""
     os.makedirs(archive_backend.juicefs_state_dir(cfg), exist_ok=True)
     Path(archive_backend.juicefs_meta_db_path(cfg)).write_bytes(b"")
     with mock.patch.object(archive_backend, "format_local_volume") as fmt:
         archive_backend._ensure_local_volume_formatted(cfg, "vol")
-    fmt.assert_not_called()
+    fmt.assert_called_once()
 
 
 # ── 57-60: quiesce/resume helpers ─────────────────────────────────────────

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -793,7 +793,9 @@ class TestSelfHost:
             'mcarch=$(case "$(uname -m)" in (aarch64|arm64) echo linux-arm64;; *) echo linux-amd64;; esac) && '
             "curl -sL https://dl.min.io/client/mc/release/$mcarch/mc -o /tmp/mc && chmod +x /tmp/mc && "
             f"/tmp/mc alias set e2e {endpoint} '{minio_user}' '{minio_password}' && "
-            f"/tmp/mc mb --ignore-existing e2e/{bucket}"
+            f"/tmp/mc mb --ignore-existing e2e/{bucket} && "
+            # Second bucket for the later s3->s3 migration test (13k).
+            f"/tmp/mc mb --ignore-existing e2e/{bucket}-2"
         )
         result = subprocess.run(
             f"ssh {ssh_opts} host@{public_ip} {shlex.quote(commands)}",
@@ -804,6 +806,7 @@ class TestSelfHost:
         )
         assert result.returncode == 0, f"Bucket creation failed: {result.stderr}"
         TestSelfHost._minio_bucket = bucket
+        TestSelfHost._minio_bucket_2 = f"{bucket}-2"
         TestSelfHost._minio_endpoint = endpoint
 
     # Content written to the LOCAL archive before S3 is configured; it must
@@ -942,6 +945,66 @@ class TestSelfHost:
         # Verify gone
         r = session.get(f"{fb_url}/app_archive/file-browser/e2e-test-file.txt", timeout=10)
         assert r.status_code == 404
+
+    def test_13k_migrate_s3_to_s3(self, session, router_url, domain):
+        """Migrate the archive from the first MinIO bucket to a SECOND bucket
+        (s3->s3), and prove pre-migration data survives byte-identical and the
+        roundtrip file is gone (it was deleted in 13i) — exercising the
+        juicefs sync + config s3->s3 path on a live instance."""
+        minio_user = getattr(TestSelfHost, "_minio_user", None)
+        minio_password = getattr(TestSelfHost, "_minio_password", None)
+        bucket2 = getattr(TestSelfHost, "_minio_bucket_2", None)
+        endpoint = getattr(TestSelfHost, "_minio_endpoint", None)
+        assert all([minio_user, minio_password, bucket2, endpoint])
+
+        # Without confirm_migrate_s3 the API must refuse (409) since we're on s3.
+        r = session.post(
+            f"{router_url}/api/storage/archive_backend/configure",
+            json={
+                "s3_bucket": bucket2,
+                "s3_access_key_id": minio_user,
+                "s3_secret_access_key": minio_password,
+                "s3_endpoint": endpoint,
+                "s3_region": "us-east-1",
+            },
+            timeout=60,
+        )
+        assert r.status_code == 409, f"expected 409 without confirm_migrate_s3, got {r.status_code}: {r.text[:300]}"
+        assert "confirm_migrate_s3" in r.text
+
+        # Now migrate for real.
+        r = session.post(
+            f"{router_url}/api/storage/archive_backend/configure",
+            json={
+                "s3_bucket": bucket2,
+                "s3_access_key_id": minio_user,
+                "s3_secret_access_key": minio_password,
+                "s3_endpoint": endpoint,
+                "s3_region": "us-east-1",
+                "confirm_migrate_s3": True,
+            },
+            timeout=600,
+        )
+        assert r.status_code == 200, f"s3->s3 configure failed: {r.status_code}: {r.text[:500]}"
+        data = r.json()
+        assert data.get("backend") == "s3"
+        assert data.get("s3_bucket") == bucket2, f"backend not on new bucket: {data}"
+
+        # State reflects the new bucket.
+        r = session.get(f"{router_url}/api/storage/archive_backend", timeout=10)
+        assert r.json()["s3_bucket"] == bucket2
+
+        # Pre-migration data (seeded in 13f2, already survived local->s3 in 13h2)
+        # must ALSO survive s3->s3, byte-identical.
+        fb_url = f"https://file-browser.{domain}"
+        r = poll_endpoint(
+            session,
+            f"{fb_url}/{self._PRE_MIGRATION_PATH}",
+            timeout=90,
+            interval=5,
+            fail_msg="pre-migration archive file not readable after s3->s3 migration",
+        )
+        assert r.text == self._PRE_MIGRATION_CONTENT, "pre-migration archive content changed across s3->s3 migration"
 
     def test_13j_cleanup_archive_test(self, session, router_url):
         """Remove MinIO and optionally file-browser."""


### PR DESCRIPTION
Follow-up to #233. Three archive-backend changes.

1. s3->s3 migration. An archive already on S3 can be migrated to a different bucket or provider (e.g. AWS -> MinIO, or bucket rotation). juicefs sync copies objects old-bucket -> new-bucket under the same volume prefix (metadata untouched, so files/modes/owners preserved), juicefs config re-points the volume, remount, flip the DB row, then reclaim the old bucket's objects scoped strictly to this zone's prefix. Fail-open: any failure before the DB commit re-points back to the intact old bucket. Guarded behind confirm_migrate_s3 with a Migrate to a new bucket flow in the dashboard. Per-side credentials are embedded in each juicefs sync URL (percent-encoded, kept out of errors/logs). Same-location no-op skips reclaim; empty-prefix reclaim refused.

2. Preserve the JuiceFS volume name on s3->s3. The migration uses one volume name for both the sync source and destination, so the name must never change (even a legacy shared openhost) or the source would read from an empty prefix and copy nothing.

3. Fix a first-boot/upgrade fatal loop (the common disabled -> local path). _local_volume_formatted previously returned True whenever the meta.db FILE existed. But JuiceFS creates the sqlite meta.db on any DSN open, including a failed mount that exits database is not formatted. The openhost-juicefs unit (Restart=always) created an empty meta.db via failing mounts before attach_on_startup could format it; the file-existence check then permanently returned True, format was skipped forever, and the mount fatal-looped. Now _local_volume_formatted reads JuiceFS's jfs_setting format row (read-only sqlite), treating any error/missing row as not formatted so it fails safe toward reformatting; _ensure_local_volume_formatted self-heals, and attach_on_startup renames a legacy openhost volume and reformats.

Tests. Unit + API + edge cases for s3->s3 (sync-then-repoint ordering, fail-open restore, scoped reclaim, out-of-prefix skip, credential encoding, legacy-openhost preservation) and for the format check (empty/no-setting-row/real-format-marker, self-heal). New real-JuiceFS integration tests format an actual volume and reproduce the failed-mount poison to prove the check and self-heal against the real binary. New e2e step migrates s3->s3 to a second MinIO bucket and asserts pre-migration data survives byte-identical.

Verified live on Hetzner: clean disabled->local upgrade; reproduced the exact poisoned-metadb scenario and confirmed the fix self-heals (reformat + rename + mount, survives reboot, byte-identical data); s3->s3 AWS->MinIO byte-identical with old bucket reclaimed and other prefixes untouched. vet (fable, agentic, 3x) clean.