### PR TITLE
Fix container-name conflict when spamming reload (OH-104)

### DIFF
--- a/compute_space/src/compute_space/tests/test_integration.py
+++ b/compute_space/src/compute_space/tests/test_integration.py
@@ -1468,21 +1468,35 @@ class TestGitUrlDeployE2E:
         assert r.json().get("app_name") == self.APP_NAME
 
     def test_app_detail_running(self, admin_session, config):
-        """Wait for the Git-cloned app to finish building and reach running status."""
+        """Wait for the Git-cloned app to finish building and reach running status.
+
+        Polls the ``/api/app_status`` DB status rather than substring-matching
+        the ``/app_detail`` HTML: that page inlines a ``.status-running`` CSS
+        rule via layout.html, so ``"running" in r.text`` is true regardless of
+        the app's actual status and would let this gate pass while the app is
+        still 'building'/'starting'.  A settled 'running' status is a genuine
+        precondition for the later reload test, which is refused with 409 while
+        the app sits in a transient state.
+        """
         base_url = _zone_url(config)
         deadline = time.time() + 120
-        r = None
+        status = None
         while time.time() < deadline:
             app_id = app_id_for(admin_session, base_url, self.APP_NAME)
             if app_id:
-                r = admin_session.get(
-                    f"{base_url}/app_detail/{self.APP_NAME}",
-                )
-                if r.status_code == 200 and "running" in r.text:
-                    break
+                sr = admin_session.get(f"{base_url}/api/app_status/{app_id}")
+                if sr.status_code == 200:
+                    status = sr.json().get("status")
+                    if status == "running":
+                        break
+                    if status == "error":
+                        pytest.fail(f"Git-deployed app entered error state: {sr.json().get('error')}")
             time.sleep(2)
-        assert r is not None and r.status_code == 200
-        assert "running" in r.text
+        assert status == "running", f"Git-deployed app did not reach running status (last status={status})"
+
+        # The app_detail page should also render and report the running status.
+        r = admin_session.get(f"{base_url}/app_detail/{self.APP_NAME}")
+        assert r.status_code == 200
 
     # -- proxy: verify the cloned app works --
 

--- a/compute_space/src/compute_space/tests/test_reload_concurrent.py
+++ b/compute_space/src/compute_space/tests/test_reload_concurrent.py
@@ -1,0 +1,152 @@
+"""Tests for the concurrent-reload guard on ``/reload_app/<app_id>``.
+
+Spamming the "Reload" button used to spawn several ``reload_app_background``
+threads that raced to create the same ``openhost-<name>`` container and failed
+with "container name is already in use" (OH-104). ``_reload_app_impl`` now
+atomically claims the reload — flipping the row to 'building' only if it isn't
+already in a transient state — so a second concurrent reload is refused with a
+409 instead of spawning a competing worker.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+from litestar import Litestar
+from litestar.testing import TestClient
+
+from compute_space.core.app_id import new_app_id
+from compute_space.db.connection import init_db
+from compute_space.tests._litestar_helpers import auth_cookie
+from compute_space.tests._litestar_helpers import make_test_app
+from compute_space.tests.conftest import _make_test_config
+from compute_space.web.routes.api.apps import api_apps_routes
+
+
+@pytest.fixture
+def cfg(tmp_path: Path) -> Any:
+    cfg = _make_test_config(tmp_path)
+    init_db(cfg.db_path)
+    return cfg
+
+
+@pytest.fixture
+def client(cfg: Any) -> Iterator[TestClient[Litestar]]:
+    with TestClient(app=make_test_app(api_apps_routes)) as c:
+        yield c
+
+
+@pytest.fixture
+def cookies(cfg: Any) -> dict[str, str]:
+    return auth_cookie(cfg)
+
+
+def _seed_app(db_path: str, name: str, status: str = "running") -> str:
+    app_id = new_app_id()
+    db = sqlite3.connect(db_path)
+    try:
+        db.execute(
+            "INSERT INTO apps (app_id, name, version, repo_path, local_port, status) "
+            "VALUES (?, ?, '1.0', '/r', 19500, ?)",
+            (app_id, name, status),
+        )
+        db.commit()
+    finally:
+        db.close()
+    return app_id
+
+
+def _status(db_path: str, app_id: str) -> str:
+    db = sqlite3.connect(db_path)
+    try:
+        row = db.execute("SELECT status FROM apps WHERE app_id = ?", (app_id,)).fetchone()
+    finally:
+        db.close()
+    assert row is not None
+    return str(row[0])
+
+
+def test_plain_reload_claims_building_and_spawns_worker(
+    cfg: Any, client: TestClient[Litestar], cookies: dict[str, str]
+) -> None:
+    """A first reload flips the row to 'building', stops the old container,
+    and spawns a background worker."""
+    app_id = _seed_app(cfg.db_path, "myapp")
+
+    with (
+        patch("compute_space.web.routes.api.apps.Thread") as Thread,
+        patch("compute_space.web.routes.api.apps.stop_app_process") as stop,
+    ):
+        resp = client.post(f"/reload_app/{app_id}", cookies=cookies)
+
+    assert resp.status_code == 200
+    assert resp.json() == {"ok": True}
+    Thread.assert_called_once()
+    Thread.return_value.start.assert_called_once()
+    stop.assert_called_once()
+    assert _status(cfg.db_path, app_id) == "building"
+
+
+@pytest.mark.parametrize("busy_status", ["building", "starting"])
+def test_reload_refused_while_transient(
+    cfg: Any, client: TestClient[Litestar], cookies: dict[str, str], busy_status: str
+) -> None:
+    """A reload is refused with 409 while an operation is already in flight
+    (the row is in a transient state), and no second worker is spawned nor
+    is the running container stopped."""
+    app_id = _seed_app(cfg.db_path, "busyapp", status=busy_status)
+
+    with (
+        patch("compute_space.web.routes.api.apps.Thread") as Thread,
+        patch("compute_space.web.routes.api.apps.stop_app_process") as stop,
+    ):
+        resp = client.post(f"/reload_app/{app_id}", cookies=cookies)
+
+    assert resp.status_code == 409
+    assert resp.json()["error"] == "App is already reloading"
+    Thread.assert_not_called()
+    stop.assert_not_called()
+    # The in-flight operation's status is left untouched.
+    assert _status(cfg.db_path, app_id) == busy_status
+
+
+def test_reload_refused_while_removing(
+    cfg: Any, client: TestClient[Litestar], cookies: dict[str, str]
+) -> None:
+    """A removing app is refused earlier (by the dedicated removing guard),
+    also with 409 and no worker — belt-and-suspenders with the reload claim."""
+    app_id = _seed_app(cfg.db_path, "goingaway", status="removing")
+
+    with (
+        patch("compute_space.web.routes.api.apps.Thread") as Thread,
+        patch("compute_space.web.routes.api.apps.stop_app_process") as stop,
+    ):
+        resp = client.post(f"/reload_app/{app_id}", cookies=cookies)
+
+    assert resp.status_code == 409
+    Thread.assert_not_called()
+    stop.assert_not_called()
+    assert _status(cfg.db_path, app_id) == "removing"
+
+
+@pytest.mark.parametrize("reloadable_status", ["running", "stopped", "error"])
+def test_reload_allowed_from_settled_states(
+    cfg: Any, client: TestClient[Litestar], cookies: dict[str, str], reloadable_status: str
+) -> None:
+    """A settled app (running/stopped/error) can always be reloaded."""
+    app_id = _seed_app(cfg.db_path, "settled", status=reloadable_status)
+
+    with (
+        patch("compute_space.web.routes.api.apps.Thread") as Thread,
+        patch("compute_space.web.routes.api.apps.stop_app_process"),
+    ):
+        resp = client.post(f"/reload_app/{app_id}", cookies=cookies)
+
+    assert resp.status_code == 200
+    Thread.assert_called_once()
+    assert _status(cfg.db_path, app_id) == "building"

--- a/compute_space/src/compute_space/tests/test_reload_concurrent.py
+++ b/compute_space/src/compute_space/tests/test_reload_concurrent.py
@@ -115,9 +115,7 @@ def test_reload_refused_while_transient(
     assert _status(cfg.db_path, app_id) == busy_status
 
 
-def test_reload_refused_while_removing(
-    cfg: Any, client: TestClient[Litestar], cookies: dict[str, str]
-) -> None:
+def test_reload_refused_while_removing(cfg: Any, client: TestClient[Litestar], cookies: dict[str, str]) -> None:
     """A removing app is refused earlier (by the dedicated removing guard),
     also with 409 and no worker — belt-and-suspenders with the reload claim."""
     app_id = _seed_app(cfg.db_path, "goingaway", status="removing")

--- a/compute_space/src/compute_space/web/routes/api/apps.py
+++ b/compute_space/src/compute_space/web/routes/api/apps.py
@@ -766,12 +766,30 @@ async def _reload_app_impl(
                 return Redirect(path=f"/app_detail/{app_name}")
             return Response(content=perm_gate, status_code=200, media_type=MediaType.JSON)
 
-    await asyncio.to_thread(stop_app_process, app_row)
-    db.execute(
-        "UPDATE apps SET status = 'building', container_id = NULL, error_message = NULL WHERE app_id = ?",
+    # Atomically claim the reload before touching the running container.
+    # ``WHERE status NOT IN (<transient states>)`` makes concurrent reloads
+    # safe: only the first request flips the row to 'building' and spawns a
+    # worker; a second one gets rowcount=0 and is refused. Without this,
+    # spamming "Reload" spawns several reload_app_background threads that race
+    # to create the same ``openhost-<name>`` container and fail with
+    # "container name is already in use". ``continue_oauth`` resumes a reload
+    # this same request already began on its initial POST (status is still the
+    # pre-reload one, since the POST bounced to OAuth before claiming), so it
+    # proceeds regardless of the rowcount.
+    cursor = db.execute(
+        "UPDATE apps SET status = 'building', container_id = NULL, error_message = NULL "
+        "WHERE app_id = ? AND status NOT IN ('building', 'starting', 'removing')",
         (app_id,),
     )
     db.commit()
+    if cursor.rowcount == 0 and not continue_oauth:
+        return Response(
+            content=ErrorResponse(error="App is already reloading"),
+            status_code=409,
+            media_type=MediaType.JSON,
+        )
+
+    await asyncio.to_thread(stop_app_process, app_row)
 
     Thread(
         target=reload_app_background,

--- a/compute_space/src/compute_space/web/static/js/dashboard.js
+++ b/compute_space/src/compute_space/web/static/js/dashboard.js
@@ -2,10 +2,21 @@ var config = JSON.parse(document.getElementById('page-config').textContent);
 
 // ─── App List ───
 //
-// Action buttons are rendered server-side by the dashboard template;
-// the polling loop only refreshes the status column. Server-side
-// guards (409 on stop/reload/rename of a removing row) make any stray
-// click a safe no-op.
+// Action buttons are rendered server-side by the dashboard template.
+// A row's action buttons are disabled while an action is in flight and
+// while the app sits in a transient state (building/starting/removing),
+// so spamming "Reload" can't fire off overlapping reloads — which used
+// to race in the backend and fail with "container name already in use".
+// Server-side guards (409 on a reload/stop/remove already in progress)
+// still make any stray click a safe no-op.
+
+// App states in which the action buttons must stay disabled: an
+// operation is already running, so a second one would be refused.
+var TRANSIENT_STATUSES = {building: true, starting: true, removing: true};
+
+function setRowBusy(row, busy) {
+  row.querySelectorAll('button').forEach(function(b) { b.disabled = busy; });
+}
 
 function refreshApps() {
   if (!config.apiAppsUrl) return;
@@ -16,6 +27,12 @@ function refreshApps() {
 }
 
 function appAction(appId, action, body) {
+  // Disable this row's buttons immediately for snappy feedback; the poll
+  // loop (updateApps) then keeps them disabled until the app leaves its
+  // transient state. On failure we re-enable right away.
+  var row = document.querySelector('tr[data-app-id="' + appId + '"]');
+  if (row) setRowBusy(row, true);
+
   var opts = {method: 'POST', credentials: 'same-origin'};
   if (body) {
     opts.headers = {'Content-Type': 'application/json'};
@@ -29,11 +46,13 @@ function appAction(appId, action, body) {
     .then(function(res) {
       if (!res.ok || (res.data && res.data.error)) {
         alert((res.data && res.data.error) || 'Request failed');
+        if (row) setRowBusy(row, false);
       }
       refreshApps();
     })
     .catch(function() {
       alert('Request failed');
+      if (row) setRowBusy(row, false);
       refreshApps();
     });
 }
@@ -57,6 +76,9 @@ function updateApps(apps) {
     var statusEl = row.querySelector('.app-status');
     statusEl.className = 'app-status status-' + info.status;
     statusEl.textContent = info.status;
+    // Keep the action buttons disabled while an operation is in flight
+    // (the app is in a transient state), re-enabling once it settles.
+    setRowBusy(row, !!TRANSIENT_STATUSES[info.status]);
   });
 }
 


### PR DESCRIPTION
Fixes [OH-104](https://linear.app/imbue/issue/OH-104/compute-space-fails-on-spamming-reload).

## Root cause
Spamming the "Reload" button fired multiple `/reload_app` requests. Each one immediately spawned a `reload_app_background` thread, and those threads raced to create the same `openhost-<name>` container — the loser failed with **"container name is already in use."** Nothing serialized concurrent reloads.

## Fix

**Backend — atomic reload claim** (`compute_space/web/routes/api/apps.py`)
`_reload_app_impl` now claims the reload with an atomic compare-and-swap, mirroring the pattern `remove_app` already uses:

```sql
UPDATE apps SET status = 'building', container_id = NULL, error_message = NULL
WHERE app_id = ? AND status NOT IN ('building', 'starting', 'removing')
```

Only the first request flips the row to `building` and spawns the worker; a concurrent one gets `rowcount == 0` and is refused with **409 "App is already reloading"** — before the running container is touched. The two requests are serialized by Litestar's single-threaded async loop (no `await` between the UPDATE and `commit()`), so exactly one wins. The OAuth continuation path (`continue_oauth`) is exempted since it resumes a reload the same request already began on its initial POST.

**Frontend — disable action buttons while busy** (`dashboard.js`)
A row's action buttons are disabled the instant an action is clicked, and the status poll keeps them disabled while the app is in a transient state (`building`/`starting`/`removing`), re-enabling once it settles. The app-detail page already did this via `setActionsBusy`, so it was left as-is.

## Tests
New `test_reload_concurrent.py` (7 cases): a first reload claims `building` + spawns a worker; a reload is refused (409, no worker, container not stopped) while `building`/`starting`/`removing`; reloads are allowed from settled states (`running`/`stopped`/`error`).

All 968 compute_space tests pass; ruff + mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)