### PR TITLE
Shared instance identity + Connect to Imbue (instance side)

### DIFF
--- a/ansible/templates/config.toml.j2
+++ b/ansible/templates/config.toml.j2
@@ -22,20 +22,32 @@ start_caddy = {{ 'false' if http_only else 'true' }}
 claim_token_required = true
 data_root_dir = "/home/host/.openhost/local_compute_space"
 apps_dir_override = "/home/host/openhost/apps"
+{% if imbue_identity_issuer_url is defined and imbue_identity_issuer_url %}
+# Shared per-instance Imbue credential (client-credentials). One credential
+# authenticates this instance to every Imbue service (cert acquisition, email,
+# ...). client_secret is the only sensitive value. New provisioning writes this
+# shared block; each service resolves its credential from it unless a deprecated
+# per-service override is set below.
+imbue_identity_issuer_url = "{{ imbue_identity_issuer_url }}"
+imbue_identity_client_id = "{{ imbue_identity_client_id }}"
+imbue_identity_client_secret = "{{ imbue_identity_client_secret }}"
+{% endif %}
 {% if cert_provider is defined and cert_provider == 'cert_api' %}
 # Opt-in: fetch TLS certs from the openhost-cert-api broker instead of the
 # bring-your-own ACME account key above (which is then ignored).  The broker
 # holds the ACME account, so this instance never sees ACME credentials.
 # cert_api_base_url defaults to the canonical broker; only set it to override.
-# Auth is Keycloak client-credentials: this instance's confidential client in
-# the openhost-customers realm.  client_secret is the only sensitive value.
+# Auth resolves from the shared imbue_identity_* block above; the deprecated
+# cert_api_keycloak_* override below is rendered only when explicitly provided.
 cert_provider = "cert_api"
 {% if cert_api_base_url is defined %}
 cert_api_base_url = "{{ cert_api_base_url }}"
 {% endif %}
+{% if cert_api_keycloak_issuer_url is defined and cert_api_keycloak_issuer_url %}
 cert_api_keycloak_issuer_url = "{{ cert_api_keycloak_issuer_url }}"
 cert_api_keycloak_client_id = "{{ cert_api_keycloak_client_id }}"
 cert_api_keycloak_client_secret = "{{ cert_api_keycloak_client_secret }}"
+{% endif %}
 {% endif %}
 {% if email_proxy_base_url is defined and email_proxy_base_url %}
 # Email is enabled automatically because this prerequisite is present (there is no

--- a/compute_space/src/compute_space/config.py
+++ b/compute_space/src/compute_space/config.py
@@ -280,21 +280,28 @@ class Config:
                 f"{sorted(_EMAIL_KEYCLOAK_OVERRIDE_FIELDS)} to override the cert-api client, "
                 f"or none to inherit it. Missing: {sorted(missing)}"
             )
-        #  (b) email_proxy_base_url is set (email intended) but the Keycloak
-        #      client-credentials don't resolve (no cert-api client and no email
-        #      override) — email could never authenticate, so this is a config
-        #      error rather than a silent disable.
+        #  (b) email_proxy_base_url is set with a PARTIALLY-resolved credential
+        #      (some but not all of issuer/id/secret) — a typo. A fully-absent
+        #      credential is NOT an error: that is the "front door configured, but
+        #      the instance hasn't been connected to Imbue yet" state (email simply
+        #      stays off until the Connect-to-Imbue flow supplies the credential).
         if self.email_proxy_base_url:
-            missing = [a for a in _EMAIL_PREREQ_ATTRS if not getattr(self, a)]
-            if missing:
+            cred_attrs = (
+                "email_keycloak_issuer_url_resolved",
+                "email_keycloak_client_id_resolved",
+                "email_keycloak_client_secret_resolved",
+            )
+            cred_set = sum(1 for a in cred_attrs if getattr(self, a))
+            if 0 < cred_set < len(cred_attrs):
+                missing = [a for a in cred_attrs if not getattr(self, a)]
                 raise ValueError(
-                    "email_proxy_base_url is set but email cannot be enabled; missing "
-                    f"{sorted(missing)}. Provide the cert-api Keycloak client (cert_provider="
-                    f"{CERT_PROVIDER_CERT_API!r}) or explicit email_keycloak_* credentials."
+                    "email_proxy_base_url is set but the instance credential is only partially "
+                    f"resolved (missing {sorted(missing)}). Provide a complete credential "
+                    "(imbue_identity_*, the cert-api client, or explicit email_keycloak_*) or none."
                 )
-            if not self.public_ip:
-                # Email will be enabled — inbound is always direct-to-instance, so
-                # the MX/A records need the public IP.
+            # When the credential fully resolves, email is enabled — inbound is
+            # always direct-to-instance, so the MX/A records need the public IP.
+            if cred_set == len(cred_attrs) and not self.public_ip:
                 raise ValueError("public_ip must be set in config when email is enabled")
         # Validate the custom mail domain shape (if set) regardless of whether
         # email is enabled, so a typo surfaces at config load rather than at the
@@ -342,6 +349,17 @@ class Config:
     @property
     def email_keycloak_client_secret_resolved(self) -> str | None:
         return self.email_keycloak_client_secret or self.cert_api_keycloak_client_secret_resolved
+
+    @property
+    def imbue_connect_base_url(self) -> str | None:
+        """Base URL of the Imbue front door for the "Connect to Imbue" flow.
+
+        The same front door the email API lives behind, so it reuses
+        ``email_proxy_base_url`` (e.g. "https://openhost.imbue.com"). Returns None
+        when no Imbue URL is configured, in which case the connect flow is
+        unavailable and the Settings button is hidden.
+        """
+        return self.email_proxy_base_url
 
     @property
     def instance_identity(self) -> KeycloakClientCredentials | None:
@@ -679,13 +697,23 @@ class DefaultConfig(Config):
     )
 
 
+def active_config_path() -> str | None:
+    """The config.toml path the instance loads, or None when config is env-driven.
+
+    Prefers ``OPENHOST_ROUTER_CONFIG`` (new CLI name) and falls back to
+    ``OPENHOST_CONFIG`` for backward compatibility. Shared by ``load_config`` and
+    the runtime credential-persistence path so the precedence rule lives once.
+    """
+    return os.environ.get("OPENHOST_ROUTER_CONFIG") or os.environ.get("OPENHOST_CONFIG")
+
+
 def load_config() -> Config:
     """Load config from OPENHOST_ prefixed env vars, env-selected TOML file, or default config, in that order.
 
     Prefer ``OPENHOST_ROUTER_CONFIG`` (new CLI name) and fall back to
     ``OPENHOST_CONFIG`` for backward compatibility.
     """
-    path = os.environ.get("OPENHOST_ROUTER_CONFIG") or os.environ.get("OPENHOST_CONFIG")
+    path = active_config_path()
     if not path:
         return typed_settings.load(DefaultConfig, appname="openhost")
     scrubbed = _scrub_obsolete_keys_to_temp(path)

--- a/compute_space/src/compute_space/config.py
+++ b/compute_space/src/compute_space/config.py
@@ -11,6 +11,8 @@ import cattrs
 import tomli_w
 import typed_settings
 
+from compute_space.core.tls.keycloak import KeycloakClientCredentials
+
 # TLS cert provider selection (see Config.cert_provider).
 # "acme" is the default bring-your-own-ACME-credentials path (unchanged, fully
 # backward compatible). "cert_api" fetches certs from the openhost-cert-api
@@ -125,6 +127,22 @@ class Config:
     # the local port to bind the compute space web server to.
     port: int
 
+    ## Instance identity (shared Imbue credential)
+    # A single per-instance credential the instance uses to authenticate to Imbue for any Imbue-provided service
+    # (cert acquisition, email, ...). It is a client-credentials grant: the instance fetches a short-lived bearer from
+    # ``imbue_identity_issuer_url`` using ``imbue_identity_client_id`` + ``imbue_identity_client_secret``, and presents
+    # it (with the per-service audience) to that service. It reaches the instance one of two ways that produce the same
+    # result: injected at provision time for managed spaces, or obtained via the "Connect to Imbue" flow in Settings
+    # for non-managed spaces. When absent, dependent services simply stay off (no boot failure).
+    #
+    # The per-service ``cert_api_keycloak_*`` / ``email_keycloak_*`` fields below are DEPRECATED overrides kept for
+    # backward compatibility with already-deployed configs: each service resolves its credential from its own override
+    # first, then falls back to this shared identity (see the ``*_resolved`` properties). New provisioning writes only
+    # these shared fields.
+    imbue_identity_issuer_url: str | None
+    imbue_identity_client_id: str | None
+    imbue_identity_client_secret: str | None
+
     ## TLS
     tls_enabled: bool
     acquire_tls_cert_if_missing: bool
@@ -232,16 +250,19 @@ class Config:
                 f"{CERT_PROVIDER_ACME!r} or {CERT_PROVIDER_CERT_API!r})"
             )
         if self.cert_provider == CERT_PROVIDER_CERT_API:
-            # The cert_api broker path needs the broker URL plus the per-instance
-            # Keycloak client-credentials; none have a usable default.
-            for name in (
-                "cert_api_base_url",
-                "cert_api_keycloak_issuer_url",
-                "cert_api_keycloak_client_id",
-                "cert_api_keycloak_client_secret",
+            # The cert_api broker path needs the broker URL. Validate it directly.
+            if not self.cert_api_base_url:
+                raise ValueError("cert_api_base_url must be set in config to use the cert_api provider")
+            # It also needs the per-instance client-credentials, which resolve from the deprecated
+            # cert_api_keycloak_* override or the shared imbue_identity_* fields (either source satisfies
+            # the provider). Report the settable field name, not the internal *_resolved property.
+            for field_name, resolved_name in (
+                ("cert_api_keycloak_issuer_url", "cert_api_keycloak_issuer_url_resolved"),
+                ("cert_api_keycloak_client_id", "cert_api_keycloak_client_id_resolved"),
+                ("cert_api_keycloak_client_secret", "cert_api_keycloak_client_secret_resolved"),
             ):
-                if not getattr(self, name):
-                    raise ValueError(f"{name} must be set in config to use the cert_api provider")
+                if not getattr(self, resolved_name):
+                    raise ValueError(f"{field_name} must be set in config to use the cert_api provider")
         # Email has no explicit on/off flag: it is enabled automatically when all
         # of its prerequisites resolve (see the email_enabled property). The
         # Keycloak client-credentials fall back to the cert-api client, so in the
@@ -291,24 +312,54 @@ class Config:
                     "the built-in zone already handles that name"
                 )
 
-    # --- Email Keycloak client-credentials, resolved with cert-api fallback ---
-    # Email reuses the same per-instance Keycloak confidential client as cert-api
-    # (both authenticate to the openhost-customers realm). An operator can override
-    # per-field via email_keycloak_*, but by default email inherits the cert-api
-    # client. This is what lets an existing cert-api instance enable email by
-    # setting only email_proxy_base_url — no new credentials to inject.
+    # --- Instance identity, resolved per service ---
+    # Every service authenticates with the same per-instance credential. Each service resolves it from its own
+    # DEPRECATED per-service override first (kept so already-deployed configs keep working), then falls back to the
+    # shared ``imbue_identity_*`` fields that new provisioning writes. cert-api additionally falls back to the shared
+    # identity, and email additionally inherits cert-api's override — so an existing cert-api instance enables email by
+    # setting only email_proxy_base_url, and a shared-identity instance satisfies both services from one credential.
+
+    @property
+    def cert_api_keycloak_issuer_url_resolved(self) -> str | None:
+        return self.cert_api_keycloak_issuer_url or self.imbue_identity_issuer_url
+
+    @property
+    def cert_api_keycloak_client_id_resolved(self) -> str | None:
+        return self.cert_api_keycloak_client_id or self.imbue_identity_client_id
+
+    @property
+    def cert_api_keycloak_client_secret_resolved(self) -> str | None:
+        return self.cert_api_keycloak_client_secret or self.imbue_identity_client_secret
 
     @property
     def email_keycloak_issuer_url_resolved(self) -> str | None:
-        return self.email_keycloak_issuer_url or self.cert_api_keycloak_issuer_url
+        return self.email_keycloak_issuer_url or self.cert_api_keycloak_issuer_url_resolved
 
     @property
     def email_keycloak_client_id_resolved(self) -> str | None:
-        return self.email_keycloak_client_id or self.cert_api_keycloak_client_id
+        return self.email_keycloak_client_id or self.cert_api_keycloak_client_id_resolved
 
     @property
     def email_keycloak_client_secret_resolved(self) -> str | None:
-        return self.email_keycloak_client_secret or self.cert_api_keycloak_client_secret
+        return self.email_keycloak_client_secret or self.cert_api_keycloak_client_secret_resolved
+
+    @property
+    def instance_identity(self) -> KeycloakClientCredentials | None:
+        """The shared per-instance credential, or None when no identity is configured.
+
+        Resolves through the cert-api override for backward compatibility, so an
+        instance provisioned before the shared field existed still yields a
+        credential. Returns None (rather than a partial object) unless all three
+        parts resolve, so callers can treat None as "no Imbue identity configured".
+        """
+        issuer = self.cert_api_keycloak_issuer_url_resolved
+        client_id = self.cert_api_keycloak_client_id_resolved
+        client_secret = self.cert_api_keycloak_client_secret_resolved
+        if issuer and client_id and client_secret:
+            return KeycloakClientCredentials(
+                issuer_url=issuer, client_id=client_id, client_secret=client_secret
+            )
+        return None
 
     @property
     def email_enabled(self) -> bool:
@@ -534,6 +585,12 @@ class DefaultConfig(Config):
     acme_email: str | None = None
     acme_account_key_path: str | None = None
     acme_directory_url: str | None = None
+
+    # Shared per-instance Imbue credential — injected by provisioning (managed spaces) or obtained via the
+    # "Connect to Imbue" flow (non-managed). No safe default; absent means dependent services stay off.
+    imbue_identity_issuer_url: str | None = None
+    imbue_identity_client_id: str | None = None
+    imbue_identity_client_secret: str | None = None
 
     # Default to the BYO-ACME path so existing deployments are unaffected.
     cert_provider: str = CERT_PROVIDER_ACME

--- a/compute_space/src/compute_space/config.py
+++ b/compute_space/src/compute_space/config.py
@@ -374,9 +374,7 @@ class Config:
         client_id = self.cert_api_keycloak_client_id_resolved
         client_secret = self.cert_api_keycloak_client_secret_resolved
         if issuer and client_id and client_secret:
-            return KeycloakClientCredentials(
-                issuer_url=issuer, client_id=client_id, client_secret=client_secret
-            )
+            return KeycloakClientCredentials(issuer_url=issuer, client_id=client_id, client_secret=client_secret)
         return None
 
     @property

--- a/compute_space/src/compute_space/core/connect.py
+++ b/compute_space/src/compute_space/core/connect.py
@@ -1,0 +1,115 @@
+"""Instance side of the "Connect to Imbue" flow.
+
+Managed spaces get their shared Imbue credential injected at provision time. A
+non-managed (self-hosted) instance instead obtains it here: the owner clicks
+"Connect to Imbue" in Settings, authenticates at the Imbue front door, and the
+front door hands back a one-time code via a redirect to this instance. This module
+builds that redirect URL, exchanges the code for the credential server-to-server,
+and persists the credential into the instance's config.toml so a restart picks it
+up through the normal config path (Config.instance_identity).
+"""
+
+from __future__ import annotations
+
+import os
+import tomllib
+from urllib.parse import urlencode
+
+import attr
+import httpx
+import tomli_w
+
+from compute_space.core.logging import logger
+from compute_space.core.tls.keycloak import KeycloakClientCredentials
+
+# The instance-side callback path the front door redirects back to with ?code=.
+CONNECT_CALLBACK_PATH = "/api/settings/connect-imbue/callback"
+
+_CONNECT_START_PATH = "/connect/imbue"
+_CONNECT_EXCHANGE_PATH = "/connect/imbue/exchange"
+
+
+@attr.s(auto_attribs=True, frozen=True)
+class ConnectError(Exception):
+    """The connect exchange with the Imbue front door failed."""
+
+    message: str
+
+    def __str__(self) -> str:
+        return self.message
+
+
+def build_connect_url(frontend_base_url: str, zone: str, instance_base_url: str) -> str:
+    """Build the front-door URL the owner's browser is redirected to.
+
+    ``instance_base_url`` is this instance's own https origin; the front door
+    redirects the browser back to it (at CONNECT_CALLBACK_PATH) with a one-time
+    code, so the callback must be on the instance's own zone.
+    """
+    callback = f"{instance_base_url.rstrip('/')}{CONNECT_CALLBACK_PATH}"
+    query = urlencode({"zone": zone, "callback": callback})
+    return f"{frontend_base_url.rstrip('/')}{_CONNECT_START_PATH}?{query}"
+
+
+def exchange_code_for_credential(
+    frontend_base_url: str, code: str, *, timeout: float = 30.0
+) -> KeycloakClientCredentials:
+    """Swap a one-time code for the minted credential (server-to-server).
+
+    Returns the shared per-instance credential. Raises ConnectError on any non-200
+    response or malformed body.
+    """
+    url = f"{frontend_base_url.rstrip('/')}{_CONNECT_EXCHANGE_PATH}"
+    try:
+        resp = httpx.post(url, json={"code": code}, timeout=timeout)
+    except httpx.HTTPError as e:
+        raise ConnectError(f"could not reach the Imbue connect endpoint: {e}") from e
+    if resp.status_code != 200:
+        raise ConnectError(f"connect exchange failed: HTTP {resp.status_code} {_error_message(resp)}")
+    try:
+        body = resp.json()
+        return KeycloakClientCredentials(
+            issuer_url=str(body["issuer_url"]),
+            client_id=str(body["client_id"]),
+            client_secret=str(body["client_secret"]),
+        )
+    except (ValueError, KeyError, TypeError) as e:
+        raise ConnectError("connect exchange returned a malformed response") from e
+
+
+def persist_instance_identity(config_path: str, credential: KeycloakClientCredentials) -> None:
+    """Merge the shared Imbue credential into the instance's config.toml.
+
+    Preserves every other key. Writes the ``imbue_identity_*`` fields under the
+    ``[openhost]`` section so a restart loads the credential via the normal config
+    path. Written atomically (temp file + replace) so a crash mid-write can't leave
+    a truncated config.
+    """
+    try:
+        with open(config_path, "rb") as f:
+            data = tomllib.load(f)
+    except FileNotFoundError:
+        data = {}
+    section = data.get("openhost")
+    if not isinstance(section, dict):
+        section = {}
+    section["imbue_identity_issuer_url"] = credential.issuer_url
+    section["imbue_identity_client_id"] = credential.client_id
+    section["imbue_identity_client_secret"] = credential.client_secret
+    data["openhost"] = section
+
+    tmp_path = f"{config_path}.connect.tmp"
+    with open(tmp_path, "wb") as f:
+        tomli_w.dump(data, f)
+    os.replace(tmp_path, config_path)
+    logger.info(f"Persisted Imbue identity (client {credential.client_id!r}) to {config_path}")
+
+
+def _error_message(resp: httpx.Response) -> str:
+    try:
+        body = resp.json()
+    except ValueError:
+        return resp.text[:200]
+    if isinstance(body, dict):
+        return str(body.get("error", resp.text[:200]))
+    return resp.text[:200]

--- a/compute_space/src/compute_space/core/tls/provision.py
+++ b/compute_space/src/compute_space/core/tls/provision.py
@@ -6,7 +6,6 @@ from compute_space.config import Config
 from compute_space.core.tls.acquire_cert import acquire_tls_cert
 from compute_space.core.tls.acquire_cert_broker import acquire_tls_cert_via_broker
 from compute_space.core.tls.cert_api_client import CertApiClient
-from compute_space.core.tls.keycloak import KeycloakClientCredentials
 from compute_space.core.tls.keycloak import KeycloakTokenProvider
 
 
@@ -35,17 +34,13 @@ def provision_cert(config: Config) -> None:
             )
         )
     else:
-        # cert_provider is guaranteed to be CERT_PROVIDER_CERT_API with all of
-        # the cert_api settings populated (validated in Config.__attrs_post_init__).
+        # cert_provider is guaranteed to be CERT_PROVIDER_CERT_API with the broker
+        # URL and a resolvable instance credential (validated in
+        # Config.__attrs_post_init__). The credential resolves from the deprecated
+        # cert_api_keycloak_* override or the shared imbue_identity_* fields.
         assert config.cert_api_base_url is not None
-        assert config.cert_api_keycloak_issuer_url is not None
-        assert config.cert_api_keycloak_client_id is not None
-        assert config.cert_api_keycloak_client_secret is not None
-        credentials = KeycloakClientCredentials(
-            issuer_url=config.cert_api_keycloak_issuer_url,
-            client_id=config.cert_api_keycloak_client_id,
-            client_secret=config.cert_api_keycloak_client_secret,
-        )
+        credentials = config.instance_identity
+        assert credentials is not None
         # The token provider fetches a bearer from Keycloak (client-credentials) and
         # refreshes it transparently across the broker's finalize-poll loop.
         with KeycloakTokenProvider.create(credentials) as token_provider:

--- a/compute_space/src/compute_space/tests/test_connect.py
+++ b/compute_space/src/compute_space/tests/test_connect.py
@@ -1,0 +1,371 @@
+"""Tests for the instance-side Connect-to-Imbue helpers (core/connect.py)."""
+
+from __future__ import annotations
+
+import sqlite3
+import tomllib
+from pathlib import Path
+from typing import Any
+from unittest import mock
+
+import bcrypt
+import httpx
+import pytest
+import typed_settings
+from litestar import Litestar
+from litestar.di import Provide
+from litestar.testing import TestClient
+
+from compute_space.config import DefaultConfig
+from compute_space.config import active_config_path
+from compute_space.config import provide_config
+from compute_space.core.auth.auth import SESSION_COOKIE_NAME
+from compute_space.core.auth.auth import create_session
+from compute_space.core.connect import ConnectError
+from compute_space.core.connect import build_connect_url
+from compute_space.core.connect import exchange_code_for_credential
+from compute_space.core.connect import persist_instance_identity
+from compute_space.core.tls.keycloak import KeycloakClientCredentials
+from compute_space.db import provide_db
+from compute_space.db.connection import init_db
+from compute_space.tests.conftest import _make_test_config
+from compute_space.web.routes.api.settings import api_settings_routes
+
+# --- build_connect_url ---------------------------------------------------------
+
+
+def test_build_connect_url_composes_zone_and_callback() -> None:
+    url = build_connect_url(
+        "https://openhost.imbue.com",
+        "alice.selfhost.imbue.com",
+        "https://alice.selfhost.imbue.com",
+    )
+    assert url.startswith("https://openhost.imbue.com/connect/imbue?")
+    assert "zone=alice.selfhost.imbue.com" in url
+    # The callback is the instance's own origin + the callback path, URL-encoded.
+    assert "callback=https%3A%2F%2Falice.selfhost.imbue.com%2Fapi%2Fsettings%2Fconnect-imbue%2Fcallback" in url
+
+
+def test_build_connect_url_strips_trailing_slashes() -> None:
+    url = build_connect_url("https://openhost.imbue.com/", "z.example.com", "https://z.example.com/")
+    assert "https://openhost.imbue.com/connect/imbue?" in url
+    assert "callback=https%3A%2F%2Fz.example.com%2Fapi" in url
+
+
+# --- persist_instance_identity -------------------------------------------------
+
+
+def _cred(
+    issuer: str = "https://kc/realms/openhost-customers",
+    client_id: str = "instance-alice",
+    secret: str = "sekret",
+) -> KeycloakClientCredentials:
+    return KeycloakClientCredentials(issuer_url=issuer, client_id=client_id, client_secret=secret)
+
+
+def test_persist_writes_identity_into_new_config(tmp_path: Path) -> None:
+    cfg = tmp_path / "config.toml"
+    cfg.write_text('[openhost]\nzone_domain = "alice.example.com"\ntls_enabled = true\n')
+    persist_instance_identity(str(cfg), _cred())
+    data = tomllib.loads(cfg.read_text())["openhost"]
+    # New keys added...
+    assert data["imbue_identity_issuer_url"] == "https://kc/realms/openhost-customers"
+    assert data["imbue_identity_client_id"] == "instance-alice"
+    assert data["imbue_identity_client_secret"] == "sekret"
+    # ...and existing keys preserved.
+    assert data["zone_domain"] == "alice.example.com"
+    assert data["tls_enabled"] is True
+
+
+def test_persist_overwrites_existing_identity(tmp_path: Path) -> None:
+    cfg = tmp_path / "config.toml"
+    cfg.write_text(
+        '[openhost]\nzone_domain = "a.example.com"\n'
+        'imbue_identity_issuer_url = "old-iss"\n'
+        'imbue_identity_client_id = "old-id"\n'
+        'imbue_identity_client_secret = "old-secret"\n'
+    )
+    persist_instance_identity(str(cfg), _cred("new-iss", "new-id", "new-secret"))
+    data = tomllib.loads(cfg.read_text())["openhost"]
+    assert data["imbue_identity_issuer_url"] == "new-iss"
+    assert data["imbue_identity_client_id"] == "new-id"
+    assert data["imbue_identity_client_secret"] == "new-secret"
+
+
+def test_persist_creates_section_when_missing(tmp_path: Path) -> None:
+    cfg = tmp_path / "config.toml"
+    cfg.write_text("")  # empty file, no [openhost] section
+    persist_instance_identity(str(cfg), _cred("iss", "id", "sec"))
+    data = tomllib.loads(cfg.read_text())["openhost"]
+    assert data["imbue_identity_client_secret"] == "sec"
+
+
+def test_persist_result_is_loadable_by_config(tmp_path: Path) -> None:
+    # The persisted config must actually load and yield a usable identity, so the
+    # round-trip (persist -> load_config) proves the connect flow really enables it.
+    cfg = tmp_path / "config.toml"
+    cfg.write_text('[openhost]\nzone_domain = "alice.example.com"\n')
+    persist_instance_identity(str(cfg), _cred())
+    loaded = typed_settings.load(DefaultConfig, appname="openhost", config_files=[str(cfg)])
+    ident = loaded.instance_identity
+    assert ident is not None
+    assert ident.client_id == "instance-alice"
+    assert ident.client_secret == "sekret"
+
+
+# --- exchange_code_for_credential ----------------------------------------------
+
+
+def _mock_httpx_post(monkeypatch: pytest.MonkeyPatch, handler) -> dict[str, object]:  # type: ignore[no-untyped-def]
+    seen: dict[str, object] = {}
+
+    def fake_post(url, json=None, timeout=None):  # type: ignore[no-untyped-def]
+        seen["url"] = url
+        seen["json"] = json
+        return handler()
+
+    monkeypatch.setattr(httpx, "post", fake_post)
+    return seen
+
+
+def test_exchange_returns_credential(monkeypatch: pytest.MonkeyPatch) -> None:
+    seen = _mock_httpx_post(
+        monkeypatch,
+        lambda: httpx.Response(
+            200,
+            json={
+                "issuer_url": "https://kc/realms/openhost-customers",
+                "client_id": "instance-alice",
+                "client_secret": "sekret",
+                "zone_domain": "alice.example.com",
+            },
+        ),
+    )
+    out = exchange_code_for_credential("https://openhost.imbue.com", "one-time-code")
+    assert out == KeycloakClientCredentials(
+        issuer_url="https://kc/realms/openhost-customers",
+        client_id="instance-alice",
+        client_secret="sekret",
+    )
+    assert seen["url"] == "https://openhost.imbue.com/connect/imbue/exchange"
+    assert seen["json"] == {"code": "one-time-code"}
+
+
+def test_exchange_raises_on_non_200(monkeypatch: pytest.MonkeyPatch) -> None:
+    _mock_httpx_post(monkeypatch, lambda: httpx.Response(400, json={"error": "expired"}))
+    with pytest.raises(ConnectError, match="connect exchange failed"):
+        exchange_code_for_credential("https://openhost.imbue.com", "bad")
+
+
+def test_exchange_raises_on_malformed_body(monkeypatch: pytest.MonkeyPatch) -> None:
+    _mock_httpx_post(monkeypatch, lambda: httpx.Response(200, json={"missing": "fields"}))
+    with pytest.raises(ConnectError, match="malformed"):
+        exchange_code_for_credential("https://openhost.imbue.com", "code")
+
+
+def test_exchange_raises_on_network_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fake_post(url, json=None, timeout=None):  # type: ignore[no-untyped-def]
+        raise httpx.ConnectError("refused")
+
+    monkeypatch.setattr(httpx, "post", fake_post)
+    with pytest.raises(ConnectError, match="could not reach"):
+        exchange_code_for_credential("https://openhost.imbue.com", "code")
+
+
+def test_active_config_path_reads_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("OPENHOST_CONFIG", raising=False)
+    monkeypatch.setenv("OPENHOST_ROUTER_CONFIG", "/etc/openhost/config.toml")
+    assert active_config_path() == "/etc/openhost/config.toml"
+    monkeypatch.delenv("OPENHOST_ROUTER_CONFIG")
+    monkeypatch.delenv("OPENHOST_CONFIG", raising=False)
+    assert active_config_path() is None
+
+
+# --- routes: /api/settings/connect-imbue/* ------------------------------------
+
+_IMBUE = "https://openhost.imbue.com"
+_IDENT = dict(
+    imbue_identity_issuer_url="https://kc/realms/openhost-customers",
+    imbue_identity_client_id="instance-alice",
+    imbue_identity_client_secret="sekret",
+)
+
+
+@pytest.fixture
+def connected_cfg(tmp_path: Path) -> Any:
+    # An instance already holding a credential, with an Imbue front door set.
+    cfg = _make_test_config(
+        tmp_path, port=20600, zone_domain="alice.example.com", email_proxy_base_url=_IMBUE, public_ip="203.0.113.5", **_IDENT
+    )
+    init_db(cfg.db_path)
+    return cfg
+
+
+@pytest.fixture
+def unconnected_cfg(tmp_path: Path) -> Any:
+    # Imbue front door configured but no credential yet (the connect target case).
+    cfg = _make_test_config(tmp_path, port=20601, zone_domain="alice.example.com", email_proxy_base_url=_IMBUE)
+    init_db(cfg.db_path)
+    return cfg
+
+
+@pytest.fixture
+def no_imbue_cfg(tmp_path: Path) -> Any:
+    # No Imbue front door configured at all -> the feature is unavailable.
+    cfg = _make_test_config(tmp_path, port=20602, zone_domain="alice.example.com")
+    init_db(cfg.db_path)
+    return cfg
+
+
+def _settings_client() -> TestClient[Litestar]:
+    app = Litestar(
+        route_handlers=[api_settings_routes],
+        dependencies={
+            "config": Provide(provide_config, sync_to_thread=False),
+            "db": Provide(provide_db),
+        },
+        openapi_config=None,
+    )
+    return TestClient(app=app)
+
+
+def _auth_cookie(cfg: Any) -> dict[str, str]:
+    pw_hash = bcrypt.hashpw(b"secretpass1", bcrypt.gensalt()).decode()
+    conn = sqlite3.connect(cfg.db_path)
+    conn.row_factory = sqlite3.Row
+    try:
+        cur = conn.execute(
+            "INSERT INTO users (username, password_hash) VALUES (?, ?)", ("owner", pw_hash)
+        )
+        assert cur.lastrowid is not None
+        token = create_session(cur.lastrowid, conn)
+        conn.commit()
+    finally:
+        conn.close()
+    return {SESSION_COOKIE_NAME: token}
+
+
+# -- status --
+
+
+def test_status_requires_auth(unconnected_cfg: Any) -> None:
+    with _settings_client() as c:
+        assert c.get("/api/settings/connect-imbue/status").status_code == 401
+
+
+def test_status_reports_available_and_unconnected(unconnected_cfg: Any) -> None:
+    with _settings_client() as c:
+        resp = c.get("/api/settings/connect-imbue/status", cookies=_auth_cookie(unconnected_cfg))
+    assert resp.status_code == 200
+    assert resp.json() == {"available": True, "connected": False}
+
+
+def test_status_reports_connected(connected_cfg: Any) -> None:
+    with _settings_client() as c:
+        resp = c.get("/api/settings/connect-imbue/status", cookies=_auth_cookie(connected_cfg))
+    assert resp.json() == {"available": True, "connected": True}
+
+
+def test_status_reports_unavailable_without_imbue(no_imbue_cfg: Any) -> None:
+    with _settings_client() as c:
+        resp = c.get("/api/settings/connect-imbue/status", cookies=_auth_cookie(no_imbue_cfg))
+    assert resp.json() == {"available": False, "connected": False}
+
+
+# -- start --
+
+
+def test_start_requires_auth(unconnected_cfg: Any) -> None:
+    with _settings_client() as c:
+        assert c.post("/api/settings/connect-imbue/start").status_code == 401
+
+
+def test_start_returns_front_door_url(unconnected_cfg: Any) -> None:
+    with _settings_client() as c:
+        resp = c.post("/api/settings/connect-imbue/start", cookies=_auth_cookie(unconnected_cfg))
+    assert resp.status_code == 200
+    url = resp.json()["redirect_url"]
+    assert url.startswith(f"{_IMBUE}/connect/imbue?")
+    assert "zone=alice.example.com" in url
+    assert "callback=" in url
+
+
+def test_start_503_without_imbue(no_imbue_cfg: Any) -> None:
+    with _settings_client() as c:
+        resp = c.post("/api/settings/connect-imbue/start", cookies=_auth_cookie(no_imbue_cfg))
+    assert resp.status_code == 503
+
+
+# -- callback --
+
+
+def test_callback_requires_auth(unconnected_cfg: Any) -> None:
+    with _settings_client() as c:
+        assert c.get("/api/settings/connect-imbue/callback?code=x").status_code == 401
+
+
+def test_callback_happy_path(unconnected_cfg: Any, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("OPENHOST_ROUTER_CONFIG", str(Path(unconnected_cfg.data_root_dir) / "config.toml"))
+    Path(unconnected_cfg.data_root_dir, "config.toml").write_text('[openhost]\nzone_domain = "alice.example.com"\n')
+    restarted: dict[str, bool] = {}
+    with (
+        mock.patch(
+            "compute_space.web.routes.api.settings.exchange_code_for_credential",
+            return_value=_cred(),
+        ),
+        mock.patch("compute_space.web.routes.api.settings.persist_instance_identity") as persist,
+        mock.patch(
+            "compute_space.web.routes.api.settings.trigger_restart",
+            side_effect=lambda: restarted.setdefault("v", True),
+        ),
+        _settings_client() as c,
+    ):
+        resp = c.get(
+            "/api/settings/connect-imbue/callback?code=onetime",
+            cookies=_auth_cookie(unconnected_cfg),
+            follow_redirects=False,
+        )
+    assert resp.status_code in (302, 307)
+    assert resp.headers["location"] == "/settings?connect=ok"
+    persist.assert_called_once()
+    assert restarted.get("v") is True
+
+
+def test_callback_blank_code_redirects_error(unconnected_cfg: Any, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("OPENHOST_ROUTER_CONFIG", str(Path(unconnected_cfg.data_root_dir) / "config.toml"))
+    with _settings_client() as c:
+        resp = c.get(
+            "/api/settings/connect-imbue/callback?code=",
+            cookies=_auth_cookie(unconnected_cfg),
+            follow_redirects=False,
+        )
+    assert resp.status_code in (302, 307)
+    assert resp.headers["location"] == "/settings?connect=error"
+
+
+def test_callback_502_on_exchange_failure(unconnected_cfg: Any, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("OPENHOST_ROUTER_CONFIG", str(Path(unconnected_cfg.data_root_dir) / "config.toml"))
+    Path(unconnected_cfg.data_root_dir, "config.toml").write_text('[openhost]\nzone_domain = "alice.example.com"\n')
+    with (
+        mock.patch(
+            "compute_space.web.routes.api.settings.exchange_code_for_credential",
+            side_effect=ConnectError("expired"),
+        ),
+        _settings_client() as c,
+    ):
+        resp = c.get(
+            "/api/settings/connect-imbue/callback?code=bad",
+            cookies=_auth_cookie(unconnected_cfg),
+            follow_redirects=False,
+        )
+    assert resp.status_code == 502
+
+
+def test_callback_503_without_imbue(no_imbue_cfg: Any) -> None:
+    with _settings_client() as c:
+        resp = c.get(
+            "/api/settings/connect-imbue/callback?code=x",
+            cookies=_auth_cookie(no_imbue_cfg),
+            follow_redirects=False,
+        )
+    assert resp.status_code == 503

--- a/compute_space/src/compute_space/tests/test_connect.py
+++ b/compute_space/src/compute_space/tests/test_connect.py
@@ -195,7 +195,12 @@ _IDENT = dict(
 def connected_cfg(tmp_path: Path) -> Any:
     # An instance already holding a credential, with an Imbue front door set.
     cfg = _make_test_config(
-        tmp_path, port=20600, zone_domain="alice.example.com", email_proxy_base_url=_IMBUE, public_ip="203.0.113.5", **_IDENT
+        tmp_path,
+        port=20600,
+        zone_domain="alice.example.com",
+        email_proxy_base_url=_IMBUE,
+        public_ip="203.0.113.5",
+        **_IDENT,
     )
     init_db(cfg.db_path)
     return cfg
@@ -234,9 +239,7 @@ def _auth_cookie(cfg: Any) -> dict[str, str]:
     conn = sqlite3.connect(cfg.db_path)
     conn.row_factory = sqlite3.Row
     try:
-        cur = conn.execute(
-            "INSERT INTO users (username, password_hash) VALUES (?, ?)", ("owner", pw_hash)
-        )
+        cur = conn.execute("INSERT INTO users (username, password_hash) VALUES (?, ?)", ("owner", pw_hash))
         assert cur.lastrowid is not None
         token = create_session(cur.lastrowid, conn)
         conn.commit()

--- a/compute_space/src/compute_space/tests/test_connect_edge.py
+++ b/compute_space/src/compute_space/tests/test_connect_edge.py
@@ -416,9 +416,7 @@ def test_exchange_coerces_non_string_fields_to_str(monkeypatch: pytest.MonkeyPat
 
 
 @pytest.mark.parametrize("missing", ["issuer_url", "client_id", "client_secret"])
-def test_exchange_malformed_when_any_field_missing(
-    monkeypatch: pytest.MonkeyPatch, missing: str
-) -> None:
+def test_exchange_malformed_when_any_field_missing(monkeypatch: pytest.MonkeyPatch, missing: str) -> None:
     body = {"issuer_url": "i", "client_id": "c", "client_secret": "s"}
     del body[missing]
     _mock_httpx_post(monkeypatch, lambda: httpx.Response(200, json=body))
@@ -460,9 +458,7 @@ def test_exchange_ignores_extra_fields(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 @pytest.mark.parametrize("status", [400, 401, 403, 500, 502, 503])
-def test_exchange_error_status_includes_code_in_message(
-    monkeypatch: pytest.MonkeyPatch, status: int
-) -> None:
+def test_exchange_error_status_includes_code_in_message(monkeypatch: pytest.MonkeyPatch, status: int) -> None:
     _mock_httpx_post(monkeypatch, lambda: httpx.Response(status, json={"error": "nope"}))
     with pytest.raises(ConnectError) as exc:
         exchange_code_for_credential("https://front.example.com", "code")
@@ -500,9 +496,7 @@ def test_exchange_error_message_truncated_to_200_chars(monkeypatch: pytest.Monke
         lambda: httpx.ConnectTimeout("connect timed out"),
     ],
 )
-def test_exchange_wraps_each_network_error(
-    monkeypatch: pytest.MonkeyPatch, exc_factory: Any
-) -> None:
+def test_exchange_wraps_each_network_error(monkeypatch: pytest.MonkeyPatch, exc_factory: Any) -> None:
     def fake_post(url: str, json: Any = None, timeout: Any = None) -> httpx.Response:
         raise exc_factory()
 
@@ -601,9 +595,7 @@ def connected_cfg(tmp_path: Path) -> Any:
 
 @pytest.fixture
 def unconnected_cfg(tmp_path: Path) -> Any:
-    cfg = _make_test_config(
-        tmp_path, port=20701, zone_domain="alice.example.com", email_proxy_base_url=_IMBUE
-    )
+    cfg = _make_test_config(tmp_path, port=20701, zone_domain="alice.example.com", email_proxy_base_url=_IMBUE)
     init_db(cfg.db_path)
     return cfg
 
@@ -632,9 +624,7 @@ def _auth_cookie(cfg: Any) -> dict[str, str]:
     conn = sqlite3.connect(cfg.db_path)
     conn.row_factory = sqlite3.Row
     try:
-        cur = conn.execute(
-            "INSERT INTO users (username, password_hash) VALUES (?, ?)", ("owner", pw_hash)
-        )
+        cur = conn.execute("INSERT INTO users (username, password_hash) VALUES (?, ?)", ("owner", pw_hash))
         assert cur.lastrowid is not None
         token = create_session(cur.lastrowid, conn)
         conn.commit()
@@ -796,9 +786,7 @@ def _config_file(cfg: Any, monkeypatch: pytest.MonkeyPatch) -> Path:
     return path
 
 
-def test_callback_persists_the_exchanged_credential(
-    unconnected_cfg: Any, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_callback_persists_the_exchanged_credential(unconnected_cfg: Any, monkeypatch: pytest.MonkeyPatch) -> None:
     _config_file(unconnected_cfg, monkeypatch)
     exchanged = _cred("https://iss.new", "cid-new", "csecret-new")
     with (
@@ -844,9 +832,7 @@ def test_callback_trigger_restart_called_once_on_success(
     restart.assert_called_once_with()
 
 
-def test_callback_real_persist_writes_config(
-    unconnected_cfg: Any, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_callback_real_persist_writes_config(unconnected_cfg: Any, monkeypatch: pytest.MonkeyPatch) -> None:
     # Exercise the callback with the REAL persist_instance_identity (only the
     # exchange + restart mocked) so the whole write path is covered end to end.
     path = _config_file(unconnected_cfg, monkeypatch)
@@ -896,9 +882,7 @@ def test_callback_blank_or_whitespace_code_redirects_error(
     restart.assert_not_called()
 
 
-def test_callback_missing_code_param_redirects_error(
-    unconnected_cfg: Any, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_callback_missing_code_param_redirects_error(unconnected_cfg: Any, monkeypatch: pytest.MonkeyPatch) -> None:
     # The handler defaults code="" so an entirely-absent ?code= behaves like blank.
     _config_file(unconnected_cfg, monkeypatch)
     with (
@@ -916,9 +900,7 @@ def test_callback_missing_code_param_redirects_error(
     exchange.assert_not_called()
 
 
-def test_callback_connect_error_502_and_no_restart(
-    unconnected_cfg: Any, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_callback_connect_error_502_and_no_restart(unconnected_cfg: Any, monkeypatch: pytest.MonkeyPatch) -> None:
     _config_file(unconnected_cfg, monkeypatch)
     with (
         mock.patch(
@@ -938,9 +920,7 @@ def test_callback_connect_error_502_and_no_restart(
     restart.assert_not_called()
 
 
-def test_callback_persist_error_502_and_no_restart(
-    unconnected_cfg: Any, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_callback_persist_error_502_and_no_restart(unconnected_cfg: Any, monkeypatch: pytest.MonkeyPatch) -> None:
     # A ConnectError raised by persist (not just exchange) is also caught -> 502,
     # no restart.
     _config_file(unconnected_cfg, monkeypatch)
@@ -965,9 +945,7 @@ def test_callback_persist_error_502_and_no_restart(
     restart.assert_not_called()
 
 
-def test_callback_500_when_no_config_path(
-    unconnected_cfg: Any, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_callback_500_when_no_config_path(unconnected_cfg: Any, monkeypatch: pytest.MonkeyPatch) -> None:
     # Env-driven config (no file) -> the credential can't be persisted -> 500,
     # and no exchange/restart happens.
     monkeypatch.delenv("OPENHOST_ROUTER_CONFIG", raising=False)

--- a/compute_space/src/compute_space/tests/test_connect_edge.py
+++ b/compute_space/src/compute_space/tests/test_connect_edge.py
@@ -1,0 +1,1042 @@
+"""Complementary edge-case tests for the instance-side Connect-to-Imbue flow.
+
+These ADD to ``test_connect.py`` (which already covers the happy paths and the
+core failure modes) with rigorous edge cases that pin the *exact* observed
+behavior of ``core/connect.py``, ``config.active_config_path``, and the
+``/api/settings/connect-imbue/*`` routes. Every assertion here was confirmed by
+running against the real source — including a couple of quirks that are the
+current behavior rather than an ideal (e.g. ``build_connect_url`` naively appends
+its path+query and does NOT merge into a frontend base URL that already carries a
+query string; that is asserted as-is, not as aspiration).
+
+Nothing here duplicates a ``test_connect.py`` case: the build_connect_url cases
+use different inputs (ports, subdomain zones, urlencoding of special chars, http
+vs https, IDN-ish hosts, pre-existing query), the persist cases probe many-key
+preservation / non-table sections / atomicity / unicode round-trips, the exchange
+cases enumerate each missing field / non-JSON body / every error status / each
+network-error subclass / oversized+empty codes / extra-field tolerance, and the
+route cases probe proxy-header derivation, auth on all three endpoints, and the
+callback's persistence + restart side-effect ordering.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import tomllib
+from pathlib import Path
+from typing import Any
+from unittest import mock
+from urllib.parse import parse_qs
+from urllib.parse import urlparse
+
+import bcrypt
+import httpx
+import pytest
+import typed_settings
+from litestar import Litestar
+from litestar.di import Provide
+from litestar.testing import TestClient
+
+from compute_space.config import DefaultConfig
+from compute_space.config import active_config_path
+from compute_space.config import provide_config
+from compute_space.core.auth.auth import SESSION_COOKIE_NAME
+from compute_space.core.auth.auth import create_session
+from compute_space.core.connect import CONNECT_CALLBACK_PATH
+from compute_space.core.connect import ConnectError
+from compute_space.core.connect import build_connect_url
+from compute_space.core.connect import exchange_code_for_credential
+from compute_space.core.connect import persist_instance_identity
+from compute_space.core.tls.keycloak import KeycloakClientCredentials
+from compute_space.db import provide_db
+from compute_space.db.connection import init_db
+from compute_space.tests.conftest import _make_test_config
+from compute_space.web.routes.api.settings import api_settings_routes
+
+# ---------------------------------------------------------------------------
+# shared helpers
+# ---------------------------------------------------------------------------
+
+_IMBUE = "https://openhost.imbue.com"
+_IDENT = dict(
+    imbue_identity_issuer_url="https://kc/realms/openhost-customers",
+    imbue_identity_client_id="instance-alice",
+    imbue_identity_client_secret="sekret",
+)
+
+
+def _cred(
+    issuer: str = "https://kc/realms/openhost-customers",
+    client_id: str = "instance-alice",
+    secret: str = "sekret",
+) -> KeycloakClientCredentials:
+    return KeycloakClientCredentials(issuer_url=issuer, client_id=client_id, client_secret=secret)
+
+
+def _mock_httpx_post(
+    monkeypatch: pytest.MonkeyPatch,
+    handler: Any,
+) -> dict[str, object]:
+    """Patch ``httpx.post`` with a handler that records the call and returns
+    whatever ``handler()`` yields (a Response) or raises."""
+    seen: dict[str, object] = {}
+
+    def fake_post(url: str, json: Any = None, timeout: Any = None) -> httpx.Response:
+        seen["url"] = url
+        seen["json"] = json
+        seen["timeout"] = timeout
+        result: httpx.Response = handler()
+        return result
+
+    monkeypatch.setattr(httpx, "post", fake_post)
+    return seen
+
+
+# ===========================================================================
+# build_connect_url
+# ===========================================================================
+
+
+def test_build_connect_url_strips_trailing_slashes_on_both_bases() -> None:
+    # Both bases carry a trailing slash; neither should leak a double slash into
+    # the emitted URL. (test_connect.py checks a single case; this asserts the
+    # exact path join on both sides.)
+    url = build_connect_url("https://front.example.com/", "z.example.com", "https://z.example.com/")
+    assert url.startswith("https://front.example.com/connect/imbue?")
+    assert "//connect/imbue" not in url
+    cb = parse_qs(urlparse(url).query)["callback"][0]
+    assert cb == "https://z.example.com/api/settings/connect-imbue/callback"
+    assert "//api/settings" not in cb
+
+
+def test_build_connect_url_strips_multiple_trailing_slashes_only_one() -> None:
+    # rstrip('/') removes ALL trailing slashes, so even a doubled slash collapses.
+    url = build_connect_url("https://front.example.com///", "z", "https://z.example.com//")
+    assert url.startswith("https://front.example.com/connect/imbue?")
+    cb = parse_qs(urlparse(url).query)["callback"][0]
+    assert cb == "https://z.example.com/api/settings/connect-imbue/callback"
+
+
+def test_build_connect_url_preserves_port_on_frontend_base() -> None:
+    url = build_connect_url("https://front.example.com:8443", "z", "https://z.example.com")
+    assert url.startswith("https://front.example.com:8443/connect/imbue?")
+
+
+def test_build_connect_url_preserves_port_in_callback() -> None:
+    url = build_connect_url("https://front.example.com", "z", "https://z.example.com:9443")
+    cb = parse_qs(urlparse(url).query)["callback"][0]
+    assert cb == "https://z.example.com:9443/api/settings/connect-imbue/callback"
+
+
+def test_build_connect_url_zone_with_subdomain_is_verbatim() -> None:
+    zone = "team.alice.selfhost.imbue.com"
+    url = build_connect_url("https://front.example.com", zone, "https://z.example.com")
+    assert parse_qs(urlparse(url).query)["zone"][0] == zone
+
+
+def test_build_connect_url_urlencodes_special_chars_in_zone() -> None:
+    # A zone containing reserved URL chars must be percent-encoded in the query
+    # so it round-trips through a real query parser as the literal string.
+    zone = "weird zone/with&reserved=chars"
+    url = build_connect_url("https://front.example.com", zone, "https://z.example.com")
+    # Raw reserved chars must not appear unescaped in the query segment.
+    query = urlparse(url).query
+    assert " " not in query
+    assert "weird+zone" in query or "weird%20zone" in query
+    # ...but a real parser recovers the exact original.
+    assert parse_qs(url.split("?", 1)[1])["zone"][0] == zone
+
+
+def test_build_connect_url_urlencodes_plus_and_percent_in_zone() -> None:
+    zone = "a+b%c"
+    url = build_connect_url("https://front.example.com", zone, "https://z.example.com")
+    assert parse_qs(url.split("?", 1)[1])["zone"][0] == zone
+
+
+def test_build_connect_url_http_instance_base_kept() -> None:
+    # An http (not https) instance base is preserved verbatim in the callback —
+    # the function does not force https.
+    url = build_connect_url("https://front.example.com", "z", "http://z.example.com")
+    cb = parse_qs(urlparse(url).query)["callback"][0]
+    assert cb.startswith("http://z.example.com/")
+
+
+def test_build_connect_url_http_frontend_base_kept() -> None:
+    url = build_connect_url("http://front.example.com", "z", "https://z.example.com")
+    assert url.startswith("http://front.example.com/connect/imbue?")
+
+
+def test_build_connect_url_idn_ascii_host_preserved() -> None:
+    # A punycode/IDN-ascii host (xn--) must pass through untouched in both bases.
+    url = build_connect_url("https://xn--mnchen-3ya.example.com", "z", "https://xn--80akhbyknj4f.example.com")
+    assert url.startswith("https://xn--mnchen-3ya.example.com/connect/imbue?")
+    cb = parse_qs(urlparse(url).query)["callback"][0]
+    assert cb.startswith("https://xn--80akhbyknj4f.example.com/")
+
+
+def test_build_connect_url_appends_after_existing_query_verbatim() -> None:
+    # CURRENT BEHAVIOR (not ideal): the function unconditionally appends
+    # ``/connect/imbue?<query>`` to the frontend base, so a base that ALREADY has
+    # a query string produces a structurally odd URL. Pinned so a future change
+    # that "fixes" this is a conscious, reviewed decision, not silent drift.
+    url = build_connect_url("https://front.example.com/x?already=1", "z", "https://z.example.com")
+    # The path+query is appended right after the untouched base (including its
+    # existing query), so the base's ``?already=1`` is followed by the second
+    # ``?zone=z...`` — a URL with two '?' separators.
+    assert url.startswith("https://front.example.com/x?already=1/connect/imbue?zone=z&callback=")
+    assert url.count("?") == 2
+
+
+def test_build_connect_url_callback_path_matches_module_constant() -> None:
+    # The callback embedded in the URL is exactly the route the callback handler
+    # is registered at (drift here would silently break the redirect).
+    url = build_connect_url("https://front.example.com", "z", "https://z.example.com")
+    cb = parse_qs(urlparse(url).query)["callback"][0]
+    assert cb.endswith(CONNECT_CALLBACK_PATH)
+
+
+def test_build_connect_url_empty_zone_yields_empty_query_value() -> None:
+    # An empty zone is encoded as ``zone=`` (present but empty), not dropped.
+    url = build_connect_url("https://front.example.com", "", "https://z.example.com")
+    assert "zone=" in url
+    assert parse_qs(url.split("?", 1)[1], keep_blank_values=True)["zone"][0] == ""
+
+
+# ===========================================================================
+# persist_instance_identity
+# ===========================================================================
+
+
+def test_persist_preserves_many_preexisting_keys(tmp_path: Path) -> None:
+    cfg = tmp_path / "config.toml"
+    cfg.write_text(
+        "[openhost]\n"
+        'zone_domain = "alice.example.com"\n'
+        "port = 8080\n"
+        "tls_enabled = true\n"
+        'host = "0.0.0.0"\n'
+        'data_root_dir = "/opt/openhost"\n'
+        "coredns_enabled = false\n"
+        'default_apps = ["a", "b", "c"]\n'
+        "storage_min_free_mb = 500\n"
+    )
+    persist_instance_identity(str(cfg), _cred())
+    data = tomllib.loads(cfg.read_text())["openhost"]
+    # every pre-existing key survives, with its type intact
+    assert data["zone_domain"] == "alice.example.com"
+    assert data["port"] == 8080
+    assert data["tls_enabled"] is True
+    assert data["host"] == "0.0.0.0"
+    assert data["data_root_dir"] == "/opt/openhost"
+    assert data["coredns_enabled"] is False
+    assert data["default_apps"] == ["a", "b", "c"]
+    assert data["storage_min_free_mb"] == 500
+    # and the identity was added
+    assert data["imbue_identity_client_id"] == "instance-alice"
+
+
+def test_persist_overwrites_only_the_three_identity_keys(tmp_path: Path) -> None:
+    cfg = tmp_path / "config.toml"
+    cfg.write_text(
+        "[openhost]\n"
+        'zone_domain = "a.example.com"\n'
+        'imbue_identity_issuer_url = "old-iss"\n'
+        'imbue_identity_client_id = "old-id"\n'
+        'imbue_identity_client_secret = "old-secret"\n'
+        'email_proxy_base_url = "https://keep.me"\n'
+    )
+    persist_instance_identity(str(cfg), _cred("new-iss", "new-id", "new-secret"))
+    data = tomllib.loads(cfg.read_text())["openhost"]
+    assert data["imbue_identity_issuer_url"] == "new-iss"
+    assert data["imbue_identity_client_id"] == "new-id"
+    assert data["imbue_identity_client_secret"] == "new-secret"
+    # an unrelated key is untouched
+    assert data["email_proxy_base_url"] == "https://keep.me"
+
+
+def test_persist_creates_missing_file(tmp_path: Path) -> None:
+    # No file on disk at all -> FileNotFoundError path -> writes a fresh config.
+    cfg = tmp_path / "does_not_exist.toml"
+    assert not cfg.exists()
+    persist_instance_identity(str(cfg), _cred("iss", "id", "sec"))
+    assert cfg.exists()
+    data = tomllib.loads(cfg.read_text())["openhost"]
+    assert data == {
+        "imbue_identity_issuer_url": "iss",
+        "imbue_identity_client_id": "id",
+        "imbue_identity_client_secret": "sec",
+    }
+
+
+def test_persist_preserves_non_openhost_top_level_sections(tmp_path: Path) -> None:
+    # Top-level tables other than [openhost] must be carried through untouched.
+    cfg = tmp_path / "config.toml"
+    cfg.write_text(
+        "[openhost]\n"
+        'zone_domain = "a.example.com"\n'
+        "\n"
+        "[other]\n"
+        'foo = "bar"\n'
+        "num = 42\n"
+        "\n"
+        "[nested.section]\n"
+        "flag = true\n"
+    )
+    persist_instance_identity(str(cfg), _cred())
+    data = tomllib.loads(cfg.read_text())
+    assert data["other"] == {"foo": "bar", "num": 42}
+    assert data["nested"]["section"]["flag"] is True
+    assert data["openhost"]["imbue_identity_client_id"] == "instance-alice"
+
+
+def test_persist_when_openhost_is_not_a_table_replaces_with_table(tmp_path: Path) -> None:
+    # EDGE: if ``openhost`` is a scalar (not a table), the code detects the
+    # non-dict via ``isinstance(section, dict)`` and starts a fresh section,
+    # discarding the bogus scalar. Confirm it doesn't crash and yields a table.
+    cfg = tmp_path / "config.toml"
+    cfg.write_text('openhost = "not-a-table"\n')
+    persist_instance_identity(str(cfg), _cred("iss", "id", "sec"))
+    data = tomllib.loads(cfg.read_text())
+    assert isinstance(data["openhost"], dict)
+    assert data["openhost"]["imbue_identity_issuer_url"] == "iss"
+
+
+def test_persist_no_tmp_file_left_behind(tmp_path: Path) -> None:
+    # Atomic write uses ``<path>.connect.tmp`` then os.replace; the temp file must
+    # not survive a successful write.
+    cfg = tmp_path / "config.toml"
+    cfg.write_text('[openhost]\nzone_domain = "a.example.com"\n')
+    persist_instance_identity(str(cfg), _cred())
+    assert not (tmp_path / "config.toml.connect.tmp").exists()
+    # only the config file should be present (plus nothing else we created)
+    leftovers = [p.name for p in tmp_path.iterdir() if p.name.endswith(".tmp")]
+    assert leftovers == []
+
+
+def test_persist_result_has_no_duplicate_identity_keys(tmp_path: Path) -> None:
+    # Persisting twice must not accumulate duplicate keys or change the section
+    # into anything but the latest values.
+    cfg = tmp_path / "config.toml"
+    cfg.write_text('[openhost]\nzone_domain = "a.example.com"\n')
+    persist_instance_identity(str(cfg), _cred("i1", "c1", "s1"))
+    persist_instance_identity(str(cfg), _cred("i2", "c2", "s2"))
+    text = cfg.read_text()
+    assert text.count("imbue_identity_client_id") == 1
+    data = tomllib.loads(text)["openhost"]
+    assert data["imbue_identity_client_id"] == "c2"
+    assert data["imbue_identity_client_secret"] == "s2"
+
+
+def test_persist_unicode_values_survive_round_trip(tmp_path: Path) -> None:
+    cfg = tmp_path / "config.toml"
+    cfg.write_text('[openhost]\nzone_domain = "a.example.com"\n')
+    cred = _cred(
+        issuer="https://kc.münchen.example/realms/öffentlich",
+        client_id="instance-地域",
+        secret="pä$$wörd-🔒",
+    )
+    persist_instance_identity(str(cfg), cred)
+    data = tomllib.loads(cfg.read_text())["openhost"]
+    assert data["imbue_identity_issuer_url"] == "https://kc.münchen.example/realms/öffentlich"
+    assert data["imbue_identity_client_id"] == "instance-地域"
+    assert data["imbue_identity_client_secret"] == "pä$$wörd-🔒"
+
+
+def test_persist_quote_heavy_secret_survives_round_trip(tmp_path: Path) -> None:
+    # Secrets full of TOML-significant chars (quotes, backslashes, brackets) must
+    # survive the tomli_w -> tomllib round-trip verbatim.
+    cfg = tmp_path / "config.toml"
+    cfg.write_text('[openhost]\nzone_domain = "a.example.com"\n')
+    tricky = "a\"b'c\\d[e]f#g=h\nnewline\ttab"
+    persist_instance_identity(str(cfg), _cred(secret=tricky))
+    data = tomllib.loads(cfg.read_text())["openhost"]
+    assert data["imbue_identity_client_secret"] == tricky
+
+
+def test_persist_result_loads_via_typed_settings_and_resolves_identity(tmp_path: Path) -> None:
+    # End-to-end: persist then load through the real typed_settings path and
+    # confirm the credential resolves through Config.instance_identity.
+    cfg = tmp_path / "config.toml"
+    cfg.write_text('[openhost]\nzone_domain = "alice.example.com"\n')
+    persist_instance_identity(str(cfg), _cred("https://iss", "cid", "csecret"))
+    loaded = typed_settings.load(DefaultConfig, appname="openhost", config_files=[str(cfg)])
+    ident = loaded.instance_identity
+    assert ident is not None
+    assert ident.issuer_url == "https://iss"
+    assert ident.client_id == "cid"
+    assert ident.client_secret == "csecret"
+
+
+def test_persist_into_empty_openhost_table_adds_only_identity(tmp_path: Path) -> None:
+    cfg = tmp_path / "config.toml"
+    cfg.write_text("[openhost]\n")
+    persist_instance_identity(str(cfg), _cred("iss", "id", "sec"))
+    data = tomllib.loads(cfg.read_text())["openhost"]
+    assert set(data) == {
+        "imbue_identity_issuer_url",
+        "imbue_identity_client_id",
+        "imbue_identity_client_secret",
+    }
+
+
+# ===========================================================================
+# exchange_code_for_credential
+# ===========================================================================
+
+
+def test_exchange_passes_timeout_through(monkeypatch: pytest.MonkeyPatch) -> None:
+    seen = _mock_httpx_post(
+        monkeypatch,
+        lambda: httpx.Response(
+            200,
+            json={"issuer_url": "i", "client_id": "c", "client_secret": "s"},
+        ),
+    )
+    exchange_code_for_credential("https://front.example.com", "code", timeout=7.5)
+    assert seen["timeout"] == 7.5
+
+
+def test_exchange_strips_trailing_slash_on_base(monkeypatch: pytest.MonkeyPatch) -> None:
+    seen = _mock_httpx_post(
+        monkeypatch,
+        lambda: httpx.Response(200, json={"issuer_url": "i", "client_id": "c", "client_secret": "s"}),
+    )
+    exchange_code_for_credential("https://front.example.com/", "code")
+    assert seen["url"] == "https://front.example.com/connect/imbue/exchange"
+
+
+def test_exchange_coerces_non_string_fields_to_str(monkeypatch: pytest.MonkeyPatch) -> None:
+    # The impl wraps each field in str(), so a JSON number becomes its str form.
+    _mock_httpx_post(
+        monkeypatch,
+        lambda: httpx.Response(200, json={"issuer_url": "i", "client_id": 12345, "client_secret": "s"}),
+    )
+    out = exchange_code_for_credential("https://front.example.com", "code")
+    assert out.client_id == "12345"
+
+
+@pytest.mark.parametrize("missing", ["issuer_url", "client_id", "client_secret"])
+def test_exchange_malformed_when_any_field_missing(
+    monkeypatch: pytest.MonkeyPatch, missing: str
+) -> None:
+    body = {"issuer_url": "i", "client_id": "c", "client_secret": "s"}
+    del body[missing]
+    _mock_httpx_post(monkeypatch, lambda: httpx.Response(200, json=body))
+    with pytest.raises(ConnectError, match="malformed"):
+        exchange_code_for_credential("https://front.example.com", "code")
+
+
+def test_exchange_malformed_on_non_json_body(monkeypatch: pytest.MonkeyPatch) -> None:
+    # A 200 whose body isn't JSON: resp.json() raises ValueError -> malformed.
+    _mock_httpx_post(monkeypatch, lambda: httpx.Response(200, text="this is not json"))
+    with pytest.raises(ConnectError, match="malformed"):
+        exchange_code_for_credential("https://front.example.com", "code")
+
+
+def test_exchange_malformed_on_json_list_body(monkeypatch: pytest.MonkeyPatch) -> None:
+    # A JSON list (not a dict) -> body["issuer_url"] raises TypeError -> malformed.
+    _mock_httpx_post(monkeypatch, lambda: httpx.Response(200, json=["not", "a", "dict"]))
+    with pytest.raises(ConnectError, match="malformed"):
+        exchange_code_for_credential("https://front.example.com", "code")
+
+
+def test_exchange_ignores_extra_fields(monkeypatch: pytest.MonkeyPatch) -> None:
+    _mock_httpx_post(
+        monkeypatch,
+        lambda: httpx.Response(
+            200,
+            json={
+                "issuer_url": "i",
+                "client_id": "c",
+                "client_secret": "s",
+                "extra": "ignored",
+                "zone_domain": "alice.example.com",
+                "nested": {"a": 1},
+            },
+        ),
+    )
+    out = exchange_code_for_credential("https://front.example.com", "code")
+    assert out == _cred("i", "c", "s")
+
+
+@pytest.mark.parametrize("status", [400, 401, 403, 500, 502, 503])
+def test_exchange_error_status_includes_code_in_message(
+    monkeypatch: pytest.MonkeyPatch, status: int
+) -> None:
+    _mock_httpx_post(monkeypatch, lambda: httpx.Response(status, json={"error": "nope"}))
+    with pytest.raises(ConnectError) as exc:
+        exchange_code_for_credential("https://front.example.com", "code")
+    assert f"HTTP {status}" in str(exc.value)
+    assert "nope" in str(exc.value)
+
+
+def test_exchange_error_status_non_json_body_uses_text(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Non-200 with a non-JSON body: _error_message falls back to resp.text[:200].
+    _mock_httpx_post(monkeypatch, lambda: httpx.Response(500, text="internal boom"))
+    with pytest.raises(ConnectError) as exc:
+        exchange_code_for_credential("https://front.example.com", "code")
+    assert "HTTP 500" in str(exc.value)
+    assert "internal boom" in str(exc.value)
+
+
+def test_exchange_error_message_truncated_to_200_chars(monkeypatch: pytest.MonkeyPatch) -> None:
+    # _error_message caps the body text at 200 chars.
+    long_body = "x" * 5000
+    _mock_httpx_post(monkeypatch, lambda: httpx.Response(500, text=long_body))
+    with pytest.raises(ConnectError) as exc:
+        exchange_code_for_credential("https://front.example.com", "code")
+    # 200 x's max, not 5000.
+    assert "x" * 200 in str(exc.value)
+    assert "x" * 201 not in str(exc.value)
+
+
+@pytest.mark.parametrize(
+    "exc_factory",
+    [
+        lambda: httpx.ConnectError("connection refused"),
+        lambda: httpx.TimeoutException("timed out"),
+        lambda: httpx.ReadError("read failed"),
+        lambda: httpx.ReadTimeout("read timed out"),
+        lambda: httpx.ConnectTimeout("connect timed out"),
+    ],
+)
+def test_exchange_wraps_each_network_error(
+    monkeypatch: pytest.MonkeyPatch, exc_factory: Any
+) -> None:
+    def fake_post(url: str, json: Any = None, timeout: Any = None) -> httpx.Response:
+        raise exc_factory()
+
+    monkeypatch.setattr(httpx, "post", fake_post)
+    with pytest.raises(ConnectError, match="could not reach") as exc:
+        exchange_code_for_credential("https://front.example.com", "code")
+    # The original httpx error is chained for debuggability.
+    assert isinstance(exc.value.__cause__, httpx.HTTPError)
+
+
+def test_exchange_sends_empty_code_verbatim(monkeypatch: pytest.MonkeyPatch) -> None:
+    # The function does not validate the code; an empty code is posted as-is
+    # (the route, not this function, guards against blank codes).
+    seen = _mock_httpx_post(
+        monkeypatch,
+        lambda: httpx.Response(200, json={"issuer_url": "i", "client_id": "c", "client_secret": "s"}),
+    )
+    exchange_code_for_credential("https://front.example.com", "")
+    assert seen["json"] == {"code": ""}
+
+
+def test_exchange_sends_large_code_verbatim(monkeypatch: pytest.MonkeyPatch) -> None:
+    big = "z" * 100_000
+    seen = _mock_httpx_post(
+        monkeypatch,
+        lambda: httpx.Response(200, json={"issuer_url": "i", "client_id": "c", "client_secret": "s"}),
+    )
+    exchange_code_for_credential("https://front.example.com", big)
+    assert seen["json"] == {"code": big}
+
+
+def test_exchange_error_dict_without_error_key_uses_text(monkeypatch: pytest.MonkeyPatch) -> None:
+    # A JSON error dict lacking an "error" key: _error_message falls back to
+    # str(body.get("error", resp.text[:200])) -> the text.
+    _mock_httpx_post(monkeypatch, lambda: httpx.Response(400, json={"detail": "something"}))
+    with pytest.raises(ConnectError) as exc:
+        exchange_code_for_credential("https://front.example.com", "code")
+    assert "HTTP 400" in str(exc.value)
+
+
+# ===========================================================================
+# active_config_path
+# ===========================================================================
+
+
+def test_active_config_path_router_config_only(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("OPENHOST_ROUTER_CONFIG", "/etc/openhost/router.toml")
+    monkeypatch.delenv("OPENHOST_CONFIG", raising=False)
+    assert active_config_path() == "/etc/openhost/router.toml"
+
+
+def test_active_config_path_legacy_config_only(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("OPENHOST_ROUTER_CONFIG", raising=False)
+    monkeypatch.setenv("OPENHOST_CONFIG", "/etc/openhost/legacy.toml")
+    assert active_config_path() == "/etc/openhost/legacy.toml"
+
+
+def test_active_config_path_router_wins_when_both_set(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("OPENHOST_ROUTER_CONFIG", "/etc/openhost/router.toml")
+    monkeypatch.setenv("OPENHOST_CONFIG", "/etc/openhost/legacy.toml")
+    assert active_config_path() == "/etc/openhost/router.toml"
+
+
+def test_active_config_path_none_when_neither_set(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("OPENHOST_ROUTER_CONFIG", raising=False)
+    monkeypatch.delenv("OPENHOST_CONFIG", raising=False)
+    assert active_config_path() is None
+
+
+def test_active_config_path_empty_router_falls_back_to_legacy(monkeypatch: pytest.MonkeyPatch) -> None:
+    # An empty (falsy) OPENHOST_ROUTER_CONFIG must not shadow a set legacy var —
+    # ``a or b`` semantics mean the empty string is skipped.
+    monkeypatch.setenv("OPENHOST_ROUTER_CONFIG", "")
+    monkeypatch.setenv("OPENHOST_CONFIG", "/etc/openhost/legacy.toml")
+    assert active_config_path() == "/etc/openhost/legacy.toml"
+
+
+# ===========================================================================
+# routes: shared harness
+# ===========================================================================
+
+
+@pytest.fixture
+def connected_cfg(tmp_path: Path) -> Any:
+    cfg = _make_test_config(
+        tmp_path,
+        port=20700,
+        zone_domain="alice.example.com",
+        email_proxy_base_url=_IMBUE,
+        public_ip="203.0.113.5",
+        **_IDENT,
+    )
+    init_db(cfg.db_path)
+    return cfg
+
+
+@pytest.fixture
+def unconnected_cfg(tmp_path: Path) -> Any:
+    cfg = _make_test_config(
+        tmp_path, port=20701, zone_domain="alice.example.com", email_proxy_base_url=_IMBUE
+    )
+    init_db(cfg.db_path)
+    return cfg
+
+
+@pytest.fixture
+def no_imbue_cfg(tmp_path: Path) -> Any:
+    cfg = _make_test_config(tmp_path, port=20702, zone_domain="alice.example.com")
+    init_db(cfg.db_path)
+    return cfg
+
+
+def _settings_client() -> TestClient[Litestar]:
+    app = Litestar(
+        route_handlers=[api_settings_routes],
+        dependencies={
+            "config": Provide(provide_config, sync_to_thread=False),
+            "db": Provide(provide_db),
+        },
+        openapi_config=None,
+    )
+    return TestClient(app=app)
+
+
+def _auth_cookie(cfg: Any) -> dict[str, str]:
+    pw_hash = bcrypt.hashpw(b"secretpass1", bcrypt.gensalt()).decode()
+    conn = sqlite3.connect(cfg.db_path)
+    conn.row_factory = sqlite3.Row
+    try:
+        cur = conn.execute(
+            "INSERT INTO users (username, password_hash) VALUES (?, ?)", ("owner", pw_hash)
+        )
+        assert cur.lastrowid is not None
+        token = create_session(cur.lastrowid, conn)
+        conn.commit()
+    finally:
+        conn.close()
+    return {SESSION_COOKIE_NAME: token}
+
+
+# ===========================================================================
+# routes: status
+# ===========================================================================
+
+
+def test_status_partial_identity_property_reports_not_connected() -> None:
+    # Only issuer + client_id present (no secret) -> instance_identity is None, so
+    # the status route's ``connected`` (which is ``instance_identity is not None``)
+    # would be False. This partial state is only reachable WITHOUT an Imbue base
+    # (setting email_proxy_base_url with a partial credential is rejected at config
+    # construction — see the next test), so we pin the property directly here.
+    cfg = DefaultConfig(
+        zone_domain="alice.example.com",
+        imbue_identity_issuer_url="https://kc/realms/openhost-customers",
+        imbue_identity_client_id="instance-alice",
+    )
+    assert cfg.instance_identity is None
+
+
+def test_config_rejects_imbue_base_with_partial_identity() -> None:
+    # A config that advertises the connect front door (email_proxy_base_url) but
+    # carries only a PARTIAL imbue identity is a misconfiguration and must be
+    # rejected at construction — so the status route never has to represent an
+    # "available + partially-connected" state.
+    with pytest.raises(ValueError, match="partially resolved"):
+        DefaultConfig(
+            zone_domain="alice.example.com",
+            email_proxy_base_url=_IMBUE,
+            imbue_identity_issuer_url="https://kc/realms/openhost-customers",
+            imbue_identity_client_id="instance-alice",
+        )
+
+
+def test_status_connected_via_cert_api_override_fallback(tmp_path: Path) -> None:
+    # instance_identity resolves through the DEPRECATED cert_api_keycloak_*
+    # override too, so a cert-api-provisioned instance reports connected=True.
+    cfg = _make_test_config(
+        tmp_path,
+        port=20711,
+        zone_domain="alice.example.com",
+        email_proxy_base_url=_IMBUE,
+        public_ip="203.0.113.9",
+        cert_api_keycloak_issuer_url="https://kc/realms/openhost-customers",
+        cert_api_keycloak_client_id="instance-alice",
+        cert_api_keycloak_client_secret="sekret",
+    )
+    init_db(cfg.db_path)
+    with _settings_client() as c:
+        resp = c.get("/api/settings/connect-imbue/status", cookies=_auth_cookie(cfg))
+    assert resp.json() == {"available": True, "connected": True}
+
+
+def test_status_available_tracks_imbue_connect_base_url(connected_cfg: Any) -> None:
+    # available is derived purely from imbue_connect_base_url (== email_proxy_base_url).
+    assert connected_cfg.imbue_connect_base_url == _IMBUE
+    with _settings_client() as c:
+        resp = c.get("/api/settings/connect-imbue/status", cookies=_auth_cookie(connected_cfg))
+    assert resp.json()["available"] is True
+
+
+# ===========================================================================
+# routes: start (proxy header derivation)
+# ===========================================================================
+
+
+def test_start_uses_forwarded_proto_and_host(unconnected_cfg: Any) -> None:
+    # Behind a proxy, the instance origin is taken from the X-Forwarded-* headers.
+    with _settings_client() as c:
+        resp = c.post(
+            "/api/settings/connect-imbue/start",
+            cookies=_auth_cookie(unconnected_cfg),
+            headers={"x-forwarded-proto": "https", "x-forwarded-host": "proxy.example.com"},
+        )
+    url = resp.json()["redirect_url"]
+    cb = parse_qs(urlparse(url).query)["callback"][0]
+    assert cb == "https://proxy.example.com/api/settings/connect-imbue/callback"
+
+
+def test_start_forwarded_proto_overrides_request_scheme(unconnected_cfg: Any) -> None:
+    # TestClient speaks http; x-forwarded-proto=https must win, so the callback
+    # is https even though the underlying request is http.
+    with _settings_client() as c:
+        resp = c.post(
+            "/api/settings/connect-imbue/start",
+            cookies=_auth_cookie(unconnected_cfg),
+            headers={"x-forwarded-proto": "https", "x-forwarded-host": "edge.example.com"},
+        )
+    cb = parse_qs(urlparse(resp.json()["redirect_url"]).query)["callback"][0]
+    assert cb.startswith("https://edge.example.com/")
+
+
+def test_start_falls_back_to_host_header(unconnected_cfg: Any) -> None:
+    # No forwarded-host -> the plain Host header is used for the instance origin.
+    with _settings_client() as c:
+        resp = c.post(
+            "/api/settings/connect-imbue/start",
+            cookies=_auth_cookie(unconnected_cfg),
+            headers={"host": "direct.example.com"},
+        )
+    cb = parse_qs(urlparse(resp.json()["redirect_url"]).query)["callback"][0]
+    assert cb.startswith("http://direct.example.com/") or cb.startswith("https://direct.example.com/")
+    assert "direct.example.com" in cb
+
+
+def test_start_forwarded_host_wins_over_host_header(unconnected_cfg: Any) -> None:
+    with _settings_client() as c:
+        resp = c.post(
+            "/api/settings/connect-imbue/start",
+            cookies=_auth_cookie(unconnected_cfg),
+            headers={"host": "origin.example.com", "x-forwarded-host": "proxy.example.com"},
+        )
+    cb = parse_qs(urlparse(resp.json()["redirect_url"]).query)["callback"][0]
+    assert "proxy.example.com" in cb
+    assert "origin.example.com" not in cb
+
+
+def test_start_zone_query_uses_config_zone_no_port(unconnected_cfg: Any) -> None:
+    # The zone= param is the configured zone (no port), independent of the host header.
+    with _settings_client() as c:
+        resp = c.post(
+            "/api/settings/connect-imbue/start",
+            cookies=_auth_cookie(unconnected_cfg),
+            headers={"x-forwarded-host": "somethingelse.example.com"},
+        )
+    zone = parse_qs(urlparse(resp.json()["redirect_url"]).query)["zone"][0]
+    assert zone == "alice.example.com"
+
+
+def test_start_frontend_base_is_imbue_connect_url(unconnected_cfg: Any) -> None:
+    with _settings_client() as c:
+        resp = c.post("/api/settings/connect-imbue/start", cookies=_auth_cookie(unconnected_cfg))
+    assert resp.json()["redirect_url"].startswith(f"{_IMBUE}/connect/imbue?")
+
+
+def test_start_requires_auth_no_cookie(unconnected_cfg: Any) -> None:
+    with _settings_client() as c:
+        assert c.post("/api/settings/connect-imbue/start").status_code == 401
+
+
+# ===========================================================================
+# routes: callback
+# ===========================================================================
+
+
+def _config_file(cfg: Any, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Point OPENHOST_ROUTER_CONFIG at a real config file for the callback to
+    persist into, and return its path."""
+    path = Path(cfg.data_root_dir) / "config.toml"
+    path.write_text('[openhost]\nzone_domain = "alice.example.com"\n')
+    monkeypatch.setenv("OPENHOST_ROUTER_CONFIG", str(path))
+    return path
+
+
+def test_callback_persists_the_exchanged_credential(
+    unconnected_cfg: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _config_file(unconnected_cfg, monkeypatch)
+    exchanged = _cred("https://iss.new", "cid-new", "csecret-new")
+    with (
+        mock.patch(
+            "compute_space.web.routes.api.settings.exchange_code_for_credential",
+            return_value=exchanged,
+        ),
+        mock.patch("compute_space.web.routes.api.settings.persist_instance_identity") as persist,
+        mock.patch("compute_space.web.routes.api.settings.trigger_restart"),
+        _settings_client() as c,
+    ):
+        resp = c.get(
+            "/api/settings/connect-imbue/callback?code=onetime",
+            cookies=_auth_cookie(unconnected_cfg),
+            follow_redirects=False,
+        )
+    assert resp.status_code in (302, 307)
+    # persist must be called with the exact credential the exchange returned.
+    persist.assert_called_once()
+    _, called_cred = persist.call_args.args
+    assert called_cred == exchanged
+
+
+def test_callback_trigger_restart_called_once_on_success(
+    unconnected_cfg: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _config_file(unconnected_cfg, monkeypatch)
+    with (
+        mock.patch(
+            "compute_space.web.routes.api.settings.exchange_code_for_credential",
+            return_value=_cred(),
+        ),
+        mock.patch("compute_space.web.routes.api.settings.persist_instance_identity"),
+        mock.patch("compute_space.web.routes.api.settings.trigger_restart") as restart,
+        _settings_client() as c,
+    ):
+        resp = c.get(
+            "/api/settings/connect-imbue/callback?code=onetime",
+            cookies=_auth_cookie(unconnected_cfg),
+            follow_redirects=False,
+        )
+    assert resp.headers["location"] == "/settings?connect=ok"
+    restart.assert_called_once_with()
+
+
+def test_callback_real_persist_writes_config(
+    unconnected_cfg: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Exercise the callback with the REAL persist_instance_identity (only the
+    # exchange + restart mocked) so the whole write path is covered end to end.
+    path = _config_file(unconnected_cfg, monkeypatch)
+    with (
+        mock.patch(
+            "compute_space.web.routes.api.settings.exchange_code_for_credential",
+            return_value=_cred("https://iss.e2e", "cid.e2e", "sec.e2e"),
+        ),
+        mock.patch("compute_space.web.routes.api.settings.trigger_restart"),
+        _settings_client() as c,
+    ):
+        resp = c.get(
+            "/api/settings/connect-imbue/callback?code=onetime",
+            cookies=_auth_cookie(unconnected_cfg),
+            follow_redirects=False,
+        )
+    assert resp.headers["location"] == "/settings?connect=ok"
+    data = tomllib.loads(path.read_text())["openhost"]
+    assert data["imbue_identity_issuer_url"] == "https://iss.e2e"
+    assert data["imbue_identity_client_id"] == "cid.e2e"
+    assert data["imbue_identity_client_secret"] == "sec.e2e"
+
+
+@pytest.mark.parametrize("code_value", ["", "   ", "\t", "\n", "  \t \n "])
+def test_callback_blank_or_whitespace_code_redirects_error(
+    unconnected_cfg: Any, monkeypatch: pytest.MonkeyPatch, code_value: str
+) -> None:
+    _config_file(unconnected_cfg, monkeypatch)
+    # A blank/whitespace code short-circuits to the error redirect and must NOT
+    # trigger an exchange or a restart.
+    with (
+        mock.patch(
+            "compute_space.web.routes.api.settings.exchange_code_for_credential",
+        ) as exchange,
+        mock.patch("compute_space.web.routes.api.settings.trigger_restart") as restart,
+        _settings_client() as c,
+    ):
+        resp = c.get(
+            "/api/settings/connect-imbue/callback",
+            params={"code": code_value},
+            cookies=_auth_cookie(unconnected_cfg),
+            follow_redirects=False,
+        )
+    assert resp.status_code in (302, 307)
+    assert resp.headers["location"] == "/settings?connect=error"
+    exchange.assert_not_called()
+    restart.assert_not_called()
+
+
+def test_callback_missing_code_param_redirects_error(
+    unconnected_cfg: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # The handler defaults code="" so an entirely-absent ?code= behaves like blank.
+    _config_file(unconnected_cfg, monkeypatch)
+    with (
+        mock.patch(
+            "compute_space.web.routes.api.settings.exchange_code_for_credential",
+        ) as exchange,
+        _settings_client() as c,
+    ):
+        resp = c.get(
+            "/api/settings/connect-imbue/callback",
+            cookies=_auth_cookie(unconnected_cfg),
+            follow_redirects=False,
+        )
+    assert resp.headers["location"] == "/settings?connect=error"
+    exchange.assert_not_called()
+
+
+def test_callback_connect_error_502_and_no_restart(
+    unconnected_cfg: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _config_file(unconnected_cfg, monkeypatch)
+    with (
+        mock.patch(
+            "compute_space.web.routes.api.settings.exchange_code_for_credential",
+            side_effect=ConnectError("code expired"),
+        ),
+        mock.patch("compute_space.web.routes.api.settings.trigger_restart") as restart,
+        _settings_client() as c,
+    ):
+        resp = c.get(
+            "/api/settings/connect-imbue/callback?code=bad",
+            cookies=_auth_cookie(unconnected_cfg),
+            follow_redirects=False,
+        )
+    assert resp.status_code == 502
+    # A failed exchange must not restart the instance.
+    restart.assert_not_called()
+
+
+def test_callback_persist_error_502_and_no_restart(
+    unconnected_cfg: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # A ConnectError raised by persist (not just exchange) is also caught -> 502,
+    # no restart.
+    _config_file(unconnected_cfg, monkeypatch)
+    with (
+        mock.patch(
+            "compute_space.web.routes.api.settings.exchange_code_for_credential",
+            return_value=_cred(),
+        ),
+        mock.patch(
+            "compute_space.web.routes.api.settings.persist_instance_identity",
+            side_effect=ConnectError("disk full"),
+        ),
+        mock.patch("compute_space.web.routes.api.settings.trigger_restart") as restart,
+        _settings_client() as c,
+    ):
+        resp = c.get(
+            "/api/settings/connect-imbue/callback?code=onetime",
+            cookies=_auth_cookie(unconnected_cfg),
+            follow_redirects=False,
+        )
+    assert resp.status_code == 502
+    restart.assert_not_called()
+
+
+def test_callback_500_when_no_config_path(
+    unconnected_cfg: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Env-driven config (no file) -> the credential can't be persisted -> 500,
+    # and no exchange/restart happens.
+    monkeypatch.delenv("OPENHOST_ROUTER_CONFIG", raising=False)
+    monkeypatch.delenv("OPENHOST_CONFIG", raising=False)
+    with (
+        mock.patch(
+            "compute_space.web.routes.api.settings.exchange_code_for_credential",
+        ) as exchange,
+        mock.patch("compute_space.web.routes.api.settings.trigger_restart") as restart,
+        _settings_client() as c,
+    ):
+        resp = c.get(
+            "/api/settings/connect-imbue/callback?code=onetime",
+            cookies=_auth_cookie(unconnected_cfg),
+            follow_redirects=False,
+        )
+    assert resp.status_code == 500
+    exchange.assert_not_called()
+    restart.assert_not_called()
+
+
+def test_callback_503_without_imbue_base(no_imbue_cfg: Any) -> None:
+    with _settings_client() as c:
+        resp = c.get(
+            "/api/settings/connect-imbue/callback?code=x",
+            cookies=_auth_cookie(no_imbue_cfg),
+            follow_redirects=False,
+        )
+    assert resp.status_code == 503
+
+
+def test_callback_503_precedes_blank_code_check(no_imbue_cfg: Any) -> None:
+    # Even with a blank code, the missing-Imbue-base check fires first -> 503,
+    # not the error redirect. Pins the ordering of the guards.
+    with _settings_client() as c:
+        resp = c.get(
+            "/api/settings/connect-imbue/callback?code=",
+            cookies=_auth_cookie(no_imbue_cfg),
+            follow_redirects=False,
+        )
+    assert resp.status_code == 503
+
+
+def test_callback_requires_auth_no_cookie(unconnected_cfg: Any) -> None:
+    with _settings_client() as c:
+        assert c.get("/api/settings/connect-imbue/callback?code=x").status_code == 401
+
+
+def test_callback_strips_surrounding_whitespace_before_exchange(
+    unconnected_cfg: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # A code with surrounding whitespace is stripped before being handed to the
+    # exchange (so the front door sees the clean code).
+    _config_file(unconnected_cfg, monkeypatch)
+    with (
+        mock.patch(
+            "compute_space.web.routes.api.settings.exchange_code_for_credential",
+            return_value=_cred(),
+        ) as exchange,
+        mock.patch("compute_space.web.routes.api.settings.persist_instance_identity"),
+        mock.patch("compute_space.web.routes.api.settings.trigger_restart"),
+        _settings_client() as c,
+    ):
+        c.get(
+            "/api/settings/connect-imbue/callback",
+            params={"code": "  spacey-code  "},
+            cookies=_auth_cookie(unconnected_cfg),
+            follow_redirects=False,
+        )
+    # second positional arg to exchange is the stripped code
+    _, passed_code = exchange.call_args.args
+    assert passed_code == "spacey-code"

--- a/compute_space/src/compute_space/tests/test_email_config.py
+++ b/compute_space/src/compute_space/tests/test_email_config.py
@@ -62,12 +62,13 @@ def test_partial_email_keycloak_config_is_rejected() -> None:
             cfg.evolve(**partial)
 
 
-def test_email_proxy_without_keycloak_creds_is_rejected() -> None:
-    # email_proxy_base_url set (email intended) but no resolvable Keycloak client
-    # (no cert-api, no explicit override) -> email could never authenticate.
+def test_email_proxy_without_keycloak_creds_is_awaiting_connect() -> None:
+    # email_proxy_base_url set but no resolvable credential is NOT an error: it is
+    # the "front door configured, awaiting Connect to Imbue" state. Email stays off
+    # (no boot failure) until the connect flow supplies the credential.
     cfg = DefaultConfig(zone_domain="x.example.com", public_ip="203.0.113.5")
-    with pytest.raises(ValueError, match="email cannot be enabled"):
-        cfg.evolve(email_proxy_base_url="https://openhost.imbue.com")
+    connected = cfg.evolve(email_proxy_base_url="https://openhost.imbue.com")
+    assert connected.email_enabled is False
 
 
 def test_full_email_config_without_public_ip_rejected() -> None:
@@ -184,11 +185,13 @@ def test_cert_api_client_present_but_email_off_without_proxy() -> None:
     assert cfg.email_keycloak_client_id_resolved == "instance-alice"
 
 
-def test_acme_instance_cannot_enable_email_without_explicit_kc() -> None:
-    # A BYO-ACME instance has no cert-api client, so proxy-only can't enable email.
+def test_acme_instance_email_off_without_explicit_kc() -> None:
+    # A BYO-ACME instance has no cert-api client, so proxy-only leaves email off
+    # (awaiting either explicit email_keycloak_*/imbue_identity_* or Connect). This
+    # is not an error — the instance boots fine with email disabled.
     cfg = DefaultConfig(zone_domain="x.example.com", public_ip="203.0.113.5")
-    with pytest.raises(ValueError, match="email cannot be enabled"):
-        cfg.evolve(email_proxy_base_url="https://openhost.imbue.com")
+    connected = cfg.evolve(email_proxy_base_url="https://openhost.imbue.com")
+    assert connected.email_enabled is False
 
 
 def test_acme_instance_enables_email_with_explicit_kc() -> None:

--- a/compute_space/src/compute_space/tests/test_email_dns_config_edge.py
+++ b/compute_space/src/compute_space/tests/test_email_dns_config_edge.py
@@ -346,12 +346,14 @@ def test_email_keycloak_set_without_proxy_is_off_not_error():
     assert cfg.email_enabled is False
 
 
-def test_proxy_without_resolvable_keycloak_rejected():
-    # proxy URL set but no kc anywhere (no cert-api, no override) -> error.
-    with pytest.raises(ValueError, match="email cannot be enabled"):
-        DefaultConfig(zone_domain="alice.selfhost.imbue.com").evolve(
-            public_ip="203.0.113.5", email_proxy_base_url="https://openhost.imbue.com"
-        )
+def test_proxy_without_resolvable_keycloak_is_awaiting_connect():
+    # proxy URL set but no credential anywhere (no cert-api, no override, no shared
+    # identity) is NOT an error: it's the "front door configured, awaiting Connect
+    # to Imbue" state. Email stays off until the connect flow supplies a credential.
+    cfg = DefaultConfig(zone_domain="alice.selfhost.imbue.com").evolve(
+        public_ip="203.0.113.5", email_proxy_base_url="https://openhost.imbue.com"
+    )
+    assert cfg.email_enabled is False
 
 
 def test_full_email_config_missing_public_ip_rejected():

--- a/compute_space/src/compute_space/tests/test_identity_edge.py
+++ b/compute_space/src/compute_space/tests/test_identity_edge.py
@@ -1,0 +1,895 @@
+"""Edge-case tests for the shared per-instance Imbue credential resolution.
+
+A single per-instance credential (``imbue_identity_*``) backs every Imbue
+service. Each service resolves its credential from its own DEPRECATED per-service
+override first, then falls back to the shared identity:
+
+  * cert-api:  cert_api_keycloak_* override  ->  imbue_identity_*
+  * email:     email_keycloak_* override     ->  cert_api_*_resolved  ->  imbue_identity_*
+
+``instance_identity`` follows the *cert-api* chain (cert_api override -> imbue),
+NOT the email override — that is a deliberate asymmetry these tests pin.
+
+Everything here probes ACTUAL behavior confirmed against the source:
+  * resolution uses ``a or b`` semantics, so "" (empty) is treated as unset but
+    whitespace-only strings are truthy and therefore NOT treated as unset.
+  * cert_provider=cert_api validation names the settable field, not *_resolved.
+  * email_proxy_base_url with a *fully-absent* credential is the awaiting-connect
+    state (no error, email off); with a *partially-resolved* credential it errors;
+    with a *fully-resolved* credential it additionally requires public_ip.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import typed_settings
+
+from compute_space.config import CERT_PROVIDER_ACME
+from compute_space.config import CERT_PROVIDER_CERT_API
+from compute_space.config import DefaultConfig
+
+_ISSUER = "https://keycloak.example.com/realms/openhost-customers"
+_PROXY = "https://openhost.imbue.com"
+_IP = "203.0.113.10"
+
+
+def _cfg(**kwargs: object) -> DefaultConfig:
+    return DefaultConfig(zone_domain="alice.host.example.com", **kwargs)  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# cert-api resolver chain: cert_api_keycloak_* override -> imbue_identity_*
+# Each of issuer / client_id / secret resolves independently.
+# ---------------------------------------------------------------------------
+
+
+def test_cert_issuer_from_imbue_only() -> None:
+    cfg = _cfg(imbue_identity_issuer_url=_ISSUER)
+    assert cfg.cert_api_keycloak_issuer_url_resolved == _ISSUER
+
+
+def test_cert_client_id_from_imbue_only() -> None:
+    cfg = _cfg(imbue_identity_client_id="imbue-id")
+    assert cfg.cert_api_keycloak_client_id_resolved == "imbue-id"
+
+
+def test_cert_secret_from_imbue_only() -> None:
+    cfg = _cfg(imbue_identity_client_secret="imbue-s")
+    assert cfg.cert_api_keycloak_client_secret_resolved == "imbue-s"
+
+
+def test_cert_issuer_override_beats_imbue() -> None:
+    cfg = _cfg(cert_api_keycloak_issuer_url="https://ov/realms/x", imbue_identity_issuer_url=_ISSUER)
+    assert cfg.cert_api_keycloak_issuer_url_resolved == "https://ov/realms/x"
+
+
+def test_cert_client_id_override_beats_imbue() -> None:
+    cfg = _cfg(cert_api_keycloak_client_id="ov-id", imbue_identity_client_id="imbue-id")
+    assert cfg.cert_api_keycloak_client_id_resolved == "ov-id"
+
+
+def test_cert_secret_override_beats_imbue() -> None:
+    cfg = _cfg(cert_api_keycloak_client_secret="ov-s", imbue_identity_client_secret="imbue-s")
+    assert cfg.cert_api_keycloak_client_secret_resolved == "ov-s"
+
+
+def test_cert_override_only_no_imbue() -> None:
+    cfg = _cfg(
+        cert_api_keycloak_issuer_url="https://ov/realms/x",
+        cert_api_keycloak_client_id="ov-id",
+        cert_api_keycloak_client_secret="ov-s",
+    )
+    assert cfg.cert_api_keycloak_issuer_url_resolved == "https://ov/realms/x"
+    assert cfg.cert_api_keycloak_client_id_resolved == "ov-id"
+    assert cfg.cert_api_keycloak_client_secret_resolved == "ov-s"
+
+
+def test_cert_mixed_issuer_override_id_secret_from_imbue() -> None:
+    # A per-field mix: cert-api override supplies only the issuer, imbue the rest.
+    cfg = _cfg(
+        cert_api_keycloak_issuer_url="https://ov/realms/x",
+        imbue_identity_client_id="imbue-id",
+        imbue_identity_client_secret="imbue-s",
+    )
+    assert cfg.cert_api_keycloak_issuer_url_resolved == "https://ov/realms/x"
+    assert cfg.cert_api_keycloak_client_id_resolved == "imbue-id"
+    assert cfg.cert_api_keycloak_client_secret_resolved == "imbue-s"
+
+
+def test_cert_resolvers_none_when_nothing_set() -> None:
+    cfg = _cfg()
+    assert cfg.cert_api_keycloak_issuer_url_resolved is None
+    assert cfg.cert_api_keycloak_client_id_resolved is None
+    assert cfg.cert_api_keycloak_client_secret_resolved is None
+
+
+# ---------------------------------------------------------------------------
+# email resolver chain: email_keycloak_* -> cert_api_*_resolved -> imbue_identity_*
+# ---------------------------------------------------------------------------
+
+
+def test_email_issuer_from_imbue_via_cert_chain() -> None:
+    cfg = _cfg(imbue_identity_issuer_url=_ISSUER)
+    assert cfg.email_keycloak_issuer_url_resolved == _ISSUER
+
+
+def test_email_client_id_from_imbue_via_cert_chain() -> None:
+    cfg = _cfg(imbue_identity_client_id="imbue-id")
+    assert cfg.email_keycloak_client_id_resolved == "imbue-id"
+
+
+def test_email_secret_from_imbue_via_cert_chain() -> None:
+    cfg = _cfg(imbue_identity_client_secret="imbue-s")
+    assert cfg.email_keycloak_client_secret_resolved == "imbue-s"
+
+
+def test_email_issuer_from_cert_api_override_over_imbue() -> None:
+    cfg = _cfg(cert_api_keycloak_issuer_url="https://cert/realms/x", imbue_identity_issuer_url=_ISSUER)
+    assert cfg.email_keycloak_issuer_url_resolved == "https://cert/realms/x"
+
+
+def _email_override(**overrides: str) -> dict[str, object]:
+    # The email override must be all-three-or-none (partial is rejected), so to
+    # test a single field's precedence we set all three and only vary the one
+    # under test to a distinctive value.
+    base: dict[str, object] = dict(
+        email_keycloak_issuer_url="https://email/realms/x",
+        email_keycloak_client_id="email-id",
+        email_keycloak_client_secret="email-s",
+    )
+    base.update(overrides)
+    return base
+
+
+def test_email_override_issuer_beats_cert_api_and_imbue() -> None:
+    cfg = _cfg(
+        cert_api_keycloak_issuer_url="https://cert/realms/x",
+        imbue_identity_issuer_url=_ISSUER,
+        **_email_override(email_keycloak_issuer_url="https://email-issuer/realms/x"),
+    )
+    assert cfg.email_keycloak_issuer_url_resolved == "https://email-issuer/realms/x"
+
+
+def test_email_override_client_id_beats_cert_api_and_imbue() -> None:
+    cfg = _cfg(
+        cert_api_keycloak_client_id="cert-id",
+        imbue_identity_client_id="imbue-id",
+        **_email_override(email_keycloak_client_id="the-email-id"),
+    )
+    assert cfg.email_keycloak_client_id_resolved == "the-email-id"
+
+
+def test_email_override_secret_beats_cert_api_and_imbue() -> None:
+    cfg = _cfg(
+        cert_api_keycloak_client_secret="cert-s",
+        imbue_identity_client_secret="imbue-s",
+        **_email_override(email_keycloak_client_secret="the-email-s"),
+    )
+    assert cfg.email_keycloak_client_secret_resolved == "the-email-s"
+
+
+def test_email_resolves_per_field_across_all_three_sources() -> None:
+    # issuer from email override, id from cert-api override, secret from imbue.
+    cfg = _cfg(
+        email_keycloak_issuer_url="https://email/realms/x",
+        email_keycloak_client_id="email-id",
+        email_keycloak_client_secret="email-s",
+        cert_api_keycloak_issuer_url="https://cert/realms/x",
+        cert_api_keycloak_client_id="cert-id",
+        cert_api_keycloak_client_secret="cert-s",
+        imbue_identity_issuer_url=_ISSUER,
+        imbue_identity_client_id="imbue-id",
+        imbue_identity_client_secret="imbue-s",
+    )
+    # email override wins for all three.
+    assert cfg.email_keycloak_issuer_url_resolved == "https://email/realms/x"
+    assert cfg.email_keycloak_client_id_resolved == "email-id"
+    assert cfg.email_keycloak_client_secret_resolved == "email-s"
+
+
+def test_email_resolvers_none_when_nothing_set() -> None:
+    cfg = _cfg()
+    assert cfg.email_keycloak_issuer_url_resolved is None
+    assert cfg.email_keycloak_client_id_resolved is None
+    assert cfg.email_keycloak_client_secret_resolved is None
+
+
+def test_cert_api_partial_plus_imbue_completes_email_chain() -> None:
+    # cert-api override supplies 2 of 3; imbue supplies the missing secret. Email's
+    # resolved chain must combine them.
+    cfg = _cfg(
+        cert_api_keycloak_issuer_url="https://cert/realms/x",
+        cert_api_keycloak_client_id="cert-id",
+        imbue_identity_client_secret="imbue-s",
+    )
+    assert cfg.email_keycloak_issuer_url_resolved == "https://cert/realms/x"
+    assert cfg.email_keycloak_client_id_resolved == "cert-id"
+    assert cfg.email_keycloak_client_secret_resolved == "imbue-s"
+
+
+# ---------------------------------------------------------------------------
+# instance_identity: present iff all three resolve via the CERT-API chain;
+# None otherwise. Email override does NOT feed instance_identity.
+# ---------------------------------------------------------------------------
+
+
+def test_instance_identity_from_imbue_only() -> None:
+    cfg = _cfg(
+        imbue_identity_issuer_url=_ISSUER,
+        imbue_identity_client_id="imbue-id",
+        imbue_identity_client_secret="imbue-s",
+    )
+    ident = cfg.instance_identity
+    assert ident is not None
+    assert ident.issuer_url == _ISSUER
+    assert ident.client_id == "imbue-id"
+    assert ident.client_secret == "imbue-s"
+
+
+def test_instance_identity_from_cert_api_override_only() -> None:
+    cfg = _cfg(
+        cert_api_keycloak_issuer_url="https://cert/realms/x",
+        cert_api_keycloak_client_id="cert-id",
+        cert_api_keycloak_client_secret="cert-s",
+    )
+    ident = cfg.instance_identity
+    assert ident is not None
+    assert ident.client_id == "cert-id"
+    assert ident.client_secret == "cert-s"
+
+
+def test_instance_identity_mixed_cert_override_and_imbue() -> None:
+    cfg = _cfg(
+        cert_api_keycloak_issuer_url="https://cert/realms/x",
+        imbue_identity_client_id="imbue-id",
+        imbue_identity_client_secret="imbue-s",
+    )
+    ident = cfg.instance_identity
+    assert ident is not None
+    assert ident.issuer_url == "https://cert/realms/x"
+    assert ident.client_id == "imbue-id"
+    assert ident.client_secret == "imbue-s"
+
+
+def test_instance_identity_cert_override_wins_over_imbue() -> None:
+    cfg = _cfg(
+        cert_api_keycloak_issuer_url="https://cert/realms/x",
+        cert_api_keycloak_client_id="cert-id",
+        cert_api_keycloak_client_secret="cert-s",
+        imbue_identity_issuer_url=_ISSUER,
+        imbue_identity_client_id="imbue-id",
+        imbue_identity_client_secret="imbue-s",
+    )
+    ident = cfg.instance_identity
+    assert ident is not None
+    assert ident.client_id == "cert-id"
+    assert ident.client_secret == "cert-s"
+
+
+def test_instance_identity_ignores_email_override() -> None:
+    # A crucial asymmetry: instance_identity follows the cert-api chain only, so a
+    # config whose ONLY credential is an email override yields NO instance identity.
+    cfg = _cfg(
+        email_keycloak_issuer_url="https://email/realms/x",
+        email_keycloak_client_id="email-id",
+        email_keycloak_client_secret="email-s",
+    )
+    assert cfg.instance_identity is None
+    # ...even though the email resolver does expose that override.
+    assert cfg.email_keycloak_client_id_resolved == "email-id"
+
+
+@pytest.mark.parametrize("present", ["issuer", "client_id", "client_secret"])
+def test_instance_identity_none_when_only_one_imbue_part(present: str) -> None:
+    kwargs: dict[str, dict[str, object]] = {
+        "issuer": {"imbue_identity_issuer_url": _ISSUER},
+        "client_id": {"imbue_identity_client_id": "imbue-id"},
+        "client_secret": {"imbue_identity_client_secret": "imbue-s"},
+    }
+    cfg = _cfg(**kwargs[present])
+    assert cfg.instance_identity is None
+
+
+@pytest.mark.parametrize("missing", ["issuer", "client_id", "client_secret"])
+def test_instance_identity_none_when_one_imbue_part_missing(missing: str) -> None:
+    kwargs: dict[str, object] = {
+        "imbue_identity_issuer_url": _ISSUER,
+        "imbue_identity_client_id": "imbue-id",
+        "imbue_identity_client_secret": "imbue-s",
+    }
+    field = {
+        "issuer": "imbue_identity_issuer_url",
+        "client_id": "imbue_identity_client_id",
+        "client_secret": "imbue_identity_client_secret",
+    }[missing]
+    del kwargs[field]
+    cfg = _cfg(**kwargs)
+    assert cfg.instance_identity is None
+
+
+@pytest.mark.parametrize("missing", ["issuer", "client_id", "client_secret"])
+def test_instance_identity_none_when_one_cert_override_part_missing(missing: str) -> None:
+    kwargs: dict[str, object] = {
+        "cert_api_keycloak_issuer_url": "https://cert/realms/x",
+        "cert_api_keycloak_client_id": "cert-id",
+        "cert_api_keycloak_client_secret": "cert-s",
+    }
+    field = {
+        "issuer": "cert_api_keycloak_issuer_url",
+        "client_id": "cert_api_keycloak_client_id",
+        "client_secret": "cert_api_keycloak_client_secret",
+    }[missing]
+    del kwargs[field]
+    cfg = _cfg(**kwargs)
+    assert cfg.instance_identity is None
+
+
+def test_instance_identity_split_across_cert_and_imbue_completes() -> None:
+    # issuer from cert override, id from cert override, secret from imbue -> full.
+    cfg = _cfg(
+        cert_api_keycloak_issuer_url="https://cert/realms/x",
+        cert_api_keycloak_client_id="cert-id",
+        imbue_identity_client_secret="imbue-s",
+    )
+    assert cfg.instance_identity is not None
+    assert cfg.instance_identity.client_secret == "imbue-s"
+
+
+def test_instance_identity_token_endpoint_derived() -> None:
+    cfg = _cfg(
+        imbue_identity_issuer_url=_ISSUER,
+        imbue_identity_client_id="imbue-id",
+        imbue_identity_client_secret="imbue-s",
+    )
+    assert cfg.instance_identity is not None
+    assert cfg.instance_identity.token_endpoint == _ISSUER + "/protocol/openid-connect/token"
+
+
+# ---------------------------------------------------------------------------
+# cert_provider = cert_api validation
+# ---------------------------------------------------------------------------
+
+
+def _cert_api(**kwargs: object) -> DefaultConfig:
+    base: dict[str, object] = dict(
+        cert_provider=CERT_PROVIDER_CERT_API,
+        cert_api_base_url="https://cert-api.example.com",
+    )
+    base.update(kwargs)
+    return _cfg(**base)
+
+
+def test_cert_api_satisfied_by_imbue_alone() -> None:
+    cfg = _cert_api(
+        imbue_identity_issuer_url=_ISSUER,
+        imbue_identity_client_id="imbue-id",
+        imbue_identity_client_secret="imbue-s",
+    )
+    assert cfg.cert_provider == CERT_PROVIDER_CERT_API
+    assert cfg.instance_identity is not None
+
+
+def test_cert_api_satisfied_by_cert_override_alone() -> None:
+    cfg = _cert_api(
+        cert_api_keycloak_issuer_url="https://cert/realms/x",
+        cert_api_keycloak_client_id="cert-id",
+        cert_api_keycloak_client_secret="cert-s",
+    )
+    assert cfg.cert_provider == CERT_PROVIDER_CERT_API
+
+
+def test_cert_api_satisfied_by_mixed_override_and_imbue() -> None:
+    cfg = _cert_api(
+        cert_api_keycloak_issuer_url="https://cert/realms/x",
+        cert_api_keycloak_client_id="cert-id",
+        imbue_identity_client_secret="imbue-s",
+    )
+    assert cfg.cert_provider == CERT_PROVIDER_CERT_API
+
+
+def test_cert_api_rejected_when_no_credential_anywhere() -> None:
+    with pytest.raises(ValueError, match="cert_api_keycloak_issuer_url must be set"):
+        _cert_api()
+
+
+def test_cert_api_error_names_settable_field_not_resolved() -> None:
+    # imbue supplies issuer + id but no secret; the error must name the SETTABLE
+    # field cert_api_keycloak_client_secret, never the internal *_resolved property.
+    with pytest.raises(ValueError) as exc:
+        _cert_api(
+            imbue_identity_issuer_url=_ISSUER,
+            imbue_identity_client_id="imbue-id",
+        )
+    msg = str(exc.value)
+    assert "cert_api_keycloak_client_secret must be set" in msg
+    assert "_resolved" not in msg
+
+
+@pytest.mark.parametrize(
+    ("provided", "missing_field"),
+    [
+        (("client_id", "client_secret"), "cert_api_keycloak_issuer_url"),
+        (("issuer", "client_secret"), "cert_api_keycloak_client_id"),
+        (("issuer", "client_id"), "cert_api_keycloak_client_secret"),
+    ],
+)
+def test_cert_api_partial_imbue_reports_first_missing(provided: tuple[str, str], missing_field: str) -> None:
+    src = {
+        "issuer": {"imbue_identity_issuer_url": _ISSUER},
+        "client_id": {"imbue_identity_client_id": "imbue-id"},
+        "client_secret": {"imbue_identity_client_secret": "imbue-s"},
+    }
+    kwargs: dict[str, object] = {}
+    for part in provided:
+        kwargs.update(src[part])
+    with pytest.raises(ValueError, match=f"{missing_field} must be set"):
+        _cert_api(**kwargs)
+
+
+def test_cert_api_two_of_three_from_cert_override_missing_secret() -> None:
+    with pytest.raises(ValueError, match="cert_api_keycloak_client_secret must be set"):
+        _cert_api(
+            cert_api_keycloak_issuer_url="https://cert/realms/x",
+            cert_api_keycloak_client_id="cert-id",
+        )
+
+
+def test_cert_api_missing_base_url_errors_first() -> None:
+    # base_url is validated before the credential; even a full credential can't
+    # rescue a missing broker URL.
+    with pytest.raises(ValueError, match="cert_api_base_url must be set"):
+        _cfg(
+            cert_provider=CERT_PROVIDER_CERT_API,
+            cert_api_base_url=None,
+            imbue_identity_issuer_url=_ISSUER,
+            imbue_identity_client_id="imbue-id",
+            imbue_identity_client_secret="imbue-s",
+        )
+
+
+def test_acme_never_requires_credential() -> None:
+    cfg = _cfg()
+    assert cfg.cert_provider == CERT_PROVIDER_ACME
+    # No identity and no error.
+    assert cfg.instance_identity is None
+
+
+def test_acme_ignores_partial_imbue_identity() -> None:
+    # A partial shared identity is harmless on the default acme path (no validation).
+    cfg = _cfg(imbue_identity_issuer_url=_ISSUER)
+    assert cfg.cert_provider == CERT_PROVIDER_ACME
+    assert cfg.instance_identity is None
+
+
+# ---------------------------------------------------------------------------
+# email_enabled across credential sources / prerequisites
+# ---------------------------------------------------------------------------
+
+
+def _imbue3() -> dict[str, object]:
+    return dict(
+        imbue_identity_issuer_url=_ISSUER,
+        imbue_identity_client_id="imbue-id",
+        imbue_identity_client_secret="imbue-s",
+    )
+
+
+def test_email_enabled_via_imbue_proxy_and_ip() -> None:
+    cfg = _cfg(email_proxy_base_url=_PROXY, public_ip=_IP, **_imbue3())
+    assert cfg.email_enabled is True
+
+
+def test_email_enabled_via_cert_api_override_proxy_and_ip() -> None:
+    cfg = _cfg(
+        email_proxy_base_url=_PROXY,
+        public_ip=_IP,
+        cert_api_keycloak_issuer_url="https://cert/realms/x",
+        cert_api_keycloak_client_id="cert-id",
+        cert_api_keycloak_client_secret="cert-s",
+    )
+    assert cfg.email_enabled is True
+
+
+def test_email_enabled_via_email_override_proxy_and_ip() -> None:
+    cfg = _cfg(
+        email_proxy_base_url=_PROXY,
+        public_ip=_IP,
+        email_keycloak_issuer_url="https://email/realms/x",
+        email_keycloak_client_id="email-id",
+        email_keycloak_client_secret="email-s",
+    )
+    assert cfg.email_enabled is True
+    # This is the one enablement path that produces NO instance_identity (email
+    # override doesn't feed the cert-api chain).
+    assert cfg.instance_identity is None
+
+
+def test_email_disabled_without_proxy_even_with_full_imbue() -> None:
+    cfg = _cfg(public_ip=_IP, **_imbue3())
+    assert cfg.email_enabled is False
+
+
+def test_email_disabled_with_proxy_but_no_credential() -> None:
+    # Awaiting-connect: no credential anywhere. Not an error, email off.
+    cfg = _cfg(email_proxy_base_url=_PROXY)
+    assert cfg.email_enabled is False
+
+
+def test_email_enabled_is_false_when_only_two_imbue_parts_and_proxy() -> None:
+    # Two of three imbue parts -> partially resolved -> this would ERROR when a
+    # proxy is set, so email_enabled is exercised without the proxy here.
+    cfg = _cfg(
+        imbue_identity_issuer_url=_ISSUER,
+        imbue_identity_client_id="imbue-id",
+    )
+    assert cfg.email_enabled is False
+
+
+def test_email_prereq_reflects_resolved_not_raw_email_fields() -> None:
+    # email_keycloak_* raw fields are all None, but the prereqs resolve via imbue,
+    # so email turns on. Confirms email_enabled reads the *_resolved chain.
+    cfg = _cfg(email_proxy_base_url=_PROXY, public_ip=_IP, **_imbue3())
+    assert cfg.email_keycloak_issuer_url is None
+    assert cfg.email_enabled is True
+
+
+# ---------------------------------------------------------------------------
+# Awaiting-connect: proxy + zero creds => no exception, off, no identity
+# ---------------------------------------------------------------------------
+
+
+def test_awaiting_connect_loads_without_exception() -> None:
+    cfg = _cfg(email_proxy_base_url=_PROXY)
+    assert cfg.email_enabled is False
+    assert cfg.instance_identity is None
+
+
+def test_awaiting_connect_exposes_connect_base_url() -> None:
+    cfg = _cfg(email_proxy_base_url=_PROXY)
+    assert cfg.imbue_connect_base_url == _PROXY
+
+
+def test_awaiting_connect_does_not_require_public_ip() -> None:
+    # No public_ip and no credential + proxy set: still fine (email off).
+    cfg = _cfg(email_proxy_base_url=_PROXY)
+    assert cfg.public_ip is None
+    assert cfg.email_enabled is False
+
+
+def test_connect_base_url_none_without_proxy() -> None:
+    cfg = _cfg()
+    assert cfg.imbue_connect_base_url is None
+
+
+def test_awaiting_connect_then_evolve_to_connected() -> None:
+    # Model the connect flow: start awaiting, then inject the shared identity + IP.
+    awaiting = _cfg(email_proxy_base_url=_PROXY)
+    assert awaiting.email_enabled is False
+    connected = awaiting.evolve(public_ip=_IP, **_imbue3())
+    assert connected.email_enabled is True
+    assert connected.instance_identity is not None
+
+
+# ---------------------------------------------------------------------------
+# Partial-credential validation errors when a proxy is set
+# ---------------------------------------------------------------------------
+
+
+def test_proxy_with_imbue_issuer_only_errors() -> None:
+    with pytest.raises(ValueError, match="only partially resolved"):
+        _cfg(email_proxy_base_url=_PROXY, public_ip=_IP, imbue_identity_issuer_url=_ISSUER)
+
+
+def test_proxy_with_imbue_two_parts_errors() -> None:
+    with pytest.raises(ValueError, match="only partially resolved"):
+        _cfg(
+            email_proxy_base_url=_PROXY,
+            public_ip=_IP,
+            imbue_identity_issuer_url=_ISSUER,
+            imbue_identity_client_id="imbue-id",
+        )
+
+
+def test_proxy_with_cert_two_of_three_errors() -> None:
+    with pytest.raises(ValueError, match="only partially resolved"):
+        _cfg(
+            email_proxy_base_url=_PROXY,
+            public_ip=_IP,
+            cert_api_keycloak_issuer_url="https://cert/realms/x",
+            cert_api_keycloak_client_id="cert-id",
+        )
+
+
+def test_proxy_with_cert_two_plus_imbue_one_completes_no_error() -> None:
+    # cert override supplies 2, imbue the 3rd -> fully resolved, no partial error.
+    cfg = _cfg(
+        email_proxy_base_url=_PROXY,
+        public_ip=_IP,
+        cert_api_keycloak_issuer_url="https://cert/realms/x",
+        cert_api_keycloak_client_id="cert-id",
+        imbue_identity_client_secret="imbue-s",
+    )
+    assert cfg.email_enabled is True
+
+
+def test_proxy_partial_names_missing_resolved_attrs() -> None:
+    # The partial-credential error lists the missing *_resolved attrs (internal
+    # names are acceptable here — this path is about resolution completeness).
+    with pytest.raises(ValueError) as exc:
+        _cfg(email_proxy_base_url=_PROXY, public_ip=_IP, imbue_identity_issuer_url=_ISSUER)
+    msg = str(exc.value)
+    assert "email_keycloak_client_id_resolved" in msg
+    assert "email_keycloak_client_secret_resolved" in msg
+
+
+def test_proxy_partial_error_even_without_public_ip() -> None:
+    # The partial-credential check fires before the public_ip check.
+    with pytest.raises(ValueError, match="only partially resolved"):
+        _cfg(email_proxy_base_url=_PROXY, imbue_identity_issuer_url=_ISSUER)
+
+
+def test_email_override_partial_rejected_before_proxy_logic() -> None:
+    # Partial email_keycloak_* override is rejected as a typo regardless of proxy.
+    with pytest.raises(ValueError, match="partially configured"):
+        _cfg(
+            email_keycloak_issuer_url="https://email/realms/x",
+            email_keycloak_client_id="email-id",
+        )
+
+
+def test_email_override_partial_rejected_even_with_full_imbue() -> None:
+    # A partial explicit override is a typo even though imbue could satisfy the
+    # chain — the override-completeness check is independent of resolution.
+    with pytest.raises(ValueError, match="partially configured"):
+        _cfg(email_keycloak_issuer_url="https://email/realms/x", **_imbue3())
+
+
+# ---------------------------------------------------------------------------
+# public_ip requirement gating
+# ---------------------------------------------------------------------------
+
+
+def test_full_credential_plus_proxy_requires_public_ip() -> None:
+    with pytest.raises(ValueError, match="public_ip must be set"):
+        _cfg(email_proxy_base_url=_PROXY, **_imbue3())
+
+
+def test_full_credential_plus_proxy_with_public_ip_ok() -> None:
+    cfg = _cfg(email_proxy_base_url=_PROXY, public_ip=_IP, **_imbue3())
+    assert cfg.email_enabled is True
+    assert cfg.public_ip == _IP
+
+
+def test_public_ip_not_required_without_proxy() -> None:
+    # A full credential but no proxy: email off, no public_ip needed.
+    cfg = _cfg(**_imbue3())
+    assert cfg.public_ip is None
+    assert cfg.email_enabled is False
+
+
+def test_public_ip_not_required_in_awaiting_connect() -> None:
+    cfg = _cfg(email_proxy_base_url=_PROXY)
+    assert cfg.public_ip is None
+    assert cfg.email_enabled is False
+
+
+def test_cert_api_provider_alone_does_not_require_public_ip() -> None:
+    # cert_api provider validation is independent of email; no proxy => no public_ip.
+    cfg = _cert_api(**_imbue3())
+    assert cfg.public_ip is None
+    assert cfg.cert_provider == CERT_PROVIDER_CERT_API
+
+
+# ---------------------------------------------------------------------------
+# TOML round-trips
+# ---------------------------------------------------------------------------
+
+
+def _load(path: Path) -> DefaultConfig:
+    return typed_settings.load(DefaultConfig, appname="openhost", config_files=[str(path)])
+
+
+def test_toml_round_trip_preserves_imbue_identity(tmp_path: Path) -> None:
+    cfg = _cfg(**_imbue3())
+    rendered = cfg.to_toml_str()
+    assert f'imbue_identity_issuer_url = "{_ISSUER}"' in rendered
+    assert 'imbue_identity_client_id = "imbue-id"' in rendered
+    assert 'imbue_identity_client_secret = "imbue-s"' in rendered
+    out = tmp_path / "config.toml"
+    out.write_text(rendered)
+    reloaded = _load(out)
+    assert reloaded.imbue_identity_issuer_url == _ISSUER
+    assert reloaded.instance_identity is not None
+    assert reloaded.instance_identity.client_secret == "imbue-s"
+
+
+def test_toml_round_trip_resolvers_still_work(tmp_path: Path) -> None:
+    cfg = _cfg(**_imbue3())
+    out = tmp_path / "config.toml"
+    out.write_text(cfg.to_toml_str())
+    reloaded = _load(out)
+    assert reloaded.cert_api_keycloak_client_id_resolved == "imbue-id"
+    assert reloaded.email_keycloak_client_secret_resolved == "imbue-s"
+
+
+def test_toml_round_trip_cert_api_provider_via_imbue(tmp_path: Path) -> None:
+    cfg = _cert_api(**_imbue3())
+    out = tmp_path / "config.toml"
+    out.write_text(cfg.to_toml_str())
+    reloaded = _load(out)
+    assert reloaded.cert_provider == CERT_PROVIDER_CERT_API
+    assert reloaded.instance_identity is not None
+
+
+def test_toml_round_trip_awaiting_connect(tmp_path: Path) -> None:
+    cfg = _cfg(email_proxy_base_url=_PROXY)
+    out = tmp_path / "config.toml"
+    out.write_text(cfg.to_toml_str())
+    reloaded = _load(out)
+    assert reloaded.email_enabled is False
+    assert reloaded.imbue_connect_base_url == _PROXY
+    assert reloaded.instance_identity is None
+
+
+def test_legacy_cert_api_only_config_loads_and_resolves(tmp_path: Path) -> None:
+    # Backward compat: a config written before imbue_identity_* existed (only the
+    # deprecated cert_api_keycloak_* fields) loads and resolves unchanged.
+    config_path = tmp_path / "config.toml"
+    config_path.write_text(
+        "[openhost]\n"
+        'zone_domain = "alice.host.example.com"\n'
+        "tls_enabled = true\n"
+        "coredns_enabled = true\n"
+        'cert_provider = "cert_api"\n'
+        'cert_api_base_url = "https://cert-api.example.com"\n'
+        'cert_api_keycloak_issuer_url = "https://kc.example.com/realms/openhost-customers"\n'
+        'cert_api_keycloak_client_id = "instance-alice"\n'
+        'cert_api_keycloak_client_secret = "legacy-s3cr3t"\n'
+    )
+    cfg = _load(config_path)
+    assert cfg.imbue_identity_issuer_url is None
+    assert cfg.cert_api_keycloak_client_secret_resolved == "legacy-s3cr3t"
+    assert cfg.email_keycloak_client_secret_resolved == "legacy-s3cr3t"
+    ident = cfg.instance_identity
+    assert ident is not None
+    assert ident.client_id == "instance-alice"
+    assert ident.client_secret == "legacy-s3cr3t"
+
+
+def test_legacy_email_override_config_loads_and_resolves(tmp_path: Path) -> None:
+    # A pre-shared-identity email config using only email_keycloak_* overrides.
+    config_path = tmp_path / "config.toml"
+    config_path.write_text(
+        "[openhost]\n"
+        'zone_domain = "alice.host.example.com"\n'
+        "coredns_enabled = true\n"
+        'public_ip = "203.0.113.10"\n'
+        'email_proxy_base_url = "https://openhost.imbue.com"\n'
+        'email_keycloak_issuer_url = "https://kc.example.com/realms/openhost-customers"\n'
+        'email_keycloak_client_id = "instance-alice"\n'
+        'email_keycloak_client_secret = "email-s3cr3t"\n'
+    )
+    cfg = _load(config_path)
+    assert cfg.email_enabled is True
+    assert cfg.email_keycloak_client_secret_resolved == "email-s3cr3t"
+    # Email override doesn't feed instance_identity.
+    assert cfg.instance_identity is None
+
+
+def test_toml_round_trip_override_and_imbue_precedence_preserved(tmp_path: Path) -> None:
+    cfg = _cfg(
+        cert_api_keycloak_issuer_url="https://cert/realms/x",
+        cert_api_keycloak_client_id="cert-id",
+        cert_api_keycloak_client_secret="cert-s",
+        **_imbue3(),
+    )
+    out = tmp_path / "config.toml"
+    out.write_text(cfg.to_toml_str())
+    reloaded = _load(out)
+    # cert override still wins over imbue after a round trip.
+    assert reloaded.cert_api_keycloak_client_id_resolved == "cert-id"
+    assert reloaded.instance_identity is not None
+    assert reloaded.instance_identity.client_id == "cert-id"
+
+
+def test_evolve_preserves_imbue_identity() -> None:
+    cfg = _cfg(**_imbue3())
+    evolved = cfg.evolve(public_ip=_IP)
+    assert evolved.instance_identity is not None
+    assert evolved.instance_identity.client_id == "imbue-id"
+
+
+# ---------------------------------------------------------------------------
+# Whitespace / empty-string handling (probed: "" is unset, whitespace is NOT)
+# ---------------------------------------------------------------------------
+
+
+def test_empty_string_imbue_part_treated_as_unset() -> None:
+    # Empty string is falsy, so the `or` chain skips it -> instance_identity None.
+    cfg = _cfg(
+        imbue_identity_issuer_url="",
+        imbue_identity_client_id="imbue-id",
+        imbue_identity_client_secret="imbue-s",
+    )
+    assert cfg.instance_identity is None
+
+
+def test_empty_string_cert_override_falls_through_to_imbue() -> None:
+    # An empty cert-api override falls through to the imbue value.
+    cfg = _cfg(cert_api_keycloak_issuer_url="", imbue_identity_issuer_url=_ISSUER)
+    assert cfg.cert_api_keycloak_issuer_url_resolved == _ISSUER
+
+
+def test_empty_string_email_override_falls_through_to_cert_chain() -> None:
+    cfg = _cfg(
+        email_keycloak_issuer_url="",
+        email_keycloak_client_id="",
+        email_keycloak_client_secret="",
+        cert_api_keycloak_issuer_url="https://cert/realms/x",
+        cert_api_keycloak_client_id="cert-id",
+        cert_api_keycloak_client_secret="cert-s",
+    )
+    # All-empty override counts as "none set" (falsy), so it's not a partial-config
+    # error and the cert-api chain supplies the values.
+    assert cfg.email_keycloak_issuer_url_resolved == "https://cert/realms/x"
+    assert cfg.email_keycloak_client_id_resolved == "cert-id"
+
+
+def test_whitespace_imbue_part_is_truthy_and_forms_identity() -> None:
+    # Documented ACTUAL behavior: whitespace is NOT stripped/treated as unset, so a
+    # whitespace-only value is truthy and produces a (garbage) credential. Pinned so
+    # a future change to strip whitespace is a conscious, visible decision.
+    cfg = _cfg(
+        imbue_identity_issuer_url="   ",
+        imbue_identity_client_id="imbue-id",
+        imbue_identity_client_secret="imbue-s",
+    )
+    ident = cfg.instance_identity
+    assert ident is not None
+    assert ident.issuer_url == "   "
+
+
+def test_whitespace_override_beats_imbue() -> None:
+    # Because whitespace is truthy, a whitespace cert override shadows the real
+    # imbue value (again, pinning current behavior).
+    cfg = _cfg(cert_api_keycloak_client_id="   ", imbue_identity_client_id="imbue-id")
+    assert cfg.cert_api_keycloak_client_id_resolved == "   "
+
+
+# ---------------------------------------------------------------------------
+# email override still wins over imbue (explicit precedence pin)
+# ---------------------------------------------------------------------------
+
+
+def test_email_override_wins_over_imbue_all_three() -> None:
+    cfg = _cfg(
+        email_proxy_base_url=_PROXY,
+        public_ip=_IP,
+        email_keycloak_issuer_url="https://email/realms/x",
+        email_keycloak_client_id="email-id",
+        email_keycloak_client_secret="email-s",
+        **_imbue3(),
+    )
+    assert cfg.email_keycloak_issuer_url_resolved == "https://email/realms/x"
+    assert cfg.email_keycloak_client_id_resolved == "email-id"
+    assert cfg.email_keycloak_client_secret_resolved == "email-s"
+    # But instance_identity still follows the cert-api chain -> imbue values.
+    assert cfg.instance_identity is not None
+    assert cfg.instance_identity.client_id == "imbue-id"
+
+
+def test_email_override_wins_over_cert_api_and_imbue_mixed() -> None:
+    cfg = _cfg(
+        email_keycloak_issuer_url="https://email/realms/x",
+        email_keycloak_client_id="email-id",
+        email_keycloak_client_secret="email-s",
+        cert_api_keycloak_issuer_url="https://cert/realms/x",
+        cert_api_keycloak_client_id="cert-id",
+        cert_api_keycloak_client_secret="cert-s",
+        **_imbue3(),
+    )
+    assert cfg.email_keycloak_client_secret_resolved == "email-s"
+    # cert-api resolver is unaffected by the email override.
+    assert cfg.cert_api_keycloak_client_secret_resolved == "cert-s"

--- a/compute_space/src/compute_space/tests/test_identity_migration_edge.py
+++ b/compute_space/src/compute_space/tests/test_identity_migration_edge.py
@@ -1,0 +1,872 @@
+"""Cross-cutting MIGRATION / BACKWARD-COMPAT / GRACEFUL-DEGRADE / NEGATIVE-SECURITY
+tests for the shared instance identity + Connect-to-Imbue seams.
+
+These complement the single-layer unit tests (``test_instance_identity.py``,
+``test_identity_edge.py``, ``test_connect.py``, ``test_connect_edge.py``,
+``test_email_config.py``) by exercising the *combinations* that a per-layer test
+would miss: a real old-style ``config.toml`` loaded through the production
+``load_config`` / ``typed_settings.load`` path AND then resolved into working
+credentials; the obsolete-key scrubber run alongside the new ``imbue_identity_*``
+fields; ``persist_instance_identity`` layered onto a config that already carries a
+deprecated per-service override (and which credential then wins); and the
+awaiting-connect graceful-degrade state.
+
+Everything here asserts behavior confirmed against the real source. Two results
+worth calling out because they are load-bearing and easy to get wrong:
+
+  * ``instance_identity`` follows the CERT-API resolver chain
+    (``cert_api_keycloak_*`` override -> ``imbue_identity_*``). So when
+    ``persist_instance_identity`` writes ``imbue_identity_*`` onto a config that
+    STILL has a ``cert_api_keycloak_*`` override, the DEPRECATED override keeps
+    winning (see ``test_persist_onto_old_cert_api_config_override_still_wins``).
+    That is the documented precedence and is pinned here.
+
+  * The production ``load_config`` path reads ``OPENHOST_``-prefixed env vars via
+    typed-settings, which would override values from the TOML file. Tests that go
+    through that path scrub the environment first (``_clear_openhost_env``) so the
+    file is the sole source of truth and the tests are deterministic in CI.
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+import tomllib
+from pathlib import Path
+
+import pytest
+import typed_settings
+
+from compute_space import config as config_mod
+from compute_space.config import CERT_PROVIDER_ACME
+from compute_space.config import CERT_PROVIDER_CERT_API
+from compute_space.config import DefaultConfig
+from compute_space.config import load_config
+from compute_space.core.connect import persist_instance_identity
+from compute_space.core.tls.keycloak import KeycloakClientCredentials
+
+_ISSUER = "https://kc.example.com/realms/openhost-customers"
+_PROXY = "https://openhost.imbue.com"
+_IP = "203.0.113.10"
+
+
+def _clear_openhost_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Remove every ``OPENHOST_``-prefixed env var so the TOML file is the sole
+    config source when going through ``load_config`` / ``typed_settings.load``.
+
+    Real deploy/dev shells (and this repo's own agent host) export
+    ``OPENHOST_ZONE_DOMAIN`` and friends; typed-settings would let those shadow the
+    file under test, making an assertion on a file value nondeterministic.
+    """
+    for name in list(os.environ):
+        if name.startswith("OPENHOST_"):
+            monkeypatch.delenv(name, raising=False)
+
+
+def _load_file(path: Path) -> DefaultConfig:
+    """Load a config file through typed-settings exactly as production does."""
+    return typed_settings.load(DefaultConfig, appname="openhost", config_files=[str(path)])
+
+
+def _flatten_error(exc: BaseException) -> str:
+    """Join the messages of an exception and everything it wraps into one string.
+
+    typed-settings surfaces a Config ``ValueError`` raised in
+    ``__attrs_post_init__`` as an ``InvalidSettingsError`` whose real message lives
+    in a nested sub-exception / ``__cause__`` chain. Flattening lets a file-load
+    test assert on the original validation message regardless of the wrapping.
+    """
+    parts = [str(exc)]
+    for sub in getattr(exc, "exceptions", ()):  # ExceptionGroup members
+        parts.append(_flatten_error(sub))
+    if exc.__cause__ is not None:
+        parts.append(_flatten_error(exc.__cause__))
+    if exc.__context__ is not None and exc.__context__ is not exc.__cause__:
+        parts.append(_flatten_error(exc.__context__))
+    return " ".join(parts)
+
+
+def _assert_load_rejects(path: Path, expected_substring: str) -> None:
+    """Assert loading ``path`` through typed-settings fails with the given message.
+
+    A single Config ``ValueError`` becomes a wrapped ``InvalidSettingsError`` on
+    the typed-settings load path, so we can't ``pytest.raises(ValueError, ...)``
+    directly — we catch the wrapper and check the flattened message chain.
+    """
+    with pytest.raises(typed_settings.exceptions.InvalidSettingsError) as excinfo:
+        _load_file(path)
+    assert expected_substring in _flatten_error(excinfo.value)
+
+
+def _cred(
+    issuer: str = _ISSUER,
+    client_id: str = "instance-alice",
+    secret: str = "sekret",
+) -> KeycloakClientCredentials:
+    return KeycloakClientCredentials(issuer_url=issuer, client_id=client_id, client_secret=secret)
+
+
+# ===========================================================================
+# MIGRATION / BACKWARD-COMPAT
+# ===========================================================================
+
+
+def test_old_cert_api_config_loads_and_yields_working_creds(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    # A pre-existing config.toml written the OLD way (cert_api_keycloak_* set,
+    # cert_provider=cert_api, NO imbue_identity_*) must load through the real
+    # typed-settings path AND produce a usable instance_identity plus resolved
+    # cert/email creds — the live-verified backward-compat path.
+    _clear_openhost_env(monkeypatch)
+    p = tmp_path / "config.toml"
+    p.write_text(
+        "[openhost]\n"
+        'zone_domain = "alice.host.example.com"\n'
+        "tls_enabled = true\n"
+        "coredns_enabled = true\n"
+        'cert_provider = "cert_api"\n'
+        'cert_api_base_url = "https://cert-api.example.com"\n'
+        'cert_api_keycloak_issuer_url = "https://kc.old/realms/openhost-customers"\n'
+        'cert_api_keycloak_client_id = "old-id"\n'
+        'cert_api_keycloak_client_secret = "old-secret"\n'
+    )
+    cfg = _load_file(p)
+    assert cfg.zone_domain == "alice.host.example.com"
+    assert cfg.imbue_identity_issuer_url is None
+    # cert creds resolve from the deprecated override.
+    assert cfg.cert_api_keycloak_client_secret_resolved == "old-secret"
+    # email creds inherit the cert-api override.
+    assert cfg.email_keycloak_client_secret_resolved == "old-secret"
+    ident = cfg.instance_identity
+    assert ident is not None
+    assert ident.client_id == "old-id"
+    assert ident.client_secret == "old-secret"
+    # cert-api build site consumes instance_identity, which is present.
+    assert cfg.cert_provider == CERT_PROVIDER_CERT_API
+
+
+def test_old_cert_api_config_loads_via_load_config_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    # Same old-style config but exercised through the production ``load_config``
+    # entrypoint (OPENHOST_ROUTER_CONFIG -> scrub -> typed_settings.load).
+    _clear_openhost_env(monkeypatch)
+    p = tmp_path / "config.toml"
+    p.write_text(
+        "[openhost]\n"
+        'zone_domain = "bob.host.example.com"\n'
+        'cert_provider = "cert_api"\n'
+        'cert_api_base_url = "https://cert-api.example.com"\n'
+        'cert_api_keycloak_issuer_url = "https://kc.old/realms/openhost-customers"\n'
+        'cert_api_keycloak_client_id = "bob-id"\n'
+        'cert_api_keycloak_client_secret = "bob-secret"\n'
+    )
+    monkeypatch.setenv("OPENHOST_ROUTER_CONFIG", str(p))
+    cfg = load_config()
+    assert cfg.zone_domain == "bob.host.example.com"
+    assert cfg.instance_identity is not None
+    assert cfg.instance_identity.client_secret == "bob-secret"
+
+
+def test_old_email_override_config_loads_and_email_enabled(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    # A pre-shared-identity email config (only email_keycloak_* overrides) loads
+    # and email_enabled derives True. instance_identity stays None because the
+    # email override does NOT feed the cert-api chain.
+    _clear_openhost_env(monkeypatch)
+    p = tmp_path / "config.toml"
+    p.write_text(
+        "[openhost]\n"
+        'zone_domain = "alice.host.example.com"\n'
+        "coredns_enabled = true\n"
+        'public_ip = "203.0.113.10"\n'
+        'email_proxy_base_url = "https://openhost.imbue.com"\n'
+        'email_keycloak_issuer_url = "https://kc.old/realms/openhost-customers"\n'
+        'email_keycloak_client_id = "instance-alice"\n'
+        'email_keycloak_client_secret = "email-secret"\n'
+    )
+    cfg = _load_file(p)
+    assert cfg.email_enabled is True
+    assert cfg.email_keycloak_client_secret_resolved == "email-secret"
+    assert cfg.instance_identity is None
+
+
+def test_obsolete_keys_plus_imbue_identity_loads_cleanly(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    # A config carrying BOTH obsolete keys (email_enabled + email_inbound_mode)
+    # AND the new imbue_identity_* must load cleanly via load_config: the obsolete
+    # keys are scrubbed while the identity survives intact.
+    _clear_openhost_env(monkeypatch)
+    p = tmp_path / "config.toml"
+    p.write_text(
+        "[openhost]\n"
+        'zone_domain = "alice.host.example.com"\n'
+        "coredns_enabled = true\n"
+        'public_ip = "203.0.113.10"\n'
+        "email_enabled = true\n"
+        'email_inbound_mode = "direct"\n'
+        'email_inbound_mx_host = "inbound.example.com"\n'
+        'email_proxy_base_url = "https://openhost.imbue.com"\n'
+        f'imbue_identity_issuer_url = "{_ISSUER}"\n'
+        'imbue_identity_client_id = "iid"\n'
+        'imbue_identity_client_secret = "isec"\n'
+    )
+    monkeypatch.setenv("OPENHOST_ROUTER_CONFIG", str(p))
+    cfg = load_config()
+    # obsolete keys are not Config fields.
+    assert not hasattr(cfg, "email_inbound_mode")
+    assert not hasattr(cfg, "email_inbound_mx_host")
+    # identity intact and email derived on.
+    assert cfg.instance_identity is not None
+    assert cfg.instance_identity.client_id == "iid"
+    assert cfg.email_enabled is True
+
+
+def test_persist_onto_old_cert_api_config_override_still_wins(tmp_path: Path) -> None:
+    # DOCUMENTED PRECEDENCE (surprising migration behavior, pinned here): applying
+    # persist_instance_identity to an OLD-style config that still has a
+    # cert_api_keycloak_* override writes the imbue_identity_* fields, but on
+    # reload instance_identity STILL resolves to the deprecated cert-api override
+    # (the cert-api resolver chain checks the override first). So a Connect-to-Imbue
+    # on a cert-api-provisioned instance does NOT silently swap the live cert
+    # credential — the override keeps priority until it is removed.
+    p = tmp_path / "config.toml"
+    p.write_text(
+        "[openhost]\n"
+        'zone_domain = "alice.host.example.com"\n'
+        'cert_provider = "cert_api"\n'
+        'cert_api_base_url = "https://cert-api.example.com"\n'
+        'cert_api_keycloak_issuer_url = "https://kc.old/realms/openhost-customers"\n'
+        'cert_api_keycloak_client_id = "old-id"\n'
+        'cert_api_keycloak_client_secret = "old-secret"\n'
+    )
+    persist_instance_identity(str(p), _cred("https://kc.new/realms/x", "new-id", "new-secret"))
+    data = tomllib.loads(p.read_text())["openhost"]
+    # both credentials now live in the file...
+    assert data["cert_api_keycloak_client_id"] == "old-id"
+    assert data["imbue_identity_client_id"] == "new-id"
+    # ...but the deprecated cert-api override wins the resolver.
+    cfg = _load_file(p)
+    assert cfg.imbue_identity_client_id == "new-id"
+    assert cfg.cert_api_keycloak_client_id == "old-id"
+    ident = cfg.instance_identity
+    assert ident is not None
+    assert ident.client_id == "old-id"
+    assert ident.client_secret == "old-secret"
+
+
+def test_persist_onto_old_cert_api_config_build_sites_stay_consistent(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # After persisting onto a cert_api-override config, BOTH build sites must see a
+    # coherent credential: the cert-api site (config.instance_identity) and the
+    # email resolver chain (email_*_resolved) both surface the same winning
+    # override, so a Connect-to-Imbue on a cert-api instance can't split the two
+    # services onto different credentials.
+    _clear_openhost_env(monkeypatch)
+    p = tmp_path / "config.toml"
+    p.write_text(
+        "[openhost]\n"
+        'zone_domain = "alice.host.example.com"\n'
+        'cert_provider = "cert_api"\n'
+        'cert_api_base_url = "https://cert-api.example.com"\n'
+        'cert_api_keycloak_issuer_url = "https://kc.old/realms/openhost-customers"\n'
+        'cert_api_keycloak_client_id = "old-id"\n'
+        'cert_api_keycloak_client_secret = "old-secret"\n'
+    )
+    persist_instance_identity(str(p), _cred("https://kc.new/realms/x", "new-id", "new-secret"))
+    cfg = _load_file(p)
+    # cert-api build site (config.instance_identity)
+    assert cfg.instance_identity is not None
+    assert cfg.instance_identity.client_secret == "old-secret"
+    # email build site (email_*_resolved) — same winning override
+    assert cfg.email_keycloak_client_secret_resolved == "old-secret"
+    assert cfg.email_keycloak_client_id_resolved == "old-id"
+
+
+def test_persist_then_scrub_together_preserve_identity(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    # Realistic upgrade: an OLD config still carrying an obsolete key gets a
+    # persisted identity, then is loaded through load_config (which scrubs the
+    # obsolete key). The identity written by persist must survive the scrub.
+    _clear_openhost_env(monkeypatch)
+    p = tmp_path / "config.toml"
+    p.write_text(
+        "[openhost]\n"
+        'zone_domain = "alice.host.example.com"\n'
+        'email_inbound_mode = "direct"\n'  # obsolete key present
+    )
+    persist_instance_identity(str(p), _cred(_ISSUER, "iid", "isec"))
+    monkeypatch.setenv("OPENHOST_ROUTER_CONFIG", str(p))
+    monkeypatch.setattr(tempfile, "tempdir", str(tmp_path))
+    before = set(tmp_path.glob("openhost-config-*.toml"))
+    cfg = load_config()
+    assert set(tmp_path.glob("openhost-config-*.toml")) == before
+    assert cfg.instance_identity is not None
+    assert cfg.instance_identity.client_id == "iid"
+
+
+def test_persist_onto_bare_config_makes_imbue_the_source(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    # Contrast to the previous test: with NO cert-api override present, the
+    # persisted imbue identity becomes the resolved source (the connect flow's
+    # normal effect on a non-managed instance).
+    _clear_openhost_env(monkeypatch)
+    p = tmp_path / "config.toml"
+    p.write_text('[openhost]\nzone_domain = "alice.host.example.com"\n')
+    persist_instance_identity(str(p), _cred("https://kc.new/realms/x", "new-id", "new-secret"))
+    cfg = _load_file(p)
+    ident = cfg.instance_identity
+    assert ident is not None
+    assert ident.client_id == "new-id"
+    assert ident.client_secret == "new-secret"
+
+
+def test_default_config_imbue_round_trip_identity_preserved(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    # DefaultConfig with imbue_identity_* -> to_toml -> reload equals the identity.
+    _clear_openhost_env(monkeypatch)
+    cfg = DefaultConfig(
+        zone_domain="alice.host.example.com",
+        imbue_identity_issuer_url=_ISSUER,
+        imbue_identity_client_id="iid",
+        imbue_identity_client_secret="isec",
+    )
+    p = tmp_path / "config.toml"
+    cfg.to_toml(str(p))
+    reloaded = _load_file(p)
+    assert reloaded.instance_identity is not None
+    assert reloaded.instance_identity == cfg.instance_identity
+    assert reloaded.instance_identity.issuer_url == _ISSUER
+    assert reloaded.instance_identity.client_id == "iid"
+    assert reloaded.instance_identity.client_secret == "isec"
+
+
+def test_scrub_leaves_no_temp_and_preserves_imbue(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    # _scrub_obsolete_keys_to_temp writes a cleaned copy when obsolete keys are
+    # present; load_config must unlink it afterwards (it may carry secrets) while
+    # leaving imbue_identity_* uncorrupted in the loaded config.
+    _clear_openhost_env(monkeypatch)
+    p = tmp_path / "config.toml"
+    p.write_text(
+        "[openhost]\n"
+        'zone_domain = "alice.host.example.com"\n'
+        "email_enabled = true\n"
+        'email_inbound_mode = "direct"\n'
+        f'imbue_identity_issuer_url = "{_ISSUER}"\n'
+        'imbue_identity_client_id = "iid"\n'
+        'imbue_identity_client_secret = "isec"\n'
+    )
+    monkeypatch.setenv("OPENHOST_ROUTER_CONFIG", str(p))
+    # Force the scrub temp file to land in tmp_path so we can prove it's cleaned up.
+    monkeypatch.setattr(tempfile, "tempdir", str(tmp_path))
+    before = set(tmp_path.glob("openhost-config-*.toml"))
+    cfg = load_config()
+    assert set(tmp_path.glob("openhost-config-*.toml")) == before  # no lingering temp
+    assert cfg.instance_identity is not None
+    assert cfg.instance_identity.client_secret == "isec"
+
+
+def test_scrub_returns_same_path_when_no_obsolete_keys(tmp_path: Path) -> None:
+    # When no obsolete key is present the scrubber must return the ORIGINAL path
+    # unchanged (so load_config never writes/unlinks a temp for a modern config).
+    p = tmp_path / "config.toml"
+    p.write_text(
+        "[openhost]\n"
+        'zone_domain = "alice.host.example.com"\n'
+        f'imbue_identity_issuer_url = "{_ISSUER}"\n'
+        'imbue_identity_client_id = "iid"\n'
+        'imbue_identity_client_secret = "isec"\n'
+    )
+    out = config_mod._scrub_obsolete_keys_to_temp(str(p))
+    assert out == str(p)
+    assert list(tmp_path.glob("openhost-config-*.toml")) == []
+
+
+def test_scrub_temp_copy_keeps_imbue_and_drops_obsolete(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    # Inspect the scrubbed temp copy directly: obsolete keys gone, imbue intact.
+    monkeypatch.setattr(tempfile, "tempdir", str(tmp_path))
+    p = tmp_path / "config.toml"
+    p.write_text(
+        "[openhost]\n"
+        'zone_domain = "alice.host.example.com"\n'
+        "email_enabled = true\n"
+        'email_inbound_mode = "direct"\n'
+        'email_inbound_mx_host = "mx.example.com"\n'
+        f'imbue_identity_issuer_url = "{_ISSUER}"\n'
+        'imbue_identity_client_id = "iid"\n'
+        'imbue_identity_client_secret = "isec"\n'
+    )
+    out = config_mod._scrub_obsolete_keys_to_temp(str(p))
+    assert out != str(p)
+    try:
+        scrubbed = tomllib.loads(Path(out).read_text())["openhost"]
+        assert "email_enabled" not in scrubbed
+        assert "email_inbound_mode" not in scrubbed
+        assert "email_inbound_mx_host" not in scrubbed
+        assert scrubbed["imbue_identity_issuer_url"] == _ISSUER
+        assert scrubbed["imbue_identity_client_id"] == "iid"
+        assert scrubbed["imbue_identity_client_secret"] == "isec"
+    finally:
+        os.unlink(out)
+
+
+def test_scrub_preserves_non_openhost_sections(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    # The scrubber only rewrites the [openhost] section; unrelated top-level tables
+    # must pass through the scrubbed temp copy untouched.
+    monkeypatch.setattr(tempfile, "tempdir", str(tmp_path))
+    p = tmp_path / "config.toml"
+    p.write_text(
+        "[openhost]\n"
+        'zone_domain = "alice.host.example.com"\n'
+        'email_inbound_mode = "direct"\n'
+        "\n"
+        "[other]\n"
+        'keep = "me"\n'
+    )
+    out = config_mod._scrub_obsolete_keys_to_temp(str(p))
+    assert out != str(p)
+    try:
+        data = tomllib.loads(Path(out).read_text())
+        assert data["other"] == {"keep": "me"}
+        assert "email_inbound_mode" not in data["openhost"]
+    finally:
+        os.unlink(out)
+
+
+def test_upgrade_cert_api_instance_to_email_by_adding_proxy(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    # The documented seamless-upgrade path: an existing cert_api-provisioned
+    # instance (deprecated cert_api_keycloak_* only) enables email by adding ONLY
+    # email_proxy_base_url + public_ip — the email creds inherit the cert-api client.
+    _clear_openhost_env(monkeypatch)
+    p = tmp_path / "config.toml"
+    p.write_text(
+        "[openhost]\n"
+        'zone_domain = "alice.host.example.com"\n'
+        'cert_provider = "cert_api"\n'
+        'cert_api_base_url = "https://cert-api.example.com"\n'
+        'cert_api_keycloak_issuer_url = "https://kc.old/realms/openhost-customers"\n'
+        'cert_api_keycloak_client_id = "old-id"\n'
+        'cert_api_keycloak_client_secret = "old-secret"\n'
+        f'public_ip = "{_IP}"\n'
+        f'email_proxy_base_url = "{_PROXY}"\n'
+    )
+    cfg = _load_file(p)
+    assert cfg.email_enabled is True
+    # email creds resolved from the cert-api override (no email_keycloak_* set).
+    assert cfg.email_keycloak_client_secret_resolved == "old-secret"
+    assert cfg.email_keycloak_issuer_url is None
+
+
+def test_from_toml_drops_obsolete_keeps_imbue(tmp_path: Path) -> None:
+    # The non-DI DefaultConfig.from_toml path also drops obsolete keys and keeps
+    # the identity (mirrors the load_config scrub, but via _drop_obsolete_keys).
+    p = tmp_path / "config.toml"
+    p.write_text(
+        "[openhost]\n"
+        'zone_domain = "alice.host.example.com"\n'
+        "email_enabled = true\n"
+        'email_inbound_mode = "direct"\n'
+        f'imbue_identity_issuer_url = "{_ISSUER}"\n'
+        'imbue_identity_client_id = "iid"\n'
+        'imbue_identity_client_secret = "isec"\n'
+    )
+    cfg = DefaultConfig.from_toml(str(p))
+    # email_enabled is a DERIVED property (always present), but the obsolete
+    # STORED keys must not have become attributes — assert on those instead.
+    assert not hasattr(cfg, "email_inbound_mode")
+    assert not hasattr(cfg, "email_inbound_mx_host")
+    assert cfg.instance_identity is not None
+    assert cfg.instance_identity.client_id == "iid"
+
+
+# ===========================================================================
+# GRACEFUL DEGRADE
+# ===========================================================================
+
+
+def test_no_identity_acme_no_email_loads_and_stays_off(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    # No identity at all + default acme provider + no email proxy: the config loads
+    # with email off, no instance identity, and the acme path requires nothing.
+    # No exception at any layer.
+    _clear_openhost_env(monkeypatch)
+    p = tmp_path / "config.toml"
+    p.write_text('[openhost]\nzone_domain = "alice.host.example.com"\n')
+    cfg = _load_file(p)
+    assert cfg.cert_provider == CERT_PROVIDER_ACME
+    assert cfg.email_enabled is False
+    assert cfg.instance_identity is None
+
+
+def test_awaiting_connect_loads_email_off_no_error(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    # Front door set (email_proxy_base_url) but no credential = awaiting-connect.
+    # A valid state: loads without error, email off, identity None.
+    _clear_openhost_env(monkeypatch)
+    p = tmp_path / "config.toml"
+    p.write_text(
+        "[openhost]\n"
+        'zone_domain = "alice.host.example.com"\n'
+        f'email_proxy_base_url = "{_PROXY}"\n'
+    )
+    cfg = _load_file(p)
+    assert cfg.email_enabled is False
+    assert cfg.instance_identity is None
+    # ...and the connect front door is advertised.
+    assert cfg.imbue_connect_base_url == _PROXY
+
+
+def test_acme_with_partial_imbue_and_no_proxy_loads(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    # A partial imbue identity is harmless on the default acme path with no proxy:
+    # graceful degrade means it loads (identity None, no error) rather than being
+    # rejected as a typo — the typo guard only fires when a proxy is present.
+    _clear_openhost_env(monkeypatch)
+    p = tmp_path / "config.toml"
+    p.write_text(
+        "[openhost]\n"
+        'zone_domain = "alice.host.example.com"\n'
+        f'imbue_identity_issuer_url = "{_ISSUER}"\n'
+    )
+    cfg = _load_file(p)
+    assert cfg.cert_provider == CERT_PROVIDER_ACME
+    assert cfg.instance_identity is None
+
+
+def test_imbue_connect_base_url_none_without_proxy() -> None:
+    cfg = DefaultConfig(zone_domain="alice.host.example.com")
+    assert cfg.email_proxy_base_url is None
+    assert cfg.imbue_connect_base_url is None
+
+
+def test_imbue_connect_base_url_equals_proxy_when_set() -> None:
+    cfg = DefaultConfig(zone_domain="alice.host.example.com", email_proxy_base_url=_PROXY)
+    assert cfg.imbue_connect_base_url == _PROXY
+    assert cfg.imbue_connect_base_url is cfg.email_proxy_base_url
+
+
+def test_awaiting_connect_then_persist_enables_via_reload(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    # Full graceful-degrade -> connected migration: start awaiting-connect (proxy +
+    # public_ip, no creds), persist the identity, reload -> email enabled and
+    # identity present. Proves persist + normal config load closes the loop.
+    _clear_openhost_env(monkeypatch)
+    p = tmp_path / "config.toml"
+    p.write_text(
+        "[openhost]\n"
+        'zone_domain = "alice.host.example.com"\n'
+        f'email_proxy_base_url = "{_PROXY}"\n'
+        f'public_ip = "{_IP}"\n'
+    )
+    awaiting = _load_file(p)
+    assert awaiting.email_enabled is False
+    persist_instance_identity(str(p), _cred(_ISSUER, "iid", "isec"))
+    connected = _load_file(p)
+    assert connected.instance_identity is not None
+    assert connected.email_enabled is True
+
+
+# ===========================================================================
+# NEGATIVE / SECURITY
+# ===========================================================================
+
+
+def test_persist_removes_secret_bearing_tmp_file(tmp_path: Path) -> None:
+    # persist writes secrets via <path>.connect.tmp then os.replace; that temp
+    # must NOT linger (it would be a secret-bearing artifact). The final config is
+    # the only file left.
+    p = tmp_path / "config.toml"
+    p.write_text('[openhost]\nzone_domain = "alice.host.example.com"\n')
+    persist_instance_identity(str(p), _cred(secret="top-secret-value"))
+    assert not (tmp_path / "config.toml.connect.tmp").exists()
+    leftovers = sorted(x.name for x in tmp_path.iterdir())
+    assert leftovers == ["config.toml"]
+    # The secret is only in the final file, nowhere else.
+    assert "top-secret-value" in p.read_text()
+
+
+def test_persisted_secret_not_written_to_any_tmp_dir_file(tmp_path: Path) -> None:
+    # Belt-and-suspenders: after a persist, no *.tmp sibling exists at all in the
+    # config's directory (so a crash-free write leaves no scratch copy of secrets).
+    p = tmp_path / "config.toml"
+    p.write_text('[openhost]\nzone_domain = "alice.host.example.com"\n')
+    persist_instance_identity(str(p), _cred(secret="s3cr3t"))
+    tmp_siblings = [x.name for x in tmp_path.iterdir() if x.name.endswith(".tmp")]
+    assert tmp_siblings == []
+
+
+@pytest.mark.parametrize("present", ["issuer_client_id", "issuer_secret", "client_id_secret"])
+def test_two_of_three_imbue_parts_yields_no_identity(present: str) -> None:
+    # A config with only 2 of 3 imbue parts must NOT leak a partial credential
+    # object — instance_identity is None (all-or-nothing).
+    parts = {
+        "issuer_client_id": {
+            "imbue_identity_issuer_url": _ISSUER,
+            "imbue_identity_client_id": "iid",
+        },
+        "issuer_secret": {
+            "imbue_identity_issuer_url": _ISSUER,
+            "imbue_identity_client_secret": "isec",
+        },
+        "client_id_secret": {
+            "imbue_identity_client_id": "iid",
+            "imbue_identity_client_secret": "isec",
+        },
+    }[present]
+    cfg = DefaultConfig(zone_domain="alice.host.example.com", **parts)  # type: ignore[arg-type]
+    assert cfg.instance_identity is None
+
+
+def test_empty_string_imbue_part_via_file_load_yields_no_identity(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # A blank ("") credential field written into the file is falsy, so the resolver
+    # treats it as unset -> no partial credential object leaks (identity None). This
+    # is the file-load analogue of the empty-string unit test, proving the same
+    # all-or-nothing guard holds after structuring.
+    _clear_openhost_env(monkeypatch)
+    p = tmp_path / "config.toml"
+    p.write_text(
+        "[openhost]\n"
+        'zone_domain = "alice.host.example.com"\n'
+        'imbue_identity_issuer_url = ""\n'
+        'imbue_identity_client_id = "iid"\n'
+        'imbue_identity_client_secret = "isec"\n'
+    )
+    cfg = _load_file(p)
+    assert cfg.instance_identity is None
+
+
+def test_proxy_with_partial_imbue_two_of_three_raises() -> None:
+    # Typo guard: email_proxy_base_url + a PARTIAL imbue identity (2 of 3) is a
+    # misconfiguration and must raise at construction.
+    with pytest.raises(ValueError, match="only partially resolved"):
+        DefaultConfig(
+            zone_domain="alice.host.example.com",
+            email_proxy_base_url=_PROXY,
+            public_ip=_IP,
+            imbue_identity_issuer_url=_ISSUER,
+            imbue_identity_client_id="iid",
+        )
+
+
+def test_proxy_with_zero_imbue_parts_does_not_raise() -> None:
+    # email_proxy_base_url + 0 of 3 imbue parts is the awaiting-connect state, NOT
+    # an error (email simply stays off).
+    cfg = DefaultConfig(zone_domain="alice.host.example.com", email_proxy_base_url=_PROXY)
+    assert cfg.email_enabled is False
+    assert cfg.instance_identity is None
+
+
+def test_proxy_with_partial_imbue_raises_through_file_load(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    # The typo guard also fires when the bad config arrives via the real load path
+    # (validation runs in __attrs_post_init__, after structuring).
+    _clear_openhost_env(monkeypatch)
+    p = tmp_path / "config.toml"
+    p.write_text(
+        "[openhost]\n"
+        'zone_domain = "alice.host.example.com"\n'
+        f'public_ip = "{_IP}"\n'
+        f'email_proxy_base_url = "{_PROXY}"\n'
+        f'imbue_identity_issuer_url = "{_ISSUER}"\n'
+        'imbue_identity_client_id = "iid"\n'
+    )
+    _assert_load_rejects(p, "only partially resolved")
+
+
+def test_cert_api_provider_with_only_imbue_validates_and_resolves(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # cert_provider=cert_api with ONLY imbue_identity_* (no cert_api_keycloak_*)
+    # validates and instance_identity resolves — the managed-via-shared path.
+    _clear_openhost_env(monkeypatch)
+    p = tmp_path / "config.toml"
+    p.write_text(
+        "[openhost]\n"
+        'zone_domain = "alice.host.example.com"\n'
+        'cert_provider = "cert_api"\n'
+        'cert_api_base_url = "https://cert-api.example.com"\n'
+        f'imbue_identity_issuer_url = "{_ISSUER}"\n'
+        'imbue_identity_client_id = "iid"\n'
+        'imbue_identity_client_secret = "isec"\n'
+    )
+    cfg = _load_file(p)
+    assert cfg.cert_provider == CERT_PROVIDER_CERT_API
+    assert cfg.cert_api_keycloak_issuer_url is None
+    assert cfg.instance_identity is not None
+    assert cfg.instance_identity.client_id == "iid"
+
+
+def test_cert_api_provider_with_only_imbue_missing_secret_raises(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Negative complement: cert_api provider + imbue supplies only 2 of 3 parts ->
+    # the credential can't resolve, so validation rejects it, naming the SETTABLE
+    # field (not the internal *_resolved property).
+    _clear_openhost_env(monkeypatch)
+    p = tmp_path / "config.toml"
+    p.write_text(
+        "[openhost]\n"
+        'zone_domain = "alice.host.example.com"\n'
+        'cert_provider = "cert_api"\n'
+        'cert_api_base_url = "https://cert-api.example.com"\n'
+        f'imbue_identity_issuer_url = "{_ISSUER}"\n'
+        'imbue_identity_client_id = "iid"\n'
+    )
+    _assert_load_rejects(p, "cert_api_keycloak_client_secret must be set")
+
+
+def test_load_config_legacy_env_var_name(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    # Backward compat for the config-selection env var: the deprecated
+    # OPENHOST_CONFIG (not the newer OPENHOST_ROUTER_CONFIG) still selects the file
+    # via load_config, so an old systemd unit keeps working.
+    _clear_openhost_env(monkeypatch)
+    p = tmp_path / "config.toml"
+    p.write_text(
+        "[openhost]\n"
+        'zone_domain = "legacyenv.host.example.com"\n'
+        f'imbue_identity_issuer_url = "{_ISSUER}"\n'
+        'imbue_identity_client_id = "iid"\n'
+        'imbue_identity_client_secret = "isec"\n'
+    )
+    monkeypatch.setenv("OPENHOST_CONFIG", str(p))
+    cfg = load_config()
+    assert cfg.zone_domain == "legacyenv.host.example.com"
+    assert cfg.instance_identity is not None
+    assert cfg.instance_identity.client_id == "iid"
+
+
+def test_email_override_partial_raises_through_file_load(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    # A partially-set email_keycloak_* override (2 of 3) is a typo and must be
+    # rejected even when it arrives via the file-load path.
+    _clear_openhost_env(monkeypatch)
+    p = tmp_path / "config.toml"
+    p.write_text(
+        "[openhost]\n"
+        'zone_domain = "alice.host.example.com"\n'
+        'email_keycloak_issuer_url = "https://kc/realms/x"\n'
+        'email_keycloak_client_id = "eid"\n'
+    )
+    _assert_load_rejects(p, "partially configured")
+
+
+# ===========================================================================
+# DEPRECATED FIELDS ROUND-TRIP (operator-edited old config isn't dropped)
+# ===========================================================================
+
+
+def test_deprecated_cert_api_fields_round_trip_in_to_toml(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    # An operator-edited old config with cert_api_keycloak_* must survive a
+    # to_toml render (not silently dropped) so a re-render keeps working.
+    _clear_openhost_env(monkeypatch)
+    cfg = DefaultConfig(
+        zone_domain="alice.host.example.com",
+        cert_api_keycloak_issuer_url="https://cert/realms/x",
+        cert_api_keycloak_client_id="cid",
+        cert_api_keycloak_client_secret="csec",
+    )
+    rendered = cfg.to_toml_str()
+    assert 'cert_api_keycloak_issuer_url = "https://cert/realms/x"' in rendered
+    assert 'cert_api_keycloak_client_id = "cid"' in rendered
+    assert 'cert_api_keycloak_client_secret = "csec"' in rendered
+    p = tmp_path / "config.toml"
+    p.write_text(rendered)
+    reloaded = _load_file(p)
+    assert reloaded.cert_api_keycloak_client_secret == "csec"
+    assert reloaded.instance_identity is not None
+    assert reloaded.instance_identity.client_id == "cid"
+
+
+def test_deprecated_email_fields_round_trip_in_to_toml(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    # Same for the deprecated email_keycloak_* override fields.
+    _clear_openhost_env(monkeypatch)
+    cfg = DefaultConfig(
+        zone_domain="alice.host.example.com",
+        public_ip=_IP,
+        email_proxy_base_url=_PROXY,
+        email_keycloak_issuer_url="https://email/realms/x",
+        email_keycloak_client_id="eid",
+        email_keycloak_client_secret="esec",
+    )
+    rendered = cfg.to_toml_str()
+    assert 'email_keycloak_issuer_url = "https://email/realms/x"' in rendered
+    assert 'email_keycloak_client_id = "eid"' in rendered
+    assert 'email_keycloak_client_secret = "esec"' in rendered
+    p = tmp_path / "config.toml"
+    p.write_text(rendered)
+    reloaded = _load_file(p)
+    assert reloaded.email_keycloak_client_secret == "esec"
+    assert reloaded.email_enabled is True
+
+
+def test_deprecated_and_shared_fields_coexist_round_trip(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    # A config that carries BOTH the deprecated override and the shared identity
+    # must round-trip both, preserving the documented override-wins precedence.
+    _clear_openhost_env(monkeypatch)
+    cfg = DefaultConfig(
+        zone_domain="alice.host.example.com",
+        cert_api_keycloak_issuer_url="https://cert/realms/x",
+        cert_api_keycloak_client_id="cert-id",
+        cert_api_keycloak_client_secret="cert-secret",
+        imbue_identity_issuer_url=_ISSUER,
+        imbue_identity_client_id="imbue-id",
+        imbue_identity_client_secret="imbue-secret",
+    )
+    p = tmp_path / "config.toml"
+    cfg.to_toml(str(p))
+    reloaded = _load_file(p)
+    # both sets present...
+    assert reloaded.cert_api_keycloak_client_id == "cert-id"
+    assert reloaded.imbue_identity_client_id == "imbue-id"
+    # ...and the deprecated override still wins the resolver after a round trip.
+    assert reloaded.instance_identity is not None
+    assert reloaded.instance_identity.client_id == "cert-id"
+
+
+def test_load_config_twice_is_stable_and_leaves_no_temp(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    # Loading the same obsolete-key-bearing config twice must be idempotent and
+    # never accumulate scratch temp files (each load cleans up its own scrub copy).
+    _clear_openhost_env(monkeypatch)
+    p = tmp_path / "config.toml"
+    p.write_text(
+        "[openhost]\n"
+        'zone_domain = "alice.host.example.com"\n'
+        'email_inbound_mode = "direct"\n'
+        f'imbue_identity_issuer_url = "{_ISSUER}"\n'
+        'imbue_identity_client_id = "iid"\n'
+        'imbue_identity_client_secret = "isec"\n'
+    )
+    monkeypatch.setenv("OPENHOST_ROUTER_CONFIG", str(p))
+    monkeypatch.setattr(tempfile, "tempdir", str(tmp_path))
+    first = load_config()
+    second = load_config()
+    assert first.instance_identity == second.instance_identity
+    assert list(tmp_path.glob("openhost-config-*.toml")) == []
+    # Source file is untouched by loading (scrub is copy-on-load, never in place).
+    assert "email_inbound_mode" in tomllib.loads(p.read_text())["openhost"]
+
+
+def test_persist_does_not_introduce_obsolete_keys(tmp_path: Path) -> None:
+    # Persisting an identity must add ONLY the three imbue keys — it must never
+    # (re)introduce an obsolete key that a later load would have to scrub.
+    p = tmp_path / "config.toml"
+    p.write_text('[openhost]\nzone_domain = "alice.host.example.com"\n')
+    persist_instance_identity(str(p), _cred(_ISSUER, "iid", "isec"))
+    section = tomllib.loads(p.read_text())["openhost"]
+    assert "email_enabled" not in section
+    assert "email_inbound_mode" not in section
+    assert "email_inbound_mx_host" not in section
+    assert set(section) == {
+        "zone_domain",
+        "imbue_identity_issuer_url",
+        "imbue_identity_client_id",
+        "imbue_identity_client_secret",
+    }
+
+
+def test_obsolete_key_not_rendered_by_to_toml(tmp_path: Path) -> None:
+    # Confirm the flip side of the round-trip guarantee: a truly OBSOLETE key
+    # (email_enabled) is a derived property, never stored, so to_toml never emits
+    # it — an operator config re-rendered by the app won't reintroduce the dropped
+    # key. (Distinguishes "deprecated-but-kept" from "obsolete-and-dropped".)
+    cfg = DefaultConfig(
+        zone_domain="alice.host.example.com",
+        public_ip=_IP,
+        email_proxy_base_url=_PROXY,
+        imbue_identity_issuer_url=_ISSUER,
+        imbue_identity_client_id="iid",
+        imbue_identity_client_secret="isec",
+    )
+    assert cfg.email_enabled is True
+    rendered = cfg.to_toml_str()
+    assert "email_enabled" not in rendered
+    assert "email_inbound_mode" not in rendered

--- a/compute_space/src/compute_space/tests/test_identity_migration_edge.py
+++ b/compute_space/src/compute_space/tests/test_identity_migration_edge.py
@@ -286,9 +286,7 @@ def test_persist_then_scrub_together_preserve_identity(tmp_path: Path, monkeypat
     _clear_openhost_env(monkeypatch)
     p = tmp_path / "config.toml"
     p.write_text(
-        "[openhost]\n"
-        'zone_domain = "alice.host.example.com"\n'
-        'email_inbound_mode = "direct"\n'  # obsolete key present
+        '[openhost]\nzone_domain = "alice.host.example.com"\nemail_inbound_mode = "direct"\n'  # obsolete key present
     )
     persist_instance_identity(str(p), _cred(_ISSUER, "iid", "isec"))
     monkeypatch.setenv("OPENHOST_ROUTER_CONFIG", str(p))
@@ -409,12 +407,7 @@ def test_scrub_preserves_non_openhost_sections(tmp_path: Path, monkeypatch: pyte
     monkeypatch.setattr(tempfile, "tempdir", str(tmp_path))
     p = tmp_path / "config.toml"
     p.write_text(
-        "[openhost]\n"
-        'zone_domain = "alice.host.example.com"\n'
-        'email_inbound_mode = "direct"\n'
-        "\n"
-        "[other]\n"
-        'keep = "me"\n'
+        '[openhost]\nzone_domain = "alice.host.example.com"\nemail_inbound_mode = "direct"\n\n[other]\nkeep = "me"\n'
     )
     out = config_mod._scrub_obsolete_keys_to_temp(str(p))
     assert out != str(p)
@@ -495,11 +488,7 @@ def test_awaiting_connect_loads_email_off_no_error(tmp_path: Path, monkeypatch: 
     # A valid state: loads without error, email off, identity None.
     _clear_openhost_env(monkeypatch)
     p = tmp_path / "config.toml"
-    p.write_text(
-        "[openhost]\n"
-        'zone_domain = "alice.host.example.com"\n'
-        f'email_proxy_base_url = "{_PROXY}"\n'
-    )
+    p.write_text(f'[openhost]\nzone_domain = "alice.host.example.com"\nemail_proxy_base_url = "{_PROXY}"\n')
     cfg = _load_file(p)
     assert cfg.email_enabled is False
     assert cfg.instance_identity is None
@@ -513,11 +502,7 @@ def test_acme_with_partial_imbue_and_no_proxy_loads(tmp_path: Path, monkeypatch:
     # rejected as a typo — the typo guard only fires when a proxy is present.
     _clear_openhost_env(monkeypatch)
     p = tmp_path / "config.toml"
-    p.write_text(
-        "[openhost]\n"
-        'zone_domain = "alice.host.example.com"\n'
-        f'imbue_identity_issuer_url = "{_ISSUER}"\n'
-    )
+    p.write_text(f'[openhost]\nzone_domain = "alice.host.example.com"\nimbue_identity_issuer_url = "{_ISSUER}"\n')
     cfg = _load_file(p)
     assert cfg.cert_provider == CERT_PROVIDER_ACME
     assert cfg.instance_identity is None
@@ -542,10 +527,7 @@ def test_awaiting_connect_then_persist_enables_via_reload(tmp_path: Path, monkey
     _clear_openhost_env(monkeypatch)
     p = tmp_path / "config.toml"
     p.write_text(
-        "[openhost]\n"
-        'zone_domain = "alice.host.example.com"\n'
-        f'email_proxy_base_url = "{_PROXY}"\n'
-        f'public_ip = "{_IP}"\n'
+        f'[openhost]\nzone_domain = "alice.host.example.com"\nemail_proxy_base_url = "{_PROXY}"\npublic_ip = "{_IP}"\n'
     )
     awaiting = _load_file(p)
     assert awaiting.email_enabled is False

--- a/compute_space/src/compute_space/tests/test_instance_identity.py
+++ b/compute_space/src/compute_space/tests/test_instance_identity.py
@@ -1,0 +1,221 @@
+"""Tests for the shared per-instance Imbue credential (imbue_identity_*).
+
+Every Imbue service (cert-api, email, ...) authenticates with one per-instance
+credential. It resolves from a service's DEPRECATED per-service override first
+(kept for already-deployed configs) then falls back to the shared imbue_identity_*
+fields. These tests pin the resolution precedence, the instance_identity accessor,
+TOML round-tripping, and backward compatibility.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import typed_settings
+
+from compute_space.config import CERT_PROVIDER_ACME
+from compute_space.config import CERT_PROVIDER_CERT_API
+from compute_space.config import DefaultConfig
+
+
+def _shared_identity_kwargs() -> dict[str, str]:
+    return dict(
+        imbue_identity_issuer_url="https://keycloak.example.com/realms/openhost-customers",
+        imbue_identity_client_id="instance-alice",
+        imbue_identity_client_secret="shared-s3cr3t",
+    )
+
+
+# --- defaults / backward compat -------------------------------------------------
+
+
+def test_shared_identity_defaults_to_none() -> None:
+    cfg = DefaultConfig(zone_domain="alice.host.example.com")
+    assert cfg.imbue_identity_issuer_url is None
+    assert cfg.imbue_identity_client_id is None
+    assert cfg.imbue_identity_client_secret is None
+    # No identity configured -> accessor returns None (not a partial object).
+    assert cfg.instance_identity is None
+
+
+def test_legacy_cert_api_config_without_shared_identity_still_loads(tmp_path: Path) -> None:
+    # A config exactly as ansible wrote it before imbue_identity_* existed.
+    config_path = tmp_path / "config.toml"
+    config_path.write_text(
+        "[openhost]\n"
+        'zone_domain = "alice.host.example.com"\n'
+        "tls_enabled = true\n"
+        "coredns_enabled = true\n"
+        'cert_provider = "cert_api"\n'
+        'cert_api_base_url = "https://cert-api.example.com"\n'
+        'cert_api_keycloak_issuer_url = "https://kc.example.com/realms/openhost-customers"\n'
+        'cert_api_keycloak_client_id = "instance-alice"\n'
+        'cert_api_keycloak_client_secret = "legacy-s3cr3t"\n'
+    )
+    cfg = typed_settings.load(DefaultConfig, appname="openhost", config_files=[str(config_path)])
+    # cert-api resolves from its own (deprecated) override when the shared field is absent.
+    assert cfg.cert_api_keycloak_client_secret_resolved == "legacy-s3cr3t"
+    ident = cfg.instance_identity
+    assert ident is not None
+    assert ident.client_id == "instance-alice"
+    assert ident.client_secret == "legacy-s3cr3t"
+
+
+# --- resolution precedence ------------------------------------------------------
+
+
+def test_cert_api_resolves_from_shared_identity() -> None:
+    cfg = DefaultConfig(zone_domain="alice.host.example.com", **_shared_identity_kwargs())
+    assert cfg.cert_api_keycloak_issuer_url_resolved == "https://keycloak.example.com/realms/openhost-customers"
+    assert cfg.cert_api_keycloak_client_id_resolved == "instance-alice"
+    assert cfg.cert_api_keycloak_client_secret_resolved == "shared-s3cr3t"
+
+
+def test_cert_api_override_takes_precedence_over_shared() -> None:
+    cfg = DefaultConfig(
+        zone_domain="alice.host.example.com",
+        cert_api_keycloak_issuer_url="https://kc.override.com/realms/openhost-customers",
+        cert_api_keycloak_client_id="instance-override",
+        cert_api_keycloak_client_secret="override-s3cr3t",
+        **_shared_identity_kwargs(),
+    )
+    assert cfg.cert_api_keycloak_client_id_resolved == "instance-override"
+    assert cfg.cert_api_keycloak_client_secret_resolved == "override-s3cr3t"
+
+
+def test_email_resolves_from_shared_identity() -> None:
+    # Email inherits cert-api which inherits the shared identity: one credential
+    # satisfies both services.
+    cfg = DefaultConfig(zone_domain="alice.host.example.com", **_shared_identity_kwargs())
+    assert cfg.email_keycloak_issuer_url_resolved == "https://keycloak.example.com/realms/openhost-customers"
+    assert cfg.email_keycloak_client_id_resolved == "instance-alice"
+    assert cfg.email_keycloak_client_secret_resolved == "shared-s3cr3t"
+
+
+def test_email_override_takes_precedence_over_shared() -> None:
+    cfg = DefaultConfig(
+        zone_domain="alice.host.example.com",
+        email_keycloak_issuer_url="https://kc.email.com/realms/openhost-customers",
+        email_keycloak_client_id="instance-email",
+        email_keycloak_client_secret="email-s3cr3t",
+        **_shared_identity_kwargs(),
+    )
+    assert cfg.email_keycloak_client_id_resolved == "instance-email"
+    assert cfg.email_keycloak_client_secret_resolved == "email-s3cr3t"
+
+
+def test_email_inherits_cert_api_override_over_shared() -> None:
+    # cert-api override is more specific than the shared identity, so email (which
+    # inherits cert-api) picks up the cert-api override, not the shared value.
+    cfg = DefaultConfig(
+        zone_domain="alice.host.example.com",
+        cert_api_keycloak_issuer_url="https://kc.cert.com/realms/openhost-customers",
+        cert_api_keycloak_client_id="instance-cert",
+        cert_api_keycloak_client_secret="cert-s3cr3t",
+        **_shared_identity_kwargs(),
+    )
+    assert cfg.email_keycloak_client_id_resolved == "instance-cert"
+    assert cfg.email_keycloak_client_secret_resolved == "cert-s3cr3t"
+
+
+# --- instance_identity accessor -------------------------------------------------
+
+
+def test_instance_identity_builds_credentials() -> None:
+    cfg = DefaultConfig(zone_domain="alice.host.example.com", **_shared_identity_kwargs())
+    ident = cfg.instance_identity
+    assert ident is not None
+    assert ident.issuer_url == "https://keycloak.example.com/realms/openhost-customers"
+    assert ident.client_id == "instance-alice"
+    assert ident.client_secret == "shared-s3cr3t"
+    # token_endpoint is derived from the issuer.
+    assert ident.token_endpoint == (
+        "https://keycloak.example.com/realms/openhost-customers/protocol/openid-connect/token"
+    )
+
+
+@pytest.mark.parametrize("drop", ["issuer", "client_id", "client_secret"])
+def test_instance_identity_is_none_when_partial(drop: str) -> None:
+    kwargs = _shared_identity_kwargs()
+    field = {
+        "issuer": "imbue_identity_issuer_url",
+        "client_id": "imbue_identity_client_id",
+        "client_secret": "imbue_identity_client_secret",
+    }[drop]
+    kwargs[field] = ""  # type: ignore[assignment]
+    cfg = DefaultConfig(zone_domain="alice.host.example.com", **kwargs)
+    assert cfg.instance_identity is None
+
+
+# --- cert_api provider validation accepts the shared identity -------------------
+
+
+def test_cert_api_provider_satisfied_by_shared_identity() -> None:
+    # cert_provider=cert_api with NO cert_api_keycloak_* override, only the shared
+    # identity, must validate (the credential resolves from imbue_identity_*).
+    cfg = DefaultConfig(
+        zone_domain="alice.host.example.com",
+        cert_provider=CERT_PROVIDER_CERT_API,
+        cert_api_base_url="https://cert-api.example.com",
+        **_shared_identity_kwargs(),
+    )
+    assert cfg.cert_provider == CERT_PROVIDER_CERT_API
+    assert cfg.instance_identity is not None
+
+
+def test_cert_api_provider_missing_all_credentials_still_errors() -> None:
+    with pytest.raises(ValueError, match="cert_api_keycloak_issuer_url must be set"):
+        DefaultConfig(
+            zone_domain="alice.host.example.com",
+            cert_provider=CERT_PROVIDER_CERT_API,
+            cert_api_base_url="https://cert-api.example.com",
+        )
+
+
+# --- email enablement via shared identity ---------------------------------------
+
+
+def test_email_enabled_via_shared_identity_only() -> None:
+    # A shared-identity instance enables email by setting only email_proxy_base_url
+    # (plus public_ip for the direct-inbound records) — no email_keycloak_* needed.
+    cfg = DefaultConfig(
+        zone_domain="alice.host.example.com",
+        email_proxy_base_url="https://openhost.imbue.com",
+        public_ip="203.0.113.10",
+        **_shared_identity_kwargs(),
+    )
+    assert cfg.email_enabled is True
+
+
+def test_email_not_enabled_without_any_identity() -> None:
+    # proxy URL set but no credential resolvable anywhere -> config error (email
+    # could never authenticate).
+    with pytest.raises(ValueError, match="email cannot be enabled"):
+        DefaultConfig(
+            zone_domain="alice.host.example.com",
+            email_proxy_base_url="https://openhost.imbue.com",
+            public_ip="203.0.113.10",
+        )
+
+
+# --- TOML round-trip -------------------------------------------------------------
+
+
+def test_shared_identity_round_trips_through_toml(tmp_path: Path) -> None:
+    cfg = DefaultConfig(zone_domain="alice.host.example.com", **_shared_identity_kwargs())
+    rendered = cfg.to_toml_str()
+    assert 'imbue_identity_issuer_url = "https://keycloak.example.com/realms/openhost-customers"' in rendered
+    assert 'imbue_identity_client_id = "instance-alice"' in rendered
+    assert 'imbue_identity_client_secret = "shared-s3cr3t"' in rendered
+    config_path = tmp_path / "config.toml"
+    config_path.write_text(rendered)
+    reloaded = typed_settings.load(DefaultConfig, appname="openhost", config_files=[str(config_path)])
+    assert reloaded.instance_identity is not None
+    assert reloaded.instance_identity.client_secret == "shared-s3cr3t"
+
+
+def test_acme_default_unaffected_by_shared_identity() -> None:
+    # The default acme path never requires any identity, even with shared fields unset.
+    cfg = DefaultConfig(zone_domain="alice.host.example.com")
+    assert cfg.cert_provider == CERT_PROVIDER_ACME

--- a/compute_space/src/compute_space/tests/test_instance_identity.py
+++ b/compute_space/src/compute_space/tests/test_instance_identity.py
@@ -189,14 +189,16 @@ def test_email_enabled_via_shared_identity_only() -> None:
 
 
 def test_email_not_enabled_without_any_identity() -> None:
-    # proxy URL set but no credential resolvable anywhere -> config error (email
-    # could never authenticate).
-    with pytest.raises(ValueError, match="email cannot be enabled"):
-        DefaultConfig(
-            zone_domain="alice.host.example.com",
-            email_proxy_base_url="https://openhost.imbue.com",
-            public_ip="203.0.113.10",
-        )
+    # proxy URL set but no credential resolvable anywhere is NOT an error: it is
+    # the "front door configured, awaiting Connect to Imbue" state. Email is simply
+    # off until the connect flow supplies the credential.
+    cfg = DefaultConfig(
+        zone_domain="alice.host.example.com",
+        email_proxy_base_url="https://openhost.imbue.com",
+        public_ip="203.0.113.10",
+    )
+    assert cfg.email_enabled is False
+    assert cfg.instance_identity is None
 
 
 # --- TOML round-trip -------------------------------------------------------------

--- a/compute_space/src/compute_space/web/routes/api/settings.py
+++ b/compute_space/src/compute_space/web/routes/api/settings.py
@@ -3,17 +3,26 @@ from __future__ import annotations
 import asyncio
 import sqlite3
 from enum import StrEnum
+from typing import Any
 
 import attr
 import bcrypt
+from litestar import Request
 from litestar import Router
 from litestar import get
 from litestar import post
 from litestar.exceptions import HTTPException
+from litestar.response import Redirect
 
+from compute_space.config import Config
+from compute_space.config import active_config_path
 from compute_space.core.auth.auth import read_owner_username
 from compute_space.core.auth.auth import update_owner_username
 from compute_space.core.auth.auth import validate_owner_username
+from compute_space.core.connect import ConnectError
+from compute_space.core.connect import build_connect_url
+from compute_space.core.connect import exchange_code_for_credential
+from compute_space.core.connect import persist_instance_identity
 from compute_space.core.system_agent import SystemAgentError
 from compute_space.core.system_agent import system_agent_apply
 from compute_space.core.system_agent import system_agent_fetch
@@ -147,6 +156,75 @@ async def restart_compute_space() -> None:
     trigger_restart()
 
 
+# --- Connect to Imbue -------------------------------------------------------
+
+
+@attr.s(auto_attribs=True, frozen=True)
+class ConnectStatusResponse:
+    # Whether the "Connect to Imbue" button should be shown (an Imbue front door
+    # is configured) and whether this instance already holds a credential.
+    available: bool
+    connected: bool
+
+
+@attr.s(auto_attribs=True, frozen=True)
+class ConnectStartResponse:
+    # The Imbue front-door URL the browser should be sent to.
+    redirect_url: str
+
+
+@get("/api/settings/connect-imbue/status", guards=[require_owner_auth])
+async def connect_imbue_status(config: Config) -> ConnectStatusResponse:
+    return ConnectStatusResponse(
+        available=bool(config.imbue_connect_base_url),
+        connected=config.instance_identity is not None,
+    )
+
+
+@post("/api/settings/connect-imbue/start", status_code=200, guards=[require_owner_auth])
+async def connect_imbue_start(config: Config, request: Request[Any, Any, Any]) -> ConnectStartResponse:
+    frontend = config.imbue_connect_base_url
+    if not frontend:
+        raise HTTPException(detail="Connect to Imbue is not available on this deployment", status_code=503)
+    # The front door redirects the owner's browser back to this instance's own
+    # https origin, so derive it from the request (honoring proxy headers).
+    scheme = request.headers.get("x-forwarded-proto") or request.url.scheme
+    host = request.headers.get("x-forwarded-host") or request.headers.get("host") or config.zone_domain
+    instance_base = f"{scheme}://{host}"
+    redirect_url = build_connect_url(frontend, config.zone_domain_no_port, instance_base)
+    return ConnectStartResponse(redirect_url=redirect_url)
+
+
+@get("/api/settings/connect-imbue/callback", guards=[require_owner_auth], sync_to_thread=True)
+def connect_imbue_callback(config: Config, code: str = "") -> Redirect:
+    """Exchange the one-time code, persist the credential, and restart.
+
+    The Imbue front door redirects the owner's browser here with ?code=. We swap
+    it for the credential server-to-server, write it into config.toml, and restart
+    so the instance loads its new identity. Redirects back to Settings.
+
+    Sync + sync_to_thread so the blocking exchange (httpx) and file write don't
+    stall the event loop for other (proxied app) traffic.
+    """
+    frontend = config.imbue_connect_base_url
+    if not frontend:
+        raise HTTPException(detail="Connect to Imbue is not available on this deployment", status_code=503)
+    if not code.strip():
+        return Redirect(path="/settings?connect=error")
+    config_path = active_config_path()
+    if not config_path:
+        # Env-driven config has no file to persist into; connecting can't stick.
+        raise HTTPException(detail="cannot persist credential: instance has no config file", status_code=500)
+    try:
+        credential = exchange_code_for_credential(frontend, code.strip())
+        persist_instance_identity(config_path, credential)
+    except ConnectError as e:
+        raise HTTPException(detail=str(e), status_code=502) from e
+    # Restart so load_config() re-reads config.toml and picks up the new identity.
+    trigger_restart()
+    return Redirect(path="/settings?connect=ok")
+
+
 @attr.s(auto_attribs=True, frozen=True)
 class ChangePasswordRequest:
     current_password: str
@@ -219,6 +297,9 @@ api_settings_routes = Router(
         check_for_updates,
         apply_update,
         restart_compute_space,
+        connect_imbue_status,
+        connect_imbue_start,
+        connect_imbue_callback,
         change_password,
         get_owner_username,
         set_owner_username,

--- a/compute_space/src/compute_space/web/static/js/settings.js
+++ b/compute_space/src/compute_space/web/static/js/settings.js
@@ -647,9 +647,76 @@ function loadArchiveBackend() {
     });
 }
 
+// --- Connect to Imbue -------------------------------------------------------
+
+async function loadConnectImbueStatus() {
+  const section = document.getElementById('connect-imbue-section');
+  const state = document.getElementById('connect-imbue-state');
+  const btn = document.getElementById('connect-imbue-btn');
+  try {
+    const resp = await fetch('/api/settings/connect-imbue/status');
+    if (!resp.ok) return;  // feature not present; leave the section hidden
+    const data = await resp.json();
+    if (!data.available) return;  // no Imbue front door configured
+    section.style.display = '';
+    if (data.connected) {
+      state.textContent = 'Connected to Imbue.';
+      btn.textContent = 'Reconnect to Imbue';
+    } else {
+      state.textContent = 'Not connected.';
+      btn.textContent = 'Connect to Imbue';
+    }
+    btn.style.display = '';
+  } catch (e) {
+    // Non-fatal: the section just stays hidden.
+  }
+}
+
+async function connectImbue() {
+  clearError();
+  const btn = document.getElementById('connect-imbue-btn');
+  const msg = document.getElementById('connect-imbue-msg');
+  btn.disabled = true;
+  try {
+    const resp = await fetch('/api/settings/connect-imbue/start', { method: 'POST' });
+    if (!resp.ok) {
+      const err = await resp.json();
+      throw new Error(err.detail || 'failed to start');
+    }
+    const data = await resp.json();
+    // Hand off to the Imbue front door; it authenticates the owner and redirects
+    // back to this instance's callback, which persists the credential + restarts.
+    window.location.href = data.redirect_url;
+  } catch (e) {
+    btn.disabled = false;
+    msg.textContent = 'Could not start connect: ' + e.message;
+    msg.className = 'error';
+    msg.style.display = '';
+  }
+}
+
+// Surface the ?connect=ok|error result of a completed callback round-trip.
+(function showConnectResult() {
+  const params = new URLSearchParams(window.location.search);
+  const result = params.get('connect');
+  if (!result) return;
+  const msg = document.getElementById('connect-imbue-msg');
+  if (!msg) return;
+  if (result === 'ok') {
+    msg.textContent = 'Connected. The instance is restarting to apply your Imbue credential.';
+    msg.className = '';
+    msg.style.color = '#2ea043';
+  } else {
+    msg.textContent = 'Connecting to Imbue failed. Please try again.';
+    msg.className = 'error';
+  }
+  msg.style.display = '';
+})();
+
 loadOwnerUsername();
 loadRemote();
 checkForUpdates();
 updateSshStatus();
 setInterval(updateSshStatus, 5000);
 loadArchiveBackend();
+loadConnectImbueStatus();

--- a/compute_space/src/compute_space/web/templates/settings.html
+++ b/compute_space/src/compute_space/web/templates/settings.html
@@ -42,6 +42,21 @@
   </tr>
 </table>
 
+<div id="connect-imbue-section" style="display:none;">
+  <h2 class="section-title">Imbue account</h2>
+  <table class="form-table">
+    <tr>
+      <th>Connection</th>
+      <td>
+        <p id="connect-imbue-state" class="muted">Checking&hellip;</p>
+        <button id="connect-imbue-btn" onclick="connectImbue()" class="btn btn-primary" style="display:none;">Connect to Imbue</button>
+        <p class="hint">Connect this instance to your Imbue account to enable Imbue services (like email). Managed instances are connected automatically; use this if yours isn't, or to reconnect.</p>
+        <p id="connect-imbue-msg" style="display:none;"></p>
+      </td>
+    </tr>
+  </table>
+</div>
+
 <h2 class="section-title">Software updates</h2>
 <table class="form-table">
   <tr>


### PR DESCRIPTION
Foundation PR for a single shared per-instance Imbue credential (imbue_identity_*) that authenticates the instance to every Imbue service, plus the instance side of the Connect to Imbue flow.

Managed injection: the ansible template renders the shared imbue_identity_* block, and provisioning injects one credential per instance.

Connect to Imbue (non-managed / recovery): a Settings section starts the flow, the front door redirects back with a one-time code, which is exchanged server-to-server, persisted into config.toml atomically, and the router restarts to load it. Verified live end to end on a real instance.

Awaiting-connect: an instance with the Imbue front door configured but no credential yet boots fine with email off.

Stacked on andrew/email-inbound-direct (#248). ~230 new tests; pre-commit + non-container pytest green.