### PR TITLE
Shared instance identity + Connect to Imbue

### DIFF
--- a/ansible/templates/config.toml.j2
+++ b/ansible/templates/config.toml.j2
@@ -26,13 +26,16 @@ apps_dir_override = "/home/host/openhost/apps"
 # bring-your-own ACME account key above (which is then ignored).  The broker
 # holds the ACME account, so this instance never sees ACME credentials.
 # cert_api_base_url defaults to the canonical broker; only set it to override.
-# Auth is Keycloak client-credentials: this instance's confidential client in
-# the openhost-customers realm.  client_secret is the only sensitive value.
+# Auth resolves from the shared Imbue credential (seeded via first_boot.toml into
+# the DB settings table); the deprecated cert_api_keycloak_* override below is
+# rendered only when explicitly provided (already-deployed instances).
 cert_provider = "cert_api"
 {% if cert_api_base_url is defined %}
 cert_api_base_url = "{{ cert_api_base_url }}"
 {% endif %}
+{% if cert_api_keycloak_issuer_url is defined and cert_api_keycloak_issuer_url %}
 cert_api_keycloak_issuer_url = "{{ cert_api_keycloak_issuer_url }}"
 cert_api_keycloak_client_id = "{{ cert_api_keycloak_client_id }}"
 cert_api_keycloak_client_secret = "{{ cert_api_keycloak_client_secret }}"
+{% endif %}
 {% endif %}

--- a/ansible/templates/first_boot.toml.j2
+++ b/ansible/templates/first_boot.toml.j2
@@ -1,6 +1,17 @@
 {% set http_only = (local_http_only | default(false)) | bool %}
-{# first_boot.toml: the fresh instance's primary domain + claim token. These values seed the
-   DB once, then are ignored after. #}
+{# first_boot.toml: the fresh instance's primary domain + claim token, and (for managed spaces) the
+   shared Imbue credential. These values seed the DB once, then are ignored after. #}
 domain = "{{ domain }}"
 tls = {{ 'false' if http_only else 'true' }}
 claim_token = "{{ effective_claim_token }}"
+{% if imbue_connect_base_url is defined and imbue_connect_base_url %}
+imbue_connect_base_url = "{{ imbue_connect_base_url }}"
+{% endif %}
+{% if imbue_identity_issuer_url is defined and imbue_identity_issuer_url %}
+# Shared per-instance Imbue credential (client-credentials), seeded into the DB settings table on
+# first boot. One credential authenticates this instance to every Imbue service.
+[imbue_identity]
+issuer_url = "{{ imbue_identity_issuer_url }}"
+client_id = "{{ imbue_identity_client_id }}"
+client_secret = "{{ imbue_identity_client_secret }}"
+{% endif %}

--- a/compute_space/src/compute_space/config.py
+++ b/compute_space/src/compute_space/config.py
@@ -105,16 +105,13 @@ class Config:
                 f"{CERT_PROVIDER_ACME!r} or {CERT_PROVIDER_CERT_API!r})"
             )
         if self.cert_provider == CERT_PROVIDER_CERT_API:
-            # The cert_api broker path needs the broker URL plus the per-instance
-            # Keycloak client-credentials; none have a usable default.
-            for name in (
-                "cert_api_base_url",
-                "cert_api_keycloak_issuer_url",
-                "cert_api_keycloak_client_id",
-                "cert_api_keycloak_client_secret",
-            ):
-                if not getattr(self, name):
-                    raise ValueError(f"{name} must be set in config to use the cert_api provider")
+            # The cert_api broker path needs the broker URL. The per-instance
+            # credential lives in the DB settings table (the shared Imbue identity),
+            # so it can't be validated here at construction time; its presence is
+            # checked at cert-acquisition time. The cert_api_keycloak_* config fields
+            # are a deprecated fallback for already-deployed instances.
+            if not self.cert_api_base_url:
+                raise ValueError("cert_api_base_url must be set in config to use the cert_api provider")
 
     def evolve(self, **kwargs: Any) -> Self:
         return attr.evolve(self, **kwargs)

--- a/compute_space/src/compute_space/core/connect.py
+++ b/compute_space/src/compute_space/core/connect.py
@@ -1,0 +1,83 @@
+"""Instance side of the "Connect to Imbue" flow.
+
+Managed spaces get their shared Imbue credential injected at provision time. A
+non-managed (self-hosted) instance instead obtains it here: the owner clicks
+"Connect to Imbue" in Settings and is sent to Imbue to authorize; Imbue returns a
+one-time code to this instance. This module builds the authorization URL, exchanges
+the code for the credential, and persists the credential into the instance's
+config.toml so a restart picks it up through the normal config path
+(Config.instance_identity).
+"""
+
+from __future__ import annotations
+
+from urllib.parse import urlencode
+
+import attr
+import httpx
+
+from compute_space.core.tls.keycloak import KeycloakClientCredentials
+
+# The instance-side callback path Imbue returns the one-time code to (?code=).
+CONNECT_CALLBACK_PATH = "/api/settings/connect-imbue/callback"
+
+_CONNECT_START_PATH = "/connect/imbue"
+_CONNECT_EXCHANGE_PATH = "/connect/imbue/exchange"
+
+
+@attr.s(auto_attribs=True, frozen=True)
+class ConnectError(Exception):
+    """The connect exchange with Imbue failed."""
+
+    message: str
+
+    def __str__(self) -> str:
+        return self.message
+
+
+def build_connect_url(frontend_base_url: str, zone: str, instance_base_url: str) -> str:
+    """Build the Imbue authorization URL the owner's browser is sent to.
+
+    ``instance_base_url`` is this instance's own https origin; the one-time code is
+    returned to it (at CONNECT_CALLBACK_PATH), so the callback must be on the
+    instance's own zone.
+    """
+    callback = f"{instance_base_url.rstrip('/')}{CONNECT_CALLBACK_PATH}"
+    query = urlencode({"zone": zone, "callback": callback})
+    return f"{frontend_base_url.rstrip('/')}{_CONNECT_START_PATH}?{query}"
+
+
+def exchange_code_for_credential(
+    frontend_base_url: str, code: str, *, timeout: float = 30.0
+) -> KeycloakClientCredentials:
+    """Swap a one-time code for the instance's credential.
+
+    Returns the shared per-instance credential. Raises ConnectError on any non-200
+    response or malformed body.
+    """
+    url = f"{frontend_base_url.rstrip('/')}{_CONNECT_EXCHANGE_PATH}"
+    try:
+        resp = httpx.post(url, json={"code": code}, timeout=timeout)
+    except httpx.HTTPError as e:
+        raise ConnectError(f"could not reach the Imbue connect endpoint: {e}") from e
+    if resp.status_code != 200:
+        raise ConnectError(f"connect exchange failed: HTTP {resp.status_code} {_error_message(resp)}")
+    try:
+        body = resp.json()
+        return KeycloakClientCredentials(
+            issuer_url=str(body["issuer_url"]),
+            client_id=str(body["client_id"]),
+            client_secret=str(body["client_secret"]),
+        )
+    except (ValueError, KeyError, TypeError) as e:
+        raise ConnectError("connect exchange returned a malformed response") from e
+
+
+def _error_message(resp: httpx.Response) -> str:
+    try:
+        body = resp.json()
+    except ValueError:
+        return resp.text[:200]
+    if isinstance(body, dict):
+        return str(body.get("error", resp.text[:200]))
+    return resp.text[:200]

--- a/compute_space/src/compute_space/core/connect.py
+++ b/compute_space/src/compute_space/core/connect.py
@@ -52,8 +52,11 @@ def exchange_code_for_credential(
 ) -> KeycloakClientCredentials:
     """Swap a one-time code for the instance's credential.
 
-    Returns the shared per-instance credential. Raises ConnectError on any non-200
-    response or malformed body.
+    ``code`` is the single-use code Imbue issued to this instance's callback after
+    the owner authorized (see the module docstring). Here we hand it back to Imbue
+    over a direct server-to-server call, so the credential itself never travels
+    through the owner's browser. Returns the shared per-instance credential; raises
+    ConnectError on any non-200 response or malformed body.
     """
     url = f"{frontend_base_url.rstrip('/')}{_CONNECT_EXCHANGE_PATH}"
     try:

--- a/compute_space/src/compute_space/core/connect.py
+++ b/compute_space/src/compute_space/core/connect.py
@@ -1,12 +1,12 @@
 """Instance side of the "Connect to Imbue" flow.
 
-Managed spaces get their shared Imbue credential injected at provision time. A
+Managed spaces get their shared Imbue credential seeded at provision time. A
 non-managed (self-hosted) instance instead obtains it here: the owner clicks
 "Connect to Imbue" in Settings and is sent to Imbue to authorize; Imbue returns a
-one-time code to this instance. This module builds the authorization URL, exchanges
-the code for the credential, and persists the credential into the instance's
-config.toml so a restart picks it up through the normal config path
-(Config.instance_identity).
+one-time code to this instance. This module builds the authorization URL and
+exchanges the code for the credential. The callback route stores the result in the
+DB settings table (see ``core.identity_store``), which is read live, so no restart
+is needed.
 """
 
 from __future__ import annotations

--- a/compute_space/src/compute_space/core/first_boot.py
+++ b/compute_space/src/compute_space/core/first_boot.py
@@ -18,10 +18,12 @@ from pathlib import Path
 import attr
 
 from compute_space.config import Config
+from compute_space.core import identity_store
 from compute_space.core import settings_store
 from compute_space.core.domains import Domain
 from compute_space.core.domains import seed_domains
 from compute_space.core.logging import logger
+from compute_space.core.tls.keycloak import KeycloakClientCredentials
 from compute_space.db import get_db
 
 
@@ -31,6 +33,13 @@ class FirstBoot:
     claim_token: str | None
     tls: bool
     mdns: bool
+    # The shared per-instance Imbue credential, injected for managed spaces. All
+    # three parts present together, or all None (no identity seeded).
+    imbue_identity_issuer_url: str | None = None
+    imbue_identity_client_id: str | None = None
+    imbue_identity_client_secret: str | None = None
+    # Base URL of the Imbue API for the "Connect to Imbue" flow (optional).
+    imbue_connect_base_url: str | None = None
 
 
 def _config_dir() -> Path | None:
@@ -54,11 +63,18 @@ def read_first_boot() -> FirstBoot | None:
     if not domain:
         logger.warning("{} has no `domain`; ignoring", fb_path)
         return None
+    identity = data.get("imbue_identity", {})
+    if not isinstance(identity, dict):
+        identity = {}
     return FirstBoot(
         domain=domain,
         claim_token=(str(data["claim_token"]) if data.get("claim_token") else None),
         tls=bool(data.get("tls", True)),
         mdns=bool(data.get("mdns", False)),
+        imbue_identity_issuer_url=(str(identity["issuer_url"]) if identity.get("issuer_url") else None),
+        imbue_identity_client_id=(str(identity["client_id"]) if identity.get("client_id") else None),
+        imbue_identity_client_secret=(str(identity["client_secret"]) if identity.get("client_secret") else None),
+        imbue_connect_base_url=(str(data["imbue_connect_base_url"]) if data.get("imbue_connect_base_url") else None),
     )
 
 
@@ -88,6 +104,7 @@ def seed_first_boot(config: Config) -> None:
         if fb is not None:
             primary = Domain(name=fb.domain, tls=fb.tls, mdns=fb.mdns)
             seed_domains(db, primary, [])
+            _seed_imbue_identity(db, fb)
 
         # Migrate the claim token into the settings store.  Relevant only pre-setup, so gate on
         # owner-absence + settings-absence rather than the domain-seeded flag — an instance that seeded
@@ -97,3 +114,26 @@ def seed_first_boot(config: Config) -> None:
             if token:
                 settings_store.set_setting(db, settings_store.CLAIM_TOKEN_KEY, token)
                 logger.info("Seeded claim token into the settings store")
+
+
+def _seed_imbue_identity(db: sqlite3.Connection, fb: FirstBoot) -> None:
+    """Seed the shared Imbue credential + connect URL from first_boot.toml, once.
+
+    Idempotent: only seeds when the settings table has no credential yet, so a
+    later Connect-to-Imbue (which writes the same keys) is never clobbered by a
+    stale first_boot.toml left on disk. Requires all three credential parts.
+    """
+    if identity_store.get_stored_instance_identity(db) is not None:
+        return
+    if fb.imbue_identity_issuer_url and fb.imbue_identity_client_id and fb.imbue_identity_client_secret:
+        identity_store.set_instance_identity(
+            db,
+            KeycloakClientCredentials(
+                issuer_url=fb.imbue_identity_issuer_url,
+                client_id=fb.imbue_identity_client_id,
+                client_secret=fb.imbue_identity_client_secret,
+            ),
+        )
+        logger.info("Seeded Imbue identity into the settings store")
+    if fb.imbue_connect_base_url and settings_store.get_setting(db, identity_store.IMBUE_CONNECT_BASE_URL_KEY) is None:
+        settings_store.set_setting(db, identity_store.IMBUE_CONNECT_BASE_URL_KEY, fb.imbue_connect_base_url)

--- a/compute_space/src/compute_space/core/first_boot.py
+++ b/compute_space/src/compute_space/core/first_boot.py
@@ -119,20 +119,17 @@ def seed_first_boot(config: Config) -> None:
 def _seed_imbue_identity(db: sqlite3.Connection, fb: FirstBoot) -> None:
     """Seed the shared Imbue credential + connect URL from first_boot.toml, once.
 
-    Idempotent: only seeds when the settings table has no credential yet, so a
+    Each is seeded independently and only when absent from the settings table, so a
     later Connect-to-Imbue (which writes the same keys) is never clobbered by a
-    stale first_boot.toml left on disk. Requires all three credential parts.
+    stale first_boot.toml left on disk. The credential requires all three parts.
     """
-    if identity_store.get_stored_instance_identity(db) is not None:
-        return
-    if fb.imbue_identity_issuer_url and fb.imbue_identity_client_id and fb.imbue_identity_client_secret:
+    issuer = fb.imbue_identity_issuer_url
+    client_id = fb.imbue_identity_client_id
+    client_secret = fb.imbue_identity_client_secret
+    if issuer and client_id and client_secret and identity_store.get_stored_instance_identity(db) is None:
         identity_store.set_instance_identity(
             db,
-            KeycloakClientCredentials(
-                issuer_url=fb.imbue_identity_issuer_url,
-                client_id=fb.imbue_identity_client_id,
-                client_secret=fb.imbue_identity_client_secret,
-            ),
+            KeycloakClientCredentials(issuer_url=issuer, client_id=client_id, client_secret=client_secret),
         )
         logger.info("Seeded Imbue identity into the settings store")
     if fb.imbue_connect_base_url and settings_store.get_setting(db, identity_store.IMBUE_CONNECT_BASE_URL_KEY) is None:

--- a/compute_space/src/compute_space/core/identity_store.py
+++ b/compute_space/src/compute_space/core/identity_store.py
@@ -49,6 +49,20 @@ def get_instance_identity(db: sqlite3.Connection, config: Config) -> KeycloakCli
     return None
 
 
+def get_stored_instance_identity(db: sqlite3.Connection) -> KeycloakClientCredentials | None:
+    """The credential from the settings table only (no config fallback), or None.
+
+    Used by first-boot seeding to decide whether the table already holds a
+    credential, independent of any deprecated config fallback.
+    """
+    issuer = settings_store.get_setting(db, IMBUE_IDENTITY_ISSUER_URL_KEY)
+    client_id = settings_store.get_setting(db, IMBUE_IDENTITY_CLIENT_ID_KEY)
+    client_secret = settings_store.get_setting(db, IMBUE_IDENTITY_CLIENT_SECRET_KEY)
+    if issuer and client_id and client_secret:
+        return KeycloakClientCredentials(issuer_url=issuer, client_id=client_id, client_secret=client_secret)
+    return None
+
+
 def set_instance_identity(db: sqlite3.Connection, credential: KeycloakClientCredentials) -> None:
     """Store the shared per-instance credential in the settings table."""
     settings_store.set_setting(db, IMBUE_IDENTITY_ISSUER_URL_KEY, credential.issuer_url)

--- a/compute_space/src/compute_space/core/identity_store.py
+++ b/compute_space/src/compute_space/core/identity_store.py
@@ -1,0 +1,64 @@
+"""The instance's shared Imbue credential, stored in the DB ``settings`` table.
+
+A single per-instance credential authenticates the instance to any Imbue service
+(cert acquisition today, more later). It reaches the instance two ways that
+produce the same result:
+
+  - managed spaces: seeded once from ``first_boot.toml`` into the settings table
+    at provision time (see ``core.first_boot``);
+  - non-managed spaces: obtained at runtime via the "Connect to Imbue" flow, which
+    writes it here (see ``core.connect``).
+
+The DB is the source of truth and is read live, mirroring how ``core.domains``
+sources the primary domain from the DB rather than from the frozen ``Config``.
+For backward compatibility with instances provisioned before this store existed
+(which carry ``cert_api_keycloak_*`` in ``config.toml``), the resolver falls back
+to those config fields when the settings table has no credential.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+from compute_space.config import Config
+from compute_space.core import settings_store
+from compute_space.core.tls.keycloak import KeycloakClientCredentials
+
+# Setting keys for the shared Imbue credential + the connect front-end URL.
+IMBUE_IDENTITY_ISSUER_URL_KEY = "imbue_identity_issuer_url"
+IMBUE_IDENTITY_CLIENT_ID_KEY = "imbue_identity_client_id"
+IMBUE_IDENTITY_CLIENT_SECRET_KEY = "imbue_identity_client_secret"
+IMBUE_CONNECT_BASE_URL_KEY = "imbue_connect_base_url"
+
+
+def get_instance_identity(db: sqlite3.Connection, config: Config) -> KeycloakClientCredentials | None:
+    """The shared per-instance credential, or None when none is configured.
+
+    Reads the settings table first, then falls back to the deprecated
+    ``cert_api_keycloak_*`` config fields (already-deployed instances). Returns
+    None unless all three parts resolve, so callers can treat None as "no Imbue
+    identity configured".
+    """
+    issuer = settings_store.get_setting(db, IMBUE_IDENTITY_ISSUER_URL_KEY) or config.cert_api_keycloak_issuer_url
+    client_id = settings_store.get_setting(db, IMBUE_IDENTITY_CLIENT_ID_KEY) or config.cert_api_keycloak_client_id
+    client_secret = (
+        settings_store.get_setting(db, IMBUE_IDENTITY_CLIENT_SECRET_KEY) or config.cert_api_keycloak_client_secret
+    )
+    if issuer and client_id and client_secret:
+        return KeycloakClientCredentials(issuer_url=issuer, client_id=client_id, client_secret=client_secret)
+    return None
+
+
+def set_instance_identity(db: sqlite3.Connection, credential: KeycloakClientCredentials) -> None:
+    """Store the shared per-instance credential in the settings table."""
+    settings_store.set_setting(db, IMBUE_IDENTITY_ISSUER_URL_KEY, credential.issuer_url)
+    settings_store.set_setting(db, IMBUE_IDENTITY_CLIENT_ID_KEY, credential.client_id)
+    settings_store.set_setting(db, IMBUE_IDENTITY_CLIENT_SECRET_KEY, credential.client_secret)
+
+
+def get_connect_base_url(db: sqlite3.Connection) -> str | None:
+    """Base URL of the Imbue API for the "Connect to Imbue" flow, or None.
+
+    When None, the connect flow is unavailable and the Settings button is hidden.
+    """
+    return settings_store.get_setting(db, IMBUE_CONNECT_BASE_URL_KEY)

--- a/compute_space/src/compute_space/core/tls/provision.py
+++ b/compute_space/src/compute_space/core/tls/provision.py
@@ -6,10 +6,10 @@ from compute_space.config import CERT_PROVIDER_ACME
 from compute_space.config import Config
 from compute_space.core.domains import is_primary_domain
 from compute_space.core.domains import primary_domain
+from compute_space.core.identity_store import get_instance_identity
 from compute_space.core.tls.acquire_cert import acquire_tls_cert
 from compute_space.core.tls.acquire_cert_broker import acquire_tls_cert_via_broker
 from compute_space.core.tls.cert_api_client import CertApiClient
-from compute_space.core.tls.keycloak import KeycloakClientCredentials
 from compute_space.core.tls.keycloak import KeycloakTokenProvider
 
 
@@ -44,17 +44,13 @@ def acquire_cert_for_domain(
             )
         )
     else:
-        # cert_provider is guaranteed to be CERT_PROVIDER_CERT_API with all of
-        # the cert_api settings populated (validated in Config.__attrs_post_init__).
+        # cert_provider is guaranteed to be CERT_PROVIDER_CERT_API with the broker
+        # URL set (validated in Config.__attrs_post_init__). The credential is the
+        # shared per-instance Imbue identity, read live from the settings table
+        # (falling back to the deprecated cert_api_keycloak_* config fields).
         assert config.cert_api_base_url is not None
-        assert config.cert_api_keycloak_issuer_url is not None
-        assert config.cert_api_keycloak_client_id is not None
-        assert config.cert_api_keycloak_client_secret is not None
-        credentials = KeycloakClientCredentials(
-            issuer_url=config.cert_api_keycloak_issuer_url,
-            client_id=config.cert_api_keycloak_client_id,
-            client_secret=config.cert_api_keycloak_client_secret,
-        )
+        credentials = get_instance_identity(db, config)
+        assert credentials is not None
         # The token provider fetches a bearer from Keycloak (client-credentials) and
         # refreshes it transparently across the broker's finalize-poll loop.
         with KeycloakTokenProvider.create(credentials) as token_provider:

--- a/compute_space/src/compute_space/tests/test_cert_provider_config.py
+++ b/compute_space/src/compute_space/tests/test_cert_provider_config.py
@@ -99,20 +99,31 @@ def test_complete_cert_api_config_is_valid() -> None:
     assert cfg.cert_provider == CERT_PROVIDER_CERT_API
 
 
+def test_cert_api_provider_requires_base_url() -> None:
+    # Only the broker URL is validated at construction; the per-instance credential
+    # now lives in the DB settings table (the shared Imbue identity), so it can't be
+    # checked here and is verified at cert-acquisition time.
+    kwargs = _full_cert_api_kwargs()
+    kwargs["cert_api_base_url"] = None  # type: ignore[assignment]
+    with pytest.raises(ValueError, match="cert_api_base_url must be set"):
+        DefaultConfig(**kwargs)
+
+
 @pytest.mark.parametrize(
     "missing_field",
     [
-        "cert_api_base_url",
         "cert_api_keycloak_issuer_url",
         "cert_api_keycloak_client_id",
         "cert_api_keycloak_client_secret",
     ],
 )
-def test_cert_api_provider_requires_all_settings(missing_field: str) -> None:
+def test_cert_api_provider_no_longer_requires_keycloak_at_construction(missing_field: str) -> None:
+    # The cert_api_keycloak_* fields are a deprecated fallback; their absence is not
+    # a construction error (the credential can come from the settings table instead).
     kwargs = _full_cert_api_kwargs()
     kwargs[missing_field] = None  # type: ignore[assignment]
-    with pytest.raises(ValueError, match=f"{missing_field} must be set"):
-        DefaultConfig(**kwargs)
+    cfg = DefaultConfig(**kwargs)
+    assert cfg.cert_provider == CERT_PROVIDER_CERT_API
 
 
 def test_acme_provider_ignores_cert_api_settings() -> None:

--- a/compute_space/src/compute_space/tests/test_connect.py
+++ b/compute_space/src/compute_space/tests/test_connect.py
@@ -1,0 +1,340 @@
+"""The instance-side "Connect to Imbue" helpers (``core/connect.py``).
+
+``build_connect_url`` composes the Imbue authorization URL (zone + instance
+callback); ``exchange_code_for_credential`` swaps the one-time code for the shared
+credential, raising ``ConnectError`` on any transport or protocol failure.  These
+tests pin URL composition and every failure mode of the exchange (mocking
+``httpx.post``).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+from urllib.parse import parse_qs
+from urllib.parse import urlparse
+
+import httpx
+import pytest
+
+from compute_space.core.connect import CONNECT_CALLBACK_PATH
+from compute_space.core.connect import ConnectError
+from compute_space.core.connect import build_connect_url
+from compute_space.core.connect import exchange_code_for_credential
+from compute_space.core.tls.keycloak import KeycloakClientCredentials
+
+_IMBUE = "https://openhost.imbue.com"
+
+# --- constant ----------------------------------------------------------------
+
+
+def test_callback_path_constant() -> None:
+    assert CONNECT_CALLBACK_PATH == "/api/settings/connect-imbue/callback"
+
+
+# --- build_connect_url -------------------------------------------------------
+
+
+def test_build_connect_url_basic_shape() -> None:
+    url = build_connect_url(_IMBUE, "alice.selfhost.imbue.com", "https://alice.selfhost.imbue.com")
+    parsed = urlparse(url)
+    assert parsed.scheme == "https"
+    assert parsed.netloc == "openhost.imbue.com"
+    assert parsed.path == "/connect/imbue"
+    qs = parse_qs(parsed.query)
+    assert qs["zone"] == ["alice.selfhost.imbue.com"]
+    assert qs["callback"] == ["https://alice.selfhost.imbue.com/api/settings/connect-imbue/callback"]
+
+
+def test_build_connect_url_callback_is_urlencoded_in_raw_string() -> None:
+    url = build_connect_url(_IMBUE, "z.example.com", "https://z.example.com")
+    # The callback's slashes/colons must be percent-encoded in the raw query.
+    assert "callback=https%3A%2F%2Fz.example.com%2Fapi%2Fsettings%2Fconnect-imbue%2Fcallback" in url
+
+
+def test_build_connect_url_strips_trailing_slash_on_frontend() -> None:
+    url = build_connect_url(_IMBUE + "/", "z.example.com", "https://z.example.com")
+    assert url.startswith(f"{_IMBUE}/connect/imbue?")
+    assert "openhost.imbue.com//connect" not in url
+
+
+def test_build_connect_url_strips_trailing_slash_on_instance_base() -> None:
+    url = build_connect_url(_IMBUE, "z.example.com", "https://z.example.com/")
+    qs = parse_qs(urlparse(url).query)
+    # No doubled slash before the callback path.
+    assert qs["callback"] == ["https://z.example.com/api/settings/connect-imbue/callback"]
+
+
+def test_build_connect_url_strips_both_trailing_slashes() -> None:
+    url = build_connect_url(_IMBUE + "/", "z.example.com", "https://z.example.com/")
+    assert url.startswith(f"{_IMBUE}/connect/imbue?")
+    qs = parse_qs(urlparse(url).query)
+    assert qs["callback"] == ["https://z.example.com/api/settings/connect-imbue/callback"]
+
+
+def test_build_connect_url_preserves_frontend_port() -> None:
+    url = build_connect_url("https://imbue.local:8443", "z.example.com", "https://z.example.com")
+    parsed = urlparse(url)
+    assert parsed.netloc == "imbue.local:8443"
+    assert parsed.path == "/connect/imbue"
+
+
+def test_build_connect_url_preserves_instance_port_in_callback() -> None:
+    url = build_connect_url(_IMBUE, "z.example.com", "https://z.example.com:18080")
+    qs = parse_qs(urlparse(url).query)
+    assert qs["callback"] == ["https://z.example.com:18080/api/settings/connect-imbue/callback"]
+
+
+def test_build_connect_url_http_instance_base() -> None:
+    url = build_connect_url(_IMBUE, "z.example.com", "http://z.example.com")
+    qs = parse_qs(urlparse(url).query)
+    assert qs["callback"] == ["http://z.example.com/api/settings/connect-imbue/callback"]
+
+
+def test_build_connect_url_http_frontend() -> None:
+    url = build_connect_url("http://imbue.local", "z.example.com", "https://z.example.com")
+    assert url.startswith("http://imbue.local/connect/imbue?")
+
+
+def test_build_connect_url_subdomain_zone() -> None:
+    url = build_connect_url(_IMBUE, "team.alice.selfhost.imbue.com", "https://team.alice.selfhost.imbue.com")
+    qs = parse_qs(urlparse(url).query)
+    assert qs["zone"] == ["team.alice.selfhost.imbue.com"]
+
+
+def test_build_connect_url_zone_with_special_chars_is_encoded() -> None:
+    # A zone value with reserved characters must be percent-encoded, not injected
+    # raw into the query string.
+    url = build_connect_url(_IMBUE, "a b&c=d", "https://z.example.com")
+    assert "zone=a b&c=d" not in url
+    qs = parse_qs(urlparse(url).query)
+    assert qs["zone"] == ["a b&c=d"]
+
+
+def test_build_connect_url_frontend_with_existing_query_appends_start_path() -> None:
+    # The builder appends the start path + a fresh query; it does not merge into a
+    # pre-existing query on the frontend base. Pin the actual (documented) behavior.
+    url = build_connect_url("https://imbue.local?ref=x", "z.example.com", "https://z.example.com")
+    assert url.startswith("https://imbue.local?ref=x/connect/imbue?")
+
+
+def test_build_connect_url_callback_uses_the_callback_path_constant() -> None:
+    url = build_connect_url(_IMBUE, "z.example.com", "https://z.example.com")
+    qs = parse_qs(urlparse(url).query)
+    assert qs["callback"][0].endswith(CONNECT_CALLBACK_PATH)
+
+
+# --- exchange_code_for_credential: mocking helper ----------------------------
+
+
+def _mock_post(monkeypatch: pytest.MonkeyPatch, handler: Callable[[], httpx.Response]) -> dict[str, Any]:
+    """Patch ``httpx.post`` with a handler; capture the call args in a dict."""
+    seen: dict[str, Any] = {}
+
+    def fake_post(url: str, json: Any = None, timeout: Any = None) -> httpx.Response:
+        seen["url"] = url
+        seen["json"] = json
+        seen["timeout"] = timeout
+        return handler()
+
+    monkeypatch.setattr(httpx, "post", fake_post)
+    return seen
+
+
+def _ok_body(**overrides: Any) -> dict[str, Any]:
+    body = {
+        "issuer_url": "https://kc/realms/openhost-customers",
+        "client_id": "instance-alice",
+        "client_secret": "sekret",
+    }
+    body.update(overrides)
+    return body
+
+
+# --- exchange: happy path ----------------------------------------------------
+
+
+def test_exchange_returns_credential(monkeypatch: pytest.MonkeyPatch) -> None:
+    _mock_post(monkeypatch, lambda: httpx.Response(200, json=_ok_body()))
+    out = exchange_code_for_credential(_IMBUE, "one-time-code")
+    assert out == KeycloakClientCredentials(
+        issuer_url="https://kc/realms/openhost-customers",
+        client_id="instance-alice",
+        client_secret="sekret",
+    )
+
+
+def test_exchange_posts_to_exchange_endpoint_with_code(monkeypatch: pytest.MonkeyPatch) -> None:
+    seen = _mock_post(monkeypatch, lambda: httpx.Response(200, json=_ok_body()))
+    exchange_code_for_credential(_IMBUE, "one-time-code")
+    assert seen["url"] == f"{_IMBUE}/connect/imbue/exchange"
+    assert seen["json"] == {"code": "one-time-code"}
+
+
+def test_exchange_strips_trailing_slash_on_base(monkeypatch: pytest.MonkeyPatch) -> None:
+    seen = _mock_post(monkeypatch, lambda: httpx.Response(200, json=_ok_body()))
+    exchange_code_for_credential(_IMBUE + "/", "code")
+    assert seen["url"] == f"{_IMBUE}/connect/imbue/exchange"
+
+
+def test_exchange_default_timeout_is_30(monkeypatch: pytest.MonkeyPatch) -> None:
+    seen = _mock_post(monkeypatch, lambda: httpx.Response(200, json=_ok_body()))
+    exchange_code_for_credential(_IMBUE, "code")
+    assert seen["timeout"] == 30.0
+
+
+def test_exchange_custom_timeout_is_forwarded(monkeypatch: pytest.MonkeyPatch) -> None:
+    seen = _mock_post(monkeypatch, lambda: httpx.Response(200, json=_ok_body()))
+    exchange_code_for_credential(_IMBUE, "code", timeout=5.0)
+    assert seen["timeout"] == 5.0
+
+
+def test_exchange_ignores_extra_fields(monkeypatch: pytest.MonkeyPatch) -> None:
+    body = _ok_body(zone_domain="alice.example.com", extra="ignored")
+    _mock_post(monkeypatch, lambda: httpx.Response(200, json=body))
+    out = exchange_code_for_credential(_IMBUE, "code")
+    assert out == KeycloakClientCredentials(
+        issuer_url="https://kc/realms/openhost-customers",
+        client_id="instance-alice",
+        client_secret="sekret",
+    )
+
+
+def test_exchange_coerces_non_string_fields_to_str(monkeypatch: pytest.MonkeyPatch) -> None:
+    # The exchange wraps each field in str(); pin that a numeric field is coerced.
+    body = _ok_body(client_id=12345)
+    _mock_post(monkeypatch, lambda: httpx.Response(200, json=body))
+    out = exchange_code_for_credential(_IMBUE, "code")
+    assert out.client_id == "12345"
+
+
+def test_exchange_accepts_empty_code(monkeypatch: pytest.MonkeyPatch) -> None:
+    # The helper itself does not validate the code (the route does); an empty code
+    # is posted as-is and a 200 body yields a credential.
+    seen = _mock_post(monkeypatch, lambda: httpx.Response(200, json=_ok_body()))
+    exchange_code_for_credential(_IMBUE, "")
+    assert seen["json"] == {"code": ""}
+
+
+def test_exchange_accepts_large_code(monkeypatch: pytest.MonkeyPatch) -> None:
+    big = "c" * 10000
+    seen = _mock_post(monkeypatch, lambda: httpx.Response(200, json=_ok_body()))
+    exchange_code_for_credential(_IMBUE, big)
+    assert seen["json"] == {"code": big}
+
+
+# --- exchange: missing fields -> ConnectError --------------------------------
+
+
+def test_exchange_missing_issuer_url_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    body = _ok_body()
+    del body["issuer_url"]
+    _mock_post(monkeypatch, lambda: httpx.Response(200, json=body))
+    with pytest.raises(ConnectError, match="malformed"):
+        exchange_code_for_credential(_IMBUE, "code")
+
+
+def test_exchange_missing_client_id_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    body = _ok_body()
+    del body["client_id"]
+    _mock_post(monkeypatch, lambda: httpx.Response(200, json=body))
+    with pytest.raises(ConnectError, match="malformed"):
+        exchange_code_for_credential(_IMBUE, "code")
+
+
+def test_exchange_missing_client_secret_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    body = _ok_body()
+    del body["client_secret"]
+    _mock_post(monkeypatch, lambda: httpx.Response(200, json=body))
+    with pytest.raises(ConnectError, match="malformed"):
+        exchange_code_for_credential(_IMBUE, "code")
+
+
+def test_exchange_empty_object_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    _mock_post(monkeypatch, lambda: httpx.Response(200, json={}))
+    with pytest.raises(ConnectError, match="malformed"):
+        exchange_code_for_credential(_IMBUE, "code")
+
+
+# --- exchange: malformed / non-JSON bodies -----------------------------------
+
+
+def test_exchange_non_json_body_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    _mock_post(monkeypatch, lambda: httpx.Response(200, text="not json at all"))
+    with pytest.raises(ConnectError, match="malformed"):
+        exchange_code_for_credential(_IMBUE, "code")
+
+
+def test_exchange_json_list_body_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    # A JSON array (not a dict) -> indexing by key raises TypeError -> ConnectError.
+    _mock_post(monkeypatch, lambda: httpx.Response(200, json=["a", "b"]))
+    with pytest.raises(ConnectError, match="malformed"):
+        exchange_code_for_credential(_IMBUE, "code")
+
+
+def test_exchange_json_null_body_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    _mock_post(monkeypatch, lambda: httpx.Response(200, json=None))
+    with pytest.raises(ConnectError, match="malformed"):
+        exchange_code_for_credential(_IMBUE, "code")
+
+
+# --- exchange: non-200 statuses ----------------------------------------------
+
+
+@pytest.mark.parametrize("status", [400, 401, 403, 404, 500, 502, 503])
+def test_exchange_non_200_raises_with_status(monkeypatch: pytest.MonkeyPatch, status: int) -> None:
+    _mock_post(monkeypatch, lambda: httpx.Response(status, json={"error": "nope"}))
+    with pytest.raises(ConnectError, match=f"HTTP {status}") as ei:
+        exchange_code_for_credential(_IMBUE, "code")
+    assert "connect exchange failed" in str(ei.value)
+
+
+def test_exchange_non_200_includes_error_message_from_body(monkeypatch: pytest.MonkeyPatch) -> None:
+    _mock_post(monkeypatch, lambda: httpx.Response(400, json={"error": "code expired"}))
+    with pytest.raises(ConnectError, match="code expired"):
+        exchange_code_for_credential(_IMBUE, "code")
+
+
+def test_exchange_non_200_non_json_body_uses_text(monkeypatch: pytest.MonkeyPatch) -> None:
+    _mock_post(monkeypatch, lambda: httpx.Response(500, text="internal boom"))
+    with pytest.raises(ConnectError, match="internal boom"):
+        exchange_code_for_credential(_IMBUE, "code")
+
+
+# --- exchange: network errors ------------------------------------------------
+
+
+def test_exchange_connect_error_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    def boom() -> httpx.Response:
+        raise httpx.ConnectError("connection refused")
+
+    _mock_post(monkeypatch, boom)
+    with pytest.raises(ConnectError, match="could not reach"):
+        exchange_code_for_credential(_IMBUE, "code")
+
+
+def test_exchange_timeout_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    def boom() -> httpx.Response:
+        raise httpx.ReadTimeout("timed out")
+
+    _mock_post(monkeypatch, boom)
+    with pytest.raises(ConnectError, match="could not reach"):
+        exchange_code_for_credential(_IMBUE, "code")
+
+
+def test_exchange_connect_timeout_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    def boom() -> httpx.Response:
+        raise httpx.ConnectTimeout("connect timed out")
+
+    _mock_post(monkeypatch, boom)
+    with pytest.raises(ConnectError, match="could not reach"):
+        exchange_code_for_credential(_IMBUE, "code")
+
+
+# --- ConnectError itself -----------------------------------------------------
+
+
+def test_connect_error_str_is_the_message() -> None:
+    err = ConnectError("something broke")
+    assert str(err) == "something broke"
+    assert isinstance(err, Exception)

--- a/compute_space/src/compute_space/tests/test_connect_routes.py
+++ b/compute_space/src/compute_space/tests/test_connect_routes.py
@@ -1,0 +1,374 @@
+"""The "Connect to Imbue" settings routes (``web/routes/api/settings.py``).
+
+Exercised through a minimal Litestar app carrying just ``api_settings_routes``
+under the real ``require_owner_auth`` guard, against a file-backed test DB.  The
+status/start/callback endpoints read the connect URL + identity live from the
+settings table, so the tests seed those via the identity_store setters and assert
+the routes' HTTP behavior (auth, availability, redirects, error codes) and the
+callback's DB side effect.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from collections.abc import Iterator
+from contextlib import closing
+from pathlib import Path
+from typing import Any
+from unittest import mock
+from urllib.parse import parse_qs
+from urllib.parse import urlparse
+
+import bcrypt
+import pytest
+from litestar import Litestar
+from litestar.di import Provide
+from litestar.testing import TestClient
+
+from compute_space.config import provide_config
+from compute_space.core.auth.auth import SESSION_COOKIE_NAME
+from compute_space.core.auth.auth import create_session
+from compute_space.core.connect import ConnectError
+from compute_space.core.identity_store import IMBUE_CONNECT_BASE_URL_KEY
+from compute_space.core.identity_store import get_stored_instance_identity
+from compute_space.core.identity_store import set_instance_identity
+from compute_space.core.settings_store import set_setting
+from compute_space.core.tls.keycloak import KeycloakClientCredentials
+from compute_space.db import init_db
+from compute_space.db import provide_db
+from compute_space.tests.conftest import _make_test_config
+from compute_space.tests.conftest import open_db
+from compute_space.web.routes.api.settings import api_settings_routes
+
+_IMBUE = "https://openhost.imbue.com"
+_ZONE = "alice.example.com"
+
+
+def _cred() -> KeycloakClientCredentials:
+    return KeycloakClientCredentials(
+        issuer_url="https://kc/realms/openhost-customers",
+        client_id="instance-alice",
+        client_secret="sekret",
+    )
+
+
+# --- fixtures ----------------------------------------------------------------
+
+
+@pytest.fixture
+def cfg(tmp_path: Path) -> Any:
+    # seed_primary=True (default) so primary_domain(db) resolves for /start.
+    cfg = _make_test_config(tmp_path, port=20700, zone_domain=_ZONE)
+    init_db(cfg.db_path)
+    return cfg
+
+
+def _seed_connect_url(cfg: Any, url: str = _IMBUE) -> None:
+    with closing(open_db(cfg)) as db:
+        set_setting(db, IMBUE_CONNECT_BASE_URL_KEY, url)
+
+
+def _seed_identity(cfg: Any, cred: KeycloakClientCredentials | None = None) -> None:
+    with closing(open_db(cfg)) as db:
+        set_instance_identity(db, cred or _cred())
+
+
+def _make_settings_app() -> Litestar:
+    return Litestar(
+        route_handlers=[api_settings_routes],
+        dependencies={
+            "config": Provide(provide_config, sync_to_thread=False),
+            "db": Provide(provide_db),
+        },
+        openapi_config=None,
+    )
+
+
+@pytest.fixture
+def client(cfg: Any) -> Iterator[TestClient[Litestar]]:
+    with TestClient(app=_make_settings_app()) as c:
+        yield c
+
+
+def _auth_cookie(cfg: Any) -> dict[str, str]:
+    pw_hash = bcrypt.hashpw(b"secretpass1", bcrypt.gensalt()).decode()
+    conn = sqlite3.connect(cfg.db_path)
+    conn.row_factory = sqlite3.Row
+    try:
+        cur = conn.execute("INSERT INTO users (username, password_hash) VALUES (?, ?)", ("owner", pw_hash))
+        assert cur.lastrowid is not None
+        token = create_session(cur.lastrowid, conn)
+        conn.commit()
+    finally:
+        conn.close()
+    return {SESSION_COOKIE_NAME: token}
+
+
+# --- status ------------------------------------------------------------------
+
+
+def test_status_requires_auth(client: TestClient[Litestar]) -> None:
+    assert client.get("/api/settings/connect-imbue/status").status_code == 401
+
+
+def test_status_unavailable_and_unconnected_when_empty(cfg: Any, client: TestClient[Litestar]) -> None:
+    resp = client.get("/api/settings/connect-imbue/status", cookies=_auth_cookie(cfg))
+    assert resp.status_code == 200
+    assert resp.json() == {"available": False, "connected": False}
+
+
+def test_status_available_when_connect_url_present(cfg: Any, client: TestClient[Litestar]) -> None:
+    _seed_connect_url(cfg)
+    resp = client.get("/api/settings/connect-imbue/status", cookies=_auth_cookie(cfg))
+    assert resp.json() == {"available": True, "connected": False}
+
+
+def test_status_connected_when_identity_present(cfg: Any, client: TestClient[Litestar]) -> None:
+    _seed_identity(cfg)
+    resp = client.get("/api/settings/connect-imbue/status", cookies=_auth_cookie(cfg))
+    # Connected true (identity resolves), available false (no connect URL seeded).
+    assert resp.json() == {"available": False, "connected": True}
+
+
+def test_status_available_and_connected(cfg: Any, client: TestClient[Litestar]) -> None:
+    _seed_connect_url(cfg)
+    _seed_identity(cfg)
+    resp = client.get("/api/settings/connect-imbue/status", cookies=_auth_cookie(cfg))
+    assert resp.json() == {"available": True, "connected": True}
+
+
+def test_status_not_connected_with_partial_identity(cfg: Any, client: TestClient[Litestar]) -> None:
+    # Only two of three identity parts stored -> not connected.
+    with closing(open_db(cfg)) as db:
+        set_setting(db, "imbue_identity_issuer_url", "iss")
+        set_setting(db, "imbue_identity_client_id", "cid")
+    resp = client.get("/api/settings/connect-imbue/status", cookies=_auth_cookie(cfg))
+    assert resp.json()["connected"] is False
+
+
+# --- start -------------------------------------------------------------------
+
+
+def test_start_requires_auth(client: TestClient[Litestar]) -> None:
+    assert client.post("/api/settings/connect-imbue/start").status_code == 401
+
+
+def test_start_503_without_connect_url(cfg: Any, client: TestClient[Litestar]) -> None:
+    resp = client.post("/api/settings/connect-imbue/start", cookies=_auth_cookie(cfg))
+    assert resp.status_code == 503
+
+
+def test_start_returns_redirect_url_with_zone_and_callback(cfg: Any, client: TestClient[Litestar]) -> None:
+    _seed_connect_url(cfg)
+    resp = client.post("/api/settings/connect-imbue/start", cookies=_auth_cookie(cfg))
+    assert resp.status_code == 200
+    url = resp.json()["redirect_url"]
+    assert url.startswith(f"{_IMBUE}/connect/imbue?")
+    qs = parse_qs(urlparse(url).query)
+    assert qs["zone"] == [_ZONE]
+    assert qs["callback"][0].endswith("/api/settings/connect-imbue/callback")
+
+
+def test_start_honors_forwarded_proto_and_host(cfg: Any, client: TestClient[Litestar]) -> None:
+    _seed_connect_url(cfg)
+    resp = client.post(
+        "/api/settings/connect-imbue/start",
+        cookies=_auth_cookie(cfg),
+        headers={"x-forwarded-proto": "https", "x-forwarded-host": "proxy.example.com"},
+    )
+    url = resp.json()["redirect_url"]
+    qs = parse_qs(urlparse(url).query)
+    # The callback origin is derived from the forwarded proxy headers.
+    assert qs["callback"] == ["https://proxy.example.com/api/settings/connect-imbue/callback"]
+    # Zone still comes from the primary domain, not the proxy host.
+    assert qs["zone"] == [_ZONE]
+
+
+def test_start_callback_host_falls_back_to_host_header(cfg: Any, client: TestClient[Litestar]) -> None:
+    _seed_connect_url(cfg)
+    resp = client.post(
+        "/api/settings/connect-imbue/start",
+        cookies=_auth_cookie(cfg),
+        headers={"host": "direct.example.com"},
+    )
+    qs = parse_qs(urlparse(resp.json()["redirect_url"]).query)
+    assert qs["callback"][0].startswith("http://direct.example.com/") or qs["callback"][0].startswith(
+        "https://direct.example.com/"
+    )
+
+
+# --- callback ----------------------------------------------------------------
+
+
+def test_callback_requires_auth(client: TestClient[Litestar]) -> None:
+    assert client.get("/api/settings/connect-imbue/callback?code=x").status_code == 401
+
+
+def test_callback_503_without_connect_url(cfg: Any, client: TestClient[Litestar]) -> None:
+    resp = client.get(
+        "/api/settings/connect-imbue/callback?code=x",
+        cookies=_auth_cookie(cfg),
+        follow_redirects=False,
+    )
+    assert resp.status_code == 503
+
+
+def test_callback_blank_code_redirects_error(cfg: Any, client: TestClient[Litestar]) -> None:
+    _seed_connect_url(cfg)
+    resp = client.get(
+        "/api/settings/connect-imbue/callback?code=",
+        cookies=_auth_cookie(cfg),
+        follow_redirects=False,
+    )
+    assert resp.status_code in (302, 307)
+    assert resp.headers["location"] == "/settings?connect=error"
+
+
+def test_callback_whitespace_code_redirects_error(cfg: Any, client: TestClient[Litestar]) -> None:
+    _seed_connect_url(cfg)
+    resp = client.get(
+        "/api/settings/connect-imbue/callback?code=%20%20",
+        cookies=_auth_cookie(cfg),
+        follow_redirects=False,
+    )
+    assert resp.status_code in (302, 307)
+    assert resp.headers["location"] == "/settings?connect=error"
+
+
+def test_callback_missing_code_param_redirects_error(cfg: Any, client: TestClient[Litestar]) -> None:
+    # No ?code= at all defaults to "" -> the blank-code error redirect.
+    _seed_connect_url(cfg)
+    resp = client.get(
+        "/api/settings/connect-imbue/callback",
+        cookies=_auth_cookie(cfg),
+        follow_redirects=False,
+    )
+    assert resp.status_code in (302, 307)
+    assert resp.headers["location"] == "/settings?connect=error"
+
+
+def test_callback_happy_path_stores_identity_and_redirects_ok(cfg: Any, client: TestClient[Litestar]) -> None:
+    _seed_connect_url(cfg)
+    with (
+        mock.patch(
+            "compute_space.web.routes.api.settings.exchange_code_for_credential",
+            return_value=_cred(),
+        ) as exchange,
+        mock.patch("compute_space.web.routes.api.settings.trigger_restart") as restart,
+    ):
+        resp = client.get(
+            "/api/settings/connect-imbue/callback?code=onetime",
+            cookies=_auth_cookie(cfg),
+            follow_redirects=False,
+        )
+    assert resp.status_code in (302, 307)
+    assert resp.headers["location"] == "/settings?connect=ok"
+    # The exchange was called with the connect URL + the (stripped) code.
+    exchange.assert_called_once_with(_IMBUE, "onetime")
+    # No restart is triggered — the DB is read live.
+    restart.assert_not_called()
+    # The credential was persisted to the settings table.
+    with closing(open_db(cfg)) as db:
+        assert get_stored_instance_identity(db) == _cred()
+
+
+def test_callback_strips_whitespace_around_code_before_exchange(cfg: Any, client: TestClient[Litestar]) -> None:
+    _seed_connect_url(cfg)
+    with (
+        mock.patch(
+            "compute_space.web.routes.api.settings.exchange_code_for_credential",
+            return_value=_cred(),
+        ) as exchange,
+        mock.patch("compute_space.web.routes.api.settings.trigger_restart"),
+    ):
+        resp = client.get(
+            "/api/settings/connect-imbue/callback?code=%20onetime%20",
+            cookies=_auth_cookie(cfg),
+            follow_redirects=False,
+        )
+    assert resp.headers["location"] == "/settings?connect=ok"
+    exchange.assert_called_once_with(_IMBUE, "onetime")
+
+
+def test_callback_connect_error_returns_502(cfg: Any, client: TestClient[Litestar]) -> None:
+    _seed_connect_url(cfg)
+    with (
+        mock.patch(
+            "compute_space.web.routes.api.settings.exchange_code_for_credential",
+            side_effect=ConnectError("code expired"),
+        ),
+        mock.patch("compute_space.web.routes.api.settings.trigger_restart") as restart,
+    ):
+        resp = client.get(
+            "/api/settings/connect-imbue/callback?code=bad",
+            cookies=_auth_cookie(cfg),
+            follow_redirects=False,
+        )
+    assert resp.status_code == 502
+    restart.assert_not_called()
+    # Nothing was persisted on failure.
+    with closing(open_db(cfg)) as db:
+        assert get_stored_instance_identity(db) is None
+
+
+def test_callback_connect_error_does_not_overwrite_existing_identity(cfg: Any, client: TestClient[Litestar]) -> None:
+    _seed_connect_url(cfg)
+    prior = KeycloakClientCredentials(issuer_url="prior-iss", client_id="prior-cid", client_secret="prior-sec")
+    _seed_identity(cfg, prior)
+    with mock.patch(
+        "compute_space.web.routes.api.settings.exchange_code_for_credential",
+        side_effect=ConnectError("boom"),
+    ):
+        resp = client.get(
+            "/api/settings/connect-imbue/callback?code=bad",
+            cookies=_auth_cookie(cfg),
+            follow_redirects=False,
+        )
+    assert resp.status_code == 502
+    with closing(open_db(cfg)) as db:
+        assert get_stored_instance_identity(db) == prior
+
+
+def test_callback_overwrites_existing_identity_on_success(cfg: Any, client: TestClient[Litestar]) -> None:
+    _seed_connect_url(cfg)
+    prior = KeycloakClientCredentials(issuer_url="prior-iss", client_id="prior-cid", client_secret="prior-sec")
+    _seed_identity(cfg, prior)
+    new = KeycloakClientCredentials(issuer_url="new-iss", client_id="new-cid", client_secret="new-sec")
+    with (
+        mock.patch(
+            "compute_space.web.routes.api.settings.exchange_code_for_credential",
+            return_value=new,
+        ),
+        mock.patch("compute_space.web.routes.api.settings.trigger_restart"),
+    ):
+        resp = client.get(
+            "/api/settings/connect-imbue/callback?code=onetime",
+            cookies=_auth_cookie(cfg),
+            follow_redirects=False,
+        )
+    assert resp.headers["location"] == "/settings?connect=ok"
+    with closing(open_db(cfg)) as db:
+        assert get_stored_instance_identity(db) == new
+
+
+def test_callback_makes_status_report_connected_afterwards(cfg: Any, client: TestClient[Litestar]) -> None:
+    # End-to-end: after a successful callback, /status must flip connected -> true
+    # (read live from the settings table, no restart in between).
+    _seed_connect_url(cfg)
+    cookies = _auth_cookie(cfg)
+    before = client.get("/api/settings/connect-imbue/status", cookies=cookies).json()
+    assert before == {"available": True, "connected": False}
+    with (
+        mock.patch(
+            "compute_space.web.routes.api.settings.exchange_code_for_credential",
+            return_value=_cred(),
+        ),
+        mock.patch("compute_space.web.routes.api.settings.trigger_restart"),
+    ):
+        client.get(
+            "/api/settings/connect-imbue/callback?code=onetime",
+            cookies=cookies,
+            follow_redirects=False,
+        )
+    after = client.get("/api/settings/connect-imbue/status", cookies=cookies).json()
+    assert after == {"available": True, "connected": True}

--- a/compute_space/src/compute_space/tests/test_first_boot_identity.py
+++ b/compute_space/src/compute_space/tests/test_first_boot_identity.py
@@ -73,7 +73,7 @@ def test_read_first_boot_parses_identity_and_connect_url(monkeypatch: pytest.Mon
     config_dir = _point_config_env(monkeypatch, tmp_path)
     _write_first_boot(
         config_dir,
-        'domain = "fresh.example.com"\n' f'imbue_connect_base_url = "{_IMBUE}"\n' + _FULL_IDENTITY,
+        f'domain = "fresh.example.com"\nimbue_connect_base_url = "{_IMBUE}"\n' + _FULL_IDENTITY,
     )
     fb = read_first_boot()
     assert fb is not None
@@ -137,7 +137,7 @@ def test_seed_writes_connect_url_into_settings(monkeypatch: pytest.MonkeyPatch, 
     config_dir = _point_config_env(monkeypatch, tmp_path)
     _write_first_boot(
         config_dir,
-        'domain = "fresh.example.com"\n' f'imbue_connect_base_url = "{_IMBUE}"\n' + _FULL_IDENTITY,
+        f'domain = "fresh.example.com"\nimbue_connect_base_url = "{_IMBUE}"\n' + _FULL_IDENTITY,
     )
 
     seed_first_boot(cfg)
@@ -151,7 +151,7 @@ def test_seed_connect_url_without_identity(monkeypatch: pytest.MonkeyPatch, tmp_
     # only the connect URL (no identity) still installs the URL.
     cfg = _cfg(tmp_path)
     config_dir = _point_config_env(monkeypatch, tmp_path)
-    _write_first_boot(config_dir, 'domain = "fresh.example.com"\n' f'imbue_connect_base_url = "{_IMBUE}"\n')
+    _write_first_boot(config_dir, f'domain = "fresh.example.com"\nimbue_connect_base_url = "{_IMBUE}"\n')
 
     seed_first_boot(cfg)
 
@@ -235,7 +235,7 @@ def test_seed_does_not_overwrite_existing_connect_url(monkeypatch: pytest.Monkey
         set_setting(db, IMBUE_CONNECT_BASE_URL_KEY, "https://existing.imbue.com")
     _write_first_boot(
         config_dir,
-        'domain = "fresh.example.com"\n' f'imbue_connect_base_url = "{_IMBUE}"\n',
+        f'domain = "fresh.example.com"\nimbue_connect_base_url = "{_IMBUE}"\n',
     )
 
     seed_first_boot(cfg)
@@ -271,7 +271,7 @@ def test_seed_preserves_existing_credential_but_still_seeds_connect_url(
         set_instance_identity(db, prior)
     _write_first_boot(
         config_dir,
-        'domain = "fresh.example.com"\n' f'imbue_connect_base_url = "{_IMBUE}"\n' + _FULL_IDENTITY,
+        f'domain = "fresh.example.com"\nimbue_connect_base_url = "{_IMBUE}"\n' + _FULL_IDENTITY,
     )
 
     seed_first_boot(cfg)

--- a/compute_space/src/compute_space/tests/test_first_boot_identity.py
+++ b/compute_space/src/compute_space/tests/test_first_boot_identity.py
@@ -1,0 +1,295 @@
+"""First-boot seeding of the shared Imbue credential + connect URL.
+
+``first_boot.toml`` may carry an ``[imbue_identity]`` table (issuer_url/client_id/
+client_secret) and a top-level ``imbue_connect_base_url``.  ``seed_first_boot``
+seeds them into the settings table, but only when the table has no credential yet
+(idempotent — a later Connect-to-Imbue must never be clobbered by a stale file on
+disk), and only when all three credential parts are present.
+"""
+
+from __future__ import annotations
+
+from contextlib import closing
+from pathlib import Path
+
+import pytest
+
+from compute_space.core.first_boot import read_first_boot
+from compute_space.core.first_boot import seed_first_boot
+from compute_space.core.identity_store import IMBUE_CONNECT_BASE_URL_KEY
+from compute_space.core.identity_store import IMBUE_IDENTITY_ISSUER_URL_KEY
+from compute_space.core.identity_store import get_connect_base_url
+from compute_space.core.identity_store import get_stored_instance_identity
+from compute_space.core.identity_store import set_instance_identity
+from compute_space.core.settings_store import get_setting
+from compute_space.core.settings_store import set_setting
+from compute_space.core.tls.keycloak import KeycloakClientCredentials
+from compute_space.db import init_db
+from compute_space.tests.conftest import _make_test_config
+from compute_space.tests.conftest import open_db
+
+_IMBUE = "https://openhost.imbue.com"
+
+# A full [imbue_identity] block for first_boot.toml.
+_FULL_IDENTITY = (
+    "[imbue_identity]\n"
+    'issuer_url = "https://kc/realms/openhost-customers"\n'
+    'client_id = "instance-alice"\n'
+    'client_secret = "sekret"\n'
+)
+
+
+def _cfg(tmp_path: Path):  # type: ignore[no-untyped-def]
+    # seed_primary=False: start from an empty (migrated) domains table; the
+    # first-boot seed itself installs the primary + identity.
+    cfg = _make_test_config(tmp_path, seed_primary=False)
+    init_db(cfg.db_path)  # migrate + point get_db() at this DB (seed opens its own conn)
+    return cfg
+
+
+def _point_config_env(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
+    config_toml = tmp_path / "config.toml"
+    config_toml.write_text("")  # only its directory matters
+    monkeypatch.setenv("OPENHOST_ROUTER_CONFIG", str(config_toml))
+    return tmp_path
+
+
+def _write_first_boot(config_dir: Path, body: str) -> None:
+    (config_dir / "first_boot.toml").write_text(body)
+
+
+def _expected_cred() -> KeycloakClientCredentials:
+    return KeycloakClientCredentials(
+        issuer_url="https://kc/realms/openhost-customers",
+        client_id="instance-alice",
+        client_secret="sekret",
+    )
+
+
+# --- read_first_boot: parsing the new fields ---------------------------------
+
+
+def test_read_first_boot_parses_identity_and_connect_url(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    config_dir = _point_config_env(monkeypatch, tmp_path)
+    _write_first_boot(
+        config_dir,
+        'domain = "fresh.example.com"\n' f'imbue_connect_base_url = "{_IMBUE}"\n' + _FULL_IDENTITY,
+    )
+    fb = read_first_boot()
+    assert fb is not None
+    assert fb.imbue_identity_issuer_url == "https://kc/realms/openhost-customers"
+    assert fb.imbue_identity_client_id == "instance-alice"
+    assert fb.imbue_identity_client_secret == "sekret"
+    assert fb.imbue_connect_base_url == _IMBUE
+
+
+def test_read_first_boot_identity_fields_none_when_block_absent(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    config_dir = _point_config_env(monkeypatch, tmp_path)
+    _write_first_boot(config_dir, 'domain = "fresh.example.com"\n')
+    fb = read_first_boot()
+    assert fb is not None
+    assert fb.imbue_identity_issuer_url is None
+    assert fb.imbue_identity_client_id is None
+    assert fb.imbue_identity_client_secret is None
+    assert fb.imbue_connect_base_url is None
+
+
+def test_read_first_boot_ignores_non_table_imbue_identity(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    # If imbue_identity is a scalar (not a table), it's ignored, not a crash.
+    config_dir = _point_config_env(monkeypatch, tmp_path)
+    _write_first_boot(config_dir, 'domain = "fresh.example.com"\nimbue_identity = "oops"\n')
+    fb = read_first_boot()
+    assert fb is not None
+    assert fb.imbue_identity_issuer_url is None
+
+
+def test_read_first_boot_partial_identity_fields(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    config_dir = _point_config_env(monkeypatch, tmp_path)
+    _write_first_boot(
+        config_dir,
+        'domain = "fresh.example.com"\n[imbue_identity]\nissuer_url = "iss"\nclient_id = "cid"\n',
+    )
+    fb = read_first_boot()
+    assert fb is not None
+    assert fb.imbue_identity_issuer_url == "iss"
+    assert fb.imbue_identity_client_id == "cid"
+    assert fb.imbue_identity_client_secret is None
+
+
+# --- seed_first_boot: full identity seeds ------------------------------------
+
+
+def test_seed_writes_identity_into_settings(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    cfg = _cfg(tmp_path)
+    config_dir = _point_config_env(monkeypatch, tmp_path)
+    _write_first_boot(config_dir, 'domain = "fresh.example.com"\n' + _FULL_IDENTITY)
+
+    seed_first_boot(cfg)
+
+    with closing(open_db(cfg)) as db:
+        assert get_stored_instance_identity(db) == _expected_cred()
+
+
+def test_seed_writes_connect_url_into_settings(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    cfg = _cfg(tmp_path)
+    config_dir = _point_config_env(monkeypatch, tmp_path)
+    _write_first_boot(
+        config_dir,
+        'domain = "fresh.example.com"\n' f'imbue_connect_base_url = "{_IMBUE}"\n' + _FULL_IDENTITY,
+    )
+
+    seed_first_boot(cfg)
+
+    with closing(open_db(cfg)) as db:
+        assert get_connect_base_url(db) == _IMBUE
+
+
+def test_seed_connect_url_without_identity(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    # The connect URL seeds independently of the credential: a first_boot.toml with
+    # only the connect URL (no identity) still installs the URL.
+    cfg = _cfg(tmp_path)
+    config_dir = _point_config_env(monkeypatch, tmp_path)
+    _write_first_boot(config_dir, 'domain = "fresh.example.com"\n' f'imbue_connect_base_url = "{_IMBUE}"\n')
+
+    seed_first_boot(cfg)
+
+    with closing(open_db(cfg)) as db:
+        assert get_connect_base_url(db) == _IMBUE
+        assert get_stored_instance_identity(db) is None
+
+
+# --- seed_first_boot: partial identity seeds nothing -------------------------
+
+
+def test_seed_partial_identity_seeds_no_credential(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    cfg = _cfg(tmp_path)
+    config_dir = _point_config_env(monkeypatch, tmp_path)
+    _write_first_boot(
+        config_dir,
+        'domain = "fresh.example.com"\n[imbue_identity]\nissuer_url = "iss"\nclient_id = "cid"\n',
+    )
+
+    seed_first_boot(cfg)
+
+    with closing(open_db(cfg)) as db:
+        assert get_stored_instance_identity(db) is None
+
+
+def test_seed_no_identity_block_seeds_nothing(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    cfg = _cfg(tmp_path)
+    config_dir = _point_config_env(monkeypatch, tmp_path)
+    _write_first_boot(config_dir, 'domain = "fresh.example.com"\n')
+
+    seed_first_boot(cfg)
+
+    with closing(open_db(cfg)) as db:
+        assert get_stored_instance_identity(db) is None
+        assert get_connect_base_url(db) is None
+
+
+# --- seed_first_boot: idempotency (never clobbers a stored credential) --------
+
+
+def test_seed_does_not_overwrite_existing_stored_identity(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    # A credential is already in the settings table (e.g. from a prior Connect).
+    # A stale first_boot.toml with a DIFFERENT identity must NOT overwrite it.
+    cfg = _cfg(tmp_path)
+    config_dir = _point_config_env(monkeypatch, tmp_path)
+    prior = KeycloakClientCredentials(issuer_url="prior-iss", client_id="prior-cid", client_secret="prior-sec")
+    with closing(open_db(cfg)) as db:
+        set_instance_identity(db, prior)
+    _write_first_boot(config_dir, 'domain = "fresh.example.com"\n' + _FULL_IDENTITY)
+
+    seed_first_boot(cfg)
+
+    with closing(open_db(cfg)) as db:
+        assert get_stored_instance_identity(db) == prior
+
+
+def test_seed_is_idempotent_across_two_boots(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    cfg = _cfg(tmp_path)
+    config_dir = _point_config_env(monkeypatch, tmp_path)
+    _write_first_boot(config_dir, 'domain = "fresh.example.com"\n' + _FULL_IDENTITY)
+    seed_first_boot(cfg)
+    # A second boot whose file carries a different identity must not re-seed.
+    _write_first_boot(
+        config_dir,
+        'domain = "fresh.example.com"\n[imbue_identity]\n'
+        'issuer_url = "other-iss"\nclient_id = "other-cid"\nclient_secret = "other-sec"\n',
+    )
+    seed_first_boot(cfg)
+
+    with closing(open_db(cfg)) as db:
+        assert get_stored_instance_identity(db) == _expected_cred()
+
+
+# --- seed_first_boot: connect url only seeded when absent ---------------------
+
+
+def test_seed_does_not_overwrite_existing_connect_url(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    cfg = _cfg(tmp_path)
+    config_dir = _point_config_env(monkeypatch, tmp_path)
+    with closing(open_db(cfg)) as db:
+        set_setting(db, IMBUE_CONNECT_BASE_URL_KEY, "https://existing.imbue.com")
+    _write_first_boot(
+        config_dir,
+        'domain = "fresh.example.com"\n' f'imbue_connect_base_url = "{_IMBUE}"\n',
+    )
+
+    seed_first_boot(cfg)
+
+    with closing(open_db(cfg)) as db:
+        assert get_connect_base_url(db) == "https://existing.imbue.com"
+
+
+def test_seed_connect_url_absent_when_not_in_first_boot(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    cfg = _cfg(tmp_path)
+    config_dir = _point_config_env(monkeypatch, tmp_path)
+    _write_first_boot(config_dir, 'domain = "fresh.example.com"\n' + _FULL_IDENTITY)
+
+    seed_first_boot(cfg)
+
+    with closing(open_db(cfg)) as db:
+        assert get_connect_base_url(db) is None
+
+
+# --- seed_first_boot: stored identity untouched even when file adds a URL ------
+
+
+def test_seed_preserves_existing_credential_but_still_seeds_connect_url(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    # A pre-existing stored credential is NOT clobbered by a stale first_boot.toml,
+    # but the credential and the connect URL are seeded independently — so the
+    # connect URL still seeds even when the credential is already present.
+    cfg = _cfg(tmp_path)
+    config_dir = _point_config_env(monkeypatch, tmp_path)
+    prior = KeycloakClientCredentials(issuer_url="prior-iss", client_id="prior-cid", client_secret="prior-sec")
+    with closing(open_db(cfg)) as db:
+        set_instance_identity(db, prior)
+    _write_first_boot(
+        config_dir,
+        'domain = "fresh.example.com"\n' f'imbue_connect_base_url = "{_IMBUE}"\n' + _FULL_IDENTITY,
+    )
+
+    seed_first_boot(cfg)
+
+    with closing(open_db(cfg)) as db:
+        # Credential preserved (not clobbered); connect URL seeded independently.
+        assert get_stored_instance_identity(db) == prior
+        assert get_connect_base_url(db) == _IMBUE
+
+
+def test_seed_does_not_write_identity_keys_when_no_identity(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    # A no-identity first boot must leave the identity settings keys entirely unset
+    # (not written as empty strings).
+    cfg = _cfg(tmp_path)
+    config_dir = _point_config_env(monkeypatch, tmp_path)
+    _write_first_boot(config_dir, 'domain = "fresh.example.com"\n')
+
+    seed_first_boot(cfg)
+
+    with closing(open_db(cfg)) as db:
+        assert get_setting(db, IMBUE_IDENTITY_ISSUER_URL_KEY) is None

--- a/compute_space/src/compute_space/tests/test_identity_store.py
+++ b/compute_space/src/compute_space/tests/test_identity_store.py
@@ -231,9 +231,7 @@ def test_repeated_set_is_idempotent(db: sqlite3.Connection) -> None:
         set_instance_identity(db, _cred("iss", "cid", "sec"))
     assert get_stored_instance_identity(db) == _cred("iss", "cid", "sec")
     # No duplicate rows accumulate under the ON CONFLICT upsert.
-    rows = db.execute(
-        "SELECT COUNT(*) AS n FROM settings WHERE key = ?", (IMBUE_IDENTITY_ISSUER_URL_KEY,)
-    ).fetchone()
+    rows = db.execute("SELECT COUNT(*) AS n FROM settings WHERE key = ?", (IMBUE_IDENTITY_ISSUER_URL_KEY,)).fetchone()
     assert rows["n"] == 1
 
 

--- a/compute_space/src/compute_space/tests/test_identity_store.py
+++ b/compute_space/src/compute_space/tests/test_identity_store.py
@@ -1,0 +1,291 @@
+"""The shared per-instance Imbue credential store (``core/identity_store``).
+
+The credential lives in the DB ``settings`` table.  ``get_instance_identity``
+resolves it, falling back to the deprecated ``cert_api_keycloak_*`` config fields
+for already-deployed instances; ``get_stored_instance_identity`` reads the settings
+table only.  These tests pin the resolution rules (all-three-or-nothing, settings
+precedence, config fallback) directly against a real DB + Config.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+from compute_space.config import Config
+from compute_space.config import DefaultConfig
+from compute_space.core.identity_store import IMBUE_CONNECT_BASE_URL_KEY
+from compute_space.core.identity_store import IMBUE_IDENTITY_CLIENT_ID_KEY
+from compute_space.core.identity_store import IMBUE_IDENTITY_CLIENT_SECRET_KEY
+from compute_space.core.identity_store import IMBUE_IDENTITY_ISSUER_URL_KEY
+from compute_space.core.identity_store import get_connect_base_url
+from compute_space.core.identity_store import get_instance_identity
+from compute_space.core.identity_store import get_stored_instance_identity
+from compute_space.core.identity_store import set_instance_identity
+from compute_space.core.settings_store import get_setting
+from compute_space.core.settings_store import set_setting
+from compute_space.core.tls.keycloak import KeycloakClientCredentials
+
+# --- helpers -----------------------------------------------------------------
+
+
+def _cred(
+    issuer: str = "https://kc.example/realms/openhost-customers",
+    client_id: str = "instance-alice",
+    secret: str = "s3kret",
+) -> KeycloakClientCredentials:
+    return KeycloakClientCredentials(issuer_url=issuer, client_id=client_id, client_secret=secret)
+
+
+def _empty_config() -> Config:
+    """A config with no cert_api_keycloak_* fallback configured."""
+    return DefaultConfig()
+
+
+def _config_with_fallback(
+    issuer: str | None = "https://cfg.example/realms/openhost-customers",
+    client_id: str | None = "cfg-client",
+    secret: str | None = "cfg-secret",
+) -> Config:
+    return DefaultConfig(
+        cert_api_keycloak_issuer_url=issuer,
+        cert_api_keycloak_client_id=client_id,
+        cert_api_keycloak_client_secret=secret,
+    )
+
+
+# --- key constants (guard against silent renames) ----------------------------
+
+
+def test_key_constants_are_the_documented_strings() -> None:
+    assert IMBUE_IDENTITY_ISSUER_URL_KEY == "imbue_identity_issuer_url"
+    assert IMBUE_IDENTITY_CLIENT_ID_KEY == "imbue_identity_client_id"
+    assert IMBUE_IDENTITY_CLIENT_SECRET_KEY == "imbue_identity_client_secret"
+    assert IMBUE_CONNECT_BASE_URL_KEY == "imbue_connect_base_url"
+
+
+# --- set / get round-trip ----------------------------------------------------
+
+
+def test_set_then_get_round_trips(db: sqlite3.Connection) -> None:
+    set_instance_identity(db, _cred())
+    got = get_instance_identity(db, _empty_config())
+    assert got == _cred()
+
+
+def test_set_writes_all_three_settings_keys(db: sqlite3.Connection) -> None:
+    set_instance_identity(db, _cred("iss", "cid", "sec"))
+    assert get_setting(db, IMBUE_IDENTITY_ISSUER_URL_KEY) == "iss"
+    assert get_setting(db, IMBUE_IDENTITY_CLIENT_ID_KEY) == "cid"
+    assert get_setting(db, IMBUE_IDENTITY_CLIENT_SECRET_KEY) == "sec"
+
+
+def test_get_stored_round_trips(db: sqlite3.Connection) -> None:
+    set_instance_identity(db, _cred("iss", "cid", "sec"))
+    assert get_stored_instance_identity(db) == _cred("iss", "cid", "sec")
+
+
+def test_get_returns_a_keycloak_client_credentials_instance(db: sqlite3.Connection) -> None:
+    set_instance_identity(db, _cred())
+    got = get_instance_identity(db, _empty_config())
+    assert isinstance(got, KeycloakClientCredentials)
+    assert got is not None
+    assert got.issuer_url == "https://kc.example/realms/openhost-customers"
+    assert got.client_id == "instance-alice"
+    assert got.client_secret == "s3kret"
+
+
+# --- None when nothing configured --------------------------------------------
+
+
+def test_get_none_when_empty_and_no_fallback(db: sqlite3.Connection) -> None:
+    assert get_instance_identity(db, _empty_config()) is None
+
+
+def test_get_stored_none_when_empty(db: sqlite3.Connection) -> None:
+    assert get_stored_instance_identity(db) is None
+
+
+# --- partial settings -> None ------------------------------------------------
+
+
+def test_get_none_when_only_issuer_set(db: sqlite3.Connection) -> None:
+    set_setting(db, IMBUE_IDENTITY_ISSUER_URL_KEY, "iss")
+    assert get_instance_identity(db, _empty_config()) is None
+
+
+def test_get_none_when_only_client_id_set(db: sqlite3.Connection) -> None:
+    set_setting(db, IMBUE_IDENTITY_CLIENT_ID_KEY, "cid")
+    assert get_instance_identity(db, _empty_config()) is None
+
+
+def test_get_none_when_only_secret_set(db: sqlite3.Connection) -> None:
+    set_setting(db, IMBUE_IDENTITY_CLIENT_SECRET_KEY, "sec")
+    assert get_instance_identity(db, _empty_config()) is None
+
+
+def test_get_none_when_two_of_three_set_missing_secret(db: sqlite3.Connection) -> None:
+    set_setting(db, IMBUE_IDENTITY_ISSUER_URL_KEY, "iss")
+    set_setting(db, IMBUE_IDENTITY_CLIENT_ID_KEY, "cid")
+    assert get_instance_identity(db, _empty_config()) is None
+
+
+def test_get_none_when_two_of_three_set_missing_client_id(db: sqlite3.Connection) -> None:
+    set_setting(db, IMBUE_IDENTITY_ISSUER_URL_KEY, "iss")
+    set_setting(db, IMBUE_IDENTITY_CLIENT_SECRET_KEY, "sec")
+    assert get_instance_identity(db, _empty_config()) is None
+
+
+def test_get_none_when_two_of_three_set_missing_issuer(db: sqlite3.Connection) -> None:
+    set_setting(db, IMBUE_IDENTITY_CLIENT_ID_KEY, "cid")
+    set_setting(db, IMBUE_IDENTITY_CLIENT_SECRET_KEY, "sec")
+    assert get_instance_identity(db, _empty_config()) is None
+
+
+def test_get_stored_none_when_partial(db: sqlite3.Connection) -> None:
+    set_setting(db, IMBUE_IDENTITY_ISSUER_URL_KEY, "iss")
+    set_setting(db, IMBUE_IDENTITY_CLIENT_ID_KEY, "cid")
+    assert get_stored_instance_identity(db) is None
+
+
+# --- empty-string values are falsy -> treated as missing ---------------------
+
+
+def test_get_none_when_a_setting_is_empty_string(db: sqlite3.Connection) -> None:
+    set_setting(db, IMBUE_IDENTITY_ISSUER_URL_KEY, "iss")
+    set_setting(db, IMBUE_IDENTITY_CLIENT_ID_KEY, "cid")
+    set_setting(db, IMBUE_IDENTITY_CLIENT_SECRET_KEY, "")
+    assert get_instance_identity(db, _empty_config()) is None
+
+
+def test_get_stored_none_when_a_setting_is_empty_string(db: sqlite3.Connection) -> None:
+    set_setting(db, IMBUE_IDENTITY_ISSUER_URL_KEY, "")
+    set_setting(db, IMBUE_IDENTITY_CLIENT_ID_KEY, "cid")
+    set_setting(db, IMBUE_IDENTITY_CLIENT_SECRET_KEY, "sec")
+    assert get_stored_instance_identity(db) is None
+
+
+# --- config fallback ---------------------------------------------------------
+
+
+def test_config_fallback_used_when_settings_empty(db: sqlite3.Connection) -> None:
+    got = get_instance_identity(db, _config_with_fallback())
+    assert got == KeycloakClientCredentials(
+        issuer_url="https://cfg.example/realms/openhost-customers",
+        client_id="cfg-client",
+        client_secret="cfg-secret",
+    )
+
+
+def test_config_fallback_none_when_config_partial_missing_secret(db: sqlite3.Connection) -> None:
+    cfg = _config_with_fallback(secret=None)
+    assert get_instance_identity(db, cfg) is None
+
+
+def test_config_fallback_none_when_config_partial_missing_issuer(db: sqlite3.Connection) -> None:
+    cfg = _config_with_fallback(issuer=None)
+    assert get_instance_identity(db, cfg) is None
+
+
+def test_config_fallback_none_when_config_partial_missing_client_id(db: sqlite3.Connection) -> None:
+    cfg = _config_with_fallback(client_id=None)
+    assert get_instance_identity(db, cfg) is None
+
+
+def test_get_stored_ignores_config_fallback(db: sqlite3.Connection) -> None:
+    # A config fallback exists, but the settings table is empty.
+    assert get_stored_instance_identity(db) is None
+
+
+# --- settings precedence over config fallback --------------------------------
+
+
+def test_settings_take_precedence_over_config_fallback(db: sqlite3.Connection) -> None:
+    set_instance_identity(db, _cred("settings-iss", "settings-cid", "settings-sec"))
+    got = get_instance_identity(db, _config_with_fallback())
+    assert got == _cred("settings-iss", "settings-cid", "settings-sec")
+
+
+def test_per_field_fallback_mixes_settings_and_config(db: sqlite3.Connection) -> None:
+    # The resolver falls back per-field: only the client_secret is in settings,
+    # the other two come from config. All three resolve -> a credential.
+    cfg = _config_with_fallback()
+    set_setting(db, IMBUE_IDENTITY_CLIENT_SECRET_KEY, "override-secret")
+    got = get_instance_identity(db, cfg)
+    assert got is not None
+    assert got.issuer_url == "https://cfg.example/realms/openhost-customers"
+    assert got.client_id == "cfg-client"
+    assert got.client_secret == "override-secret"
+
+
+# --- overwrite / idempotency -------------------------------------------------
+
+
+def test_set_overwrites_previous_identity(db: sqlite3.Connection) -> None:
+    set_instance_identity(db, _cred("old-iss", "old-cid", "old-sec"))
+    set_instance_identity(db, _cred("new-iss", "new-cid", "new-sec"))
+    assert get_stored_instance_identity(db) == _cred("new-iss", "new-cid", "new-sec")
+
+
+def test_repeated_set_is_idempotent(db: sqlite3.Connection) -> None:
+    for _ in range(3):
+        set_instance_identity(db, _cred("iss", "cid", "sec"))
+    assert get_stored_instance_identity(db) == _cred("iss", "cid", "sec")
+    # No duplicate rows accumulate under the ON CONFLICT upsert.
+    rows = db.execute(
+        "SELECT COUNT(*) AS n FROM settings WHERE key = ?", (IMBUE_IDENTITY_ISSUER_URL_KEY,)
+    ).fetchone()
+    assert rows["n"] == 1
+
+
+# --- unicode / long / whitespace values --------------------------------------
+
+
+def test_round_trips_unicode_values(db: sqlite3.Connection) -> None:
+    cred = _cred("https://kc.exämple/realms/naïve", "instance-café", "sëcret-ü")
+    set_instance_identity(db, cred)
+    assert get_stored_instance_identity(db) == cred
+
+
+def test_round_trips_long_values(db: sqlite3.Connection) -> None:
+    cred = _cred("https://kc/" + "a" * 4000, "c" * 2000, "s" * 5000)
+    set_instance_identity(db, cred)
+    assert get_stored_instance_identity(db) == cred
+
+
+def test_whitespace_only_values_are_truthy_and_resolve(db: sqlite3.Connection) -> None:
+    # identity_store treats any non-empty string as present (no strip()), so a
+    # whitespace-only value resolves (it is truthy). Pins the actual behavior.
+    cred = _cred(" ", " ", " ")
+    set_instance_identity(db, cred)
+    assert get_stored_instance_identity(db) == cred
+
+
+# --- connect base url --------------------------------------------------------
+
+
+def test_get_connect_base_url_none_when_absent(db: sqlite3.Connection) -> None:
+    assert get_connect_base_url(db) is None
+
+
+def test_get_connect_base_url_present(db: sqlite3.Connection) -> None:
+    set_setting(db, IMBUE_CONNECT_BASE_URL_KEY, "https://openhost.imbue.com")
+    assert get_connect_base_url(db) == "https://openhost.imbue.com"
+
+
+def test_get_connect_base_url_empty_string_returned_verbatim(db: sqlite3.Connection) -> None:
+    # get_connect_base_url returns the stored value directly (no truthiness
+    # collapsing), so an empty string comes back as "".
+    set_setting(db, IMBUE_CONNECT_BASE_URL_KEY, "")
+    assert get_connect_base_url(db) == ""
+
+
+def test_connect_base_url_is_independent_of_identity(db: sqlite3.Connection) -> None:
+    set_setting(db, IMBUE_CONNECT_BASE_URL_KEY, "https://openhost.imbue.com")
+    # Setting the connect URL does not conjure an identity.
+    assert get_instance_identity(db, _empty_config()) is None
+    assert get_connect_base_url(db) == "https://openhost.imbue.com"
+
+
+def test_setting_identity_does_not_set_connect_base_url(db: sqlite3.Connection) -> None:
+    set_instance_identity(db, _cred())
+    assert get_connect_base_url(db) is None

--- a/compute_space/src/compute_space/web/routes/api/settings.py
+++ b/compute_space/src/compute_space/web/routes/api/settings.py
@@ -3,17 +3,28 @@ from __future__ import annotations
 import asyncio
 import sqlite3
 from enum import StrEnum
+from typing import Any
 
 import attr
 import bcrypt
+from litestar import Request
 from litestar import Router
 from litestar import get
 from litestar import post
 from litestar.exceptions import HTTPException
+from litestar.response import Redirect
 
+from compute_space.config import Config
 from compute_space.core.auth.auth import read_owner_username
 from compute_space.core.auth.auth import update_owner_username
 from compute_space.core.auth.auth import validate_owner_username
+from compute_space.core.connect import ConnectError
+from compute_space.core.connect import build_connect_url
+from compute_space.core.connect import exchange_code_for_credential
+from compute_space.core.domains import primary_domain
+from compute_space.core.identity_store import get_connect_base_url
+from compute_space.core.identity_store import get_instance_identity
+from compute_space.core.identity_store import set_instance_identity
 from compute_space.core.system_agent import SystemAgentError
 from compute_space.core.system_agent import system_agent_apply
 from compute_space.core.system_agent import system_agent_fetch
@@ -147,6 +158,72 @@ async def restart_compute_space() -> None:
     trigger_restart()
 
 
+# --- Connect to Imbue -------------------------------------------------------
+
+
+@attr.s(auto_attribs=True, frozen=True)
+class ConnectStatusResponse:
+    # Whether the "Connect to Imbue" button should be shown (an Imbue URL is
+    # configured) and whether this instance already holds a credential.
+    available: bool
+    connected: bool
+
+
+@attr.s(auto_attribs=True, frozen=True)
+class ConnectStartResponse:
+    # The Imbue authorization URL the browser should be sent to.
+    redirect_url: str
+
+
+@get("/api/settings/connect-imbue/status", guards=[require_owner_auth])
+async def connect_imbue_status(config: Config, db: sqlite3.Connection) -> ConnectStatusResponse:
+    return ConnectStatusResponse(
+        available=bool(get_connect_base_url(db)),
+        connected=get_instance_identity(db, config) is not None,
+    )
+
+
+@post("/api/settings/connect-imbue/start", status_code=200, guards=[require_owner_auth])
+async def connect_imbue_start(
+    config: Config, db: sqlite3.Connection, request: Request[Any, Any, Any]
+) -> ConnectStartResponse:
+    frontend = get_connect_base_url(db)
+    if not frontend:
+        raise HTTPException(detail="Connect to Imbue is not available on this deployment", status_code=503)
+    # The one-time code is returned to this instance's own https origin, so derive
+    # it from the request (honoring proxy headers).
+    scheme = request.headers.get("x-forwarded-proto") or request.url.scheme
+    zone = primary_domain(db).name
+    host = request.headers.get("x-forwarded-host") or request.headers.get("host") or zone
+    instance_base = f"{scheme}://{host}"
+    redirect_url = build_connect_url(frontend, zone, instance_base)
+    return ConnectStartResponse(redirect_url=redirect_url)
+
+
+@get("/api/settings/connect-imbue/callback", guards=[require_owner_auth], sync_to_thread=True)
+def connect_imbue_callback(config: Config, db: sqlite3.Connection, code: str = "") -> Redirect:
+    """Exchange the one-time code and store the credential.
+
+    Imbue returns the one-time code here (?code=). We exchange it for the credential
+    and write it into the DB settings table, which is read live by the services
+    that use it — so no restart is needed. Redirects back to Settings.
+
+    Sync + sync_to_thread so the blocking exchange (httpx) doesn't stall the event
+    loop for other (proxied app) traffic.
+    """
+    frontend = get_connect_base_url(db)
+    if not frontend:
+        raise HTTPException(detail="Connect to Imbue is not available on this deployment", status_code=503)
+    if not code.strip():
+        return Redirect(path="/settings?connect=error")
+    try:
+        credential = exchange_code_for_credential(frontend, code.strip())
+        set_instance_identity(db, credential)
+    except ConnectError as e:
+        raise HTTPException(detail=str(e), status_code=502) from e
+    return Redirect(path="/settings?connect=ok")
+
+
 @attr.s(auto_attribs=True, frozen=True)
 class ChangePasswordRequest:
     current_password: str
@@ -219,6 +296,9 @@ api_settings_routes = Router(
         check_for_updates,
         apply_update,
         restart_compute_space,
+        connect_imbue_status,
+        connect_imbue_start,
+        connect_imbue_callback,
         change_password,
         get_owner_username,
         set_owner_username,

--- a/compute_space/src/compute_space/web/static/js/settings.js
+++ b/compute_space/src/compute_space/web/static/js/settings.js
@@ -649,9 +649,76 @@ function loadArchiveBackend() {
     });
 }
 
+// --- Connect to Imbue -------------------------------------------------------
+
+async function loadConnectImbueStatus() {
+  const section = document.getElementById('connect-imbue-section');
+  const state = document.getElementById('connect-imbue-state');
+  const btn = document.getElementById('connect-imbue-btn');
+  try {
+    const resp = await fetch('/api/settings/connect-imbue/status');
+    if (!resp.ok) return;  // feature not present; leave the section hidden
+    const data = await resp.json();
+    if (!data.available) return;  // no Imbue URL configured
+    section.style.display = '';
+    if (data.connected) {
+      state.textContent = 'Connected to Imbue.';
+      btn.textContent = 'Reconnect to Imbue';
+    } else {
+      state.textContent = 'Not connected.';
+      btn.textContent = 'Connect to Imbue';
+    }
+    btn.style.display = '';
+  } catch (e) {
+    // Non-fatal: the section just stays hidden.
+  }
+}
+
+async function connectImbue() {
+  clearError();
+  const btn = document.getElementById('connect-imbue-btn');
+  const msg = document.getElementById('connect-imbue-msg');
+  btn.disabled = true;
+  try {
+    const resp = await fetch('/api/settings/connect-imbue/start', { method: 'POST' });
+    if (!resp.ok) {
+      const err = await resp.json();
+      throw new Error(err.detail || 'failed to start');
+    }
+    const data = await resp.json();
+    // Hand off to Imbue to authorize; it returns to this instance's callback,
+    // which persists the credential + restarts.
+    window.location.href = data.redirect_url;
+  } catch (e) {
+    btn.disabled = false;
+    msg.textContent = 'Could not start connect: ' + e.message;
+    msg.className = 'error';
+    msg.style.display = '';
+  }
+}
+
+// Surface the ?connect=ok|error result of a completed callback round-trip.
+(function showConnectResult() {
+  const params = new URLSearchParams(window.location.search);
+  const result = params.get('connect');
+  if (!result) return;
+  const msg = document.getElementById('connect-imbue-msg');
+  if (!msg) return;
+  if (result === 'ok') {
+    msg.textContent = 'Connected. The instance is restarting to apply your Imbue credential.';
+    msg.className = '';
+    msg.style.color = '#2ea043';
+  } else {
+    msg.textContent = 'Connecting to Imbue failed. Please try again.';
+    msg.className = 'error';
+  }
+  msg.style.display = '';
+})();
+
 loadOwnerUsername();
 loadRemote();
 checkForUpdates();
 updateSshStatus();
 setInterval(updateSshStatus, 5000);
 loadArchiveBackend();
+loadConnectImbueStatus();

--- a/compute_space/src/compute_space/web/static/js/settings.js
+++ b/compute_space/src/compute_space/web/static/js/settings.js
@@ -687,7 +687,7 @@ async function connectImbue() {
     }
     const data = await resp.json();
     // Hand off to Imbue to authorize; it returns to this instance's callback,
-    // which persists the credential + restarts.
+    // which stores the credential.
     window.location.href = data.redirect_url;
   } catch (e) {
     btn.disabled = false;
@@ -705,7 +705,7 @@ async function connectImbue() {
   const msg = document.getElementById('connect-imbue-msg');
   if (!msg) return;
   if (result === 'ok') {
-    msg.textContent = 'Connected. The instance is restarting to apply your Imbue credential.';
+    msg.textContent = 'Connected to Imbue.';
     msg.className = '';
     msg.style.color = '#2ea043';
   } else {

--- a/compute_space/src/compute_space/web/templates/settings.html
+++ b/compute_space/src/compute_space/web/templates/settings.html
@@ -42,6 +42,21 @@
   </tr>
 </table>
 
+<div id="connect-imbue-section" style="display:none;">
+  <h2 class="section-title">Imbue account</h2>
+  <table class="form-table">
+    <tr>
+      <th>Connection</th>
+      <td>
+        <p id="connect-imbue-state" class="muted" style="margin-bottom:1em;">Checking&hellip;</p>
+        <button id="connect-imbue-btn" onclick="connectImbue()" class="btn btn-primary" style="display:none;">Connect to Imbue</button>
+        <p class="hint">Connect this instance to your Imbue account to enable Imbue services. Managed instances are connected automatically; use this if yours isn't, or to reconnect.</p>
+        <p id="connect-imbue-msg" style="display:none;"></p>
+      </td>
+    </tr>
+  </table>
+</div>
+
 <h2 class="section-title">Software updates</h2>
 <table class="form-table">
   <tr>


### PR DESCRIPTION
Introduce a single shared per-instance Imbue credential that authenticates the instance to Imbue services, plus a Connect to Imbue flow. Reworked to use the DB settings table + first_boot.toml introduced in #249 (no config.toml mutation, no restart).

State management: the credential lives in the DB settings table (core/identity_store.py), read live like domains. Managed spaces seed it from first_boot.toml on first boot; non-managed spaces obtain it via Connect. cert-api reads the credential from the store, falling back to the deprecated cert_api_keycloak_* config fields for already-deployed instances.

Connect to Imbue: a Settings section sends the owner to Imbue to authorize; Imbue returns a one-time code, which the instance exchanges server-to-server and writes to the settings table. No config file mutation, no restart (read live). Verified live end to end on a real instance: the credential lands in the settings table and the status endpoint flips to connected with no restart.

Around 113 new tests plus 50+ live edge cases on a real instance; pre-commit and test CI green.

Depends on #249 (merged).