### PR TITLE
Fix S3 bug deleting data when migrating to the same volume

### DIFF
--- a/compute_space/src/compute_space/core/archive_backend.py
+++ b/compute_space/src/compute_space/core/archive_backend.py
@@ -1425,14 +1425,9 @@ def configure_backend(
         assert state.s3_bucket is not None
         assert state.s3_access_key_id is not None
         assert state.s3_secret_access_key is not None
-        # Skip reclaim in the degenerate case where the new store is the SAME
-        # bucket+endpoint+prefix as the old (a no-op "migration"): deleting the
-        # prefix would wipe the data we just kept in place.
-        same_location = (
-            state.s3_bucket == s3_bucket
-            and (state.s3_endpoint or None) == (s3_endpoint or None)
-            and (state.s3_region or None) == (s3_region or None)
-        )
+        # Check for whether the source is the same location and do not delete if so
+        source_volume = state.juicefs_volume_name or DEFAULT_VOLUME_NAME
+        same_location = state.s3_bucket == s3_bucket and source_volume == volume
         if not same_location:
             _remove_s3_object_prefix(
                 s3_bucket=state.s3_bucket,

--- a/compute_space/src/compute_space/tests/test_archive_backend.py
+++ b/compute_space/src/compute_space/tests/test_archive_backend.py
@@ -744,7 +744,7 @@ def test_configure_backend_s3_to_s3_preserves_legacy_openhost_volume(cfg, db):
 
 
 def test_configure_backend_s3_to_s3_same_location_skips_reclaim(cfg, db):
-    """A no-op 'migration' to the SAME bucket/endpoint/region must NOT reclaim
+    """A no-op 'migration' to the SAME (bucket, volume) must NOT reclaim
     the prefix (that would delete the data we kept in place)."""
     db.execute(
         "UPDATE archive_backend SET backend='s3', s3_bucket='b', s3_region='us-east-1', "


### PR DESCRIPTION
Failure case was when s3_region was previously set and new location is None, which resolves to the same location but fails the equality check. Also was sensitive to exact url spelling.