### PR TITLE
Detect and self-heal rootless-podman overlay build-cache corruption

### DIFF
--- a/compute_space/src/compute_space/core/containers.py
+++ b/compute_space/src/compute_space/core/containers.py
@@ -78,6 +78,10 @@ DEFAULT_CAPABILITIES: frozenset[str] = frozenset(
 _BUILD_CACHE_CORRUPT_FRAGMENTS_UNCONDITIONAL = (
     "storage-driver errored",
     "layer not known",
+    # buildah aborts a build step when the overlay layer it just tried to
+    # mount is unusable (see _OVERLAY_LINK_CORRUPT_RE) and then reports the
+    # discarded build container as "identifier is not a container".
+    "identifier is not a container",
 )
 
 # The "missing local layer blob" error from containers-storage.  The
@@ -85,11 +89,21 @@ _BUILD_CACHE_CORRUPT_FRAGMENTS_UNCONDITIONAL = (
 # errors that happen to mention a sha256 digest.
 _MISSING_LAYER_RE = re.compile(r"content digest sha256:[0-9a-f]+:\s*not found", re.IGNORECASE)
 
+# containers-storage overlay corruption: when a layer's short-name "link"
+# file is empty or missing, the overlay driver assembles a lowerdir that
+# resolves to the bare `overlay`/`overlay/l` directory, and the mount
+# fails with `readlink <...>/overlay[/l]: invalid argument` — at build
+# time ("mounting new container") or at container start.  Retrying reuses
+# the same corrupt cached layer, so only a cache prune fixes it.
+# Requiring "readlink", "overlay" and "invalid argument" on one line keeps
+# this from matching unrelated readlink/EINVAL noise.
+_OVERLAY_LINK_CORRUPT_RE = re.compile(r"readlink .*overlay.*: invalid argument", re.IGNORECASE)
+
 
 def _is_build_cache_corrupt_line(line: str) -> bool:
     if any(frag in line for frag in _BUILD_CACHE_CORRUPT_FRAGMENTS_UNCONDITIONAL):
         return True
-    return bool(_MISSING_LAYER_RE.search(line))
+    return bool(_MISSING_LAYER_RE.search(line) or _OVERLAY_LINK_CORRUPT_RE.search(line))
 
 
 def _log_path(app_name: str, temp_data_dir: str) -> str:

--- a/compute_space/src/compute_space/core/startup.py
+++ b/compute_space/src/compute_space/core/startup.py
@@ -5,6 +5,8 @@ import time
 
 from compute_space.config import Config
 from compute_space.core.apps import start_app_process
+from compute_space.core.containers import BUILD_CACHE_CORRUPT_MARKER
+from compute_space.core.containers import drop_docker_build_cache
 from compute_space.core.containers import is_container_running
 from compute_space.core.default_apps import deploy_default_apps
 from compute_space.core.logging import logger
@@ -74,6 +76,11 @@ def check_app_status(config: Config) -> None:
                 (row["app_id"],),
             )
             apps_to_restart.append(row["app_id"])
+
+        # Recover apps whose build corrupted containers-storage onto the same
+        # serial rebuild path (which exists precisely to avoid that corruption).
+        apps_to_restart.extend(_recover_cache_corrupt_apps(db))
+
         db.commit()
     finally:
         db.close()
@@ -84,6 +91,46 @@ def check_app_status(config: Config) -> None:
             args=(apps_to_restart, config),
             daemon=True,
         ).start()
+
+
+def _recover_cache_corrupt_apps(db: sqlite3.Connection) -> list[str]:
+    """Prune the build cache and return app_ids to rebuild, for apps that
+    failed with a cache-corruption marker.
+
+    A plain retry can't recover — the corruption is cached — so the cache is
+    dropped before the caller rebuilds these serially.  No attempt
+    bookkeeping is needed to avoid looping: recovery clears the app's error,
+    so it only reappears here if a serial, freshly-pruned rebuild reproduced
+    the corruption, which the concurrency that causes it can't.  The caller
+    commits ``db``.
+    """
+    rows = db.execute(
+        "SELECT app_id, repo_path FROM apps WHERE status = 'error' AND error_message LIKE ?",
+        (f"%{BUILD_CACHE_CORRUPT_MARKER}%",),
+    ).fetchall()
+    corrupt = [r["app_id"] for r in rows if r["repo_path"] and os.path.isdir(r["repo_path"])]
+    if not corrupt:
+        return []
+
+    logger.warning(
+        "containers-storage cache corruption in %d app(s); dropping build cache and rebuilding serially: %s",
+        len(corrupt),
+        corrupt,
+    )
+    try:
+        output = drop_docker_build_cache()
+        logger.info("dropped build cache before serial rebuild: %s", output)
+    except Exception as e:
+        # Rebuild anyway — a partial prune plus a fresh serial build often
+        # still recovers.
+        logger.error("failed to drop build cache during corruption recovery: %s", e)
+
+    for app_id in corrupt:
+        db.execute(
+            "UPDATE apps SET status = 'starting', error_message = NULL WHERE app_id = ?",
+            (app_id,),
+        )
+    return corrupt
 
 
 def _restart_apps_sequential(app_ids: list[str], config: Config) -> None:

--- a/compute_space/src/compute_space/tests/test_check_app_status.py
+++ b/compute_space/src/compute_space/tests/test_check_app_status.py
@@ -14,6 +14,7 @@ from typing import Any
 
 import compute_space.core.startup as startup
 from compute_space.core.app_id import new_app_id
+from compute_space.core.containers import BUILD_CACHE_CORRUPT_MARKER
 from compute_space.db.connection import init_db
 
 from .conftest import _make_test_config
@@ -57,6 +58,43 @@ def _status(cfg: Any, app_id: str) -> str:
         return status
     finally:
         db.close()
+
+
+def _seed_error_app(cfg: Any, *, name: str, port: int, repo_path: str, error_message: str) -> str:
+    """Seed an app already in 'error' with a specific error_message."""
+    app_id = new_app_id()
+    db = sqlite3.connect(cfg.db_path)
+    try:
+        db.execute(
+            """INSERT INTO apps (app_id, name, version, repo_path, local_port, status, container_id, error_message)
+               VALUES (?, ?, '1.0', ?, ?, 'error', NULL, ?)""",
+            (app_id, name, repo_path, port, error_message),
+        )
+        db.commit()
+    finally:
+        db.close()
+    return app_id
+
+
+def _error_message(cfg: Any, app_id: str) -> str | None:
+    db = sqlite3.connect(cfg.db_path)
+    try:
+        row = db.execute("SELECT error_message FROM apps WHERE app_id = ?", (app_id,)).fetchone()
+        return row[0] if row else None
+    finally:
+        db.close()
+
+
+def _stub_drop_cache(monkeypatch: Any) -> list[bool]:
+    """Record calls to drop_docker_build_cache without shelling out to podman."""
+    calls: list[bool] = []
+
+    def fake_drop() -> str:
+        calls.append(True)
+        return "deleted: sha256:abc"
+
+    monkeypatch.setattr(startup, "drop_docker_build_cache", fake_drop)
+    return calls
 
 
 def _capture_restart_sweep(monkeypatch: Any) -> tuple[list[str], threading.Event]:
@@ -256,6 +294,152 @@ def test_inflight_build_at_exact_process_start_is_not_restarted(tmp_path: Path, 
     assert not done.is_set()
     assert app_id not in restarted
     assert _status(cfg, app_id) == "starting"
+
+
+# ---------------------------------------------------------------------------
+# Cache-corruption recovery: drop the build cache once and rebuild serially.
+# ---------------------------------------------------------------------------
+
+
+def test_cache_corrupt_app_is_pruned_and_serially_rebuilt(tmp_path: Path, monkeypatch: Any) -> None:
+    # The concurrent initial deploy corrupted containers-storage; the boot sweep
+    # must drop the build cache and queue the app onto the (serial) rebuild path.
+    cfg = _make_test_config(tmp_path, port=21600)
+    init_db(cfg.db_path)
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    app_id = _seed_error_app(
+        cfg,
+        name="corrupt",
+        port=21610,
+        repo_path=str(repo),
+        error_message=f"{BUILD_CACHE_CORRUPT_MARKER} Container build cache is corrupted.",
+    )
+
+    monkeypatch.setattr(startup, "is_container_running", lambda cid: False)
+    drop_calls = _stub_drop_cache(monkeypatch)
+    restarted, done = _capture_restart_sweep(monkeypatch)
+
+    startup.check_app_status(cfg)
+
+    assert done.wait(5), "cache-corrupt app was never queued for serial rebuild"
+    assert drop_calls == [True], "build cache should be dropped exactly once"
+    assert app_id in restarted
+    # Reset to transitional state so the dashboard reflects the retry.
+    assert _status(cfg, app_id) == "starting"
+    assert _error_message(cfg, app_id) is None
+
+
+def test_non_corrupt_error_app_is_left_alone(tmp_path: Path, monkeypatch: Any) -> None:
+    # A build that failed for an ordinary reason (bad Dockerfile, etc.) must NOT
+    # trigger a cache drop or an automatic rebuild — only the corruption marker does.
+    cfg = _make_test_config(tmp_path, port=21700)
+    init_db(cfg.db_path)
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    app_id = _seed_error_app(
+        cfg,
+        name="badfile",
+        port=21710,
+        repo_path=str(repo),
+        error_message="Container build failed (exit code 1): COPY failed: no such file",
+    )
+
+    monkeypatch.setattr(startup, "is_container_running", lambda cid: False)
+    drop_calls = _stub_drop_cache(monkeypatch)
+    restarted, done = _capture_restart_sweep(monkeypatch)
+
+    startup.check_app_status(cfg)
+
+    assert not done.is_set()
+    assert drop_calls == []
+    assert app_id not in restarted
+    assert _status(cfg, app_id) == "error"
+
+
+def test_recovered_app_is_not_re_pruned_once_marker_cleared(tmp_path: Path, monkeypatch: Any) -> None:
+    # No persisted ledger: bounding relies on recovery clearing the marker.
+    # After the first sweep sets the app to 'starting' with a null error, a
+    # second sweep in the same state must not prune or rebuild it again.
+    cfg = _make_test_config(tmp_path, port=21800)
+    init_db(cfg.db_path)
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    app_id = _seed_error_app(
+        cfg,
+        name="recovered",
+        port=21810,
+        repo_path=str(repo),
+        error_message=f"{BUILD_CACHE_CORRUPT_MARKER} Container build cache is corrupted.",
+    )
+
+    monkeypatch.setattr(startup, "is_container_running", lambda cid: False)
+    drop_calls = _stub_drop_cache(monkeypatch)
+    _capture_restart_sweep(monkeypatch)
+
+    startup.check_app_status(cfg)  # first sweep: recovers (prunes) the app
+    assert drop_calls == [True]
+    assert _status(cfg, app_id) == "starting"
+
+    # Second sweep with the app now in 'starting' (marker cleared): the
+    # normal sweep handles it (dead container -> rebuild) but the corruption
+    # recovery must NOT prune again.
+    startup.check_app_status(cfg)
+    assert drop_calls == [True], "cache must not be dropped again once the marker is cleared"
+
+
+def test_multiple_corrupt_apps_prune_once_and_all_rebuild(tmp_path: Path, monkeypatch: Any) -> None:
+    # A single global prune clears every corrupt layer, so N corrupt apps must
+    # trigger exactly one drop and then all rebuild serially in one sweep.
+    cfg = _make_test_config(tmp_path, port=21900)
+    init_db(cfg.db_path)
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    ids = {
+        _seed_error_app(
+            cfg,
+            name=f"corrupt{i}",
+            port=21910 + i,
+            repo_path=str(repo),
+            error_message=f"{BUILD_CACHE_CORRUPT_MARKER} Container build cache is corrupted.",
+        )
+        for i in range(3)
+    }
+
+    monkeypatch.setattr(startup, "is_container_running", lambda cid: False)
+    drop_calls = _stub_drop_cache(monkeypatch)
+    restarted, done = _capture_restart_sweep(monkeypatch)
+
+    startup.check_app_status(cfg)
+
+    assert done.wait(5)
+    assert drop_calls == [True], "prune must run exactly once for the whole sweep"
+    assert ids.issubset(set(restarted))
+
+
+def test_corrupt_app_with_missing_repo_is_not_recovered(tmp_path: Path, monkeypatch: Any) -> None:
+    # No checkout to rebuild from — a prune would be pointless, so skip it.
+    cfg = _make_test_config(tmp_path, port=22000)
+    init_db(cfg.db_path)
+    missing = tmp_path / "gone"  # never created
+    app_id = _seed_error_app(
+        cfg,
+        name="corrupt-norepo",
+        port=22010,
+        repo_path=str(missing),
+        error_message=f"{BUILD_CACHE_CORRUPT_MARKER} Container build cache is corrupted.",
+    )
+
+    monkeypatch.setattr(startup, "is_container_running", lambda cid: False)
+    drop_calls = _stub_drop_cache(monkeypatch)
+    restarted, done = _capture_restart_sweep(monkeypatch)
+
+    startup.check_app_status(cfg)
+
+    assert not done.is_set()
+    assert drop_calls == []
+    assert app_id not in restarted
+    assert _status(cfg, app_id) == "error"
 
 
 def test_running_app_with_live_container_is_left_alone(tmp_path: Path, monkeypatch: Any) -> None:

--- a/compute_space/src/compute_space/tests/test_containers.py
+++ b/compute_space/src/compute_space/tests/test_containers.py
@@ -71,6 +71,14 @@ def test_build_image_uses_podman_build(monkeypatch: pytest.MonkeyPatch) -> None:
         "error: content digest sha256:deadbeef: not found",
         "Error: storage-driver errored: something happened",
         "Error: layer not known: sha256:whatever",
+        # Overlay short-name "link" corruption (empty link file): buildah
+        # fails mounting the next build layer.  Observed on rootless podman
+        # after a concurrent initial build.
+        "Error: identifier is not a container: preparing container for next step: "
+        'mounting new container "e156": readlink '
+        "/home/host/.local/share/containers/storage/overlay/l: invalid argument",
+        # Same corruption surfacing at container start (bare overlay dir).
+        "Error: readlink /home/host/.local/share/containers/storage/overlay: invalid argument",
     ],
 )
 def test_build_image_detects_every_known_cache_corrupt_fragment(
@@ -97,6 +105,10 @@ def test_build_image_detects_every_known_cache_corrupt_fragment(
         "error: content digest sha256:deadbeef: not found",
         "Error: storage-driver errored: something happened",
         "Error: layer not known: sha256:whatever",
+        "Error: identifier is not a container: preparing container for next step: "
+        'mounting new container "e156": readlink '
+        "/home/host/.local/share/containers/storage/overlay/l: invalid argument",
+        "Error: readlink /home/host/.local/share/containers/storage/overlay: invalid argument",
     ],
 )
 def test_build_image_streaming_path_detects_cache_corrupt(
@@ -250,6 +262,13 @@ def test_build_image_streaming_path_reaps_child_on_timeout(tmp_path, monkeypatch
         # would help; dropping the local cache would not.
         "Error: initializing source docker://registry.example.com/unknown@sha256:abc: image not found",
         "Error: pulling image sha256:abc123: manifest not found in registry",
+        # readlink/EINVAL unrelated to overlay storage — the overlay
+        # matcher must require "overlay" on the same line, so a bare
+        # readlink failure in the app's own build script must NOT trip it.
+        "readlink /app/config/link: invalid argument",
+        # Mentions overlay but is normal driver progress, not a readlink
+        # EINVAL — must not match.
+        "Mounted overlay lowerdir for layer sha256:abc successfully",
     ],
 )
 def test_build_image_does_not_misclassify_innocuous_output_as_cache_corrupt(


### PR DESCRIPTION
## Problem

On a fresh instance, the initial default-app deploy builds every app **in parallel** (`deploy_default_apps` → `insert_and_deploy` spawns a background build thread per app). Concurrent image builds against one rootless **containers-storage** instance can corrupt the overlay layer metadata — specifically, some layers end up with **empty short-name `link` files**. Any build whose layer chain includes a corrupt layer then fails at mount time:

```
Error: identifier is not a container: preparing container for next step:
mounting new container "...": readlink .../containers/storage/overlay/l: invalid argument
```

(and `readlink .../overlay: invalid argument` at container start). It's **deterministic on retry**, because the corruption is cached. Observed in practice: 2 of 6 default apps (catalog, filestash) stuck in `error` after setup, unfixable by the built-in retry.

Two gaps caused this to be a dead end rather than a self-correcting hiccup:

1. The cache-corruption **detector didn't recognize this pattern**, so the failure was surfaced as a raw error instead of the "drop cache & rebuild" remediation.
2. Nothing **cleared the cache** before retrying — the boot-time serial rebuild and the cross-boot retry both reused the corrupt cached layers.

## Changes

**1. Detection — `core/containers.py`**
`_is_build_cache_corrupt` now also matches `identifier is not a container` and a narrow `readlink .*overlay.*: invalid argument` regex, so the failure is tagged with `BUILD_CACHE_CORRUPT_MARKER`. This both surfaces the dashboard's drop-cache remediation and lands the marker in the app's `error_message` (which #2 keys off).

**2. Self-heal — `core/startup.py`** (no flag)
The boot sweep `check_app_status` now finds apps left in `error` carrying the marker, drops the build cache **once** (global `podman image prune --all --force`), clears their error, and queues them onto the **existing serial** `_restart_apps_sequential` — the one-at-a-time rebuild path that already exists *"to avoid concurrent image builds against the same containers-storage instance."*

Net behaviour: **parallel builds when healthy (fast), prune + serial rebuild on corruption (safe)** — the happy path is untouched.

The corruption signal is read straight from `router.db` (`status='error'` + the marker in `error_message`), which already persists across the restart — no extra state file. Recovery is naturally **one-shot**: it clears each app's error before the serial rebuild, so an app only reappears in the sweep if a *serial*, freshly-pruned rebuild failed with the marker again — which the concurrency that causes the corruption can't produce. A genuinely broken build (bad Dockerfile) fails with a non-marker message and is left alone.

## Testing

- `tests/test_containers.py`: the two real corruption strings (build-time `overlay/l`, start-time bare `overlay`) added to both detection tests, plus innocuous guards (a non-overlay `readlink … invalid argument`; a benign line mentioning `overlay`) so the matcher stays tight.
- `tests/test_check_app_status.py` (5 new): corrupt app → pruned + serially rebuilt + error cleared; non-corrupt error → left alone (no prune); recovered app (marker cleared) → **not** re-pruned on a second sweep; N corrupt apps → **exactly one** prune, all rebuilt; missing repo → skipped.
- Full `compute_space` suite green (699 passed / 32 skipped); ruff + mypy clean.

## Notes / follow-ups

- Recovery fires at the post-setup restart / next boot (when `check_app_status` runs), not mid-setup — in practice seconds later, since setup triggers a restart. A same-session watchdog could make it instant but was left out to keep the change small.
- The deeper prevention (serialize the initial parallel builds, or a global build lock) is intentionally **not** in this PR — the "fast parallel, self-heal on corruption" approach here keeps the happy path fast and was preferred over a flag.
- Verified the root cause end-to-end on an arm64 QEMU VM: repairing the empty `link` files unblocked the builds, and a clean prune + serial rebuild brought catalog and filestash to `running`. (Confirmed the arch defaults in those Dockerfiles are a red herring — podman auto-populates `TARGETARCH` to the native platform; images build `arm64/linux`.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)