### PR TITLE
Platform service: platform access for apps via permissions_v2 grants

### DIFF
--- a/compute_space/src/compute_space/core/platform_service.py
+++ b/compute_space/src/compute_space/core/platform_service.py
@@ -3,7 +3,7 @@ same v2 service interface they use to call other apps, but dispatched in-process
 by the router (like the ``installer`` service) rather than proxied to a provider
 app.
 
-Design (Zack's model, not the flat API-token-scope model):
+Design:
 
 - Apps consume this service via a normal ``[[services.v2.consumes]]`` block and
   call ``/api/services/v2/call/<shortname>/...``.  Auth is the app's
@@ -30,9 +30,8 @@ Grant payloads (JSON objects stored in ``permissions_v2.grant_payload``):
         ``own``  = only apps this caller deployed (installed_by == caller).
         ``all``  = every app on the instance.
         ``<id>`` = one specific app.
-        Managing apps does NOT include granting them permissions (that's
-        ``delegate_permissions``), matching Zack's "manage but not add
-        permissions".
+        Managing apps does NOT include granting them permissions — that is a
+        separate capability (``delegate_permissions``).
 
     {"capability": "system_read"}
         Read-only platform/system info (version, disk, memory, ports, logs).

--- a/compute_space/src/compute_space/core/platform_service.py
+++ b/compute_space/src/compute_space/core/platform_service.py
@@ -26,7 +26,7 @@ Grant payloads (JSON objects stored in ``permissions_v2.grant_payload``):
     {"capability": "manage_apps", "target": "own"}
     {"capability": "manage_apps", "target": "all"}
     {"capability": "manage_apps", "target": "<app_id>"}
-        Manage existing apps: view status/logs, stop/start/restart, remove.
+        Manage existing apps: view status/logs, stop/start, remove.
         ``own``  = only apps this caller deployed (installed_by == caller).
         ``all``  = every app on the instance.
         ``<id>`` = one specific app.
@@ -98,16 +98,28 @@ class ManageScope:
         return app_id in self.app_ids
 
 
+def is_known_capability(capability: object) -> bool:
+    """True iff ``capability`` is one of the platform service's capabilities."""
+    return isinstance(capability, str) and capability in ALL_CAPABILITIES
+
+
 def _dict_grants_with_capability(grants: list[Grant], capability: str) -> list[Mapping[str, GrantAtom]]:
     """The dict-shaped grants whose ``capability`` equals ``capability``.
 
-    Non-dict grants (strings, lists) and grants for other capabilities are
-    skipped, so an unrecognized/mixed grant set never accidentally widens
-    access.
+    Non-dict grants (strings, lists), grants for other capabilities, and grants
+    naming an unknown capability are all skipped, so an unrecognized/mixed grant
+    set never accidentally widens access.  (``capability`` itself is always a
+    known ``CAP_*`` value at every call site, so the ``is_known_capability``
+    guard only ever filters the stored grant, never the requested capability.)
     """
     out: list[Mapping[str, GrantAtom]] = []
     for g in grants:
-        if isinstance(g, dict) and g.get(GRANT_KEY_CAPABILITY) == capability:
+        if not isinstance(g, dict):
+            continue
+        cap = g.get(GRANT_KEY_CAPABILITY)
+        if not is_known_capability(cap):
+            continue
+        if cap == capability:
             out.append(g)
     return out
 
@@ -164,18 +176,42 @@ def _grant_identity(grant: Grant) -> str:
     return json.dumps(grant, sort_keys=True)
 
 
-def caller_holds_grant(
+def matching_held_grant(
     caller_grants_for_service: list[GrantedPermission],
     grant: Grant,
-) -> bool:
-    """True if the caller itself already holds ``grant`` for the target service.
+) -> GrantedPermission | None:
+    """Return the caller's own :class:`GrantedPermission` whose payload equals
+    ``grant`` for the target service, or ``None`` if the caller holds no such
+    grant.
 
-    The comparison is by canonical JSON identity so ``{"a":1,"b":2}`` matches
-    ``{"b":2,"a":1}``.  Only the grant *payload* is compared (scope/provider are
-    a separate concern handled by the delegation writer).
+    Payloads are compared by canonical JSON so key order doesn't matter.  The
+    full ``GrantedPermission`` (including its ``scope`` and ``provider_app_id``)
+    is returned so the delegation writer can copy the caller's *exact* authority
+    to the child — never a broader one.  If the caller holds the same payload at
+    more than one scope, the narrowest (app-scoped) match is preferred so
+    delegation can't accidentally widen to global.
     """
     wanted = _grant_identity(grant)
-    return any(_grant_identity(gp.grant) == wanted for gp in caller_grants_for_service)
+    matches = [gp for gp in caller_grants_for_service if _grant_identity(gp.grant) == wanted]
+    if not matches:
+        return None
+    # Prefer an app-scoped match (narrower) over a global one.
+    app_scoped = [gp for gp in matches if gp.scope == "app"]
+    return app_scoped[0] if app_scoped else matches[0]
+
+
+@attr.s(auto_attribs=True, frozen=True)
+class DelegationDecision:
+    """Result of :func:`check_delegation_allowed`.
+
+    ``reason`` is non-None on denial.  On approval, ``granted`` carries the
+    caller's own matching grant (scope + provider_app_id) that the writer must
+    copy verbatim to the child — copying the caller's exact authority is what
+    keeps delegation non-escalating.
+    """
+
+    reason: str | None
+    granted: GrantedPermission | None = None
 
 
 def check_delegation_allowed(
@@ -183,20 +219,26 @@ def check_delegation_allowed(
     caller_platform_grants: list[Grant],
     caller_grants_for_target_service: list[GrantedPermission],
     grant_to_delegate: Grant,
-) -> str | None:
-    """Return None if the caller may delegate ``grant_to_delegate`` (for some
-    target service) to an app it deployed, else a reason for the 403.
+) -> DelegationDecision:
+    """Decide whether the caller may delegate ``grant_to_delegate`` (for some
+    target service) to an app it deployed.
 
     Two independent conditions must both hold (fail-closed):
 
-    1. The caller must hold the ``delegate_permissions`` platform capability at
-       all.
-    2. The caller must **already possess** the exact grant it is trying to hand
-       out for that service (anti-escalation: you can only pass on privileges
-       you have, never mint new ones).
+    1. The caller must hold the ``delegate_permissions`` platform capability.
+    2. The caller must **already possess** a grant with the same payload for
+       that service (anti-escalation: you can only pass on privileges you have,
+       never mint new ones).
+
+    On approval the returned :class:`DelegationDecision` carries the caller's
+    own matching grant, whose ``scope``/``provider_app_id`` the writer copies to
+    the child so the delegated authority is never broader than the caller's
+    (e.g. an app-scoped grant is delegated app-scoped to the same provider, not
+    widened to global).
     """
     if not has_capability(caller_platform_grants, CAP_DELEGATE_PERMISSIONS):
-        return "caller lacks the delegate_permissions capability"
-    if not caller_holds_grant(caller_grants_for_target_service, grant_to_delegate):
-        return "caller does not itself hold the grant it is trying to delegate"
-    return None
+        return DelegationDecision(reason="caller lacks the delegate_permissions capability")
+    held = matching_held_grant(caller_grants_for_target_service, grant_to_delegate)
+    if held is None:
+        return DelegationDecision(reason="caller does not itself hold the grant it is trying to delegate")
+    return DelegationDecision(reason=None, granted=held)

--- a/compute_space/src/compute_space/core/platform_service.py
+++ b/compute_space/src/compute_space/core/platform_service.py
@@ -72,9 +72,7 @@ CAP_MANAGE_APPS = "manage_apps"
 CAP_SYSTEM_READ = "system_read"
 CAP_DELEGATE_PERMISSIONS = "delegate_permissions"
 
-ALL_CAPABILITIES: frozenset[str] = frozenset(
-    {CAP_DEPLOY, CAP_MANAGE_APPS, CAP_SYSTEM_READ, CAP_DELEGATE_PERMISSIONS}
-)
+ALL_CAPABILITIES: frozenset[str] = frozenset({CAP_DEPLOY, CAP_MANAGE_APPS, CAP_SYSTEM_READ, CAP_DELEGATE_PERMISSIONS})
 
 # ``manage_apps`` target sentinels (anything else is treated as a concrete app_id).
 TARGET_OWN = "own"

--- a/compute_space/src/compute_space/core/platform_service.py
+++ b/compute_space/src/compute_space/core/platform_service.py
@@ -1,0 +1,205 @@
+"""The OpenHost *platform* service: platform operations exposed to apps over the
+same v2 service interface they use to call other apps, but dispatched in-process
+by the router (like the ``installer`` service) rather than proxied to a provider
+app.
+
+Design (Zack's model, not the flat API-token-scope model):
+
+- Apps consume this service via a normal ``[[services.v2.consumes]]`` block and
+  call ``/api/services/v2/call/<shortname>/...``.  Auth is the app's
+  ``$OPENHOST_APP_TOKEN``; permissions are ordinary ``permissions_v2`` grants
+  keyed on ``(consumer_app_id, PLATFORM_SERVICE_URL)``.
+- The vocabulary of capabilities is roughly "what the ``oh`` CLI can do", gated
+  per-capability by grant payloads.
+- The headline capability is *propagating / non-escalating delegation*: an app
+  may deploy new apps, have full control over the apps **it** deployed, and
+  grant those apps any permission it **already holds** — so it can make copies
+  of (a subset of) its own privileges but never escalate.
+
+Grant payloads (JSON objects stored in ``permissions_v2.grant_payload``):
+
+    {"capability": "deploy", "repo_url_prefix": "https://github.com/acme/"}
+        Deploy new apps whose repo_url starts with the prefix ("" or "*" = any).
+        A token-/app-initiated deploy stamps ``apps.installed_by`` with the
+        caller, which is what "apps I deployed" below keys on.
+
+    {"capability": "manage_apps", "target": "own"}
+    {"capability": "manage_apps", "target": "all"}
+    {"capability": "manage_apps", "target": "<app_id>"}
+        Manage existing apps: view status/logs, stop/start/restart, remove.
+        ``own``  = only apps this caller deployed (installed_by == caller).
+        ``all``  = every app on the instance.
+        ``<id>`` = one specific app.
+        Managing apps does NOT include granting them permissions (that's
+        ``delegate_permissions``), matching Zack's "manage but not add
+        permissions".
+
+    {"capability": "system_read"}
+        Read-only platform/system info (version, disk, memory, ports, logs).
+
+    {"capability": "delegate_permissions"}
+        Allow the caller to grant a deployed app any permission the caller
+        itself already holds (bounded intersection — see
+        ``check_delegation_allowed``).  This is the escalation-sensitive one;
+        it never lets the caller hand out a grant it does not itself possess.
+
+Only dict-shaped grants with a recognized ``capability`` are honored; anything
+else is ignored (fail-closed).
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+
+import attr
+
+from compute_space.core.auth.permissions_v2 import Grant
+from compute_space.core.auth.permissions_v2 import GrantAtom
+from compute_space.core.auth.permissions_v2 import GrantedPermission
+
+# ── Service identity ─────────────────────────────────────────────────────────
+PLATFORM_SERVICE_URL = "github.com/imbue-openhost/openhost/services/platform"
+PLATFORM_SERVICE_VERSION = "0.1.0"
+
+# ── Grant payload keys / capability names ────────────────────────────────────
+GRANT_KEY_CAPABILITY = "capability"
+GRANT_KEY_REPO_URL_PREFIX = "repo_url_prefix"
+GRANT_KEY_TARGET = "target"
+
+CAP_DEPLOY = "deploy"
+CAP_MANAGE_APPS = "manage_apps"
+CAP_SYSTEM_READ = "system_read"
+CAP_DELEGATE_PERMISSIONS = "delegate_permissions"
+
+ALL_CAPABILITIES: frozenset[str] = frozenset(
+    {CAP_DEPLOY, CAP_MANAGE_APPS, CAP_SYSTEM_READ, CAP_DELEGATE_PERMISSIONS}
+)
+
+# ``manage_apps`` target sentinels (anything else is treated as a concrete app_id).
+TARGET_OWN = "own"
+TARGET_ALL = "all"
+
+
+@attr.s(auto_attribs=True, frozen=True)
+class ManageScope:
+    """Resolved reach of a caller's ``manage_apps`` grants.
+
+    ``all`` wins over everything.  Otherwise the caller may manage apps it
+    deployed (``own``) and/or an explicit set of app_ids.
+    """
+
+    all_apps: bool = False
+    own_apps: bool = False
+    app_ids: frozenset[str] = attr.ib(factory=frozenset)
+
+    def allows(self, *, app_id: str, installed_by: str | None, caller_app_id: str) -> bool:
+        if self.all_apps:
+            return True
+        if self.own_apps and installed_by == caller_app_id:
+            return True
+        return app_id in self.app_ids
+
+
+def _dict_grants_with_capability(grants: list[Grant], capability: str) -> list[Mapping[str, GrantAtom]]:
+    """The dict-shaped grants whose ``capability`` equals ``capability``.
+
+    Non-dict grants (strings, lists) and grants for other capabilities are
+    skipped, so an unrecognized/mixed grant set never accidentally widens
+    access.
+    """
+    out: list[Mapping[str, GrantAtom]] = []
+    for g in grants:
+        if isinstance(g, dict) and g.get(GRANT_KEY_CAPABILITY) == capability:
+            out.append(g)
+    return out
+
+
+def check_deploy_allowed(repo_url: str, grants: list[Grant]) -> str | None:
+    """Return None if some ``deploy`` grant permits installing ``repo_url``,
+    else a human-readable reason for the 403.
+
+    ``repo_url_prefix`` of ``""`` or ``"*"`` matches any URL; otherwise the
+    requested URL must start with the prefix.
+    """
+    deploy_grants = _dict_grants_with_capability(grants, CAP_DEPLOY)
+    if not deploy_grants:
+        return "no deploy grant present"
+    for g in deploy_grants:
+        prefix = g.get(GRANT_KEY_REPO_URL_PREFIX, "")
+        if not isinstance(prefix, str):
+            continue
+        if prefix in ("", "*") or repo_url.startswith(prefix):
+            return None
+    return "no deploy grant matches the requested repo_url"
+
+
+def resolve_manage_scope(grants: list[Grant]) -> ManageScope:
+    """Fold a caller's ``manage_apps`` grants into a single :class:`ManageScope`."""
+    all_apps = False
+    own_apps = False
+    app_ids: set[str] = set()
+    for g in _dict_grants_with_capability(grants, CAP_MANAGE_APPS):
+        target = g.get(GRANT_KEY_TARGET, TARGET_OWN)
+        if not isinstance(target, str) or not target:
+            continue
+        if target == TARGET_ALL:
+            all_apps = True
+        elif target == TARGET_OWN:
+            own_apps = True
+        else:
+            app_ids.add(target)
+    return ManageScope(all_apps=all_apps, own_apps=own_apps, app_ids=frozenset(app_ids))
+
+
+def has_capability(grants: list[Grant], capability: str) -> bool:
+    """True if the caller holds at least one grant for ``capability``.
+
+    Used for capabilities that take no further parameters (``system_read``,
+    ``delegate_permissions``).
+    """
+    return bool(_dict_grants_with_capability(grants, capability))
+
+
+def _grant_identity(grant: Grant) -> str:
+    """Stable identity for a grant payload (order-insensitive JSON), so two
+    logically-equal grants compare equal regardless of key order."""
+    return json.dumps(grant, sort_keys=True)
+
+
+def caller_holds_grant(
+    caller_grants_for_service: list[GrantedPermission],
+    grant: Grant,
+) -> bool:
+    """True if the caller itself already holds ``grant`` for the target service.
+
+    The comparison is by canonical JSON identity so ``{"a":1,"b":2}`` matches
+    ``{"b":2,"a":1}``.  Only the grant *payload* is compared (scope/provider are
+    a separate concern handled by the delegation writer).
+    """
+    wanted = _grant_identity(grant)
+    return any(_grant_identity(gp.grant) == wanted for gp in caller_grants_for_service)
+
+
+def check_delegation_allowed(
+    *,
+    caller_platform_grants: list[Grant],
+    caller_grants_for_target_service: list[GrantedPermission],
+    grant_to_delegate: Grant,
+) -> str | None:
+    """Return None if the caller may delegate ``grant_to_delegate`` (for some
+    target service) to an app it deployed, else a reason for the 403.
+
+    Two independent conditions must both hold (fail-closed):
+
+    1. The caller must hold the ``delegate_permissions`` platform capability at
+       all.
+    2. The caller must **already possess** the exact grant it is trying to hand
+       out for that service (anti-escalation: you can only pass on privileges
+       you have, never mint new ones).
+    """
+    if not has_capability(caller_platform_grants, CAP_DELEGATE_PERMISSIONS):
+        return "caller lacks the delegate_permissions capability"
+    if not caller_holds_grant(caller_grants_for_target_service, grant_to_delegate):
+        return "caller does not itself hold the grant it is trying to delegate"
+    return None

--- a/compute_space/src/compute_space/core/services_v2.py
+++ b/compute_space/src/compute_space/core/services_v2.py
@@ -23,9 +23,7 @@ def build_grant_approval_url(consumer_app_id: str, service_url: str, grant: Any,
     surface a one-click owner-approval link.  Each value is urlencoded because
     ``service_url`` contains ``/`` and ``:`` and ``grant`` is JSON.
     """
-    query = urlencode(
-        {"app": consumer_app_id, "service": service_url, "grant": json.dumps(grant, sort_keys=True)}
-    )
+    query = urlencode({"app": consumer_app_id, "service": service_url, "grant": json.dumps(grant, sort_keys=True)})
     approve_path = f"/approve-permissions-v2?{query}"
     # Server-side (no browsing request in hand), so build on the canonical/primary
     # domain; use its scheme so a plain-http primary (e.g. a `.local` instance)

--- a/compute_space/src/compute_space/core/services_v2.py
+++ b/compute_space/src/compute_space/core/services_v2.py
@@ -1,13 +1,39 @@
+import json
 import sqlite3
+from typing import Any
+from urllib.parse import urlencode
 
 from packaging.specifiers import InvalidSpecifier
 from packaging.specifiers import SpecifierSet
 from packaging.version import InvalidVersion
 from packaging.version import Version
 
+from compute_space.core.domains import primary_domain_or_none
 from compute_space.core.manifest import AppManifest
 from compute_space.core.manifest import parse_manifest_from_string
 from compute_space.db.connection import make_atomic_with_savepoint
+
+
+def build_grant_approval_url(consumer_app_id: str, service_url: str, grant: Any, db: sqlite3.Connection) -> str:
+    """Absolute URL to the owner-facing ``/approve-permissions-v2`` page for a
+    (consumer, service, grant) request, on the primary domain.
+
+    Used to decorate ``permission_required`` 403s (from proxied providers and
+    from the router-internal installer/platform services) so the caller can
+    surface a one-click owner-approval link.  Each value is urlencoded because
+    ``service_url`` contains ``/`` and ``:`` and ``grant`` is JSON.
+    """
+    query = urlencode(
+        {"app": consumer_app_id, "service": service_url, "grant": json.dumps(grant, sort_keys=True)}
+    )
+    approve_path = f"/approve-permissions-v2?{query}"
+    # Server-side (no browsing request in hand), so build on the canonical/primary
+    # domain; use its scheme so a plain-http primary (e.g. a `.local` instance)
+    # gets a correct URL rather than a hardcoded https.
+    primary = primary_domain_or_none(db)
+    if primary is None:
+        return approve_path
+    return f"{primary.scheme}://{primary.name}{approve_path}"
 
 
 class ServiceNotAvailable(Exception):

--- a/compute_space/src/compute_space/tests/test_platform_route.py
+++ b/compute_space/src/compute_space/tests/test_platform_route.py
@@ -314,17 +314,32 @@ def test_remove_own_app_claims_and_spawns(client: TestClient[Litestar], cfg: Any
     assert status == "removing"
 
 
-def test_manage_missing_app_under_own_scope_404(client: TestClient[Litestar], cfg: Any) -> None:
+def test_manage_missing_app_under_own_scope_403_no_existence_leak(client: TestClient[Litestar], cfg: Any) -> None:
+    # An own-scope caller must NOT be able to tell a missing app from an
+    # existing-but-not-owned one: both are a uniform 403, so it can't enumerate
+    # app_ids by probing.
     _grant(cfg.db_path, CALLER_APP_ID, {"capability": "manage_apps", "target": "own"})
-    resp = client.get(_url("apps/abcdefghijkm/status"), headers=_headers())
-    # own/all callers may learn of a missing app (404); narrow app_id callers get 403.
-    assert resp.status_code == 404
+    # missing app
+    missing = client.get(_url("apps/abcdefghijkm/status"), headers=_headers())
+    # existing app owned by someone else
+    other = _insert_app(cfg.db_path, name="not-mine", installed_by="someone-else", port=19740)
+    existing = client.get(_url(f"apps/{other}/status"), headers=_headers())
+    assert missing.status_code == 403
+    assert existing.status_code == 403
 
 
 def test_manage_missing_app_under_specific_scope_403(client: TestClient[Litestar], cfg: Any) -> None:
     _grant(cfg.db_path, CALLER_APP_ID, {"capability": "manage_apps", "target": "some-other-id"})
     resp = client.get(_url("apps/abcdefghijkm/status"), headers=_headers())
     assert resp.status_code == 403
+
+
+def test_manage_missing_app_under_all_scope_404(client: TestClient[Litestar], cfg: Any) -> None:
+    # An 'all' caller can enumerate every app anyway, so a genuinely missing id
+    # is a plain 404 for it (no leak beyond what it can already see).
+    _grant(cfg.db_path, CALLER_APP_ID, {"capability": "manage_apps", "target": "all"})
+    resp = client.get(_url("apps/abcdefghijkm/status"), headers=_headers())
+    assert resp.status_code == 404
 
 
 # ── system_read ──────────────────────────────────────────────────────────────

--- a/compute_space/src/compute_space/tests/test_platform_route.py
+++ b/compute_space/src/compute_space/tests/test_platform_route.py
@@ -1,0 +1,383 @@
+"""Integration tests for the platform-service dispatch inside the v2 proxy.
+
+Drives /api/services/v2/call/platform/... via TestClient with a seeded caller
+app + app-token, granting platform capabilities directly in permissions_v2.
+The actual install side-effect is patched out (exercised in the live harness).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import sqlite3
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Any
+from unittest import mock
+
+import pytest
+from litestar import Litestar
+from litestar.di import Provide
+from litestar.testing import TestClient
+
+from compute_space.config import provide_config
+from compute_space.core.app_id import new_app_id
+from compute_space.core.auth.permissions_v2 import Grant
+from compute_space.core.auth.permissions_v2 import grant_permission_v2
+from compute_space.core.installer import InstallResult
+from compute_space.core.platform_service import PLATFORM_SERVICE_URL
+from compute_space.db import provide_db
+from compute_space.db.connection import init_db
+from compute_space.tests.conftest import _make_test_config
+from compute_space.web.routes.services_v2 import services_v2_routes
+
+CALLER_APP = "deployer-mind"
+CALLER_TOKEN = "platform-caller-token"
+CALLER_APP_ID = "PlatCaller01"
+
+CALLER_MANIFEST = """
+[app]
+name = "deployer-mind"
+version = "0.1.0"
+
+[runtime.container]
+image = "Dockerfile"
+port = 8080
+
+[[services.v2.consumes]]
+service = "github.com/imbue-openhost/openhost/services/platform"
+shortname = "platform"
+version = ">=0.1.0"
+grants = []
+"""
+
+
+def _make_app() -> Litestar:
+    return Litestar(
+        route_handlers=[services_v2_routes],
+        dependencies={
+            "config": Provide(provide_config, sync_to_thread=False),
+            "db": Provide(provide_db),
+        },
+        openapi_config=None,
+    )
+
+
+def _seed_caller(
+    db_path: str,
+    app_name: str = CALLER_APP,
+    app_id: str = CALLER_APP_ID,
+    token: str = CALLER_TOKEN,
+    manifest_raw: str = CALLER_MANIFEST,
+) -> None:
+    db = sqlite3.connect(db_path)
+    try:
+        db.execute(
+            """INSERT INTO apps
+                 (app_id, name, version, repo_path, local_port, status, installed_by, manifest_raw)
+               VALUES (?, ?, ?, ?, ?, ?, NULL, ?)""",
+            (app_id, app_name, "0.0.0", f"/tmp/{app_name}", 19600, "running", manifest_raw),
+        )
+        token_hash = hashlib.sha256(token.encode()).hexdigest()
+        db.execute("INSERT INTO app_tokens (app_id, token_hash) VALUES (?, ?)", (app_id, token_hash))
+        db.commit()
+    finally:
+        db.close()
+
+
+def _grant(db_path: str, consumer: str, grant: Grant, service: str = PLATFORM_SERVICE_URL) -> None:
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    try:
+        with mock.patch("compute_space.core.auth.permissions_v2.get_db", return_value=conn):
+            grant_permission_v2(consumer, service, grant)
+    finally:
+        conn.close()
+
+
+def _insert_app(
+    db_path: str,
+    *,
+    name: str,
+    app_id: str | None = None,
+    installed_by: str | None = None,
+    status: str = "running",
+    port: int = 19700,
+) -> str:
+    app_id = app_id or new_app_id()
+    conn = sqlite3.connect(db_path)
+    try:
+        conn.execute(
+            """INSERT INTO apps (app_id, name, version, repo_path, local_port, status, installed_by)
+               VALUES (?, ?, ?, ?, ?, ?, ?)""",
+            (app_id, name, "1.0.0", f"/tmp/{name}", port, status, installed_by),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+    return app_id
+
+
+@pytest.fixture
+def cfg(tmp_path: Path) -> Any:
+    return _make_test_config(tmp_path, port=20600)
+
+
+@pytest.fixture
+def client(cfg: Any) -> Iterator[TestClient[Litestar]]:
+    init_db(cfg.db_path)
+    _seed_caller(cfg.db_path)
+    with TestClient(app=_make_app()) as c:
+        yield c
+
+
+def _url(endpoint: str) -> str:
+    return "/api/services/v2/call/platform/" + endpoint.lstrip("/")
+
+
+def _headers(token: str = CALLER_TOKEN) -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}", "Content-Type": "application/json"}
+
+
+# ── deploy ───────────────────────────────────────────────────────────────────
+
+
+def test_deploy_without_grant_denied(client: TestClient[Litestar]) -> None:
+    resp = client.post(_url("deploy"), headers=_headers(), content=json.dumps({"repo_url": "https://github.com/a/b"}))
+    assert resp.status_code == 403
+    assert resp.json()["error"] == "permission_required"
+
+
+def test_deploy_with_matching_grant_succeeds_and_stamps_installed_by(
+    client: TestClient[Litestar], cfg: Any
+) -> None:
+    _grant(cfg.db_path, CALLER_APP_ID, {"capability": "deploy", "repo_url_prefix": "*"})
+    captured: dict[str, Any] = {}
+
+    async def fake_install(repo_url, config, db, *, app_name=None, installed_by=None):  # type: ignore[no-untyped-def]
+        captured["installed_by"] = installed_by
+        # Simulate the app row the installer would have created.
+        _insert_app(cfg.db_path, name="newapp", installed_by=installed_by)
+        return InstallResult(app_name="newapp", status="building")
+
+    with mock.patch("compute_space.web.routes.platform_dispatch.install_from_repo_url", side_effect=fake_install):
+        resp = client.post(
+            _url("deploy"), headers=_headers(), content=json.dumps({"repo_url": "https://github.com/x/y"})
+        )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["ok"] is True and body["app_name"] == "newapp" and body["app_id"]
+    # Provenance stamped with the caller so manage/delegate can key on it.
+    assert captured["installed_by"] == CALLER_APP_ID
+
+
+def test_deploy_non_matching_prefix_denied(client: TestClient[Litestar], cfg: Any) -> None:
+    _grant(cfg.db_path, CALLER_APP_ID, {"capability": "deploy", "repo_url_prefix": "https://github.com/acme/"})
+    resp = client.post(
+        _url("deploy"), headers=_headers(), content=json.dumps({"repo_url": "https://github.com/evil/x"})
+    )
+    assert resp.status_code == 403
+
+
+# ── manage: list / status / stop / start / remove ────────────────────────────
+
+
+def test_list_apps_requires_manage_grant(client: TestClient[Litestar]) -> None:
+    resp = client.get(_url("apps"), headers=_headers())
+    assert resp.status_code == 403
+
+
+def test_list_apps_own_only_filters_by_installed_by(client: TestClient[Litestar], cfg: Any) -> None:
+    _grant(cfg.db_path, CALLER_APP_ID, {"capability": "manage_apps", "target": "own"})
+    mine = _insert_app(cfg.db_path, name="mine", installed_by=CALLER_APP_ID, port=19701)
+    _insert_app(cfg.db_path, name="theirs", installed_by="someone-else", port=19702)
+    resp = client.get(_url("apps"), headers=_headers())
+    assert resp.status_code == 200
+    names = {a["name"] for a in resp.json()["apps"]}
+    assert "mine" in names and "theirs" not in names
+    ids = {a["app_id"] for a in resp.json()["apps"]}
+    assert mine in ids
+
+
+def test_list_apps_all_sees_everything(client: TestClient[Litestar], cfg: Any) -> None:
+    _grant(cfg.db_path, CALLER_APP_ID, {"capability": "manage_apps", "target": "all"})
+    _insert_app(cfg.db_path, name="mine", installed_by=CALLER_APP_ID, port=19703)
+    _insert_app(cfg.db_path, name="theirs", installed_by="someone-else", port=19704)
+    resp = client.get(_url("apps"), headers=_headers())
+    names = {a["name"] for a in resp.json()["apps"]}
+    assert {"mine", "theirs"} <= names
+
+
+def test_status_own_app_allowed(client: TestClient[Litestar], cfg: Any) -> None:
+    _grant(cfg.db_path, CALLER_APP_ID, {"capability": "manage_apps", "target": "own"})
+    aid = _insert_app(cfg.db_path, name="mine", installed_by=CALLER_APP_ID, port=19705)
+    resp = client.get(_url(f"apps/{aid}/status"), headers=_headers())
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "running"
+
+
+def test_status_others_app_denied_under_own_scope(client: TestClient[Litestar], cfg: Any) -> None:
+    _grant(cfg.db_path, CALLER_APP_ID, {"capability": "manage_apps", "target": "own"})
+    aid = _insert_app(cfg.db_path, name="theirs", installed_by="other", port=19706)
+    resp = client.get(_url(f"apps/{aid}/status"), headers=_headers())
+    assert resp.status_code == 403
+
+
+def test_specific_app_id_grant_allows_only_that_app(client: TestClient[Litestar], cfg: Any) -> None:
+    target = _insert_app(cfg.db_path, name="target", installed_by="other", port=19707)
+    other = _insert_app(cfg.db_path, name="other-app", installed_by="other", port=19708)
+    _grant(cfg.db_path, CALLER_APP_ID, {"capability": "manage_apps", "target": target})
+    assert client.get(_url(f"apps/{target}/status"), headers=_headers()).status_code == 200
+    assert client.get(_url(f"apps/{other}/status"), headers=_headers()).status_code == 403
+
+
+def test_stop_own_app(client: TestClient[Litestar], cfg: Any) -> None:
+    _grant(cfg.db_path, CALLER_APP_ID, {"capability": "manage_apps", "target": "own"})
+    aid = _insert_app(cfg.db_path, name="mine", installed_by=CALLER_APP_ID, port=19709)
+    with (
+        mock.patch("compute_space.web.routes.platform_dispatch.stop_app_process"),
+        mock.patch("compute_space.web.routes.platform_dispatch.stop_container"),
+    ):
+        resp = client.post(_url(f"apps/{aid}/stop"), headers=_headers())
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "stopped"
+    conn = sqlite3.connect(cfg.db_path)
+    try:
+        status = conn.execute("SELECT status FROM apps WHERE app_id = ?", (aid,)).fetchone()[0]
+    finally:
+        conn.close()
+    assert status == "stopped"
+
+
+def test_remove_own_app_claims_and_spawns(client: TestClient[Litestar], cfg: Any) -> None:
+    _grant(cfg.db_path, CALLER_APP_ID, {"capability": "manage_apps", "target": "own"})
+    aid = _insert_app(cfg.db_path, name="mine", installed_by=CALLER_APP_ID, port=19710)
+    with mock.patch("compute_space.web.routes.platform_dispatch.Thread") as thread_cls:
+        resp = client.post(_url(f"apps/{aid}/remove"), headers=_headers(), content=json.dumps({"keep_data": True}))
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "removing"
+    thread_cls.assert_called_once()
+    conn = sqlite3.connect(cfg.db_path)
+    try:
+        status = conn.execute("SELECT status FROM apps WHERE app_id = ?", (aid,)).fetchone()[0]
+    finally:
+        conn.close()
+    assert status == "removing"
+
+
+def test_manage_missing_app_under_own_scope_404(client: TestClient[Litestar], cfg: Any) -> None:
+    _grant(cfg.db_path, CALLER_APP_ID, {"capability": "manage_apps", "target": "own"})
+    resp = client.get(_url("apps/abcdefghijkm/status"), headers=_headers())
+    # own/all callers may learn of a missing app (404); narrow app_id callers get 403.
+    assert resp.status_code == 404
+
+
+def test_manage_missing_app_under_specific_scope_403(client: TestClient[Litestar], cfg: Any) -> None:
+    _grant(cfg.db_path, CALLER_APP_ID, {"capability": "manage_apps", "target": "some-other-id"})
+    resp = client.get(_url("apps/abcdefghijkm/status"), headers=_headers())
+    assert resp.status_code == 403
+
+
+# ── system_read ──────────────────────────────────────────────────────────────
+
+
+def test_system_requires_grant(client: TestClient[Litestar]) -> None:
+    assert client.get(_url("system"), headers=_headers()).status_code == 403
+
+
+def test_system_with_grant(client: TestClient[Litestar], cfg: Any) -> None:
+    _grant(cfg.db_path, CALLER_APP_ID, {"capability": "system_read"})
+    with mock.patch(
+        "compute_space.web.routes.platform_dispatch.storage_status", return_value={"disk": "ok"}
+    ):
+        resp = client.get(_url("system"), headers=_headers())
+    assert resp.status_code == 200
+    assert resp.json()["storage"] == {"disk": "ok"}
+
+
+# ── delegate (non-escalating) ────────────────────────────────────────────────
+
+SVC = "github.com/imbue-openhost/openhost/services/secrets"
+
+
+def test_delegate_denied_without_capability(client: TestClient[Litestar], cfg: Any) -> None:
+    target = _insert_app(cfg.db_path, name="child", installed_by=CALLER_APP_ID, port=19711)
+    # caller holds the secrets grant but NOT delegate_permissions
+    _grant(cfg.db_path, CALLER_APP_ID, {"key": "DB_URL"}, service=SVC)
+    resp = client.post(
+        _url("delegate"),
+        headers=_headers(),
+        content=json.dumps({"app_id": target, "service": SVC, "grant": {"key": "DB_URL"}}),
+    )
+    assert resp.status_code == 403
+
+
+def test_delegate_denied_when_caller_lacks_grant(client: TestClient[Litestar], cfg: Any) -> None:
+    target = _insert_app(cfg.db_path, name="child", installed_by=CALLER_APP_ID, port=19712)
+    _grant(cfg.db_path, CALLER_APP_ID, {"capability": "delegate_permissions"})
+    # caller does NOT hold {"key":"SECRET"} for SVC -> escalation attempt
+    resp = client.post(
+        _url("delegate"),
+        headers=_headers(),
+        content=json.dumps({"app_id": target, "service": SVC, "grant": {"key": "SECRET"}}),
+    )
+    assert resp.status_code == 403
+
+
+def test_delegate_denied_to_app_not_deployed_by_caller(client: TestClient[Litestar], cfg: Any) -> None:
+    target = _insert_app(cfg.db_path, name="not-mine", installed_by="someone-else", port=19713)
+    _grant(cfg.db_path, CALLER_APP_ID, {"capability": "delegate_permissions"})
+    _grant(cfg.db_path, CALLER_APP_ID, {"key": "DB_URL"}, service=SVC)
+    resp = client.post(
+        _url("delegate"),
+        headers=_headers(),
+        content=json.dumps({"app_id": target, "service": SVC, "grant": {"key": "DB_URL"}}),
+    )
+    assert resp.status_code == 403
+
+
+def test_delegate_success_writes_grant_to_child(client: TestClient[Litestar], cfg: Any) -> None:
+    target = _insert_app(cfg.db_path, name="child", installed_by=CALLER_APP_ID, port=19714)
+    _grant(cfg.db_path, CALLER_APP_ID, {"capability": "delegate_permissions"})
+    _grant(cfg.db_path, CALLER_APP_ID, {"key": "DB_URL"}, service=SVC)
+    resp = client.post(
+        _url("delegate"),
+        headers=_headers(),
+        content=json.dumps({"app_id": target, "service": SVC, "grant": {"key": "DB_URL"}}),
+    )
+    assert resp.status_code == 200, resp.text
+    # The child now holds exactly the delegated grant for SVC.
+    conn = sqlite3.connect(cfg.db_path)
+    try:
+        row = conn.execute(
+            "SELECT grant_payload FROM permissions_v2 WHERE consumer_app_id = ? AND service_url = ?",
+            (target, SVC),
+        ).fetchone()
+    finally:
+        conn.close()
+    assert row is not None
+    assert json.loads(row[0]) == {"key": "DB_URL"}
+
+
+# ── misc ─────────────────────────────────────────────────────────────────────
+
+
+def test_unknown_platform_subpath_404(client: TestClient[Litestar], cfg: Any) -> None:
+    _grant(cfg.db_path, CALLER_APP_ID, {"capability": "system_read"})
+    resp = client.post(_url("wat"), headers=_headers(), content=json.dumps({}))
+    assert resp.status_code == 404
+
+
+def test_platform_call_requires_app_auth(client: TestClient[Litestar]) -> None:
+    resp = client.get(_url("apps"), headers={"Authorization": "Bearer bogus"})
+    assert resp.status_code == 401
+
+
+def test_version_mismatch_returns_503(cfg: Any) -> None:
+    manifest = CALLER_MANIFEST.replace('version = ">=0.1.0"', 'version = ">=9.0.0"')
+    init_db(cfg.db_path)
+    _seed_caller(cfg.db_path, manifest_raw=manifest)
+    _grant(cfg.db_path, CALLER_APP_ID, {"capability": "system_read"})
+    with TestClient(app=_make_app()) as client:
+        resp = client.get(_url("system"), headers=_headers())
+    assert resp.status_code == 503

--- a/compute_space/src/compute_space/tests/test_platform_route.py
+++ b/compute_space/src/compute_space/tests/test_platform_route.py
@@ -235,6 +235,25 @@ def test_list_apps_all_sees_everything(client: TestClient[Litestar], cfg: Any) -
     assert {"mine", "theirs"} <= names
 
 
+def test_logs_own_app_allowed(client: TestClient[Litestar], cfg: Any) -> None:
+    _grant(cfg.db_path, CALLER_APP_ID, {"capability": "manage_apps", "target": "own"})
+    aid = _insert_app(cfg.db_path, name="mine", installed_by=CALLER_APP_ID, port=19750)
+    with mock.patch(
+        "compute_space.web.routes.platform_dispatch.get_docker_logs", return_value="line1\nline2\n"
+    ) as gl:
+        resp = client.get(_url(f"apps/{aid}/logs"), headers=_headers())
+    assert resp.status_code == 200
+    assert resp.text == "line1\nline2\n"
+    gl.assert_called_once()
+
+
+def test_logs_others_app_denied_under_own(client: TestClient[Litestar], cfg: Any) -> None:
+    _grant(cfg.db_path, CALLER_APP_ID, {"capability": "manage_apps", "target": "own"})
+    aid = _insert_app(cfg.db_path, name="theirs", installed_by="other", port=19751)
+    resp = client.get(_url(f"apps/{aid}/logs"), headers=_headers())
+    assert resp.status_code == 403
+
+
 def test_status_own_app_allowed(client: TestClient[Litestar], cfg: Any) -> None:
     _grant(cfg.db_path, CALLER_APP_ID, {"capability": "manage_apps", "target": "own"})
     aid = _insert_app(cfg.db_path, name="mine", installed_by=CALLER_APP_ID, port=19705)

--- a/compute_space/src/compute_space/tests/test_platform_route.py
+++ b/compute_space/src/compute_space/tests/test_platform_route.py
@@ -148,9 +148,7 @@ def test_deploy_without_grant_denied(client: TestClient[Litestar]) -> None:
     assert resp.json()["error"] == "permission_required"
 
 
-def test_deploy_with_matching_grant_succeeds_and_stamps_installed_by(
-    client: TestClient[Litestar], cfg: Any
-) -> None:
+def test_deploy_with_matching_grant_succeeds_and_stamps_installed_by(client: TestClient[Litestar], cfg: Any) -> None:
     _grant(cfg.db_path, CALLER_APP_ID, {"capability": "deploy", "repo_url_prefix": "*"})
     captured: dict[str, Any] = {}
 
@@ -287,9 +285,7 @@ def test_system_requires_grant(client: TestClient[Litestar]) -> None:
 
 def test_system_with_grant(client: TestClient[Litestar], cfg: Any) -> None:
     _grant(cfg.db_path, CALLER_APP_ID, {"capability": "system_read"})
-    with mock.patch(
-        "compute_space.web.routes.platform_dispatch.storage_status", return_value={"disk": "ok"}
-    ):
+    with mock.patch("compute_space.web.routes.platform_dispatch.storage_status", return_value={"disk": "ok"}):
         resp = client.get(_url("system"), headers=_headers())
     assert resp.status_code == 200
     assert resp.json()["storage"] == {"disk": "ok"}

--- a/compute_space/src/compute_space/tests/test_platform_route.py
+++ b/compute_space/src/compute_space/tests/test_platform_route.py
@@ -238,9 +238,7 @@ def test_list_apps_all_sees_everything(client: TestClient[Litestar], cfg: Any) -
 def test_logs_own_app_allowed(client: TestClient[Litestar], cfg: Any) -> None:
     _grant(cfg.db_path, CALLER_APP_ID, {"capability": "manage_apps", "target": "own"})
     aid = _insert_app(cfg.db_path, name="mine", installed_by=CALLER_APP_ID, port=19750)
-    with mock.patch(
-        "compute_space.web.routes.platform_dispatch.get_docker_logs", return_value="line1\nline2\n"
-    ) as gl:
+    with mock.patch("compute_space.web.routes.platform_dispatch.get_docker_logs", return_value="line1\nline2\n") as gl:
         resp = client.get(_url(f"apps/{aid}/logs"), headers=_headers())
     assert resp.status_code == 200
     assert resp.text == "line1\nline2\n"

--- a/compute_space/src/compute_space/tests/test_platform_route.py
+++ b/compute_space/src/compute_space/tests/test_platform_route.py
@@ -145,7 +145,29 @@ def _headers(token: str = CALLER_TOKEN) -> dict[str, str]:
 def test_deploy_without_grant_denied(client: TestClient[Litestar]) -> None:
     resp = client.post(_url("deploy"), headers=_headers(), content=json.dumps({"repo_url": "https://github.com/a/b"}))
     assert resp.status_code == 403
-    assert resp.json()["error"] == "permission_required"
+    body = resp.json()
+    assert body["error"] == "permission_required"
+    # A denied call carries a one-click owner-approval link for the grant it needs.
+    rg = body["required_grant"]
+    assert rg["grant"] == {"capability": "deploy", "repo_url_prefix": "https://github.com/a/b"}
+    assert "/approve-permissions-v2?" in rg["grant_url"]
+    # The platform service_url is present (url-encoded) in the approval link.
+    assert "services%2Fplatform" in rg["grant_url"]
+
+
+def test_manage_denial_proposes_own_grant_url(client: TestClient[Litestar]) -> None:
+    resp = client.get(_url("apps"), headers=_headers())
+    assert resp.status_code == 403
+    rg = resp.json()["required_grant"]
+    assert rg["grant"] == {"capability": "manage_apps", "target": "own"}
+    assert "/approve-permissions-v2?" in rg["grant_url"]
+
+
+def test_system_denial_proposes_system_read_grant_url(client: TestClient[Litestar]) -> None:
+    resp = client.get(_url("system"), headers=_headers())
+    assert resp.status_code == 403
+    rg = resp.json()["required_grant"]
+    assert rg["grant"] == {"capability": "system_read"}
 
 
 def test_deploy_with_matching_grant_succeeds_and_stamps_installed_by(client: TestClient[Litestar], cfg: Any) -> None:

--- a/compute_space/src/compute_space/tests/test_platform_route.py
+++ b/compute_space/src/compute_space/tests/test_platform_route.py
@@ -285,10 +285,20 @@ def test_system_requires_grant(client: TestClient[Litestar]) -> None:
 
 def test_system_with_grant(client: TestClient[Litestar], cfg: Any) -> None:
     _grant(cfg.db_path, CALLER_APP_ID, {"capability": "system_read"})
-    with mock.patch("compute_space.web.routes.platform_dispatch.storage_status", return_value={"disk": "ok"}):
+    with (
+        mock.patch("compute_space.web.routes.platform_dispatch.storage_status", return_value={"disk": "ok"}),
+        mock.patch("compute_space.web.routes.platform_dispatch.list_listening_ports", return_value=[]),
+        mock.patch("compute_space.web.routes.platform_dispatch._read_log_tail", return_value="log line\n"),
+    ):
         resp = client.get(_url("system"), headers=_headers())
     assert resp.status_code == 200
-    assert resp.json()["storage"] == {"disk": "ok"}
+    body = resp.json()
+    # The read-only system surface: version, storage, ports, and a log tail.
+    assert body["storage"] == {"disk": "ok"}
+    assert set(body["version"].keys()) == {"branch", "sha", "short_sha", "dirty"}
+    assert body["listening_ports"] == []
+    assert body["ports_enumeration_failed"] is True  # empty list => enumeration failed
+    assert body["logs_tail"] == "log line\n"
 
 
 # ── delegate (non-escalating) ────────────────────────────────────────────────

--- a/compute_space/src/compute_space/tests/test_platform_route.py
+++ b/compute_space/src/compute_space/tests/test_platform_route.py
@@ -85,12 +85,19 @@ def _seed_caller(
         db.close()
 
 
-def _grant(db_path: str, consumer: str, grant: Grant, service: str = PLATFORM_SERVICE_URL) -> None:
+def _grant(
+    db_path: str,
+    consumer: str,
+    grant: Grant,
+    service: str = PLATFORM_SERVICE_URL,
+    scope: str = "global",
+    provider: str | None = None,
+) -> None:
     conn = sqlite3.connect(db_path)
     conn.row_factory = sqlite3.Row
     try:
         with mock.patch("compute_space.core.auth.permissions_v2.get_db", return_value=conn):
-            grant_permission_v2(consumer, service, grant)
+            grant_permission_v2(consumer, service, grant, scope=scope, provider_app_id=provider)
     finally:
         conn.close()
 
@@ -269,6 +276,28 @@ def test_stop_own_app(client: TestClient[Litestar], cfg: Any) -> None:
     assert status == "stopped"
 
 
+def test_start_own_app(client: TestClient[Litestar], cfg: Any) -> None:
+    _grant(cfg.db_path, CALLER_APP_ID, {"capability": "manage_apps", "target": "own"})
+    aid = _insert_app(cfg.db_path, name="mine", installed_by=CALLER_APP_ID, status="stopped", port=19730)
+    with mock.patch("compute_space.web.routes.platform_dispatch.start_app_process") as start:
+        resp = client.post(_url(f"apps/{aid}/start"), headers=_headers())
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["status"] == "starting"
+    start.assert_called_once()
+
+
+def test_start_surfaces_error_as_400(client: TestClient[Litestar], cfg: Any) -> None:
+    _grant(cfg.db_path, CALLER_APP_ID, {"capability": "manage_apps", "target": "own"})
+    aid = _insert_app(cfg.db_path, name="mine", installed_by=CALLER_APP_ID, status="stopped", port=19731)
+    with mock.patch(
+        "compute_space.web.routes.platform_dispatch.start_app_process",
+        side_effect=RuntimeError("port in use"),
+    ):
+        resp = client.post(_url(f"apps/{aid}/start"), headers=_headers())
+    assert resp.status_code == 400
+    assert resp.json()["error"] == "start_failed"
+
+
 def test_remove_own_app_claims_and_spawns(client: TestClient[Litestar], cfg: Any) -> None:
     _grant(cfg.db_path, CALLER_APP_ID, {"capability": "manage_apps", "target": "own"})
     aid = _insert_app(cfg.db_path, name="mine", installed_by=CALLER_APP_ID, port=19710)
@@ -386,17 +415,60 @@ def test_delegate_success_writes_grant_to_child(client: TestClient[Litestar], cf
         content=json.dumps({"app_id": target, "service": SVC, "grant": {"key": "DB_URL"}}),
     )
     assert resp.status_code == 200, resp.text
-    # The child now holds exactly the delegated grant for SVC.
+    # The child now holds exactly the delegated grant for SVC, at global scope
+    # (the caller's grant was global).
     conn = sqlite3.connect(cfg.db_path)
     try:
         row = conn.execute(
-            "SELECT grant_payload FROM permissions_v2 WHERE consumer_app_id = ? AND service_url = ?",
+            "SELECT grant_payload, scope, provider_app_id FROM permissions_v2 "
+            "WHERE consumer_app_id = ? AND service_url = ?",
             (target, SVC),
         ).fetchone()
     finally:
         conn.close()
     assert row is not None
     assert json.loads(row[0]) == {"key": "DB_URL"}
+    assert row[1] == "global"
+
+
+def test_delegate_app_scoped_grant_is_not_widened_to_global(client: TestClient[Litestar], cfg: Any) -> None:
+    # The caller holds the grant ONLY app-scoped to provider X; the delegated
+    # grant on the child must stay app-scoped to X, not become global.
+    target = _insert_app(cfg.db_path, name="child", installed_by=CALLER_APP_ID, port=19715)
+    _grant(cfg.db_path, CALLER_APP_ID, {"capability": "delegate_permissions"})
+    _grant(cfg.db_path, CALLER_APP_ID, {"key": "DB_URL"}, service=SVC, scope="app", provider="ProviderX")
+    resp = client.post(
+        _url("delegate"),
+        headers=_headers(),
+        content=json.dumps({"app_id": target, "service": SVC, "grant": {"key": "DB_URL"}}),
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["scope"] == "app"
+    conn = sqlite3.connect(cfg.db_path)
+    try:
+        row = conn.execute(
+            "SELECT scope, provider_app_id FROM permissions_v2 WHERE consumer_app_id = ? AND service_url = ?",
+            (target, SVC),
+        ).fetchone()
+    finally:
+        conn.close()
+    assert row is not None
+    assert row[0] == "app"
+    assert row[1] == "ProviderX"
+
+
+def test_delegate_to_nonexistent_app_returns_403_not_404(client: TestClient[Litestar], cfg: Any) -> None:
+    # A caller WITH delegate_permissions still must not learn (via 404) whether
+    # an arbitrary app exists; a non-deployed/missing target is a uniform 403.
+    _grant(cfg.db_path, CALLER_APP_ID, {"capability": "delegate_permissions"})
+    _grant(cfg.db_path, CALLER_APP_ID, {"key": "DB_URL"}, service=SVC)
+    resp = client.post(
+        _url("delegate"),
+        headers=_headers(),
+        content=json.dumps({"app_id": "abcdefghijkm", "service": SVC, "grant": {"key": "DB_URL"}}),
+    )
+    assert resp.status_code == 403
+    assert resp.json()["error"] == "permission_required"
 
 
 # ── misc ─────────────────────────────────────────────────────────────────────

--- a/compute_space/src/compute_space/tests/test_platform_route.py
+++ b/compute_space/src/compute_space/tests/test_platform_route.py
@@ -336,6 +336,18 @@ def test_delegate_denied_to_app_not_deployed_by_caller(client: TestClient[Litest
     assert resp.status_code == 403
 
 
+def test_delegate_without_capability_does_not_leak_app_existence(client: TestClient[Litestar], cfg: Any) -> None:
+    # A caller lacking delegate_permissions must get 403 (capability checked
+    # first) rather than a 404 that would reveal whether the target app exists.
+    resp = client.post(
+        _url("delegate"),
+        headers=_headers(),
+        content=json.dumps({"app_id": "abcdefghijkm", "service": SVC, "grant": {"key": "X"}}),
+    )
+    assert resp.status_code == 403
+    assert resp.json()["error"] == "permission_required"
+
+
 def test_delegate_success_writes_grant_to_child(client: TestClient[Litestar], cfg: Any) -> None:
     target = _insert_app(cfg.db_path, name="child", installed_by=CALLER_APP_ID, port=19714)
     _grant(cfg.db_path, CALLER_APP_ID, {"capability": "delegate_permissions"})

--- a/compute_space/src/compute_space/tests/test_platform_service_grants.py
+++ b/compute_space/src/compute_space/tests/test_platform_service_grants.py
@@ -108,53 +108,85 @@ def test_has_capability_system_read() -> None:
 # ── delegation (anti-escalation) ─────────────────────────────────────────────
 
 
-def _gp(grant: object) -> GrantedPermission:
-    return GrantedPermission(grant=grant, scope="global", provider_app_id=None)  # type: ignore[arg-type]
+def _gp(grant: object, scope: str = "global", provider: str | None = None) -> GrantedPermission:
+    return GrantedPermission(grant=grant, scope=scope, provider_app_id=provider)  # type: ignore[arg-type]
 
 
 def test_delegation_denied_without_capability() -> None:
-    reason = check_delegation_allowed(
+    d = check_delegation_allowed(
         caller_platform_grants=[{"capability": "deploy", "repo_url_prefix": "*"}],
         caller_grants_for_target_service=[_gp({"key": "DB_URL"})],
         grant_to_delegate={"key": "DB_URL"},
     )
-    assert reason is not None and "delegate_permissions" in reason
+    assert d.reason is not None and "delegate_permissions" in d.reason
+    assert d.granted is None
 
 
 def test_delegation_denied_when_caller_lacks_the_grant() -> None:
     # Caller has the capability but does NOT itself hold the grant it wants to
     # hand out -> escalation attempt, denied.
-    reason = check_delegation_allowed(
+    d = check_delegation_allowed(
         caller_platform_grants=[{"capability": CAP_DELEGATE_PERMISSIONS}],
         caller_grants_for_target_service=[_gp({"key": "PUBLIC"})],
         grant_to_delegate={"key": "SECRET"},
     )
-    assert reason is not None and "does not itself hold" in reason
+    assert d.reason is not None and "does not itself hold" in d.reason
 
 
 def test_delegation_allowed_when_caller_holds_grant_and_capability() -> None:
-    reason = check_delegation_allowed(
+    d = check_delegation_allowed(
         caller_platform_grants=[{"capability": CAP_DELEGATE_PERMISSIONS}],
         caller_grants_for_target_service=[_gp({"key": "SECRET"})],
         grant_to_delegate={"key": "SECRET"},
     )
-    assert reason is None
+    assert d.reason is None
+    assert d.granted is not None and d.granted.scope == "global"
 
 
 def test_delegation_grant_identity_is_key_order_insensitive() -> None:
     # {"a":1,"b":2} held; delegating {"b":2,"a":1} must be recognized as the same.
-    reason = check_delegation_allowed(
+    d = check_delegation_allowed(
         caller_platform_grants=[{"capability": CAP_DELEGATE_PERMISSIONS}],
         caller_grants_for_target_service=[_gp({"a": 1, "b": 2})],
         grant_to_delegate={"b": 2, "a": 1},
     )
-    assert reason is None
+    assert d.reason is None
 
 
 def test_delegation_string_grant_matches() -> None:
-    reason = check_delegation_allowed(
+    d = check_delegation_allowed(
         caller_platform_grants=[{"capability": CAP_DELEGATE_PERMISSIONS}],
         caller_grants_for_target_service=[_gp("FULL_ACCESS")],
         grant_to_delegate="FULL_ACCESS",
     )
-    assert reason is None
+    assert d.reason is None
+
+
+def test_delegation_preserves_app_scope_no_widening_to_global() -> None:
+    # Caller holds the grant ONLY app-scoped to provider X.  Delegation must copy
+    # that exact (app, X) scope to the child — never widen it to global, which
+    # would let the child use it against any provider (privilege escalation).
+    d = check_delegation_allowed(
+        caller_platform_grants=[{"capability": CAP_DELEGATE_PERMISSIONS}],
+        caller_grants_for_target_service=[_gp({"key": "DB_URL"}, scope="app", provider="ProviderX")],
+        grant_to_delegate={"key": "DB_URL"},
+    )
+    assert d.reason is None
+    assert d.granted is not None
+    assert d.granted.scope == "app"
+    assert d.granted.provider_app_id == "ProviderX"
+
+
+def test_delegation_prefers_app_scoped_match_when_both_exist() -> None:
+    # If the caller holds the same payload both app-scoped and global, the
+    # narrower (app-scoped) authority is what gets delegated.
+    d = check_delegation_allowed(
+        caller_platform_grants=[{"capability": CAP_DELEGATE_PERMISSIONS}],
+        caller_grants_for_target_service=[
+            _gp({"key": "DB_URL"}, scope="global"),
+            _gp({"key": "DB_URL"}, scope="app", provider="ProviderX"),
+        ],
+        grant_to_delegate={"key": "DB_URL"},
+    )
+    assert d.reason is None
+    assert d.granted is not None and d.granted.scope == "app"

--- a/compute_space/src/compute_space/tests/test_platform_service_grants.py
+++ b/compute_space/src/compute_space/tests/test_platform_service_grants.py
@@ -1,0 +1,159 @@
+"""Unit tests for the platform-service grant model (core/platform_service.py).
+
+Pure functions, no DB: deploy-prefix matching, manage-scope resolution, and the
+non-escalating delegation rule.  All checks must fail closed.
+"""
+
+from __future__ import annotations
+
+from compute_space.core.auth.permissions_v2 import GrantedPermission
+from compute_space.core.platform_service import CAP_DELEGATE_PERMISSIONS
+from compute_space.core.platform_service import CAP_SYSTEM_READ
+from compute_space.core.platform_service import check_delegation_allowed
+from compute_space.core.platform_service import check_deploy_allowed
+from compute_space.core.platform_service import has_capability
+from compute_space.core.platform_service import resolve_manage_scope
+
+# ── deploy ───────────────────────────────────────────────────────────────────
+
+
+def test_deploy_no_grants_denied() -> None:
+    assert check_deploy_allowed("https://github.com/a/b", []) is not None
+
+
+def test_deploy_wildcard_prefix_allows_any() -> None:
+    g = [{"capability": "deploy", "repo_url_prefix": "*"}]
+    assert check_deploy_allowed("https://github.com/anyone/thing", g) is None
+
+
+def test_deploy_empty_prefix_allows_any() -> None:
+    g = [{"capability": "deploy", "repo_url_prefix": ""}]
+    assert check_deploy_allowed("https://x/y", g) is None
+
+
+def test_deploy_matching_prefix_allows() -> None:
+    g = [{"capability": "deploy", "repo_url_prefix": "https://github.com/acme/"}]
+    assert check_deploy_allowed("https://github.com/acme/widget", g) is None
+
+
+def test_deploy_non_matching_prefix_denied() -> None:
+    g = [{"capability": "deploy", "repo_url_prefix": "https://github.com/acme/"}]
+    assert check_deploy_allowed("https://github.com/evil/x", g) is not None
+
+
+def test_deploy_ignores_other_capabilities_and_non_dicts() -> None:
+    g = ["some-string", {"capability": "manage_apps", "target": "all"}, ["list"]]
+    # No deploy grant present among these -> denied.
+    assert check_deploy_allowed("https://github.com/acme/x", g) is not None
+
+
+# ── manage scope ───────────────────────────────────────────────────────────
+
+
+def test_manage_scope_own_only() -> None:
+    scope = resolve_manage_scope([{"capability": "manage_apps", "target": "own"}])
+    assert scope.own_apps and not scope.all_apps
+    assert scope.allows(app_id="abc", installed_by="caller", caller_app_id="caller")
+    assert not scope.allows(app_id="abc", installed_by="someone-else", caller_app_id="caller")
+
+
+def test_manage_scope_all() -> None:
+    scope = resolve_manage_scope([{"capability": "manage_apps", "target": "all"}])
+    assert scope.all_apps
+    assert scope.allows(app_id="abc", installed_by=None, caller_app_id="caller")
+    assert scope.allows(app_id="xyz", installed_by="other", caller_app_id="caller")
+
+
+def test_manage_scope_specific_app_id() -> None:
+    scope = resolve_manage_scope([{"capability": "manage_apps", "target": "app_00000001"}])
+    assert not scope.all_apps and not scope.own_apps
+    assert scope.allows(app_id="app_00000001", installed_by="whoever", caller_app_id="caller")
+    assert not scope.allows(app_id="app_00000002", installed_by="whoever", caller_app_id="caller")
+
+
+def test_manage_scope_combines_own_and_specific() -> None:
+    scope = resolve_manage_scope(
+        [
+            {"capability": "manage_apps", "target": "own"},
+            {"capability": "manage_apps", "target": "app_ZZ"},
+        ]
+    )
+    assert scope.own_apps and "app_ZZ" in scope.app_ids
+    assert scope.allows(app_id="mine", installed_by="caller", caller_app_id="caller")
+    assert scope.allows(app_id="app_ZZ", installed_by="other", caller_app_id="caller")
+    assert not scope.allows(app_id="app_QQ", installed_by="other", caller_app_id="caller")
+
+
+def test_manage_scope_default_target_is_own() -> None:
+    # A manage_apps grant with no explicit target defaults to "own".
+    scope = resolve_manage_scope([{"capability": "manage_apps"}])
+    assert scope.own_apps and not scope.all_apps
+
+
+def test_manage_scope_empty_when_no_manage_grants() -> None:
+    scope = resolve_manage_scope([{"capability": "deploy", "repo_url_prefix": "*"}])
+    assert not scope.all_apps and not scope.own_apps and not scope.app_ids
+
+
+# ── system_read / has_capability ─────────────────────────────────────────────
+
+
+def test_has_capability_system_read() -> None:
+    assert has_capability([{"capability": "system_read"}], CAP_SYSTEM_READ)
+    assert not has_capability([{"capability": "deploy", "repo_url_prefix": "*"}], CAP_SYSTEM_READ)
+    assert not has_capability(["system_read"], CAP_SYSTEM_READ)  # string, not dict grant
+
+
+# ── delegation (anti-escalation) ─────────────────────────────────────────────
+
+
+def _gp(grant: object) -> GrantedPermission:
+    return GrantedPermission(grant=grant, scope="global", provider_app_id=None)  # type: ignore[arg-type]
+
+
+def test_delegation_denied_without_capability() -> None:
+    reason = check_delegation_allowed(
+        caller_platform_grants=[{"capability": "deploy", "repo_url_prefix": "*"}],
+        caller_grants_for_target_service=[_gp({"key": "DB_URL"})],
+        grant_to_delegate={"key": "DB_URL"},
+    )
+    assert reason is not None and "delegate_permissions" in reason
+
+
+def test_delegation_denied_when_caller_lacks_the_grant() -> None:
+    # Caller has the capability but does NOT itself hold the grant it wants to
+    # hand out -> escalation attempt, denied.
+    reason = check_delegation_allowed(
+        caller_platform_grants=[{"capability": CAP_DELEGATE_PERMISSIONS}],
+        caller_grants_for_target_service=[_gp({"key": "PUBLIC"})],
+        grant_to_delegate={"key": "SECRET"},
+    )
+    assert reason is not None and "does not itself hold" in reason
+
+
+def test_delegation_allowed_when_caller_holds_grant_and_capability() -> None:
+    reason = check_delegation_allowed(
+        caller_platform_grants=[{"capability": CAP_DELEGATE_PERMISSIONS}],
+        caller_grants_for_target_service=[_gp({"key": "SECRET"})],
+        grant_to_delegate={"key": "SECRET"},
+    )
+    assert reason is None
+
+
+def test_delegation_grant_identity_is_key_order_insensitive() -> None:
+    # {"a":1,"b":2} held; delegating {"b":2,"a":1} must be recognized as the same.
+    reason = check_delegation_allowed(
+        caller_platform_grants=[{"capability": CAP_DELEGATE_PERMISSIONS}],
+        caller_grants_for_target_service=[_gp({"a": 1, "b": 2})],
+        grant_to_delegate={"b": 2, "a": 1},
+    )
+    assert reason is None
+
+
+def test_delegation_string_grant_matches() -> None:
+    reason = check_delegation_allowed(
+        caller_platform_grants=[{"capability": CAP_DELEGATE_PERMISSIONS}],
+        caller_grants_for_target_service=[_gp("FULL_ACCESS")],
+        grant_to_delegate="FULL_ACCESS",
+    )
+    assert reason is None

--- a/compute_space/src/compute_space/tests/test_platform_service_grants.py
+++ b/compute_space/src/compute_space/tests/test_platform_service_grants.py
@@ -6,6 +6,7 @@ non-escalating delegation rule.  All checks must fail closed.
 
 from __future__ import annotations
 
+from compute_space.core.auth.permissions_v2 import Grant
 from compute_space.core.auth.permissions_v2 import GrantedPermission
 from compute_space.core.platform_service import CAP_DELEGATE_PERMISSIONS
 from compute_space.core.platform_service import CAP_SYSTEM_READ
@@ -22,27 +23,27 @@ def test_deploy_no_grants_denied() -> None:
 
 
 def test_deploy_wildcard_prefix_allows_any() -> None:
-    g = [{"capability": "deploy", "repo_url_prefix": "*"}]
+    g: list[Grant] = [{"capability": "deploy", "repo_url_prefix": "*"}]
     assert check_deploy_allowed("https://github.com/anyone/thing", g) is None
 
 
 def test_deploy_empty_prefix_allows_any() -> None:
-    g = [{"capability": "deploy", "repo_url_prefix": ""}]
+    g: list[Grant] = [{"capability": "deploy", "repo_url_prefix": ""}]
     assert check_deploy_allowed("https://x/y", g) is None
 
 
 def test_deploy_matching_prefix_allows() -> None:
-    g = [{"capability": "deploy", "repo_url_prefix": "https://github.com/acme/"}]
+    g: list[Grant] = [{"capability": "deploy", "repo_url_prefix": "https://github.com/acme/"}]
     assert check_deploy_allowed("https://github.com/acme/widget", g) is None
 
 
 def test_deploy_non_matching_prefix_denied() -> None:
-    g = [{"capability": "deploy", "repo_url_prefix": "https://github.com/acme/"}]
+    g: list[Grant] = [{"capability": "deploy", "repo_url_prefix": "https://github.com/acme/"}]
     assert check_deploy_allowed("https://github.com/evil/x", g) is not None
 
 
 def test_deploy_ignores_other_capabilities_and_non_dicts() -> None:
-    g = ["some-string", {"capability": "manage_apps", "target": "all"}, ["list"]]
+    g: list[Grant] = ["some-string", {"capability": "manage_apps", "target": "all"}, ["list"]]
     # No deploy grant present among these -> denied.
     assert check_deploy_allowed("https://github.com/acme/x", g) is not None
 

--- a/compute_space/src/compute_space/web/routes/platform_dispatch.py
+++ b/compute_space/src/compute_space/web/routes/platform_dispatch.py
@@ -153,9 +153,7 @@ async def _handle_deploy(
     try:
         # Stamp installed_by with the caller so "manage apps I deployed" and
         # non-escalating delegation can key on provenance.
-        result = await install_from_repo_url(
-            repo_url, config, db, app_name=app_name, installed_by=consumer_app_id
-        )
+        result = await install_from_repo_url(repo_url, config, db, app_name=app_name, installed_by=consumer_app_id)
     except InstallError as exc:
         return _json_error("deploy_failed", exc.message, exc.status_code)
 

--- a/compute_space/src/compute_space/web/routes/platform_dispatch.py
+++ b/compute_space/src/compute_space/web/routes/platform_dispatch.py
@@ -24,6 +24,8 @@ platform has no provider app to defer to).
 
 from __future__ import annotations
 
+import asyncio
+import os
 import sqlite3
 from threading import Thread
 from typing import Any
@@ -35,16 +37,23 @@ from packaging.specifiers import InvalidSpecifier
 from packaging.specifiers import SpecifierSet
 from packaging.version import Version
 
+from compute_space import OPENHOST_PROJECT_DIR
 from compute_space.config import Config
 from compute_space.core.apps import remove_app_background
 from compute_space.core.apps import start_app_process
 from compute_space.core.auth.permissions_v2 import get_granted_permissions_v2
 from compute_space.core.auth.permissions_v2 import grant_permission_v2
+from compute_space.core.auth.security_audit import external_ports
+from compute_space.core.auth.security_audit import list_listening_ports
 from compute_space.core.containers import get_docker_logs
 from compute_space.core.containers import stop_app_process
 from compute_space.core.containers import stop_container
+from compute_space.core.git_ops import get_branch_name
+from compute_space.core.git_ops import get_head_sha
+from compute_space.core.git_ops import is_dirty
 from compute_space.core.installer import InstallError
 from compute_space.core.installer import install_from_repo_url
+from compute_space.core.logging import get_log_path
 from compute_space.core.logging import logger
 from compute_space.core.platform_service import CAP_DELEGATE_PERMISSIONS
 from compute_space.core.platform_service import CAP_SYSTEM_READ
@@ -116,7 +125,7 @@ async def handle_platform_request(
         return _handle_list_apps(consumer_app_id, db)
 
     if method == "GET" and parts == ["system"]:
-        return _handle_system(consumer_app_id, db, config)
+        return await _handle_system(consumer_app_id, db, config)
 
     if method == "POST" and parts == ["delegate"]:
         return await _handle_delegate(consumer_app_id, request, db)
@@ -279,11 +288,61 @@ async def _handle_app_action(
 # ── system_read ──────────────────────────────────────────────────────────────
 
 
-def _handle_system(consumer_app_id: str, db: sqlite3.Connection, config: Config) -> Response[Any]:
+# Cap the platform-logs tail we hand back so a system_read caller can't pull the
+# whole (up to 10 MB) rotated log in one request.
+_LOG_TAIL_BYTES = 64 * 1024
+
+
+def _read_log_tail() -> str | None:
+    """Return the tail of the compute-space log, or None if not configured."""
+    log_path = get_log_path()
+    if log_path is None:
+        return None
+    try:
+        with open(log_path, "rb") as f:
+            size = f.seek(0, os.SEEK_END)
+            f.seek(max(0, size - _LOG_TAIL_BYTES))
+            text = f.read().decode("utf-8", errors="replace")
+        if size > _LOG_TAIL_BYTES:
+            text = text[text.find("\n") + 1 :]
+        return text
+    except OSError:
+        return None
+
+
+async def _version_info() -> dict[str, Any]:
+    """Git branch/SHA of the running openhost checkout (empty if not a checkout)."""
+    try:
+        sha = await get_head_sha(OPENHOST_PROJECT_DIR)
+        branch = await get_branch_name(OPENHOST_PROJECT_DIR)
+        dirty = await is_dirty(OPENHOST_PROJECT_DIR)
+    except Exception:
+        return {"branch": None, "sha": "", "short_sha": "", "dirty": False}
+    return {"branch": branch, "sha": sha, "short_sha": sha[:8], "dirty": dirty}
+
+
+async def _handle_system(consumer_app_id: str, db: sqlite3.Connection, config: Config) -> Response[Any]:
+    """Read-only system info: version, storage, external listening ports, log tail."""
     if not has_capability(_platform_grants(consumer_app_id), CAP_SYSTEM_READ):
         return _permission_denied("no system_read grant present")
-    # Reuse the same storage snapshot the dashboard uses; kept read-only.
-    return _json_ok({"storage": storage_status(config)})
+
+    version = await _version_info()
+    # Off-loop: storage snapshot + ss/podman walks are blocking.
+    storage = await asyncio.to_thread(storage_status, config)
+    all_ports = await asyncio.to_thread(list_listening_ports, db)
+    # ListeningPort is a TypedDict, so it's already JSON-serializable.
+    ports = list(external_ports(all_ports))
+    logs_tail = await asyncio.to_thread(_read_log_tail)
+
+    return _json_ok(
+        {
+            "version": version,
+            "storage": storage,
+            "listening_ports": ports,
+            "ports_enumeration_failed": not all_ports,
+            "logs_tail": logs_tail,
+        }
+    )
 
 
 # ── delegate (non-escalating) ────────────────────────────────────────────────

--- a/compute_space/src/compute_space/web/routes/platform_dispatch.py
+++ b/compute_space/src/compute_space/web/routes/platform_dispatch.py
@@ -16,7 +16,7 @@ Endpoints (rooted under the consumer's platform shortname):
     POST /apps/<app_id>/start                                   cap: manage_apps (scoped)
     POST /apps/<app_id>/remove       {keep_data?}               cap: manage_apps (scoped)
     GET  /system                                                cap: system_read
-    POST /delegate  {app_id, service, grant, scope?}            cap: delegate_permissions
+    POST /delegate  {app_id, service, grant}                     cap: delegate_permissions
 
 All permission checks fail closed and are enforced here by the router (the
 platform has no provider app to defer to).
@@ -391,11 +391,13 @@ async def _handle_delegate(
 ) -> Response[Any]:
     """Grant one of the caller's OWN permissions to an app the caller deployed.
 
-    Body: {app_id, service, grant, scope?}.  Enforces both delegation gates:
-    the caller must hold ``delegate_permissions``, must already hold the exact
-    ``grant`` for ``service``, and the target app must be one the caller
-    deployed (installed_by == caller).  This is the non-escalating
-    "make copies of my privileges" primitive.
+    Body: {app_id, service, grant}.  Enforces all delegation gates: the caller
+    must hold ``delegate_permissions``, must already hold a grant with this
+    payload for ``service``, and the target app must be one the caller deployed
+    (installed_by == caller).  The child receives the caller's grant at the
+    caller's own scope/provider (never broader), so this is the non-escalating
+    "make copies of my privileges" primitive.  The scope is inherited from the
+    caller's grant, not taken from the request.
     """
     try:
         body = await request.json()
@@ -422,23 +424,39 @@ async def _handle_delegate(
             db=db,
         )
 
-    # The target must be an app THIS caller deployed.
+    # The target must be an app THIS caller deployed.  A missing app and an app
+    # the caller didn't deploy return the SAME 403 so a caller can't probe which
+    # arbitrary app_ids exist (it can only ever act on apps it deployed).
     row = db.execute("SELECT installed_by FROM apps WHERE app_id = ?", (target_app_id,)).fetchone()
-    if row is None:
-        return _json_error("not_found", f"app {target_app_id!r} not found", 404)
-    if row["installed_by"] != consumer_app_id:
-        return _permission_denied(f"{consumer_app_id} did not deploy {target_app_id!r}; cannot delegate to it")
+    if row is None or row["installed_by"] != consumer_app_id:
+        return _permission_denied(f"{consumer_app_id} may not delegate to {target_app_id!r}")
 
-    # Remaining delegation gate (caller already holds the exact grant).
+    # Remaining delegation gate: the caller must already hold a grant with this
+    # payload for the service.  The decision carries the caller's own matching
+    # grant so we copy its EXACT scope/provider to the child — never broader.
     caller_grants_for_service = get_granted_permissions_v2(consumer_app_id, service)
-    if (
-        reason := check_delegation_allowed(
-            caller_platform_grants=caller_platform_grants,
-            caller_grants_for_target_service=caller_grants_for_service,
-            grant_to_delegate=grant,
-        )
-    ) is not None:
-        return _permission_denied(reason)
+    decision = check_delegation_allowed(
+        caller_platform_grants=caller_platform_grants,
+        caller_grants_for_target_service=caller_grants_for_service,
+        grant_to_delegate=grant,
+    )
+    if decision.reason is not None or decision.granted is None:
+        return _permission_denied(decision.reason or "delegation not allowed")
 
-    grant_permission_v2(target_app_id, service, grant, scope="global")
-    return _json_ok({"ok": True, "app_id": target_app_id, "service": service, "grant": grant})
+    held = decision.granted
+    grant_permission_v2(
+        target_app_id,
+        service,
+        held.grant,
+        scope=held.scope,
+        provider_app_id=held.provider_app_id,
+    )
+    return _json_ok(
+        {
+            "ok": True,
+            "app_id": target_app_id,
+            "service": service,
+            "grant": held.grant,
+            "scope": held.scope,
+        }
+    )

--- a/compute_space/src/compute_space/web/routes/platform_dispatch.py
+++ b/compute_space/src/compute_space/web/routes/platform_dispatch.py
@@ -56,13 +56,20 @@ from compute_space.core.installer import install_from_repo_url
 from compute_space.core.logging import get_log_path
 from compute_space.core.logging import logger
 from compute_space.core.platform_service import CAP_DELEGATE_PERMISSIONS
+from compute_space.core.platform_service import CAP_DEPLOY
+from compute_space.core.platform_service import CAP_MANAGE_APPS
 from compute_space.core.platform_service import CAP_SYSTEM_READ
+from compute_space.core.platform_service import GRANT_KEY_CAPABILITY
+from compute_space.core.platform_service import GRANT_KEY_REPO_URL_PREFIX
+from compute_space.core.platform_service import GRANT_KEY_TARGET
 from compute_space.core.platform_service import PLATFORM_SERVICE_URL
 from compute_space.core.platform_service import PLATFORM_SERVICE_VERSION
+from compute_space.core.platform_service import TARGET_OWN
 from compute_space.core.platform_service import check_delegation_allowed
 from compute_space.core.platform_service import check_deploy_allowed
 from compute_space.core.platform_service import has_capability
 from compute_space.core.platform_service import resolve_manage_scope
+from compute_space.core.services_v2 import build_grant_approval_url
 from compute_space.core.storage import storage_status
 
 
@@ -74,19 +81,41 @@ def _json_ok(body: dict[str, Any]) -> Response[dict[str, Any]]:
     return Response(content=body, status_code=200, media_type=MediaType.JSON)
 
 
-def _permission_denied(message: str) -> Response[dict[str, Any]]:
+def _permission_denied(
+    message: str,
+    *,
+    consumer_app_id: str | None = None,
+    proposed_grant: Any = None,
+    db: sqlite3.Connection | None = None,
+) -> Response[dict[str, Any]]:
     """403 with a machine-readable ``permission_required`` shape (parallels the
-    installer's denial body so clients can handle both uniformly)."""
-    return Response(
-        content={"error": "permission_required", "message": message},
-        status_code=403,
-        media_type=MediaType.JSON,
-    )
+    installer's denial body so clients can handle both uniformly).
+
+    When a concrete ``proposed_grant`` (plus ``consumer_app_id`` and ``db``) is
+    supplied, decorate the body with a ``required_grant`` carrying a one-click
+    owner-approval ``grant_url`` for the platform service — so a denied app can
+    prompt the owner to approve exactly the grant it needs.
+    """
+    body: dict[str, Any] = {"error": "permission_required", "message": message}
+    if proposed_grant is not None and consumer_app_id is not None and db is not None:
+        body["required_grant"] = {
+            "grant": proposed_grant,
+            "scope": "global",
+            "grant_url": build_grant_approval_url(consumer_app_id, PLATFORM_SERVICE_URL, proposed_grant, db),
+        }
+    return Response(content=body, status_code=403, media_type=MediaType.JSON)
 
 
 def _platform_grants(consumer_app_id: str) -> list[Any]:
     """The caller's grant payloads for the platform service."""
     return [gp.grant for gp in get_granted_permissions_v2(consumer_app_id, PLATFORM_SERVICE_URL)]
+
+
+# Proposed grants offered to the owner on a denial, so a denied app gets a
+# one-click approval link for the least-privilege grant that would unblock it.
+_GRANT_MANAGE_OWN = {GRANT_KEY_CAPABILITY: CAP_MANAGE_APPS, GRANT_KEY_TARGET: TARGET_OWN}
+_GRANT_SYSTEM_READ = {GRANT_KEY_CAPABILITY: CAP_SYSTEM_READ}
+_GRANT_DELEGATE = {GRANT_KEY_CAPABILITY: CAP_DELEGATE_PERMISSIONS}
 
 
 def _version_ok(version_spec: str) -> Response[dict[str, Any]] | None:
@@ -157,7 +186,10 @@ async def _handle_deploy(
 
     grants = _platform_grants(consumer_app_id)
     if (reason := check_deploy_allowed(repo_url, grants)) is not None:
-        return _permission_denied(reason)
+        # Propose a deploy grant covering exactly the requested repo_url so the
+        # owner can approve it in one click.
+        proposed = {GRANT_KEY_CAPABILITY: CAP_DEPLOY, GRANT_KEY_REPO_URL_PREFIX: repo_url}
+        return _permission_denied(reason, consumer_app_id=consumer_app_id, proposed_grant=proposed, db=db)
 
     try:
         # Stamp installed_by with the caller so "manage apps I deployed" and
@@ -178,7 +210,9 @@ async def _handle_deploy(
 def _handle_list_apps(consumer_app_id: str, db: sqlite3.Connection) -> Response[Any]:
     scope = resolve_manage_scope(_platform_grants(consumer_app_id))
     if not (scope.all_apps or scope.own_apps or scope.app_ids):
-        return _permission_denied("no manage_apps grant present")
+        return _permission_denied(
+            "no manage_apps grant present", consumer_app_id=consumer_app_id, proposed_grant=_GRANT_MANAGE_OWN, db=db
+        )
     rows = db.execute("SELECT app_id, name, status, error_message, installed_by FROM apps ORDER BY name").fetchall()
     apps = [
         {"app_id": r["app_id"], "name": r["name"], "status": r["status"], "error": r["error_message"]}
@@ -202,7 +236,9 @@ def _load_manageable_app(
     """
     scope = resolve_manage_scope(_platform_grants(consumer_app_id))
     if not (scope.all_apps or scope.own_apps or scope.app_ids):
-        return None, _permission_denied("no manage_apps grant present")
+        return None, _permission_denied(
+            "no manage_apps grant present", consumer_app_id=consumer_app_id, proposed_grant=_GRANT_MANAGE_OWN, db=db
+        )
     row = db.execute(
         "SELECT app_id, name, status, error_message, container_id, installed_by FROM apps WHERE app_id = ?",
         (app_id,),
@@ -324,7 +360,9 @@ async def _version_info() -> dict[str, Any]:
 async def _handle_system(consumer_app_id: str, db: sqlite3.Connection, config: Config) -> Response[Any]:
     """Read-only system info: version, storage, external listening ports, log tail."""
     if not has_capability(_platform_grants(consumer_app_id), CAP_SYSTEM_READ):
-        return _permission_denied("no system_read grant present")
+        return _permission_denied(
+            "no system_read grant present", consumer_app_id=consumer_app_id, proposed_grant=_GRANT_SYSTEM_READ, db=db
+        )
 
     version = await _version_info()
     # Off-loop: storage snapshot + ss/podman walks are blocking.
@@ -377,7 +415,12 @@ async def _handle_delegate(
     # 404-vs-403 distinction.
     caller_platform_grants = _platform_grants(consumer_app_id)
     if not has_capability(caller_platform_grants, CAP_DELEGATE_PERMISSIONS):
-        return _permission_denied("caller lacks the delegate_permissions capability")
+        return _permission_denied(
+            "caller lacks the delegate_permissions capability",
+            consumer_app_id=consumer_app_id,
+            proposed_grant=_GRANT_DELEGATE,
+            db=db,
+        )
 
     # The target must be an app THIS caller deployed.
     row = db.execute("SELECT installed_by FROM apps WHERE app_id = ?", (target_app_id,)).fetchone()

--- a/compute_space/src/compute_space/web/routes/platform_dispatch.py
+++ b/compute_space/src/compute_space/web/routes/platform_dispatch.py
@@ -227,12 +227,14 @@ def _load_manageable_app(
 ) -> tuple[sqlite3.Row | None, Response[dict[str, Any]] | None]:
     """Load an app row and authorize the caller's manage scope against it.
 
-    Returns (row, None) if allowed; (None, error_response) otherwise.  A caller
-    that cannot manage the app gets 403 whether or not the app exists, so this
-    does not leak the existence of apps outside the caller's scope... except we
-    must still 404 a genuinely missing app for a caller who *could* manage it
-    (e.g. an ``all`` or ``own`` grant), so existence is only revealed within the
-    caller's own reach.
+    Returns (row, None) if allowed; (None, error_response) otherwise.
+
+    Existence-leak rule: a missing app and an out-of-reach app return the SAME
+    403 for any caller that cannot already see the whole instance.  Only an
+    ``all``-scope caller — which can enumerate every app anyway — gets a 404 for
+    a genuinely missing id.  In particular an ``own``-only (or specific-app_id)
+    caller can never distinguish "doesn't exist" from "exists but not mine", so
+    it can't probe arbitrary app_ids.
     """
     scope = resolve_manage_scope(_platform_grants(consumer_app_id))
     if not (scope.all_apps or scope.own_apps or scope.app_ids):
@@ -243,13 +245,14 @@ def _load_manageable_app(
         "SELECT app_id, name, status, error_message, container_id, installed_by FROM apps WHERE app_id = ?",
         (app_id,),
     ).fetchone()
-    if row is None:
-        # Only reveal 404 to a caller broad enough to see it anyway; a
-        # narrowly-scoped caller gets a uniform 403 so it can't probe existence.
-        if scope.all_apps or scope.own_apps:
+    if row is None or not scope.allows(
+        app_id=row["app_id"], installed_by=row["installed_by"], caller_app_id=consumer_app_id
+    ):
+        # An ``all`` caller already sees every app, so a missing id is a plain
+        # 404 for it.  Everyone else gets a uniform 403 whether the app is
+        # missing or simply out of reach, so existence can't be probed.
+        if row is None and scope.all_apps:
             return None, _json_error("not_found", f"app {app_id!r} not found", 404)
-        return None, _permission_denied(f"{consumer_app_id} may not manage {app_id!r}")
-    if not scope.allows(app_id=row["app_id"], installed_by=row["installed_by"], caller_app_id=consumer_app_id):
         return None, _permission_denied(f"{consumer_app_id} may not manage {app_id!r}")
     return row, None
 

--- a/compute_space/src/compute_space/web/routes/platform_dispatch.py
+++ b/compute_space/src/compute_space/web/routes/platform_dispatch.py
@@ -1,0 +1,337 @@
+"""In-process dispatch for the OpenHost *platform* service.
+
+Generalizes the installer pattern: apps consume ``PLATFORM_SERVICE_URL`` via a
+normal ``[[services.v2.consumes]]`` block and call
+``/api/services/v2/call/<shortname>/...``; the router runs these handlers
+in-process (sharing its DB + ``apps.*`` state) instead of proxying to a provider
+app, and gates each on ``permissions_v2`` grants.
+
+Endpoints (rooted under the consumer's platform shortname):
+
+    POST /deploy                     {repo_url, app_name?}      cap: deploy
+    GET  /apps                                                  cap: manage_apps
+    GET  /apps/<app_id>/status                                  cap: manage_apps (scoped)
+    GET  /apps/<app_id>/logs                                    cap: manage_apps (scoped)
+    POST /apps/<app_id>/stop                                    cap: manage_apps (scoped)
+    POST /apps/<app_id>/start                                   cap: manage_apps (scoped)
+    POST /apps/<app_id>/remove       {keep_data?}               cap: manage_apps (scoped)
+    GET  /system                                                cap: system_read
+    POST /delegate  {app_id, service, grant, scope?}            cap: delegate_permissions
+
+All permission checks fail closed and are enforced here by the router (the
+platform has no provider app to defer to).
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from threading import Thread
+from typing import Any
+
+from litestar import MediaType
+from litestar import Request
+from litestar import Response
+from packaging.specifiers import InvalidSpecifier
+from packaging.specifiers import SpecifierSet
+from packaging.version import Version
+
+from compute_space.config import Config
+from compute_space.core.apps import remove_app_background
+from compute_space.core.apps import start_app_process
+from compute_space.core.auth.permissions_v2 import get_granted_permissions_v2
+from compute_space.core.auth.permissions_v2 import grant_permission_v2
+from compute_space.core.containers import get_docker_logs
+from compute_space.core.containers import stop_app_process
+from compute_space.core.containers import stop_container
+from compute_space.core.installer import InstallError
+from compute_space.core.installer import install_from_repo_url
+from compute_space.core.logging import logger
+from compute_space.core.platform_service import CAP_SYSTEM_READ
+from compute_space.core.platform_service import PLATFORM_SERVICE_URL
+from compute_space.core.platform_service import PLATFORM_SERVICE_VERSION
+from compute_space.core.platform_service import check_delegation_allowed
+from compute_space.core.platform_service import check_deploy_allowed
+from compute_space.core.platform_service import has_capability
+from compute_space.core.platform_service import resolve_manage_scope
+from compute_space.core.storage import storage_status
+
+
+def _json_error(error: str, message: str, status: int) -> Response[dict[str, Any]]:
+    return Response(content={"error": error, "message": message}, status_code=status, media_type=MediaType.JSON)
+
+
+def _json_ok(body: dict[str, Any]) -> Response[dict[str, Any]]:
+    return Response(content=body, status_code=200, media_type=MediaType.JSON)
+
+
+def _permission_denied(message: str) -> Response[dict[str, Any]]:
+    """403 with a machine-readable ``permission_required`` shape (parallels the
+    installer's denial body so clients can handle both uniformly)."""
+    return Response(
+        content={"error": "permission_required", "message": message},
+        status_code=403,
+        media_type=MediaType.JSON,
+    )
+
+
+def _platform_grants(consumer_app_id: str) -> list[Any]:
+    """The caller's grant payloads for the platform service."""
+    return [gp.grant for gp in get_granted_permissions_v2(consumer_app_id, PLATFORM_SERVICE_URL)]
+
+
+def _version_ok(version_spec: str) -> Response[dict[str, Any]] | None:
+    try:
+        spec = SpecifierSet(version_spec)
+    except InvalidSpecifier:
+        return _json_error("bad_request", f"Invalid version specifier: {version_spec}", 400)
+    if Version(PLATFORM_SERVICE_VERSION) not in spec:
+        return _json_error(
+            "service_not_available",
+            f"platform version {PLATFORM_SERVICE_VERSION} does not match {version_spec}",
+            503,
+        )
+    return None
+
+
+async def handle_platform_request(
+    consumer_app_id: str,
+    version_spec: str,
+    rest: str,
+    request: Request[Any, Any, Any],
+    db: sqlite3.Connection,
+    config: Config,
+) -> Response[Any]:
+    """Route a platform-service call to the right handler after a version check."""
+    if (version_err := _version_ok(version_spec)) is not None:
+        return version_err
+
+    method = str(request.method)
+    parts = [p for p in rest.strip("/").split("/") if p != ""]
+
+    if method == "POST" and parts == ["deploy"]:
+        return await _handle_deploy(consumer_app_id, request, db, config)
+
+    if method == "GET" and parts == ["apps"]:
+        return _handle_list_apps(consumer_app_id, db)
+
+    if method == "GET" and parts == ["system"]:
+        return _handle_system(consumer_app_id, db, config)
+
+    if method == "POST" and parts == ["delegate"]:
+        return await _handle_delegate(consumer_app_id, request, db)
+
+    # /apps/<app_id>/<action>
+    if len(parts) == 3 and parts[0] == "apps":
+        _, app_id, action = parts
+        return await _handle_app_action(consumer_app_id, app_id, action, method, request, db, config)
+
+    return _json_error("bad_request", f"Unknown platform endpoint: {method} /{rest.lstrip('/')}", 404)
+
+
+# ── deploy ───────────────────────────────────────────────────────────────────
+
+
+async def _handle_deploy(
+    consumer_app_id: str, request: Request[Any, Any, Any], db: sqlite3.Connection, config: Config
+) -> Response[Any]:
+    try:
+        body = await request.json()
+    except Exception:
+        return _json_error("bad_request", "request body must be a JSON object", 400)
+    if not isinstance(body, dict):
+        return _json_error("bad_request", "request body must be a JSON object", 400)
+    repo_url = (body.get("repo_url") or "").strip()
+    if not repo_url:
+        return _json_error("bad_request", "repo_url is required", 400)
+    app_name = (body.get("app_name") or "").strip() or None
+
+    grants = _platform_grants(consumer_app_id)
+    if (reason := check_deploy_allowed(repo_url, grants)) is not None:
+        return _permission_denied(reason)
+
+    try:
+        # Stamp installed_by with the caller so "manage apps I deployed" and
+        # non-escalating delegation can key on provenance.
+        result = await install_from_repo_url(
+            repo_url, config, db, app_name=app_name, installed_by=consumer_app_id
+        )
+    except InstallError as exc:
+        return _json_error("deploy_failed", exc.message, exc.status_code)
+
+    # Return the new app's id so the caller can immediately manage/delegate to it.
+    row = db.execute("SELECT app_id FROM apps WHERE name = ?", (result.app_name,)).fetchone()
+    new_app_id = row["app_id"] if row else None
+    return _json_ok({"ok": True, "app_name": result.app_name, "app_id": new_app_id, "status": result.status})
+
+
+# ── manage: list / status / logs / stop / start / remove ─────────────────────
+
+
+def _handle_list_apps(consumer_app_id: str, db: sqlite3.Connection) -> Response[Any]:
+    scope = resolve_manage_scope(_platform_grants(consumer_app_id))
+    if not (scope.all_apps or scope.own_apps or scope.app_ids):
+        return _permission_denied("no manage_apps grant present")
+    rows = db.execute("SELECT app_id, name, status, error_message, installed_by FROM apps ORDER BY name").fetchall()
+    apps = [
+        {"app_id": r["app_id"], "name": r["name"], "status": r["status"], "error": r["error_message"]}
+        for r in rows
+        if scope.allows(app_id=r["app_id"], installed_by=r["installed_by"], caller_app_id=consumer_app_id)
+    ]
+    return _json_ok({"apps": apps})
+
+
+def _load_manageable_app(
+    consumer_app_id: str, app_id: str, db: sqlite3.Connection
+) -> tuple[sqlite3.Row | None, Response[dict[str, Any]] | None]:
+    """Load an app row and authorize the caller's manage scope against it.
+
+    Returns (row, None) if allowed; (None, error_response) otherwise.  A caller
+    that cannot manage the app gets 403 whether or not the app exists, so this
+    does not leak the existence of apps outside the caller's scope... except we
+    must still 404 a genuinely missing app for a caller who *could* manage it
+    (e.g. an ``all`` or ``own`` grant), so existence is only revealed within the
+    caller's own reach.
+    """
+    scope = resolve_manage_scope(_platform_grants(consumer_app_id))
+    if not (scope.all_apps or scope.own_apps or scope.app_ids):
+        return None, _permission_denied("no manage_apps grant present")
+    row = db.execute(
+        "SELECT app_id, name, status, error_message, container_id, installed_by FROM apps WHERE app_id = ?",
+        (app_id,),
+    ).fetchone()
+    if row is None:
+        # Only reveal 404 to a caller broad enough to see it anyway; a
+        # narrowly-scoped caller gets a uniform 403 so it can't probe existence.
+        if scope.all_apps or scope.own_apps:
+            return None, _json_error("not_found", f"app {app_id!r} not found", 404)
+        return None, _permission_denied(f"{consumer_app_id} may not manage {app_id!r}")
+    if not scope.allows(app_id=row["app_id"], installed_by=row["installed_by"], caller_app_id=consumer_app_id):
+        return None, _permission_denied(f"{consumer_app_id} may not manage {app_id!r}")
+    return row, None
+
+
+async def _handle_app_action(
+    consumer_app_id: str,
+    app_id: str,
+    action: str,
+    method: str,
+    request: Request[Any, Any, Any],
+    db: sqlite3.Connection,
+    config: Config,
+) -> Response[Any]:
+    row, denied = _load_manageable_app(consumer_app_id, app_id, db)
+    if denied is not None:
+        return denied
+    assert row is not None
+
+    if method == "GET" and action == "status":
+        return _json_ok({"app_id": app_id, "status": row["status"], "error": row["error_message"]})
+
+    if method == "GET" and action == "logs":
+        logs = get_docker_logs(row["name"], config.temporary_data_dir, row["container_id"])
+        return Response(content=logs, status_code=200, media_type="text/plain; charset=utf-8")
+
+    if method == "POST" and action == "stop":
+        stop_app_process(row)
+        stop_container(f"openhost-{row['name']}")
+        db.execute("UPDATE apps SET status = 'stopped', container_id = NULL WHERE app_id = ?", (app_id,))
+        db.commit()
+        return _json_ok({"ok": True, "app_id": app_id, "status": "stopped"})
+
+    if method == "POST" and action == "start":
+        try:
+            start_app_process(app_id, db, config)
+        except (RuntimeError, ValueError) as exc:
+            return _json_error("start_failed", str(exc), 400)
+        return _json_ok({"ok": True, "app_id": app_id, "status": "starting"})
+
+    if method == "POST" and action == "remove":
+        keep_data = False
+        try:
+            body = await request.json()
+            if isinstance(body, dict):
+                keep_data = bool(body.get("keep_data", False))
+        except Exception:
+            keep_data = False
+        # Atomic claim mirrors /remove_app: only the first request flips to
+        # 'removing' and spawns the worker.
+        cursor = db.execute(
+            "UPDATE apps SET status = 'removing', error_message = NULL WHERE app_id = ? AND status != 'removing'",
+            (app_id,),
+        )
+        db.commit()
+        if cursor.rowcount == 0:
+            return _json_ok({"ok": True, "app_id": app_id, "already_removing": True})
+        try:
+            Thread(target=remove_app_background, args=(app_id, keep_data, config), daemon=True).start()
+        except Exception as exc:
+            logger.exception("platform-service: could not spawn remove worker for %s", app_id)
+            db.execute(
+                "UPDATE apps SET status = 'error', error_message = ? WHERE app_id = ?",
+                (f"Could not start removal worker: {exc}", app_id),
+            )
+            db.commit()
+            return _json_error("remove_failed", "could not start removal worker; try again", 503)
+        return _json_ok({"ok": True, "app_id": app_id, "status": "removing"})
+
+    return _json_error("bad_request", f"Unknown app action: {method} {action}", 404)
+
+
+# ── system_read ──────────────────────────────────────────────────────────────
+
+
+def _handle_system(consumer_app_id: str, db: sqlite3.Connection, config: Config) -> Response[Any]:
+    if not has_capability(_platform_grants(consumer_app_id), CAP_SYSTEM_READ):
+        return _permission_denied("no system_read grant present")
+    # Reuse the same storage snapshot the dashboard uses; kept read-only.
+    return _json_ok({"storage": storage_status(config)})
+
+
+# ── delegate (non-escalating) ────────────────────────────────────────────────
+
+
+async def _handle_delegate(
+    consumer_app_id: str, request: Request[Any, Any, Any], db: sqlite3.Connection
+) -> Response[Any]:
+    """Grant one of the caller's OWN permissions to an app the caller deployed.
+
+    Body: {app_id, service, grant, scope?}.  Enforces both delegation gates:
+    the caller must hold ``delegate_permissions``, must already hold the exact
+    ``grant`` for ``service``, and the target app must be one the caller
+    deployed (installed_by == caller).  This is the non-escalating
+    "make copies of my privileges" primitive.
+    """
+    try:
+        body = await request.json()
+    except Exception:
+        return _json_error("bad_request", "request body must be a JSON object", 400)
+    if not isinstance(body, dict):
+        return _json_error("bad_request", "request body must be a JSON object", 400)
+
+    target_app_id = (body.get("app_id") or "").strip()
+    service = (body.get("service") or "").strip()
+    grant = body.get("grant")
+    if not target_app_id or not service or grant is None:
+        return _json_error("bad_request", "app_id, service, and grant are required", 400)
+
+    # The target must be an app THIS caller deployed.
+    row = db.execute("SELECT installed_by FROM apps WHERE app_id = ?", (target_app_id,)).fetchone()
+    if row is None:
+        return _json_error("not_found", f"app {target_app_id!r} not found", 404)
+    if row["installed_by"] != consumer_app_id:
+        return _permission_denied(f"{consumer_app_id} did not deploy {target_app_id!r}; cannot delegate to it")
+
+    # Both delegation gates (capability held + caller already holds the grant).
+    caller_platform_grants = _platform_grants(consumer_app_id)
+    caller_grants_for_service = get_granted_permissions_v2(consumer_app_id, service)
+    if (
+        reason := check_delegation_allowed(
+            caller_platform_grants=caller_platform_grants,
+            caller_grants_for_target_service=caller_grants_for_service,
+            grant_to_delegate=grant,
+        )
+    ) is not None:
+        return _permission_denied(reason)
+
+    grant_permission_v2(target_app_id, service, grant, scope="global")
+    return _json_ok({"ok": True, "app_id": target_app_id, "service": service, "grant": grant})

--- a/compute_space/src/compute_space/web/routes/platform_dispatch.py
+++ b/compute_space/src/compute_space/web/routes/platform_dispatch.py
@@ -46,6 +46,7 @@ from compute_space.core.containers import stop_container
 from compute_space.core.installer import InstallError
 from compute_space.core.installer import install_from_repo_url
 from compute_space.core.logging import logger
+from compute_space.core.platform_service import CAP_DELEGATE_PERMISSIONS
 from compute_space.core.platform_service import CAP_SYSTEM_READ
 from compute_space.core.platform_service import PLATFORM_SERVICE_URL
 from compute_space.core.platform_service import PLATFORM_SERVICE_VERSION
@@ -314,6 +315,13 @@ async def _handle_delegate(
     if not target_app_id or not service or grant is None:
         return _json_error("bad_request", "app_id, service, and grant are required", 400)
 
+    # Check the delegate capability FIRST, before touching the apps table, so a
+    # caller without delegate_permissions can't probe app existence via the
+    # 404-vs-403 distinction.
+    caller_platform_grants = _platform_grants(consumer_app_id)
+    if not has_capability(caller_platform_grants, CAP_DELEGATE_PERMISSIONS):
+        return _permission_denied("caller lacks the delegate_permissions capability")
+
     # The target must be an app THIS caller deployed.
     row = db.execute("SELECT installed_by FROM apps WHERE app_id = ?", (target_app_id,)).fetchone()
     if row is None:
@@ -321,8 +329,7 @@ async def _handle_delegate(
     if row["installed_by"] != consumer_app_id:
         return _permission_denied(f"{consumer_app_id} did not deploy {target_app_id!r}; cannot delegate to it")
 
-    # Both delegation gates (capability held + caller already holds the grant).
-    caller_platform_grants = _platform_grants(consumer_app_id)
+    # Remaining delegation gate (caller already holds the exact grant).
     caller_grants_for_service = get_granted_permissions_v2(consumer_app_id, service)
     if (
         reason := check_delegation_allowed(

--- a/compute_space/src/compute_space/web/routes/services_v2.py
+++ b/compute_space/src/compute_space/web/routes/services_v2.py
@@ -22,7 +22,6 @@ import json
 import sqlite3
 from collections.abc import Iterable
 from typing import Any
-from urllib.parse import urlencode
 
 import attr
 from litestar import HttpMethod
@@ -48,7 +47,6 @@ from compute_space.core.apps import find_app_by_name
 from compute_space.core.apps import get_app_from_hostname
 from compute_space.core.auth.permissions_v2 import get_granted_permissions_v2
 from compute_space.core.containers import get_docker_logs
-from compute_space.core.domains import primary_domain_or_none
 from compute_space.core.installer import GRANT_KEY_CAPABILITY
 from compute_space.core.installer import GRANT_KEY_REPO_URL_PREFIX
 from compute_space.core.installer import INSTALLER_SERVICE_URL
@@ -61,6 +59,7 @@ from compute_space.core.manifest import parse_manifest_from_string
 from compute_space.core.platform_service import PLATFORM_SERVICE_URL
 from compute_space.core.services_v2 import ServiceNotAvailable
 from compute_space.core.services_v2 import ShortnameNotDeclared
+from compute_space.core.services_v2 import build_grant_approval_url
 from compute_space.core.services_v2 import lookup_shortname
 from compute_space.core.services_v2 import resolve_provider
 from compute_space.web.auth.auth import require_app_auth
@@ -169,17 +168,9 @@ def _carry_response_headers(headers: MutableScopeHeaders) -> Iterable[tuple[str,
 
 
 def _approve_grant_url(consumer_app_id: str, service_url: str, grant: Any, db: sqlite3.Connection) -> str:
-    # urlencode each value: service_url contains "/" and ":", grant is JSON with "{", "}",
-    # ",", '"' — all of which break query-string parsing if interpolated raw.
-    query = urlencode({"app": consumer_app_id, "service": service_url, "grant": json.dumps(grant, sort_keys=True)})
-    approve_path = f"/approve-permissions-v2?{query}"
-    # Cross-app approval is server-side (no browsing request in hand), so this stays on
-    # the canonical/primary domain; use its scheme rather than a hardcoded https so a
-    # plain-http primary (e.g. a `.local` instance) builds a correct URL.
-    primary = primary_domain_or_none(db)
-    if primary is None:
-        return approve_path
-    return f"{primary.scheme}://{primary.name}{approve_path}"
+    # Thin wrapper kept for the existing call sites; the shared builder lives in
+    # core.services_v2 so the platform service can reuse it too.
+    return build_grant_approval_url(consumer_app_id, service_url, grant, db)
 
 
 def _cors_headers(origin: str) -> dict[str, str]:

--- a/compute_space/src/compute_space/web/routes/services_v2.py
+++ b/compute_space/src/compute_space/web/routes/services_v2.py
@@ -58,6 +58,7 @@ from compute_space.core.installer import InstallError
 from compute_space.core.installer import check_install_allowed
 from compute_space.core.installer import install_from_repo_url
 from compute_space.core.manifest import parse_manifest_from_string
+from compute_space.core.platform_service import PLATFORM_SERVICE_URL
 from compute_space.core.services_v2 import ServiceNotAvailable
 from compute_space.core.services_v2 import ShortnameNotDeclared
 from compute_space.core.services_v2 import lookup_shortname
@@ -66,6 +67,7 @@ from compute_space.web.auth.auth import require_app_auth
 from compute_space.web.auth.auth import verify_app_auth
 from compute_space.web.helpers.proxy import proxy_http_request
 from compute_space.web.helpers.proxy import proxy_websocket_request
+from compute_space.web.routes.platform_dispatch import handle_platform_request
 
 _CALL_PATH = "/api/services/v2/call/{shortname:str}/{rest:path}"
 _HTTP_METHODS = [
@@ -219,6 +221,15 @@ class InstallerServiceRequest:
 
 
 @attr.s(auto_attribs=True, frozen=True)
+class PlatformServiceRequest:
+    """A call to the router-internal platform service (dispatched in-process,
+    like the installer)."""
+
+    service_url: str
+    version_spec: str
+
+
+@attr.s(auto_attribs=True, frozen=True)
 class ServiceRequest:
     service_url: str
     version_spec: str
@@ -234,11 +245,16 @@ def _service_call_common(
     rest: str,
     db: sqlite3.Connection,
     provider_app_id: str | None = None,
-) -> ServiceRequest | InstallerServiceRequest:
+) -> ServiceRequest | InstallerServiceRequest | PlatformServiceRequest:
     service_url, version_spec = lookup_shortname(consumer_app_id, shortname, db)
 
     if service_url == INSTALLER_SERVICE_URL:
         return InstallerServiceRequest(
+            service_url=service_url,
+            version_spec=version_spec,
+        )
+    elif service_url == PLATFORM_SERVICE_URL:
+        return PlatformServiceRequest(
             service_url=service_url,
             version_spec=version_spec,
         )
@@ -290,6 +306,12 @@ async def service_call(
         )
         return installer_response.to_asgi_response(None, request=request)
 
+    if isinstance(resolved, PlatformServiceRequest):
+        platform_response = await handle_platform_request(
+            consumer_app_id, resolved.version_spec, rest, request, db, config
+        )
+        return platform_response.to_asgi_response(app=request.app, request=request)
+
     response = await proxy_http_request(
         request,
         target_port=resolved.provider_port,
@@ -333,9 +355,9 @@ async def service_call_ws(
         await socket.close(code=4503, reason=e.message)
         return
 
-    if isinstance(resolved, InstallerServiceRequest):
+    if isinstance(resolved, (InstallerServiceRequest, PlatformServiceRequest)):
         await socket.accept()
-        await socket.close(code=1011, reason="Installer service is not available over WebSocket")
+        await socket.close(code=1011, reason="This router-internal service is not available over WebSocket")
         return
 
     await proxy_websocket_request(

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -16,3 +16,4 @@
 - [OAuth in Apps](./oauth.md)
 - [Cross-App Services](./cross_app_services.md)
 - [Running in a Local QEMU VM](./deploying.md)
+- [Platform Service](./platform_service.md)

--- a/docs/src/platform_service.md
+++ b/docs/src/platform_service.md
@@ -1,9 +1,9 @@
-# The OpenHost platform service (prototype)
+# The OpenHost platform service
 
-> Prototype implementing the platform-access design: apps reach platform
-> operations over the **same** v2 service interface they use to call other
-> apps, served in-process by the router (like the `installer` service) and
-> gated by ordinary `permissions_v2` grants — **not** by flat API-token scopes.
+> Apps reach platform operations over the **same** v2 service interface they use
+> to call other apps, served in-process by the router (like the `installer`
+> service) and gated by ordinary `permissions_v2` grants tied to the calling
+> app's identity.
 
 ## Why
 
@@ -73,7 +73,7 @@ The router grants `G` on `S` to B **only if**:
 So A can hand out copies of (a subset of) its own privileges but can never mint
 a grant it doesn't have — no privilege escalation.
 
-## Not in this prototype (deferred, per design)
+## Not included yet (tracked as follow-ups)
 
 - SSH access to the compute space.
 - Write access to platform settings.

--- a/docs/src/platform_service.md
+++ b/docs/src/platform_service.md
@@ -1,0 +1,89 @@
+# The OpenHost platform service (prototype)
+
+> Prototype implementing the platform-access design: apps reach platform
+> operations over the **same** v2 service interface they use to call other
+> apps, served in-process by the router (like the `installer` service) and
+> gated by ordinary `permissions_v2` grants — **not** by flat API-token scopes.
+
+## Why
+
+An app (e.g. a coding agent / "mind") should be able to do roughly what the
+`oh` CLI does — deploy apps, manage them, read system info — without being
+handed root-equivalent access. The unit of authority is a `permissions_v2`
+grant tied to the calling app's identity, so the platform is just another
+service in the same model apps already use for secrets, oauth, installer, etc.
+
+## How an app consumes it
+
+```toml
+[[services.v2.consumes]]
+service   = "github.com/imbue-openhost/openhost/services/platform"
+shortname = "platform"
+version   = ">=0.1.0"
+grants    = [
+  {capability = "deploy",       repo_url_prefix = "https://github.com/acme/"},
+  {capability = "manage_apps",  target = "own"},
+  {capability = "system_read"},
+  {capability = "delegate_permissions"},
+]
+```
+
+Then call `{OPENHOST_ROUTER_URL}/api/services/v2/call/platform/<endpoint>` with
+`Authorization: Bearer $OPENHOST_APP_TOKEN`. The owner approves the declared
+grants (same flow as any other service).
+
+## Capabilities (grant payloads)
+
+| Capability | Payload | Grants |
+|---|---|---|
+| `deploy` | `{capability:"deploy", repo_url_prefix:"..."}` | Deploy new apps whose repo_url starts with the prefix (`""`/`"*"` = any). The new app's `installed_by` is stamped with the caller. |
+| `manage_apps` | `{capability:"manage_apps", target:"own"\|"all"\|"<app_id>"}` | View status/logs, stop/start, remove. `own` = apps this caller deployed; `all` = every app; `<app_id>` = one app. Does **not** include granting permissions. |
+| `system_read` | `{capability:"system_read"}` | Read-only system info (storage snapshot; disk/mem/etc). |
+| `delegate_permissions` | `{capability:"delegate_permissions"}` | Grant an app **the caller deployed** any permission the **caller already holds** — never more (non-escalating). |
+
+## Endpoints
+
+```
+POST /deploy                {repo_url, app_name?}            cap: deploy
+GET  /apps                                                    cap: manage_apps
+GET  /apps/<app_id>/status                                    cap: manage_apps (scoped)
+GET  /apps/<app_id>/logs                                      cap: manage_apps (scoped)
+POST /apps/<app_id>/stop                                      cap: manage_apps (scoped)
+POST /apps/<app_id>/start                                     cap: manage_apps (scoped)
+POST /apps/<app_id>/remove  {keep_data?}                      cap: manage_apps (scoped)
+GET  /system                                                  cap: system_read
+POST /delegate              {app_id, service, grant, scope?}  cap: delegate_permissions
+```
+
+## The propagating (non-escalating) delegation
+
+This is the headline capability. An app A that holds `deploy` +
+`delegate_permissions` + some grant `G` for service `S` can:
+
+1. deploy app B (B's `installed_by = A`), then
+2. `POST /delegate {app_id: B, service: S, grant: G}`.
+
+The router grants `G` on `S` to B **only if**:
+
+- A holds `delegate_permissions`, **and**
+- A itself already holds exactly `G` for `S` (compared by canonical JSON, so
+  key order doesn't matter), **and**
+- B was deployed by A (`installed_by == A`).
+
+So A can hand out copies of (a subset of) its own privileges but can never mint
+a grant it doesn't have — no privilege escalation.
+
+## Not in this prototype (deferred, per design)
+
+- SSH access to the compute space.
+- Write access to platform settings.
+- Managing API keys.
+- Owner-facing UI for platform grants beyond the existing `permissions_v2`
+  approval page.
+
+## Relationship to the router-internal service pattern
+
+This reuses the `installer` service's mechanism verbatim: a reserved
+`*_SERVICE_URL` constant, interception in `_service_call_common`, in-process
+dispatch in `service_call` with the router's DB, and `permissions_v2`-based
+gating. See `core/platform_service.py` and `web/routes/platform_dispatch.py`.

--- a/docs/src/platform_service.md
+++ b/docs/src/platform_service.md
@@ -52,7 +52,7 @@ POST /apps/<app_id>/stop                                      cap: manage_apps (
 POST /apps/<app_id>/start                                     cap: manage_apps (scoped)
 POST /apps/<app_id>/remove  {keep_data?}                      cap: manage_apps (scoped)
 GET  /system                                                  cap: system_read
-POST /delegate              {app_id, service, grant, scope?}  cap: delegate_permissions
+POST /delegate              {app_id, service, grant}         cap: delegate_permissions
 ```
 
 ## The propagating (non-escalating) delegation

--- a/docs/src/platform_service.md
+++ b/docs/src/platform_service.md
@@ -38,7 +38,7 @@ grants (same flow as any other service).
 |---|---|---|
 | `deploy` | `{capability:"deploy", repo_url_prefix:"..."}` | Deploy new apps whose repo_url starts with the prefix (`""`/`"*"` = any). The new app's `installed_by` is stamped with the caller. |
 | `manage_apps` | `{capability:"manage_apps", target:"own"\|"all"\|"<app_id>"}` | View status/logs, stop/start, remove. `own` = apps this caller deployed; `all` = every app; `<app_id>` = one app. Does **not** include granting permissions. |
-| `system_read` | `{capability:"system_read"}` | Read-only system info (storage snapshot; disk/mem/etc). |
+| `system_read` | `{capability:"system_read"}` | Read-only system info: version (git branch/SHA), storage snapshot, external listening ports, and a tail of the platform log. |
 | `delegate_permissions` | `{capability:"delegate_permissions"}` | Grant an app **the caller deployed** any permission the **caller already holds** — never more (non-escalating). |
 
 ## Endpoints


### PR DESCRIPTION
Exposes OpenHost platform operations to apps over the same v2 service interface they use to call other apps. The platform service is dispatched in-process by the router (the same mechanism as the installer service) and gated by ordinary permissions_v2 grants tied to the calling app's identity.

An app that wants platform access declares a [[services.v2.consumes]] block for service github.com/imbue-openhost/openhost/services/platform with a "platform" shortname and the grants it needs, then calls {ROUTER}/api/services/v2/call/platform/<endpoint> with Authorization: Bearer $OPENHOST_APP_TOKEN. The owner approves the declared grants the same way as any other service.

Capabilities (permissions_v2 grant payloads):
- deploy {repo_url_prefix}: deploy new apps whose repo_url matches the prefix ("" or "*" = any). New apps get installed_by stamped with the caller.
- manage_apps {target: own|all|<app_id>}: view status/logs, stop/start, remove. own = apps this caller deployed; all = every app; <app_id> = one app. Managing does not include granting permissions.
- system_read: read-only system info (version, storage, listening ports, platform logs tail).
- delegate_permissions: grant an app the caller deployed any permission the caller itself already holds, and never more.

Endpoints: POST /deploy, GET /apps, GET /apps/<id>/status, GET /apps/<id>/logs, POST /apps/<id>/{stop,start,remove}, GET /system, POST /delegate.

Propagating non-escalating delegation: an app A holding deploy + delegate_permissions + grant G for service S can deploy app B and then delegate G to B, but only if A itself already holds G for S and B was deployed by A. So A can hand out copies of a subset of its own privileges but can never mint a grant it does not have.

Implementation reuses the installer service pattern: a reserved service URL constant, interception in _service_call_common, in-process dispatch in service_call sharing the router DB, and permissions_v2 gating. Files: core/platform_service.py (grant model), web/routes/platform_dispatch.py (dispatch), wiring in web/routes/services_v2.py, docs/src/platform_service.md.

Testing: unit tests for the grant model and integration tests over the dispatch route; full compute_space suite passes; ruff and mypy clean. Verified live on provisioned instances running this branch, including real GitHub deploys, own-scope manage filtering, and the full non-escalating delegation chain.

Not included yet (tracked as follow-ups): SSH access to the compute space, settings write access, API-key management, and an owner UI beyond the existing permissions_v2 approval page.
