### PR TITLE
Email on the shared identity: outbound via a router-mediated 'email' service (SMTP), inbound direct

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ openhost up --dev
 # (for example: http://my-app.lvh.me:8080)
 openhost up --dev --zone-domain lvh.me
 
+
 # check prerequisites
 openhost doctor
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,6 @@ openhost up --dev
 # (for example: http://my-app.lvh.me:8080)
 openhost up --dev --zone-domain lvh.me
 
-
 # check prerequisites
 openhost doctor
 

--- a/ansible/templates/config.toml.j2
+++ b/ansible/templates/config.toml.j2
@@ -42,9 +42,9 @@ cert_api_keycloak_client_secret = "{{ cert_api_keycloak_client_secret }}"
 {% if email_proxy_base_url is defined and email_proxy_base_url %}
 # Email is enabled automatically because this prerequisite is present (there is no
 # on/off flag): the instance publishes email DNS records (SPF/DKIM/DMARC/MX) into
-# its CoreDNS zone and relays outbound mail through the openhost-email-proxy. Auth
+# its CoreDNS zone and relays outbound mail through the Imbue email relay. Auth
 # resolves from the shared Imbue identity (seeded via first_boot.toml into the DB
-# settings table) — the same credential cert_api uses — so enabling email on an
+# settings table), the same credential cert_api uses, so enabling email on an
 # existing instance needs only this one value. public_ip (rendered above) is also
 # required because inbound is delivered directly to this instance.
 email_proxy_base_url = "{{ email_proxy_base_url }}"

--- a/ansible/templates/config.toml.j2
+++ b/ansible/templates/config.toml.j2
@@ -39,3 +39,21 @@ cert_api_keycloak_client_id = "{{ cert_api_keycloak_client_id }}"
 cert_api_keycloak_client_secret = "{{ cert_api_keycloak_client_secret }}"
 {% endif %}
 {% endif %}
+{% if email_proxy_base_url is defined and email_proxy_base_url %}
+# Email is enabled automatically because this prerequisite is present (there is no
+# on/off flag): the instance publishes email DNS records (SPF/DKIM/DMARC/MX) into
+# its CoreDNS zone and relays outbound mail through the openhost-email-proxy. Auth
+# resolves from the shared Imbue identity (seeded via first_boot.toml into the DB
+# settings table) — the same credential cert_api uses — so enabling email on an
+# existing instance needs only this one value. public_ip (rendered above) is also
+# required because inbound is delivered directly to this instance.
+email_proxy_base_url = "{{ email_proxy_base_url }}"
+{% if email_dmarc_rua is defined %}
+email_dmarc_rua = "{{ email_dmarc_rua }}"
+{% endif %}
+{% if email_custom_domain is defined and email_custom_domain %}
+# Optional custom mail domain the owner delegates to this instance with a single NS
+# record (ns.<zone>). The instance then serves it as a second authoritative zone.
+email_custom_domain = "{{ email_custom_domain }}"
+{% endif %}
+{% endif %}

--- a/compute_space/src/compute_space/config.py
+++ b/compute_space/src/compute_space/config.py
@@ -1,4 +1,5 @@
 import os
+import re
 import sqlite3
 import tomllib
 from pathlib import Path
@@ -18,6 +19,40 @@ from compute_space.core.domains import is_primary_domain
 # broker, which holds the ACME account so the instance never sees ACME creds.
 CERT_PROVIDER_ACME = "acme"
 CERT_PROVIDER_CERT_API = "cert_api"
+
+
+# A DNS label: 1-63 chars, alphanumeric plus internal hyphens.  A well-formed
+# domain is one or more such labels joined by single dots (no empty labels, so no
+# leading/trailing/double dots).  Deliberately conservative — used to reject a
+# malformed email_custom_domain at config load.
+_DOMAIN_LABEL_RE = re.compile(r"^(?!-)[a-z0-9-]{1,63}(?<!-)$")
+
+
+def _is_well_formed_domain(domain: str) -> bool:
+    domain = domain.strip().lower().rstrip(".")
+    if not domain or len(domain) > 253:
+        return False
+    labels = domain.split(".")
+    if len(labels) < 2:
+        return False
+    return all(_DOMAIN_LABEL_RE.match(label) for label in labels)
+
+
+@attr.s(auto_attribs=True, frozen=True)
+class DelegationRecord:
+    """A single DNS record the owner must add at their registrar.
+
+    Used to tell the owner exactly what to paste to delegate a custom mail domain
+    to this instance (see Config.custom_domain_delegation_record).
+    """
+
+    name: str
+    record_type: str
+    value: str
+
+    def as_display_line(self) -> str:
+        """A registrar-style one-liner, e.g. 'mail.mydomain.com  NS  ns.<zone>'."""
+        return f"{self.name}   {self.record_type}   {self.value}"
 
 
 @attr.s(auto_attribs=True, frozen=True)
@@ -95,6 +130,31 @@ class Config:
     # /api/add_app and do not need to be present on disk ahead of time.
     default_apps: list[str]
 
+    ## Email
+    # Email has no on/off flag: it is enabled automatically when its prerequisites are present (see
+    # ``core.email.enablement.email_enabled``, which needs the DB for the shared Imbue identity). The
+    # prerequisites are the proxy URL, the per-instance Keycloak identity (from the DB settings table), and
+    # the public IP.  Provisioning supplies these when email infra is configured; otherwise the instance runs
+    # without email (no boot failure).
+    # Base URL of the email API, e.g. "https://openhost.imbue.com". The instance calls its /api/email/* endpoints.
+    email_proxy_base_url: str | None
+    # Inbound mail is ALWAYS delivered directly to this instance: MX points at mail.<zone> -> public_ip and the mail
+    # server receives on port 25, so inbound never traverses OpenHost infra and the platform cannot read tenant mail.
+    # Outbound relays through the central proxy -> SES. Requires inbound port 25 be reachable.
+    # Optional DMARC aggregate-report address published in the _dmarc record.
+    email_dmarc_rua: str | None
+    # Optional custom mail domain the owner delegated to this instance's CoreDNS with a single NS record (e.g.
+    # "mail.mydomain.com"). When set, the instance serves it as a second authoritative zone and publishes the same
+    # SPF/DKIM/DMARC/MX records, so mail can send/receive as that domain in addition to the built-in <zone> subdomain.
+    email_custom_domain: str | None
+    # App name(s) allowed to fetch the SMTP relay config from /api/email/relay-config. The relay credential is not
+    # stored on the instance; it is fetched at runtime and the endpoint is scoped to these mailbox app names.
+    email_mailbox_app_names: list[str]
+    # Default apps (bare dirnames or remote git URLs, same as ``default_apps``) auto-deployed ONLY when email is
+    # enabled — the mailbox server + webmail client. Kept separate from ``default_apps`` so a non-email instance has
+    # no mailbox; appended by ``effective_default_apps`` when email is enabled.
+    email_default_apps: list[str]
+
     def __attrs_post_init__(self) -> None:
         # Validate cert provider selection up front so any Config object can be
         # trusted as valid by the rest of the system (rather than discovering a
@@ -112,6 +172,13 @@ class Config:
             # are a deprecated fallback for already-deployed instances.
             if not self.cert_api_base_url:
                 raise ValueError("cert_api_base_url must be set in config to use the cert_api provider")
+
+        # Validate the custom mail domain's shape at config load (not zone overlap —
+        # the instance zone lives in the DB, not in Config), so a typo surfaces here
+        # rather than at the first boot that turns email on.
+        custom = self.email_custom_domain_normalized
+        if custom is not None and not _is_well_formed_domain(custom):
+            raise ValueError(f"email_custom_domain {self.email_custom_domain!r} is not a well-formed domain")
 
     def evolve(self, **kwargs: Any) -> Self:
         return attr.evolve(self, **kwargs)
@@ -260,6 +327,65 @@ class Config:
     def default_apps_sentinel_path(self) -> str:
         return str(Path(self.openhost_data_path) / "default_apps.json")
 
+    def inbound_mail_host_for(self, domain: str) -> str:
+        """The mail hostname whose A record the MX points at, for direct inbound.
+
+        Uses ``mail.<domain>`` — a dedicated mail host under the served zone, so
+        the apex A record is left untouched. If the domain is *already* a
+        ``mail.`` host (common for delegated custom domains like
+        ``mail.mydomain.com``), it is used as-is rather than doubled to
+        ``mail.mail.mydomain.com``.
+        """
+        d = domain.strip().lower().rstrip(".")
+        return d if d.startswith("mail.") else f"mail.{d}"
+
+    @property
+    def email_custom_domain_normalized(self) -> str | None:
+        """The custom mail domain lowercased and stripped of any trailing dot.
+
+        Returns None when no custom domain is configured (or it is blank after
+        normalization), so callers can treat "unset" and "blank" identically.
+        """
+        if not self.email_custom_domain:
+            return None
+        normalized = self.email_custom_domain.strip().lower().rstrip(".")
+        return normalized or None
+
+    def custom_domain_delegation_record(self, primary_zone: str) -> DelegationRecord | None:
+        """The single NS record the owner must add at their registrar to delegate
+        their custom mail domain to this instance, or None if none is configured.
+
+        ``primary_zone`` is the instance's zone (from the DB primary domain).  The
+        nameserver host lives under it (``ns.<zone>``), which already resolves to
+        the instance's public IP, so this one record is all that is required.
+        """
+        custom = self.email_custom_domain_normalized
+        if custom is None:
+            return None
+        zone = primary_zone.split(":")[0]
+        return DelegationRecord(
+            name=custom,
+            record_type="NS",
+            value=f"ns.{zone}",
+        )
+
+    def effective_default_apps(self, email_on: bool) -> list[str]:
+        """The apps to auto-deploy: ``default_apps`` plus the email apps when email is on.
+
+        The mailbox + webmail apps are only useful (and only correctly scoped for
+        the relay-config endpoint) when email is on, so they are appended here
+        rather than living in ``default_apps`` — an instance with email off ships
+        no mailbox.  De-duplicated preserving order so an operator who already
+        listed one of them in ``default_apps`` doesn't get it twice.  ``email_on``
+        is threaded in by the caller (email enablement needs the DB).
+        """
+        specs = list(self.default_apps)
+        if email_on:
+            for spec in self.email_default_apps:
+                if spec not in specs:
+                    specs.append(spec)
+        return specs
+
     def make_all_dirs(self) -> None:
         """Make all necessary directories for the config."""
         assert os.path.exists(self.data_root_dir)
@@ -354,6 +480,22 @@ class DefaultConfig(Config):
             "https://github.com/imbue-openhost/openhost-catalog",
             "https://github.com/imbue-openhost/openhost-backup",
             "https://github.com/imbue-openhost/openhost-community-chat",
+        ]
+    )
+
+    # Email — no on/off flag; enabled automatically when its prerequisites (the proxy URL, the shared
+    # Imbue identity in the DB, and the public IP) are present.  Provisioning sets them when the operator
+    # has email infra configured.
+    email_proxy_base_url: str | None = None
+    email_dmarc_rua: str | None = None
+    email_custom_domain: str | None = None
+    email_mailbox_app_names: list[str] = attr.Factory(lambda: ["stalwart-email-server"])
+    # The mailbox server + webmail client, deployed only when email is enabled (see effective_default_apps).
+    # Stalwart's manifest name must stay in email_mailbox_app_names for it to be allowed to fetch the relay config.
+    email_default_apps: list[str] = attr.Factory(
+        lambda: [
+            "https://github.com/imbue-openhost/openhost-stalwart-email-server",
+            "https://github.com/imbue-openhost/openhost-bulwark-email-client",
         ]
     )
 

--- a/compute_space/src/compute_space/config.py
+++ b/compute_space/src/compute_space/config.py
@@ -147,9 +147,6 @@ class Config:
     # "mail.mydomain.com"). When set, the instance serves it as a second authoritative zone and publishes the same
     # SPF/DKIM/DMARC/MX records, so mail can send/receive as that domain in addition to the built-in <zone> subdomain.
     email_custom_domain: str | None
-    # App name(s) allowed to fetch the SMTP relay config from /api/email/relay-config. The relay credential is not
-    # stored on the instance; it is fetched at runtime and the endpoint is scoped to these mailbox app names.
-    email_mailbox_app_names: list[str]
     # Default apps (bare dirnames or remote git URLs, same as ``default_apps``) auto-deployed ONLY when email is
     # enabled — the mailbox server + webmail client. Kept separate from ``default_apps`` so a non-email instance has
     # no mailbox; appended by ``effective_default_apps`` when email is enabled.
@@ -372,10 +369,9 @@ class Config:
     def effective_default_apps(self, email_on: bool) -> list[str]:
         """The apps to auto-deploy: ``default_apps`` plus the email apps when email is on.
 
-        The mailbox + webmail apps are only useful (and only correctly scoped for
-        the relay-config endpoint) when email is on, so they are appended here
-        rather than living in ``default_apps`` — an instance with email off ships
-        no mailbox.  De-duplicated preserving order so an operator who already
+        The mailbox + webmail apps are only useful when email is on, so they are
+        appended here rather than living in ``default_apps`` — an instance with
+        email off ships no mailbox.  De-duplicated preserving order so an operator who already
         listed one of them in ``default_apps`` doesn't get it twice.  ``email_on``
         is threaded in by the caller (email enablement needs the DB).
         """
@@ -489,9 +485,7 @@ class DefaultConfig(Config):
     email_proxy_base_url: str | None = None
     email_dmarc_rua: str | None = None
     email_custom_domain: str | None = None
-    email_mailbox_app_names: list[str] = attr.Factory(lambda: ["stalwart-email-server"])
     # The mailbox server + webmail client, deployed only when email is enabled (see effective_default_apps).
-    # Stalwart's manifest name must stay in email_mailbox_app_names for it to be allowed to fetch the relay config.
     email_default_apps: list[str] = attr.Factory(
         lambda: [
             "https://github.com/imbue-openhost/openhost-stalwart-email-server",

--- a/compute_space/src/compute_space/core/auth/security_audit.py
+++ b/compute_space/src/compute_space/core/auth/security_audit.py
@@ -166,6 +166,12 @@ def _secure_ports() -> dict[int, str]:
         # If the config isn't available (e.g. unit-testing the helper directly),
         # fall back to the public-only set.
         pass
+    # The router's outbound-email SMTP submission listener (email v2 service) binds
+    # 127.0.0.1 + 10.200.0.1 only (never public), and only when email is enabled;
+    # mark it expected so the audit doesn't flag it. Static import (no heavy deps).
+    from compute_space.core.email.service import ROUTER_SMTP_PORT  # noqa: PLC0415 — avoid import cycle
+
+    secure[ROUTER_SMTP_PORT] = "Router email service (SMTP)"
     return secure
 
 

--- a/compute_space/src/compute_space/core/data.py
+++ b/compute_space/src/compute_space/core/data.py
@@ -8,6 +8,7 @@ import subprocess
 
 from compute_space.core.containers import ROUTER_GATEWAY_HOST
 from compute_space.core.containers import ROUTER_LOOPBACK_HOST
+from compute_space.core.email.service import ROUTER_SMTP_PORT
 from compute_space.core.logging import logger
 from compute_space.core.manifest import AppManifest
 
@@ -158,14 +159,18 @@ def provision_data(
     # Generate app token for cross-app service calls
     env_vars["OPENHOST_APP_TOKEN"] = secrets_mod.token_urlsafe(32)
 
-    if manifest.network_host:
-        # network_host containers share the host's network namespace, so
-        # localhost IS the host.  host.containers.internal doesn't exist.
-        env_vars["OPENHOST_ROUTER_URL"] = f"http://{ROUTER_LOOPBACK_HOST}:{port}"
-    else:
-        # Pasta containers: 127.0.0.1 is the container itself, not the host.
-        # host.containers.internal (podman's host-gateway alias) reaches the host.
-        env_vars["OPENHOST_ROUTER_URL"] = f"http://{ROUTER_GATEWAY_HOST}:{port}"
+    # The host apps use to reach the router (same for HTTP and the email SMTP
+    # listener): the loopback for network_host containers, the podman host-gateway
+    # alias for pasta containers.
+    router_host = ROUTER_LOOPBACK_HOST if manifest.network_host else ROUTER_GATEWAY_HOST
+    env_vars["OPENHOST_ROUTER_URL"] = f"http://{router_host}:{port}"
+
+    # Endpoint of the router's outbound email SMTP submission listener (the
+    # 'email' v2 service). Apps granted the email 'send' permission relay through
+    # this with SMTP AUTH (username = app name, password = OPENHOST_APP_TOKEN); the
+    # router attaches the real relay credential and forwards to the Imbue smarthost.
+    env_vars["OPENHOST_SMTP_HOST"] = router_host
+    env_vars["OPENHOST_SMTP_PORT"] = str(ROUTER_SMTP_PORT)
 
     # Zone identity info so apps can build federated auth flows
     env_vars["OPENHOST_ZONE_DOMAIN"] = zone_domain

--- a/compute_space/src/compute_space/core/default_apps.py
+++ b/compute_space/src/compute_space/core/default_apps.py
@@ -30,6 +30,7 @@ from compute_space.core.apps import clone_and_read_manifest
 from compute_space.core.apps import insert_and_deploy
 from compute_space.core.apps import move_clone_to_app_temp_dir
 from compute_space.core.apps import validate_manifest
+from compute_space.core.email.enablement import email_enabled
 from compute_space.core.logging import logger
 from compute_space.core.manifest import AppManifest
 from compute_space.core.manifest import parse_manifest
@@ -217,13 +218,16 @@ def _install_one(spec: str, config: Config, db: sqlite3.Connection) -> tuple[str
 def deploy_default_apps(config: Config, db: sqlite3.Connection) -> list[DefaultAppOutcome]:
     """Idempotent across boots.  ok/skipped are terminal; failed retries
     up to MAX_RETRY_ATTEMPTS.  Never raises."""
-    if not config.default_apps:
+    # The email apps (mailbox + webmail) are appended only when email is enabled,
+    # which needs the DB (the shared Imbue identity lives in the settings table).
+    specs = config.effective_default_apps(email_on=email_enabled(config, db))
+    if not specs:
         return []
 
     sentinel = _load_sentinel(config.default_apps_sentinel_path)
     outcomes: list[DefaultAppOutcome] = []
 
-    for spec in config.default_apps:
+    for spec in specs:
         prior = sentinel.get(spec) or {}
         prior_status = prior.get("status")
         try:

--- a/compute_space/src/compute_space/core/dns.py
+++ b/compute_space/src/compute_space/core/dns.py
@@ -116,21 +116,37 @@ class DnsZone:
 
 
 def public_dns_zones(config: Config, db: sqlite3.Connection) -> tuple[DnsZone, ...]:
-    """The zones CoreDNS is authoritative for: every non-mDNS domain the instance answers on.
+    """The zones CoreDNS is authoritative for: every non-mDNS domain the instance answers on,
+    plus the delegated custom mail domain (if configured).
 
     mDNS ``.local`` domains are served by the wildcard mDNS responder, never CoreDNS/ACME, so
     they are excluded.  The primary keeps the legacy ``zonefile`` path; additional public domains
-    get a per-domain file under ``zones/`` (see ``Config.coredns_zonefile_path_for``)."""
+    get a per-domain file under ``zones/`` (see ``Config.coredns_zonefile_path_for``).
+
+    The custom mail domain is a *mail-only* zone: the owner delegates it here with one NS record
+    so the instance can serve its SPF/DKIM/DMARC/MX (published by email provisioning).  It is NOT a
+    web-routing domain (no Caddy site, no TLS cert), so it lives outside the ``domains`` table and
+    is appended here as a DNS-only zone.  Without this, email provisioning would write the custom
+    domain's records into a zone file CoreDNS never serves."""
     primary = primary_domain_or_none(db)
     primary_no_port = primary.name_no_port if primary else None
-    return tuple(
+    zones = [
         DnsZone(
             domain=d.name_no_port,
             zonefile_path=config.coredns_zonefile_path_for(d.name_no_port, d.name_no_port == primary_no_port),
         )
         for d in effective_domains(db)
         if not d.mdns
-    )
+    ]
+    custom_mail = config.email_custom_domain_normalized
+    if custom_mail is not None and not any(z.domain == custom_mail for z in zones):
+        zones.append(
+            DnsZone(
+                domain=custom_mail,
+                zonefile_path=config.coredns_zonefile_path_for(custom_mail, is_primary=False),
+            )
+        )
+    return tuple(zones)
 
 
 def _write_coredns_config(

--- a/compute_space/src/compute_space/core/dns.py
+++ b/compute_space/src/compute_space/core/dns.py
@@ -9,7 +9,7 @@ restart — see ``reload_coredns_for_domains``.
 
 For DNS-01 ACME challenges, the router calls append_txt_records() on a domain's own
 zone file to add TXT records, waits for CoreDNS to pick them up, then calls
-clear_txt() after the cert is issued.
+clear_acme_challenge_records() after the cert is issued.
 """
 
 from __future__ import annotations
@@ -329,12 +329,32 @@ def append_txt_records(zone_file_path: Path, records: list[TxtRecord]) -> None:
     logger.info(f"Appended {len(records)} TXT record(s)")
 
 
-def clear_txt(zone_file_path: Path) -> None:
-    """Remove all TXT records from the zone file and bump the SOA serial."""
+# ACME DNS-01 challenge TXT records are published at this owner name (relative to the
+# zone $ORIGIN, or as the absolute FQDN). clear_acme_challenge_records scopes its removal
+# to these so it never deletes persistent email TXT records (SPF at the apex, DMARC at
+# _dmarc) that share the "IN TXT" shape.
+_ACME_CHALLENGE_LABEL = "_acme-challenge"
+
+
+def _is_acme_challenge_txt(line: str) -> bool:
+    """True iff ``line`` is an ACME-challenge TXT record (owned by _acme-challenge)."""
+    if "IN TXT" not in line:
+        return False
+    owner = line.split(None, 1)[0] if line.split() else ""
+    return owner == _ACME_CHALLENGE_LABEL or owner.startswith(_ACME_CHALLENGE_LABEL + ".")
+
+
+def clear_acme_challenge_records(zone_file_path: Path) -> None:
+    """Remove ACME-challenge TXT records from the zone file and bump the SOA serial.
+
+    Only ``_acme-challenge`` TXT records are removed; persistent email records (SPF at
+    the apex, DMARC at ``_dmarc``, DKIM CNAMEs) are left intact so a cert renewal never
+    disturbs mail deliverability.
+    """
     with open(zone_file_path) as f:
         content = f.read()
-    lines = [line for line in content.splitlines() if "IN TXT" not in line]
+    lines = [line for line in content.splitlines() if not _is_acme_challenge_txt(line)]
     content = _bump_serial("\n".join(lines) + "\n")
     with open(zone_file_path, "w") as f:
         f.write(content)
-    logger.info(f"Cleared TXT records from {zone_file_path}")
+    logger.info(f"Cleared ACME-challenge TXT records from {zone_file_path}")

--- a/compute_space/src/compute_space/core/dns.py
+++ b/compute_space/src/compute_space/core/dns.py
@@ -329,6 +329,89 @@ def append_txt_records(zone_file_path: Path, records: list[TxtRecord]) -> None:
     logger.info(f"Appended {len(records)} TXT record(s)")
 
 
+@attr.s(auto_attribs=True, frozen=True)
+class DkimCname:
+    """One DKIM CNAME record SES requires the zone to publish.
+
+    ``name`` and ``target`` are absolute (SES returns fully-qualified names), so both
+    are written as FQDNs (trailing dot) into the zone file.
+    """
+
+    name: str
+    target: str
+
+
+def render_email_records(
+    domain: str,
+    *,
+    inbound_mail_host: str,
+    inbound_mail_ip: str,
+    dkim_cnames: list[DkimCname],
+    dmarc_rua: str | None = None,
+) -> str:
+    """Render the persistent email DNS records for ``domain`` as zone-file lines.
+
+    Produces SPF (apex TXT authorizing SES — outbound always relays via SES), a DMARC
+    policy (_dmarc TXT), the MX record, and the DKIM CNAMEs SES requires. Deterministic
+    given the inputs, so they can be re-applied idempotently on every boot.
+
+    Inbound is always direct to this instance: the MX points at the instance's own mail
+    host (``inbound_mail_host``, e.g. ``mail.<domain>``) and an A record is published for
+    that host -> the instance IP, so the instance's own mail server receives mail on port
+    25. Mail is never routed through OpenHost infrastructure inbound. Only outbound goes
+    through the central SES relay. ``domain`` is accepted for symmetry/logging; records
+    are keyed by ``@``/host relative to the zone $ORIGIN.
+    """
+    if not inbound_mail_host:
+        raise ValueError("inbound_mail_host is required")
+    if not inbound_mail_ip:
+        raise ValueError("inbound_mail_ip is required for the mail host A record")
+    lines: list[str] = ["; --- openhost email records (managed) ---"]
+    lines.append('@   IN TXT  "v=spf1 include:amazonses.com ~all"')
+    dmarc = "v=DMARC1; p=quarantine"
+    if dmarc_rua:
+        dmarc += f"; rua=mailto:{dmarc_rua}"
+    lines.append(f'_dmarc   IN TXT  "{dmarc}"')
+    host = inbound_mail_host.rstrip(".")
+    lines.append(f"@   IN MX   10 {host}.")
+    lines.append(f"{host}.   IN A   {inbound_mail_ip}")
+    for c in dkim_cnames:
+        lines.append(f"{c.name.rstrip('.')}.   IN CNAME  {c.target.rstrip('.')}.")
+    lines.append("; --- end openhost email records ---")
+    return "\n".join(lines) + "\n"
+
+
+def apply_email_records(
+    zone_file_path: Path,
+    domain: str,
+    *,
+    inbound_mail_host: str,
+    inbound_mail_ip: str,
+    dkim_cnames: list[DkimCname],
+    dmarc_rua: str | None = None,
+) -> None:
+    """Append the persistent email records to ``zone_file_path`` and bump the serial.
+
+    Called once after CoreDNS starts on each boot (the zone file is regenerated from
+    template there). Appending (rather than templating) keeps the DKIM tokens — only
+    known after the SES identity is created — out of the boot-time template.
+    """
+    block = render_email_records(
+        domain,
+        inbound_mail_host=inbound_mail_host,
+        inbound_mail_ip=inbound_mail_ip,
+        dkim_cnames=dkim_cnames,
+        dmarc_rua=dmarc_rua,
+    )
+    with open(zone_file_path) as f:
+        content = f.read()
+    content = _bump_serial(content)
+    content = content.rstrip("\n") + "\n" + block
+    with open(zone_file_path, "w") as f:
+        f.write(content)
+    logger.info(f"Applied {len(dkim_cnames)} DKIM CNAME(s) + SPF/DMARC/MX to {zone_file_path}")
+
+
 # ACME DNS-01 challenge TXT records are published at this owner name (relative to the
 # zone $ORIGIN, or as the absolute FQDN). clear_acme_challenge_records scopes its removal
 # to these so it never deletes persistent email TXT records (SPF at the apex, DMARC at

--- a/compute_space/src/compute_space/core/email/enablement.py
+++ b/compute_space/src/compute_space/core/email/enablement.py
@@ -1,0 +1,39 @@
+"""Whether email is active on this instance, and the identity it authenticates with.
+
+Email has no stored on/off flag: it is enabled iff its prerequisites resolve. Two
+of the three live outside the frozen ``Config`` — the shared per-instance Imbue
+identity is read live from the DB settings table (``core.identity_store``), so
+enablement needs the DB. Kept in its own tiny module (rather than as a Config
+property) precisely so it can take the DB.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+from compute_space.config import Config
+from compute_space.core.identity_store import get_instance_identity
+from compute_space.core.tls.keycloak import KeycloakClientCredentials
+
+
+def email_enabled(config: Config, db: sqlite3.Connection) -> bool:
+    """True iff all email prerequisites are present.
+
+    Requires the email proxy URL, the shared Imbue identity (DB settings, with the
+    deprecated cert_api_keycloak_* config fallback), and the public IP (inbound is
+    always direct-to-instance, so the MX/A records need the instance's own IP).
+    """
+    return bool(
+        config.email_proxy_base_url
+        and get_instance_identity(db, config) is not None
+        and config.public_ip
+    )
+
+
+def resolve_email_identity(config: Config, db: sqlite3.Connection) -> KeycloakClientCredentials | None:
+    """The Keycloak client-credentials email authenticates with, or None.
+
+    A thin wrapper over ``get_instance_identity`` — email reuses the shared
+    per-instance Imbue identity rather than a separate email-only client.
+    """
+    return get_instance_identity(db, config)

--- a/compute_space/src/compute_space/core/email/enablement.py
+++ b/compute_space/src/compute_space/core/email/enablement.py
@@ -23,11 +23,7 @@ def email_enabled(config: Config, db: sqlite3.Connection) -> bool:
     deprecated cert_api_keycloak_* config fallback), and the public IP (inbound is
     always direct-to-instance, so the MX/A records need the instance's own IP).
     """
-    return bool(
-        config.email_proxy_base_url
-        and get_instance_identity(db, config) is not None
-        and config.public_ip
-    )
+    return bool(config.email_proxy_base_url and get_instance_identity(db, config) is not None and config.public_ip)
 
 
 def resolve_email_identity(config: Config, db: sqlite3.Connection) -> KeycloakClientCredentials | None:

--- a/compute_space/src/compute_space/core/email/provision.py
+++ b/compute_space/src/compute_space/core/email/provision.py
@@ -1,0 +1,123 @@
+"""Provision the instance's email DNS records at startup.
+
+When email is enabled, this:
+  1. authenticates to the email proxy with the instance's shared Imbue identity,
+  2. asks the proxy to create/ensure the SES domain identity and return the
+     DKIM CNAME records SES requires,
+  3. writes those DKIM records plus SPF/DMARC/MX into the CoreDNS zone.
+
+This runs for the instance's built-in zone (the DB primary domain), and — when the
+owner has delegated a custom mail domain (email_custom_domain) to this instance with
+an NS record — also for that custom zone, so a single NS record is all it takes to
+send/receive as the custom domain.
+
+Runs after start_coredns on each boot (the zone file is regenerated from template
+there, so the email records must be re-applied every time). Best-effort: a proxy or
+SES hiccup logs and returns rather than blocking router startup — mail is not
+load-bearing for the instance coming up.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+from compute_space.config import Config
+from compute_space.core.dns import DkimCname
+from compute_space.core.dns import apply_email_records
+from compute_space.core.domains import is_primary_domain
+from compute_space.core.domains import primary_domain
+from compute_space.core.email.enablement import email_enabled
+from compute_space.core.email.enablement import resolve_email_identity
+from compute_space.core.email.proxy_client import EmailProxyClient
+from compute_space.core.email.proxy_client import EmailProxyError
+from compute_space.core.logging import logger
+from compute_space.core.tls.keycloak import KeycloakTokenProvider
+
+
+def provision_email_records(config: Config, db: sqlite3.Connection) -> None:
+    """Create the SES identity/identities and publish email DNS records.
+
+    Provisions the instance's built-in zone, and the delegated custom mail domain
+    when one is configured. No-op when email is not enabled. Past the guard, the
+    email prerequisites (proxy URL, Imbue identity, public IP) are all present.
+    """
+    if not email_enabled(config, db):
+        return
+    assert config.email_proxy_base_url is not None
+    credentials = resolve_email_identity(config, db)
+    assert credentials is not None
+    # Inbound is always direct-to-instance, so the MX/A records need the instance's
+    # public IP (guaranteed non-None by email_enabled).
+    assert config.public_ip is not None
+
+    primary = primary_domain(db)
+    zone = primary.name_no_port
+    try:
+        with KeycloakTokenProvider.create(credentials) as token_provider:
+            with EmailProxyClient.create(config.email_proxy_base_url, token_provider) as client:
+                # Built-in zone: the proxy defaults to the caller's zone when no
+                # domain is passed.
+                _ensure_identity_and_publish_records(
+                    config,
+                    db,
+                    client,
+                    domain=zone,
+                    request_domain=None,
+                )
+                # Delegated custom mail domain (optional, one NS record).
+                custom_domain = config.email_custom_domain_normalized
+                if custom_domain is not None:
+                    delegation = config.custom_domain_delegation_record(zone)
+                    if delegation is not None:
+                        logger.info(
+                            f"Custom mail domain {custom_domain}: ensure this single NS record is set "
+                            f"at the registrar to delegate it to this instance:  {delegation.as_display_line()}"
+                        )
+                    _ensure_identity_and_publish_records(
+                        config,
+                        db,
+                        client,
+                        domain=custom_domain,
+                        request_domain=custom_domain,
+                    )
+    except EmailProxyError as e:
+        logger.warning(f"Email provisioning skipped: could not reach email proxy: {e}")
+        return
+    except Exception as e:  # noqa: BLE001
+        logger.warning(f"Email provisioning skipped: {e}")
+        return
+
+
+def _ensure_identity_and_publish_records(
+    config: Config,
+    db: sqlite3.Connection,
+    client: EmailProxyClient,
+    *,
+    domain: str,
+    request_domain: str | None,
+) -> None:
+    """Ensure the SES identity for ``domain`` and write its records into ``domain``'s zone file.
+
+    ``request_domain`` is what we ask the proxy for: None means "the caller's own
+    zone" (the proxy scopes it), while a concrete value is the delegated custom
+    domain the proxy must be authorized to create an identity for.
+    """
+    result = client.ensure_identity(request_domain)
+    dkim_cnames = [DkimCname(name=r.name, target=r.value) for r in result.dkim_records]
+    zone_file_path = config.coredns_zonefile_path_for(domain, is_primary_domain(db, domain))
+    # Inbound is always direct-to-instance: MX -> mail.<domain> -> instance IP, so
+    # mail is delivered straight to the instance's own mail server (never through
+    # OpenHost infra). Outbound relays through SES regardless.
+    assert config.public_ip is not None  # guaranteed by email_enabled
+    apply_email_records(
+        zone_file_path,
+        domain,
+        inbound_mail_host=config.inbound_mail_host_for(domain),
+        inbound_mail_ip=config.public_ip,
+        dkim_cnames=dkim_cnames,
+        dmarc_rua=config.email_dmarc_rua,
+    )
+    logger.info(
+        f"Published email DNS records for {domain} "
+        f"({len(dkim_cnames)} DKIM CNAME(s); identity verified={result.verified})"
+    )

--- a/compute_space/src/compute_space/core/email/proxy_client.py
+++ b/compute_space/src/compute_space/core/email/proxy_client.py
@@ -90,10 +90,15 @@ def _parse_identity(resp: httpx.Response) -> IdentityResult:
     # so a freshly-created identity (201) is not mistaken for an error.
     if not (200 <= resp.status_code < 300):
         raise EmailProxyError(f"email API returned HTTP {resp.status_code}: {resp.text}")
-    body = resp.json()
-    records = tuple(DkimRecord(name=r["name"], value=r["value"]) for r in body.get("dkim_records", []))
-    return IdentityResult(
-        domain=body["domain"],
-        verified=bool(body.get("verified")),
-        dkim_records=records,
-    )
+    # A 2xx with a malformed body is still a failure — surface it as EmailProxyError
+    # (not a raw KeyError/ValueError) so callers handle it uniformly.
+    try:
+        body = resp.json()
+        records = tuple(DkimRecord(name=r["name"], value=r["value"]) for r in body.get("dkim_records", []))
+        return IdentityResult(
+            domain=body["domain"],
+            verified=bool(body.get("verified")),
+            dkim_records=records,
+        )
+    except (ValueError, KeyError, TypeError) as e:
+        raise EmailProxyError(f"email API returned a malformed identity response: {e}") from e

--- a/compute_space/src/compute_space/core/email/proxy_client.py
+++ b/compute_space/src/compute_space/core/email/proxy_client.py
@@ -23,7 +23,6 @@ class DkimRecord:
 
 @attr.s(auto_attribs=True, frozen=True)
 class IdentityResult:
-    domain: str
     verified: bool
     dkim_records: tuple[DkimRecord, ...]
 
@@ -96,7 +95,6 @@ def _parse_identity(resp: httpx.Response) -> IdentityResult:
         body = resp.json()
         records = tuple(DkimRecord(name=r["name"], value=r["value"]) for r in body.get("dkim_records", []))
         return IdentityResult(
-            domain=body["domain"],
             verified=bool(body.get("verified")),
             dkim_records=records,
         )

--- a/compute_space/src/compute_space/core/email/proxy_client.py
+++ b/compute_space/src/compute_space/core/email/proxy_client.py
@@ -1,0 +1,99 @@
+"""HTTP client for the email API.
+
+Presents a Keycloak bearer (via the shared KeycloakTokenProvider) and calls the
+email API's ``/api/email/*`` endpoints. The instance uses it at startup to create
+its SES domain identity and learn the DKIM CNAME records to publish in CoreDNS.
+"""
+
+from __future__ import annotations
+
+from types import TracebackType
+
+import attr
+import httpx
+
+from compute_space.core.tls.keycloak import TokenProvider
+
+
+@attr.s(auto_attribs=True, frozen=True)
+class DkimRecord:
+    name: str
+    value: str
+
+
+@attr.s(auto_attribs=True, frozen=True)
+class IdentityResult:
+    domain: str
+    verified: bool
+    dkim_records: tuple[DkimRecord, ...]
+
+
+class EmailProxyError(RuntimeError):
+    """The email proxy returned an error or was unreachable."""
+
+
+@attr.s(auto_attribs=True)
+class EmailProxyClient:
+    base_url: str
+    token_provider: TokenProvider
+    http_client: httpx.Client
+
+    @classmethod
+    def create(cls, base_url: str, token_provider: TokenProvider, timeout: float = 30.0) -> EmailProxyClient:
+        return cls(
+            base_url=base_url.rstrip("/"),
+            token_provider=token_provider,
+            http_client=httpx.Client(timeout=timeout),
+        )
+
+    def __enter__(self) -> EmailProxyClient:
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
+    ) -> None:
+        self.http_client.close()
+
+    def _auth_headers(self) -> dict[str, str]:
+        # Fetch fresh per call so the token refreshes transparently.
+        return {"Authorization": f"Bearer {self.token_provider.get_token()}"}
+
+    def ensure_identity(self, domain: str | None = None) -> IdentityResult:
+        """Create the SES domain identity for the instance's zone (or a delegated
+        subdomain) and return its DKIM records + verification status."""
+        body = {"domain": domain} if domain else {}
+        try:
+            resp = self.http_client.post(
+                f"{self.base_url}/api/email/identity", json=body, headers=self._auth_headers()
+            )
+        except httpx.HTTPError as e:
+            raise EmailProxyError(f"email API unreachable: {e}") from e
+        return _parse_identity(resp)
+
+    def identity_status(self, domain: str | None = None) -> IdentityResult:
+        params = {"domain": domain} if domain else {}
+        try:
+            resp = self.http_client.get(
+                f"{self.base_url}/api/email/identity", params=params, headers=self._auth_headers()
+            )
+        except httpx.HTTPError as e:
+            raise EmailProxyError(f"email API unreachable: {e}") from e
+        return _parse_identity(resp)
+
+
+def _parse_identity(resp: httpx.Response) -> IdentityResult:
+    # The frontend returns 200 for an already-existing identity and 201 when it
+    # creates one, both with the same body (domain + DKIM records). Accept any 2xx
+    # so a freshly-created identity (201) is not mistaken for an error.
+    if not (200 <= resp.status_code < 300):
+        raise EmailProxyError(f"email API returned HTTP {resp.status_code}: {resp.text}")
+    body = resp.json()
+    records = tuple(DkimRecord(name=r["name"], value=r["value"]) for r in body.get("dkim_records", []))
+    return IdentityResult(
+        domain=body["domain"],
+        verified=bool(body.get("verified")),
+        dkim_records=records,
+    )

--- a/compute_space/src/compute_space/core/email/relay_credential.py
+++ b/compute_space/src/compute_space/core/email/relay_credential.py
@@ -41,14 +41,16 @@ _CACHE_TTL_SECONDS = 300.0
 
 @attr.s(auto_attribs=True, frozen=True)
 class RelayCredential:
-    """The SMTP smarthost config the mailbox app needs to relay outbound mail."""
+    """The SMTP smarthost login the router needs to relay outbound mail.
+
+    Just the four SMTP-connect fields; From-scope is enforced centrally at the
+    proxy, so the instance-side relay never needs the zone/custom-domain here.
+    """
 
     smtp_relay_host: str
     smtp_relay_port: int
     smtp_relay_user: str
     smtp_relay_password: str
-    zone_domain: str
-    custom_domain: str | None
 
 
 class RelayCredentialError(RuntimeError):
@@ -95,18 +97,13 @@ class RelayCredentialProvider:
             now = self.monotonic()  # type: ignore[operator]
             if self._cached is not None and self._cache_key == key and now < self._expires_at:
                 return self._cached
-            cred = self._fetch(credentials, zone, custom_domain)
+            cred = self._fetch(credentials)
             self._cached = cred
             self._cache_key = key
             self._expires_at = now + _CACHE_TTL_SECONDS
             return cred
 
-    def _fetch(
-        self,
-        credentials: KeycloakClientCredentials,
-        zone: str,
-        custom_domain: str | None,
-    ) -> RelayCredential:
+    def _fetch(self, credentials: KeycloakClientCredentials) -> RelayCredential:
         base_url = self.config.email_proxy_base_url
         assert base_url is not None  # guaranteed by email_enabled
         url = f"{base_url.rstrip('/')}/api/email/relay-config"
@@ -128,8 +125,6 @@ class RelayCredentialProvider:
                 smtp_relay_port=int(body["smtp_relay_port"]),
                 smtp_relay_user=body["smtp_relay_user"],
                 smtp_relay_password=body["smtp_relay_password"],
-                zone_domain=body.get("zone_domain") or zone,
-                custom_domain=custom_domain,
             )
         except (KeyError, TypeError, ValueError) as e:
             raise RelayCredentialError(f"relay-config response malformed: {e}") from e

--- a/compute_space/src/compute_space/core/email/relay_credential.py
+++ b/compute_space/src/compute_space/core/email/relay_credential.py
@@ -133,3 +133,33 @@ class RelayCredentialProvider:
             )
         except (KeyError, TypeError, ValueError) as e:
             raise RelayCredentialError(f"relay-config response malformed: {e}") from e
+
+
+# Process-wide relay-credential providers, keyed on the config fields the
+# credential depends on (NOT id(config): provide_config() hands each request a
+# freshly-built Config, so an id()-based key would never hit the TTL cache and
+# would leak a provider per request). The identity/zone the credential also
+# depends on are sourced live from the DB and keyed inside the provider itself.
+_relay_providers: dict[tuple[object, ...], RelayCredentialProvider] = {}
+_relay_providers_lock = threading.Lock()
+
+
+def _relay_provider_key(config: Config) -> tuple[object, ...]:
+    """A stable key over the config fields the relay credential depends on."""
+    return (config.email_proxy_base_url, config.email_custom_domain_normalized)
+
+
+def get_relay_credential_provider(config: Config) -> RelayCredentialProvider:
+    """Return the shared, cached relay-credential provider for this config.
+
+    Both the router SMTP email service and any owner-facing route share one
+    provider per distinct config so the frontend fetch is cached (short TTL)
+    across all callers rather than refetched per request.
+    """
+    key = _relay_provider_key(config)
+    with _relay_providers_lock:
+        provider = _relay_providers.get(key)
+        if provider is None:
+            provider = RelayCredentialProvider(config=config)
+            _relay_providers[key] = provider
+        return provider

--- a/compute_space/src/compute_space/core/email/relay_credential.py
+++ b/compute_space/src/compute_space/core/email/relay_credential.py
@@ -1,0 +1,135 @@
+"""Fetch this instance's SMTP relay credential from the frontend at runtime.
+
+The relay credential (host/port + username/password) is deliberately NOT baked
+into the instance's config. Instead the router fetches it from the email frontend
+(imbue-hosted-spaces) using the same per-instance shared Imbue identity the
+instance already holds for cert-api/email, and the frontend has the backend derive
+``HMAC(RELAY_SECRET, zone)``. This means:
+
+  * nothing email-specific (no relay password) is stored in per-instance config,
+    so enabling email needs no secret injection and upgrades never touch it;
+  * rotating ``RELAY_SECRET`` (which lives only on the backend) rotates every
+    instance's credential automatically — the instance just refetches.
+
+The result is cached in-process with a short TTL so the mailbox app's
+relay-config calls and the inbound-auth check don't hit the frontend on every
+request, while still picking up a rotated secret within the TTL. The cache is
+keyed on the identity/zone the credential depends on, so distinct instances (or
+tests) never bleed into each other.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import threading
+import time
+
+import attr
+import httpx
+
+from compute_space.config import Config
+from compute_space.core.domains import primary_domain
+from compute_space.core.email.enablement import email_enabled
+from compute_space.core.email.enablement import resolve_email_identity
+from compute_space.core.tls.keycloak import KeycloakClientCredentials
+from compute_space.core.tls.keycloak import KeycloakTokenProvider
+
+# How long a fetched credential is trusted before we refetch. Short enough that a
+# rotated RELAY_SECRET propagates quickly; long enough to avoid per-request calls.
+_CACHE_TTL_SECONDS = 300.0
+
+
+@attr.s(auto_attribs=True, frozen=True)
+class RelayCredential:
+    """The SMTP smarthost config the mailbox app needs to relay outbound mail."""
+
+    smtp_relay_host: str
+    smtp_relay_port: int
+    smtp_relay_user: str
+    smtp_relay_password: str
+    zone_domain: str
+    custom_domain: str | None
+
+
+class RelayCredentialError(RuntimeError):
+    pass
+
+
+@attr.s(auto_attribs=True)
+class RelayCredentialProvider:
+    """Fetches + caches this instance's relay credential from the frontend.
+
+    ``get`` takes the DB because the credential's inputs (the shared Imbue identity
+    and the primary zone) are sourced live from the DB, not from the frozen Config.
+    """
+
+    config: Config
+    monotonic: object = time.monotonic
+    _cached: RelayCredential | None = attr.ib(default=None, init=False)
+    _expires_at: float = attr.ib(default=0.0, init=False)
+    _cache_key: tuple[object, ...] | None = attr.ib(default=None, init=False)
+    _lock: threading.Lock = attr.ib(factory=threading.Lock, init=False)
+
+    def get(self, db: sqlite3.Connection) -> RelayCredential | None:
+        """Return the current relay credential, or None when email isn't configured.
+
+        Raises RelayCredentialError only on an unexpected fetch failure while email
+        IS configured (so callers can distinguish "off" from "temporarily broken").
+        """
+        if not email_enabled(self.config, db):
+            return None
+        credentials = resolve_email_identity(self.config, db)
+        assert credentials is not None  # guaranteed by email_enabled
+        zone = primary_domain(db).name_no_port
+        custom_domain = self.config.email_custom_domain_normalized
+        # Key the cache on the inputs the credential depends on so a rotated
+        # identity/zone/custom-domain doesn't serve a stale entry.
+        key: tuple[object, ...] = (
+            credentials.issuer_url,
+            credentials.client_id,
+            credentials.client_secret,
+            zone,
+            custom_domain,
+        )
+        with self._lock:
+            now = self.monotonic()  # type: ignore[operator]
+            if self._cached is not None and self._cache_key == key and now < self._expires_at:
+                return self._cached
+            cred = self._fetch(credentials, zone, custom_domain)
+            self._cached = cred
+            self._cache_key = key
+            self._expires_at = now + _CACHE_TTL_SECONDS
+            return cred
+
+    def _fetch(
+        self,
+        credentials: KeycloakClientCredentials,
+        zone: str,
+        custom_domain: str | None,
+    ) -> RelayCredential:
+        base_url = self.config.email_proxy_base_url
+        assert base_url is not None  # guaranteed by email_enabled
+        url = f"{base_url.rstrip('/')}/api/email/relay-config"
+        try:
+            with KeycloakTokenProvider.create(credentials) as tokens:
+                token = tokens.get_token()
+                with httpx.Client(timeout=30.0) as client:
+                    resp = client.get(url, headers={"Authorization": f"Bearer {token}"})
+        except httpx.HTTPError as e:
+            raise RelayCredentialError(f"relay-config fetch failed: {e}") from e
+        if resp.status_code != 200:
+            raise RelayCredentialError(f"relay-config returned HTTP {resp.status_code}")
+        body = resp.json()
+        if not body.get("configured"):
+            raise RelayCredentialError("frontend reports relay not configured")
+        try:
+            return RelayCredential(
+                smtp_relay_host=body["smtp_relay_host"],
+                smtp_relay_port=int(body["smtp_relay_port"]),
+                smtp_relay_user=body["smtp_relay_user"],
+                smtp_relay_password=body["smtp_relay_password"],
+                zone_domain=body.get("zone_domain") or zone,
+                custom_domain=custom_domain,
+            )
+        except (KeyError, TypeError, ValueError) as e:
+            raise RelayCredentialError(f"relay-config response malformed: {e}") from e

--- a/compute_space/src/compute_space/core/email/relay_credential.py
+++ b/compute_space/src/compute_space/core/email/relay_credential.py
@@ -1,15 +1,15 @@
 """Fetch this instance's SMTP relay credential from the frontend at runtime.
 
 The relay credential (host/port + username/password) is deliberately NOT baked
-into the instance's config. Instead the router fetches it from the email frontend
-(imbue-hosted-spaces) using the same per-instance shared Imbue identity the
-instance already holds for cert-api/email, and the frontend has the backend derive
+into the instance's config. Instead the router fetches it from the Imbue email
+frontend using the same per-instance shared Imbue identity the instance already
+holds for cert-api/email, and the frontend has the backend derive
 ``HMAC(RELAY_SECRET, zone)``. This means:
 
   * nothing email-specific (no relay password) is stored in per-instance config,
     so enabling email needs no secret injection and upgrades never touch it;
   * rotating ``RELAY_SECRET`` (which lives only on the backend) rotates every
-    instance's credential automatically — the instance just refetches.
+    instance's credential automatically: the instance just refetches.
 
 The result is cached in-process with a short TTL so the mailbox app's
 relay-config calls and the inbound-auth check don't hit the frontend on every

--- a/compute_space/src/compute_space/core/email/service.py
+++ b/compute_space/src/compute_space/core/email/service.py
@@ -1,0 +1,44 @@
+"""Identity + grant model for the OpenHost ``email`` v2 service.
+
+Email is an OpenHost-provided service (like ``installer``): apps declare they
+consume it in their manifest and request the ``send`` grant; the router runs an
+SMTP submission listener that authenticates the app, checks this grant, and
+relays the message to the Imbue email proxy smarthost with the per-instance
+relay credential attached. The app never sees that credential.
+
+The service URL is only compared (never fetched) by the grant check, mirroring
+``INSTALLER_SERVICE_URL``. Human-readable spec lives at ``services/email`` in
+this repo.
+"""
+
+from __future__ import annotations
+
+from compute_space.core.auth.permissions_v2 import Grant
+
+# Service URL apps put in their manifest's [[services.v2.consumes]] to use email.
+EMAIL_SERVICE_URL = "github.com/imbue-openhost/openhost/services/email"
+
+# SemVer this build of the email service exposes.
+EMAIL_SERVICE_VERSION = "0.1.0"
+
+# Internal SMTP submission port the router listens on for local apps (the email
+# service). Not public (bound to loopback + the container gateway only) and
+# distinct from 25, which Stalwart uses for inbound delivery. Lives here (a
+# dependency-light module) so container provisioning can inject it without
+# pulling in aiosmtpd.
+ROUTER_SMTP_PORT = 2525
+
+# The single grant the email service currently defines: permission to send
+# outbound mail through the instance's relay. An opaque string grant (the doc's
+# "simple flag-style permission" shape).
+EMAIL_GRANT_SEND = "send"
+
+
+def grants_allow_send(grants: list[Grant]) -> bool:
+    """True iff any granted payload authorizes outbound send.
+
+    Accepts the bare ``"send"` string grant. Kept as a function (not an ``in``
+    check at the call site) so richer grant shapes (e.g. per-address objects)
+    can be added here without touching the SMTP auth path.
+    """
+    return any(g == EMAIL_GRANT_SEND for g in grants)

--- a/compute_space/src/compute_space/core/email/smtp_service.py
+++ b/compute_space/src/compute_space/core/email/smtp_service.py
@@ -25,11 +25,10 @@ inbound mail is unaffected (still delivered directly to Stalwart on 25).
 
 from __future__ import annotations
 
+import asyncio
 import smtplib
 import ssl
 import threading
-from email import message_from_bytes
-from email.policy import default as default_policy
 
 from aiosmtpd.controller import Controller
 from aiosmtpd.smtp import SMTP
@@ -126,10 +125,17 @@ class EmailServiceHandler:
         if not to_addresses:
             return "554 5.5.0 no recipients"
 
+        # Credential fetch (httpx) and the smarthost relay (smtplib) are blocking
+        # network I/O; run them off the aiosmtpd event loop so one slow upstream
+        # call can't stall every other in-flight SMTP session.
+        return await asyncio.to_thread(self._deliver, raw, from_address, to_addresses)
+
+    def _deliver(self, raw: bytes, from_address: str, to_addresses: list[str]) -> str:
+        """Blocking: fetch the relay credential and relay the message. Returns the
+        SMTP status line. Runs in a worker thread (see handle_DATA)."""
         cred = self._fetch_credential()
         if cred is None:
             return "451 4.3.0 email relay not configured on this instance"
-
         try:
             _relay_to_smarthost(cred, raw, from_address, to_addresses)
         except smtplib.SMTPException as e:
@@ -163,16 +169,6 @@ def _relay_to_smarthost(cred: RelayCredential, raw: bytes, from_address: str, to
     with smtplib.SMTP_SSL(host=cred.smtp_relay_host, port=cred.smtp_relay_port, context=context, timeout=30) as client:
         client.login(cred.smtp_relay_user, cred.smtp_relay_password)
         client.sendmail(from_address, to_addresses, raw)
-
-
-def header_from(raw: bytes) -> str | None:
-    """Best-effort message header From address (used by callers/tests)."""
-    try:
-        msg = message_from_bytes(raw, policy=default_policy)
-    except Exception:  # noqa: BLE001
-        return None
-    value = msg.get("From")
-    return str(value) if value is not None else None
 
 
 _controllers: list[Controller] = []

--- a/compute_space/src/compute_space/core/email/smtp_service.py
+++ b/compute_space/src/compute_space/core/email/smtp_service.py
@@ -1,14 +1,10 @@
 """Router-mediated outbound email: the ``email`` v2 service, spoken over SMTP.
 
-Zack's model: email is an OpenHost-provided service (not an app). Any app that
-wants to send mail requests the ``email`` service's ``send`` grant in its
-manifest; the router runs a local SMTP submission listener that the app relays
-through, and the router attaches the real relay credential and forwards to the
-Imbue email proxy smarthost. The app never sees that credential.
-
-This replaces the previous app-scoped model where the mailbox app fetched the
-raw SMTP relay password over ``/api/email/relay-config`` (an allowlist of app
-names) and relayed to the Imbue proxy itself.
+Email is an OpenHost-provided service (not an app). Any app that wants to send
+mail requests the ``email`` service's ``send`` grant in its manifest; the router
+runs a local SMTP submission listener that the app relays through, and the router
+attaches the real relay credential and forwards to the Imbue email proxy
+smarthost. The app never sees that credential.
 
 Auth: the app connects with SMTP AUTH LOGIN/PLAIN, username = its app name,
 password = its ``OPENHOST_APP_TOKEN`` (the same per-app bearer used for HTTP

--- a/compute_space/src/compute_space/core/email/smtp_service.py
+++ b/compute_space/src/compute_space/core/email/smtp_service.py
@@ -96,10 +96,10 @@ class EmailServiceAuthenticator:
             return AuthResult(success=False, handled=False)
         app_id = _authenticated_app_id(username, password)
         if app_id is None:
-            logger.info("email service: SMTP auth failed for app %r", username)
+            logger.info(f"email service: SMTP auth failed for app {username!r}")
             return AuthResult(success=False, handled=False)
         if not _app_may_send(app_id):
-            logger.info("email service: app %r lacks the email 'send' grant", username)
+            logger.info(f"email service: app {username!r} lacks the email 'send' grant")
             return AuthResult(success=False, handled=False)
         # Bind the authenticated app_id to the session for the DATA handler.
         return AuthResult(success=True, auth_data=app_id)
@@ -133,10 +133,10 @@ class EmailServiceHandler:
         try:
             _relay_to_smarthost(cred, raw, from_address, to_addresses)
         except smtplib.SMTPException as e:
-            logger.warning("email service: relay to smarthost failed: %s", e)
+            logger.warning(f"email service: relay to smarthost failed: {e}")
             return f"451 4.4.0 upstream relay failed: {e}"
         except OSError as e:
-            logger.warning("email service: smarthost connection failed: %s", e)
+            logger.warning(f"email service: smarthost connection failed: {e}")
             return f"451 4.4.0 upstream relay unreachable: {e}"
         return "250 OK message accepted for delivery"
 
@@ -145,7 +145,7 @@ class EmailServiceHandler:
         try:
             return get_relay_credential_provider(self._config).get(db)
         except RelayCredentialError as e:
-            logger.warning("email service: could not fetch relay credential: %s", e)
+            logger.warning(f"email service: could not fetch relay credential: {e}")
             return None
         finally:
             db.close()
@@ -212,9 +212,9 @@ def start_email_smtp_service(config: Config, *, hosts: list[str], port: int = RO
                 controller = _make_controller(config, host, port)
                 controller.start()
             except OSError as e:
-                logger.warning("email service: could not bind SMTP listener on %s:%d: %s", host, port, e)
+                logger.warning(f"email service: could not bind SMTP listener on {host}:{port}: {e}")
                 continue
-            logger.info("email service: SMTP submission listener started on %s:%d", host, port)
+            logger.info(f"email service: SMTP submission listener started on {host}:{port}")
             started.append(controller)
         _controllers = started
         return started

--- a/compute_space/src/compute_space/core/email/smtp_service.py
+++ b/compute_space/src/compute_space/core/email/smtp_service.py
@@ -1,0 +1,220 @@
+"""Router-mediated outbound email: the ``email`` v2 service, spoken over SMTP.
+
+Zack's model: email is an OpenHost-provided service (not an app). Any app that
+wants to send mail requests the ``email`` service's ``send`` grant in its
+manifest; the router runs a local SMTP submission listener that the app relays
+through, and the router attaches the real relay credential and forwards to the
+Imbue email proxy smarthost. The app never sees that credential.
+
+This replaces the previous app-scoped model where the mailbox app fetched the
+raw SMTP relay password over ``/api/email/relay-config`` (an allowlist of app
+names) and relayed to the Imbue proxy itself.
+
+Auth: the app connects with SMTP AUTH LOGIN/PLAIN, username = its app name,
+password = its ``OPENHOST_APP_TOKEN`` (the same per-app bearer used for HTTP
+service calls; no new secret). The router validates the token, resolves the
+app_id, and checks the app was granted the ``email`` service ``send`` permission
+(``permissions_v2``) — i.e. permissioned exactly like every other service.
+
+Relay: on an accepted message, the router fetches the per-instance relay
+credential (``RelayCredentialProvider``, cached) and relays the raw message to
+the Imbue smarthost over implicit TLS. The listener binds only on loopback + the
+container gateway (``host.containers.internal``), never a public interface;
+inbound mail is unaffected (still delivered directly to Stalwart on 25).
+"""
+
+from __future__ import annotations
+
+import smtplib
+import ssl
+import threading
+from email import message_from_bytes
+from email.policy import default as default_policy
+
+from aiosmtpd.controller import Controller
+from aiosmtpd.smtp import SMTP
+from aiosmtpd.smtp import AuthResult
+from aiosmtpd.smtp import Envelope
+from aiosmtpd.smtp import LoginPassword
+from aiosmtpd.smtp import Session
+
+from compute_space.config import Config
+from compute_space.core.auth.auth import validate_app_token
+from compute_space.core.auth.permissions_v2 import get_granted_permissions_v2
+from compute_space.core.email.relay_credential import RelayCredential
+from compute_space.core.email.relay_credential import RelayCredentialError
+from compute_space.core.email.relay_credential import get_relay_credential_provider
+from compute_space.core.email.service import EMAIL_SERVICE_URL
+from compute_space.core.email.service import ROUTER_SMTP_PORT
+from compute_space.core.email.service import grants_allow_send
+from compute_space.core.logging import logger
+from compute_space.db.connection import get_db
+
+__all__ = ["ROUTER_SMTP_PORT", "start_email_smtp_service", "EmailServiceAuthenticator", "EmailServiceHandler"]
+
+
+def _authenticated_app_id(username: str, password: str) -> str | None:
+    """Resolve the app whose token is ``password`` and whose name is ``username``.
+
+    Returns the app_id on success, or None if the token is invalid or does not
+    belong to the named app. A fresh DB connection is opened because this runs on
+    the aiosmtpd event-loop thread, not a request thread.
+    """
+    db = get_db()
+    try:
+        authed = validate_app_token(password, db)
+        if authed is None:
+            return None
+        row = db.execute("SELECT name FROM apps WHERE app_id = ?", (authed.app_id,)).fetchone()
+        if row is None or row["name"] != username:
+            # Token must match the claimed app name (defense in depth; the token
+            # alone already identifies the app).
+            return None
+        return authed.app_id
+    finally:
+        db.close()
+
+
+def _app_may_send(app_id: str) -> bool:
+    """True iff ``app_id`` holds the email service ``send`` grant."""
+    granted = get_granted_permissions_v2(app_id, EMAIL_SERVICE_URL)
+    return grants_allow_send([g.grant for g in granted])
+
+
+class EmailServiceAuthenticator:
+    """aiosmtpd auth callback: authenticate the local app + check the send grant."""
+
+    def __call__(
+        self, server: SMTP, session: Session, envelope: Envelope, mechanism: str, auth_data: object
+    ) -> AuthResult:
+        if not isinstance(auth_data, LoginPassword):
+            return AuthResult(success=False, handled=False)
+        try:
+            username = auth_data.login.decode("utf-8", "strict")
+            password = auth_data.password.decode("utf-8", "strict")
+        except UnicodeDecodeError:
+            return AuthResult(success=False, handled=False)
+        app_id = _authenticated_app_id(username, password)
+        if app_id is None:
+            logger.info("email service: SMTP auth failed for app %r", username)
+            return AuthResult(success=False, handled=False)
+        if not _app_may_send(app_id):
+            logger.info("email service: app %r lacks the email 'send' grant", username)
+            return AuthResult(success=False, handled=False)
+        # Bind the authenticated app_id to the session for the DATA handler.
+        return AuthResult(success=True, auth_data=app_id)
+
+
+class EmailServiceHandler:
+    """aiosmtpd handler: relay an authenticated app's message to the Imbue smarthost."""
+
+    def __init__(self, config: Config) -> None:
+        self._config = config
+
+    async def handle_DATA(self, server: SMTP, session: Session, envelope: Envelope) -> str:
+        app_id = getattr(session, "auth_data", None)
+        if not isinstance(app_id, str):
+            return "530 5.7.0 Authentication required"
+
+        raw = envelope.original_content or envelope.content
+        if raw is None:
+            return "554 5.5.0 empty message"
+        if isinstance(raw, str):
+            raw = raw.encode("utf-8", "surrogateescape")
+        from_address = envelope.mail_from or ""
+        to_addresses = [a for a in envelope.rcpt_tos if a]
+        if not to_addresses:
+            return "554 5.5.0 no recipients"
+
+        cred = self._fetch_credential()
+        if cred is None:
+            return "451 4.3.0 email relay not configured on this instance"
+
+        try:
+            _relay_to_smarthost(cred, raw, from_address, to_addresses)
+        except smtplib.SMTPException as e:
+            logger.warning("email service: relay to smarthost failed: %s", e)
+            return f"451 4.4.0 upstream relay failed: {e}"
+        except OSError as e:
+            logger.warning("email service: smarthost connection failed: %s", e)
+            return f"451 4.4.0 upstream relay unreachable: {e}"
+        return "250 OK message accepted for delivery"
+
+    def _fetch_credential(self) -> RelayCredential | None:
+        db = get_db()
+        try:
+            return get_relay_credential_provider(self._config).get(db)
+        except RelayCredentialError as e:
+            logger.warning("email service: could not fetch relay credential: %s", e)
+            return None
+        finally:
+            db.close()
+
+
+def _relay_to_smarthost(cred: RelayCredential, raw: bytes, from_address: str, to_addresses: list[str]) -> None:
+    """Relay ``raw`` to the Imbue smarthost over implicit TLS with the credential.
+
+    The smarthost (the Imbue email proxy) terminates implicit TLS at its edge on
+    whatever submission port it publishes (465/587), so we always connect with
+    implicit TLS. Envelope from/to are preserved; the message body is sent
+    verbatim (SES signs DKIM downstream).
+    """
+    context = ssl.create_default_context()
+    with smtplib.SMTP_SSL(host=cred.smtp_relay_host, port=cred.smtp_relay_port, context=context, timeout=30) as client:
+        client.login(cred.smtp_relay_user, cred.smtp_relay_password)
+        client.sendmail(from_address, to_addresses, raw)
+
+
+def header_from(raw: bytes) -> str | None:
+    """Best-effort message header From address (used by callers/tests)."""
+    try:
+        msg = message_from_bytes(raw, policy=default_policy)
+    except Exception:  # noqa: BLE001
+        return None
+    value = msg.get("From")
+    return str(value) if value is not None else None
+
+
+_controllers: list[Controller] = []
+_start_lock = threading.Lock()
+
+
+def _make_controller(config: Config, host: str, port: int) -> Controller:
+    return Controller(
+        EmailServiceHandler(config),
+        hostname=host,
+        port=port,
+        authenticator=EmailServiceAuthenticator(),
+        # Require AUTH; do not accept unauthenticated submission. auth_require_tls
+        # is False because the listener is loopback/gateway-only (never public)
+        # and the app<->router hop stays on the host.
+        auth_required=True,
+        auth_require_tls=False,
+    )
+
+
+def start_email_smtp_service(config: Config, *, hosts: list[str], port: int = ROUTER_SMTP_PORT) -> list[Controller]:
+    """Start the router's SMTP submission listener(s) for the email service.
+
+    Idempotent: starts at most once per process. Binds one listener per host in
+    ``hosts`` (loopback for network_host apps, the container gateway for pasta
+    apps, reached via ``host.containers.internal``). A host that can't be bound
+    (interface absent in dev/CI) is skipped rather than failing boot. Returns the
+    started controllers.
+    """
+    global _controllers
+    with _start_lock:
+        if _controllers:
+            return _controllers
+        started: list[Controller] = []
+        for host in hosts:
+            try:
+                controller = _make_controller(config, host, port)
+                controller.start()
+            except OSError as e:
+                logger.warning("email service: could not bind SMTP listener on %s:%d: %s", host, port, e)
+                continue
+            logger.info("email service: SMTP submission listener started on %s:%d", host, port)
+            started.append(controller)
+        _controllers = started
+        return started

--- a/compute_space/src/compute_space/core/identity_store.py
+++ b/compute_space/src/compute_space/core/identity_store.py
@@ -35,9 +35,11 @@ def get_instance_identity(db: sqlite3.Connection, config: Config) -> KeycloakCli
     """The shared per-instance credential, or None when none is configured.
 
     Reads the settings table first, then falls back to the deprecated
-    ``cert_api_keycloak_*`` config fields (already-deployed instances). Returns
-    None unless all three parts resolve, so callers can treat None as "no Imbue
-    identity configured".
+    ``cert_api_keycloak_*`` config fields for instances that predate the settings
+    store and have not yet run ``openhost update`` (which migrates the credential
+    into the settings table + scrubs the config via system-agent migration v8).
+    Once every instance has migrated, this config fallback can be removed. Returns
+    None unless all three parts resolve, so callers treat None as "no identity".
     """
     issuer = settings_store.get_setting(db, IMBUE_IDENTITY_ISSUER_URL_KEY) or config.cert_api_keycloak_issuer_url
     client_id = settings_store.get_setting(db, IMBUE_IDENTITY_CLIENT_ID_KEY) or config.cert_api_keycloak_client_id

--- a/compute_space/src/compute_space/core/tls/acquire_cert_broker.py
+++ b/compute_space/src/compute_space/core/tls/acquire_cert_broker.py
@@ -125,7 +125,7 @@ def acquire_tls_cert_via_broker(
         )
     finally:
         # Always pull the challenge records back out, success or failure.
-        dns_module.clear_txt(coredns_zonefile_path)
+        dns_module.clear_acme_challenge_records(coredns_zonefile_path)
 
     write_cert_and_key(cert_path, key_path, certificate.encode(), tls_private_key_to_pem(tls_key))
     logger.info(f"Installed broker-issued TLS cert for {domain} -> {cert_path}")

--- a/compute_space/src/compute_space/core/tls/util.py
+++ b/compute_space/src/compute_space/core/tls/util.py
@@ -193,7 +193,7 @@ def _acquire_cert_dns01(
                 time.sleep(2)
 
             # Clean up DNS record
-            dns_module.clear_txt(coredns_zonefile_path)
+            dns_module.clear_acme_challenge_records(coredns_zonefile_path)
 
             if not order.fullchain_pem:
                 raise RuntimeError(f"Failed to get cert for {domains}: order not finalized")
@@ -202,7 +202,7 @@ def _acquire_cert_dns01(
 
         except (errors.ValidationError, RuntimeError) as exc:
             # Clean up DNS records before retrying
-            dns_module.clear_txt(coredns_zonefile_path)
+            dns_module.clear_acme_challenge_records(coredns_zonefile_path)
 
             if attempt < max_attempts:
                 wait = 30 * attempt

--- a/compute_space/src/compute_space/tests/test_dns.py
+++ b/compute_space/src/compute_space/tests/test_dns.py
@@ -12,7 +12,7 @@ from compute_space.config import DefaultConfig
 from compute_space.core.dns import DnsZone
 from compute_space.core.dns import TxtRecord
 from compute_space.core.dns import append_txt_records
-from compute_space.core.dns import clear_txt
+from compute_space.core.dns import clear_acme_challenge_records
 from compute_space.core.dns import public_dns_zones
 from compute_space.core.dns import reload_coredns_for_domains
 from compute_space.core.dns import set_active_coredns
@@ -119,14 +119,35 @@ def test_append_txt_records_writes_absolute_fqdn_names_verbatim(tmp_path: Path) 
     assert "app.example.com.app.example.com" not in content
 
 
-def test_clear_txt_removes_records(tmp_path: Path) -> None:
+def test_clear_acme_challenge_records_removes_acme_txt(tmp_path: Path) -> None:
     zonefile = tmp_path / "zonefile"
     _write_zonefile(zonefile)
     append_txt_records(zonefile, [TxtRecord(record_name="_acme-challenge.app.example.com.", record_value="v")])
 
-    clear_txt(zonefile)
+    clear_acme_challenge_records(zonefile)
 
     assert "IN TXT" not in zonefile.read_text()
+
+
+def test_clear_acme_challenge_records_preserves_email_txt(tmp_path: Path) -> None:
+    # SPF (apex) and DMARC (_dmarc) TXT records must survive a cert renewal.
+    zonefile = tmp_path / "zonefile"
+    _write_zonefile(zonefile)
+    append_txt_records(
+        zonefile,
+        [
+            TxtRecord(record_name="_acme-challenge.app.example.com.", record_value="challenge"),
+            TxtRecord(record_name="@", record_value="v=spf1 include:amazonses.com -all"),
+            TxtRecord(record_name="_dmarc", record_value="v=DMARC1; p=quarantine"),
+        ],
+    )
+
+    clear_acme_challenge_records(zonefile)
+
+    text = zonefile.read_text()
+    assert "challenge" not in text  # ACME challenge removed
+    assert "v=spf1" in text  # SPF preserved
+    assert "v=DMARC1" in text  # DMARC preserved
 
 
 class _FakeProc:

--- a/compute_space/src/compute_space/tests/test_dns.py
+++ b/compute_space/src/compute_space/tests/test_dns.py
@@ -9,12 +9,15 @@ import pytest
 
 import compute_space.core.dns as dns_mod
 from compute_space.config import DefaultConfig
+from compute_space.core.dns import DkimCname
 from compute_space.core.dns import DnsZone
 from compute_space.core.dns import TxtRecord
 from compute_space.core.dns import append_txt_records
+from compute_space.core.dns import apply_email_records
 from compute_space.core.dns import clear_acme_challenge_records
 from compute_space.core.dns import public_dns_zones
 from compute_space.core.dns import reload_coredns_for_domains
+from compute_space.core.dns import render_email_records
 from compute_space.core.dns import set_active_coredns
 from compute_space.core.domains import Domain
 from compute_space.core.domains import DomainRecord
@@ -363,3 +366,128 @@ def test_reload_coredns_for_domains_noop_when_not_running(tmp_path: Path) -> Non
     config = _seed_dns_cfg(tmp_path, Domain(name="host.example.com", tls=True), public_ip="203.0.113.10")
     with closing(open_db(config)) as db:
         assert reload_coredns_for_domains(config, db) is False
+
+
+# --- render_email_records / apply_email_records (email DNS block) -------------
+
+
+def _dkim() -> list[DkimCname]:
+    return [DkimCname(name="tok1._domainkey.z.example.com", target="tok1.dkim.amazonses.com")]
+
+
+def test_render_email_records_includes_spf_dmarc_mx_a_dkim() -> None:
+    block = render_email_records(
+        "z.example.com",
+        inbound_mail_host="mail.z.example.com",
+        inbound_mail_ip="203.0.113.9",
+        dkim_cnames=_dkim(),
+    )
+    assert '@   IN TXT  "v=spf1 include:amazonses.com ~all"' in block
+    assert '_dmarc   IN TXT  "v=DMARC1; p=quarantine"' in block
+    assert "@   IN MX   10 mail.z.example.com." in block
+    assert "mail.z.example.com.   IN A   203.0.113.9" in block
+    assert "tok1._domainkey.z.example.com.   IN CNAME  tok1.dkim.amazonses.com." in block
+
+
+def test_render_email_records_wraps_in_managed_markers() -> None:
+    block = render_email_records(
+        "z.example.com",
+        inbound_mail_host="mail.z.example.com",
+        inbound_mail_ip="203.0.113.9",
+        dkim_cnames=[],
+    )
+    assert block.startswith("; --- openhost email records (managed) ---")
+    assert block.rstrip().endswith("; --- end openhost email records ---")
+
+
+def test_render_email_records_dmarc_rua_appended_when_set() -> None:
+    block = render_email_records(
+        "z.example.com",
+        inbound_mail_host="mail.z.example.com",
+        inbound_mail_ip="203.0.113.9",
+        dkim_cnames=[],
+        dmarc_rua="reports@example.com",
+    )
+    assert '_dmarc   IN TXT  "v=DMARC1; p=quarantine; rua=mailto:reports@example.com"' in block
+
+
+def test_render_email_records_no_rua_by_default() -> None:
+    block = render_email_records(
+        "z.example.com",
+        inbound_mail_host="mail.z.example.com",
+        inbound_mail_ip="203.0.113.9",
+        dkim_cnames=[],
+    )
+    assert "rua=" not in block
+
+
+def test_render_email_records_strips_trailing_dots_on_mail_host_and_dkim() -> None:
+    block = render_email_records(
+        "z.example.com",
+        inbound_mail_host="mail.z.example.com.",
+        inbound_mail_ip="203.0.113.9",
+        dkim_cnames=[DkimCname(name="t._domainkey.z.example.com.", target="t.dkim.amazonses.com.")],
+    )
+    # Exactly one trailing dot each (no doubled dots).
+    assert "mail.z.example.com.   IN A" in block
+    assert "mail.z.example.com..   IN A" not in block
+    assert "t._domainkey.z.example.com.   IN CNAME  t.dkim.amazonses.com." in block
+
+
+def test_render_email_records_requires_inbound_mail_host() -> None:
+    with pytest.raises(ValueError, match="inbound_mail_host is required"):
+        render_email_records("z.example.com", inbound_mail_host="", inbound_mail_ip="203.0.113.9", dkim_cnames=[])
+
+
+def test_render_email_records_requires_inbound_mail_ip() -> None:
+    with pytest.raises(ValueError, match="inbound_mail_ip is required"):
+        render_email_records(
+            "z.example.com", inbound_mail_host="mail.z.example.com", inbound_mail_ip="", dkim_cnames=[]
+        )
+
+
+def test_render_email_records_multiple_dkim_cnames() -> None:
+    block = render_email_records(
+        "z.example.com",
+        inbound_mail_host="mail.z.example.com",
+        inbound_mail_ip="203.0.113.9",
+        dkim_cnames=[
+            DkimCname(name="a._domainkey.z.example.com", target="a.dkim.amazonses.com"),
+            DkimCname(name="b._domainkey.z.example.com", target="b.dkim.amazonses.com"),
+        ],
+    )
+    assert "a._domainkey.z.example.com.   IN CNAME  a.dkim.amazonses.com." in block
+    assert "b._domainkey.z.example.com.   IN CNAME  b.dkim.amazonses.com." in block
+
+
+def test_apply_email_records_appends_block_and_bumps_serial(tmp_path: Path) -> None:
+    zonefile = tmp_path / "zonefile"
+    _write_zonefile(zonefile, serial=100)
+    apply_email_records(
+        zonefile,
+        "app.example.com",
+        inbound_mail_host="mail.app.example.com",
+        inbound_mail_ip="203.0.113.9",
+        dkim_cnames=[DkimCname(name="t._domainkey.app.example.com", target="t.dkim.amazonses.com")],
+    )
+    content = zonefile.read_text()
+    assert "101   ; serial" in content
+    assert "v=spf1 include:amazonses.com" in content
+    assert "@   IN MX   10 mail.app.example.com." in content
+    # The original zone content is preserved (records appended, not replaced).
+    assert "$ORIGIN app.example.com." in content
+
+
+def test_apply_email_records_preserves_existing_records(tmp_path: Path) -> None:
+    zonefile = tmp_path / "zonefile"
+    _write_zonefile(zonefile)
+    original_a = "@   IN A    127.0.0.1"
+    assert original_a in zonefile.read_text()
+    apply_email_records(
+        zonefile,
+        "app.example.com",
+        inbound_mail_host="mail.app.example.com",
+        inbound_mail_ip="203.0.113.9",
+        dkim_cnames=[],
+    )
+    assert original_a in zonefile.read_text()

--- a/compute_space/src/compute_space/tests/test_dns.py
+++ b/compute_space/src/compute_space/tests/test_dns.py
@@ -304,6 +304,87 @@ def test_public_dns_zones_covers_every_public_domain_and_skips_mdns(tmp_path: Pa
     assert zones[1].zonefile_path == config.zones_dir / "host.example.org.zone"
 
 
+def test_public_dns_zones_includes_custom_mail_domain(tmp_path: Path) -> None:
+    # The custom mail domain is a mail-only zone (not in the domains table); it must
+    # still be served by CoreDNS so its SPF/DKIM/DMARC/MX resolve.
+    config = _seed_dns_cfg(
+        tmp_path,
+        Domain(name="host.example.com", tls=True),
+        email_custom_domain="mail.mydomain.com",
+    )
+    with closing(open_db(config)) as db:
+        zones = public_dns_zones(config, db)
+    domains = [z.domain for z in zones]
+    assert "mail.mydomain.com" in domains
+    custom = next(z for z in zones if z.domain == "mail.mydomain.com")
+    # Served from a per-domain zone file (never the primary's legacy path).
+    assert custom.zonefile_path == config.zones_dir / "mail.mydomain.com.zone"
+
+
+def test_public_dns_zones_no_custom_mail_domain_when_unset(tmp_path: Path) -> None:
+    config = _seed_dns_cfg(tmp_path, Domain(name="host.example.com", tls=True))
+    with closing(open_db(config)) as db:
+        zones = public_dns_zones(config, db)
+    assert [z.domain for z in zones] == ["host.example.com"]
+
+
+def test_public_dns_zones_dedupes_custom_mail_domain(tmp_path: Path) -> None:
+    # If the custom mail domain coincides with an existing web domain, it is not
+    # duplicated (the web domain's zone already serves it).
+    config = _seed_dns_cfg(
+        tmp_path,
+        Domain(name="host.example.com", tls=True),
+        Domain(name="mail.mydomain.com", tls=True),
+        email_custom_domain="mail.mydomain.com",
+    )
+    with closing(open_db(config)) as db:
+        zones = public_dns_zones(config, db)
+    assert [z.domain for z in zones].count("mail.mydomain.com") == 1
+
+
+def test_start_coredns_creates_custom_mail_zone_file_for_email_records(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # End-to-end of the boot ordering fix: public_dns_zones includes the custom
+    # mail domain, so start_coredns creates its zone file from template, and email
+    # provisioning can then append records into a zone CoreDNS actually serves.
+    # Regression guard: previously the custom zone file was never created here, so
+    # apply_email_records had nothing to append to on a real instance.
+    monkeypatch.setattr(dns_mod, "_coredns_bind_ip", lambda ip: "10.0.0.5")
+    monkeypatch.setattr(dns_mod, "_gateway_ip_is_bindable", lambda ip: False)
+    _stub_popen(monkeypatch)
+
+    config = _seed_dns_cfg(
+        tmp_path,
+        Domain(name="host.example.com", tls=True),
+        email_custom_domain="mail.mydomain.com",
+    )
+    with closing(open_db(config)) as db:
+        zones = public_dns_zones(config, db)
+    custom_zonefile = config.coredns_zonefile_path_for("mail.mydomain.com", is_primary=False)
+    assert not custom_zonefile.exists()  # not pre-created
+
+    dns_mod.start_coredns(zones, "203.0.113.10", config.coredns_corefile_path)
+
+    # start_coredns created the custom zone file (authoritative for its origin) and
+    # the Corefile has a server block for it.
+    assert custom_zonefile.exists()
+    assert "$ORIGIN mail.mydomain.com." in custom_zonefile.read_text()
+    assert "mail.mydomain.com:53 {" in config.coredns_corefile_path.read_text()
+
+    # Email provisioning can now append records into the served zone (no FileNotFound).
+    apply_email_records(
+        custom_zonefile,
+        "mail.mydomain.com",
+        inbound_mail_host="mail.mydomain.com",
+        inbound_mail_ip="203.0.113.10",
+        dkim_cnames=[DkimCname(name="tok._domainkey.mail.mydomain.com", target="tok.dkim.amazonses.com")],
+    )
+    content = custom_zonefile.read_text()
+    assert "@   IN MX   10 mail.mydomain.com." in content
+    assert "tok._domainkey.mail.mydomain.com.   IN CNAME  tok.dkim.amazonses.com." in content
+
+
 def test_start_coredns_writes_a_zone_block_and_file_per_public_domain(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/compute_space/src/compute_space/tests/test_email_config.py
+++ b/compute_space/src/compute_space/tests/test_email_config.py
@@ -32,10 +32,6 @@ def test_email_fields_default_to_none() -> None:
     assert cfg.email_custom_domain is None
 
 
-def test_email_mailbox_app_names_default() -> None:
-    assert DefaultConfig().email_mailbox_app_names == ["stalwart-email-server"]
-
-
 def test_email_default_apps_default() -> None:
     assert DefaultConfig().email_default_apps == [_STALWART, _BULWARK]
 
@@ -247,7 +243,6 @@ def test_email_fields_round_trip_through_toml(tmp_path: Path) -> None:
     assert reloaded.email_proxy_base_url == "https://openhost.imbue.com"
     assert reloaded.email_dmarc_rua == "dmarc-reports@example.com"
     assert reloaded.email_custom_domain == "mail.mydomain.com"
-    assert reloaded.email_mailbox_app_names == ["stalwart-email-server"]
     assert reloaded.email_default_apps == [_STALWART, _BULWARK]
 
 
@@ -260,7 +255,7 @@ def test_email_toml_omits_unset_none_fields() -> None:
     assert "email_dmarc_rua" not in section
     assert "email_custom_domain" not in section
     # The list fields always have a (non-None) default, so they DO render.
-    assert section["email_mailbox_app_names"] == ["stalwart-email-server"]
+    assert section["email_default_apps"] == [_STALWART, _BULWARK]
 
 
 def test_email_toml_renders_set_fields() -> None:

--- a/compute_space/src/compute_space/tests/test_email_config.py
+++ b/compute_space/src/compute_space/tests/test_email_config.py
@@ -1,0 +1,270 @@
+"""Config tests for the email fields on the shared-identity branch.
+
+Email has no on/off Config flag any more (enablement is DB-based, see
+``core.email.enablement``); Config only carries the static email fields and a few
+pure helpers.  These tests pin the field defaults, the domain-normalization and
+delegation helpers, ``effective_default_apps(email_on)``, the well-formed
+custom-domain validation, and a TOML round trip of the email fields.  Config is
+built directly via ``DefaultConfig(**kwargs)`` (no DB needed for any of this).
+"""
+
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+
+import pytest
+
+from compute_space.config import DefaultConfig
+from compute_space.config import DelegationRecord
+
+_STALWART = "https://github.com/imbue-openhost/openhost-stalwart-email-server"
+_BULWARK = "https://github.com/imbue-openhost/openhost-bulwark-email-client"
+
+
+# --- field defaults ----------------------------------------------------------
+
+
+def test_email_fields_default_to_none() -> None:
+    cfg = DefaultConfig()
+    assert cfg.email_proxy_base_url is None
+    assert cfg.email_dmarc_rua is None
+    assert cfg.email_custom_domain is None
+
+
+def test_email_mailbox_app_names_default() -> None:
+    assert DefaultConfig().email_mailbox_app_names == ["stalwart-email-server"]
+
+
+def test_email_default_apps_default() -> None:
+    assert DefaultConfig().email_default_apps == [_STALWART, _BULWARK]
+
+
+def test_email_default_apps_is_not_shared_between_instances() -> None:
+    # attr.Factory builds a fresh list per instance; mutating one must not leak.
+    a = DefaultConfig()
+    b = DefaultConfig()
+    a.email_default_apps.append("mutated")
+    assert b.email_default_apps == [_STALWART, _BULWARK]
+
+
+def test_config_has_no_email_enabled_attribute() -> None:
+    # Enablement moved to core.email.enablement (needs the DB), so Config must not
+    # expose an email_enabled flag/property any more.
+    assert not hasattr(DefaultConfig(), "email_enabled")
+
+
+# --- email_custom_domain_normalized ------------------------------------------
+
+
+def test_custom_domain_normalized_none_by_default() -> None:
+    assert DefaultConfig().email_custom_domain_normalized is None
+
+
+def test_custom_domain_normalized_lowercases() -> None:
+    cfg = DefaultConfig(email_custom_domain="Mail.MyDomain.Com")
+    assert cfg.email_custom_domain_normalized == "mail.mydomain.com"
+
+
+def test_custom_domain_normalized_strips_whitespace() -> None:
+    cfg = DefaultConfig(email_custom_domain="  mail.mydomain.com  ")
+    assert cfg.email_custom_domain_normalized == "mail.mydomain.com"
+
+
+def test_custom_domain_normalized_strips_trailing_dot() -> None:
+    cfg = DefaultConfig(email_custom_domain="mail.mydomain.com.")
+    assert cfg.email_custom_domain_normalized == "mail.mydomain.com"
+
+
+def test_custom_domain_normalized_all_at_once() -> None:
+    cfg = DefaultConfig(email_custom_domain="  Mail.MyDomain.Com.  ")
+    assert cfg.email_custom_domain_normalized == "mail.mydomain.com"
+
+
+def test_custom_domain_blank_treated_as_unset() -> None:
+    # A blank string (or whitespace-only) normalizes to None so callers treat
+    # "unset" and "blank" identically.  A bare "." also validates as a domain
+    # but must not sneak past normalization.
+    assert DefaultConfig(email_custom_domain="   ").email_custom_domain_normalized is None
+    assert DefaultConfig(email_custom_domain=".").email_custom_domain_normalized is None
+
+
+# --- inbound_mail_host_for ----------------------------------------------------
+
+
+def test_inbound_mail_host_prefixes_mail() -> None:
+    assert DefaultConfig().inbound_mail_host_for("example.com") == "mail.example.com"
+
+
+def test_inbound_mail_host_leaves_existing_mail_host() -> None:
+    # A domain already under mail. is used as-is, not doubled to mail.mail.*.
+    assert DefaultConfig().inbound_mail_host_for("mail.mydomain.com") == "mail.mydomain.com"
+
+
+def test_inbound_mail_host_normalizes_case_and_dot() -> None:
+    assert DefaultConfig().inbound_mail_host_for("Example.Com.") == "mail.example.com"
+
+
+# --- custom_domain_delegation_record -----------------------------------------
+
+
+def test_delegation_record_none_without_custom_domain() -> None:
+    assert DefaultConfig().custom_domain_delegation_record("alice.example.com") is None
+
+
+def test_delegation_record_shape() -> None:
+    cfg = DefaultConfig(email_custom_domain="mail.mydomain.com")
+    rec = cfg.custom_domain_delegation_record("alice.selfhost.imbue.com")
+    assert rec == DelegationRecord(
+        name="mail.mydomain.com",
+        record_type="NS",
+        value="ns.alice.selfhost.imbue.com",
+    )
+
+
+def test_delegation_record_strips_port_from_zone() -> None:
+    cfg = DefaultConfig(email_custom_domain="mail.mydomain.com")
+    rec = cfg.custom_domain_delegation_record("alice.selfhost.imbue.com:8443")
+    assert rec is not None
+    assert rec.value == "ns.alice.selfhost.imbue.com"
+
+
+def test_delegation_record_display_line() -> None:
+    cfg = DefaultConfig(email_custom_domain="mail.mydomain.com")
+    rec = cfg.custom_domain_delegation_record("alice.example.com")
+    assert rec is not None
+    assert rec.as_display_line() == "mail.mydomain.com   NS   ns.alice.example.com"
+
+
+# --- effective_default_apps ---------------------------------------------------
+
+
+def test_effective_default_apps_excludes_email_apps_when_off() -> None:
+    cfg = DefaultConfig(default_apps=["oauth_provider"])
+    assert cfg.effective_default_apps(False) == ["oauth_provider"]
+
+
+def test_effective_default_apps_appends_email_apps_when_on() -> None:
+    cfg = DefaultConfig(default_apps=["oauth_provider"])
+    apps = cfg.effective_default_apps(True)
+    assert apps == ["oauth_provider", _STALWART, _BULWARK]
+
+
+def test_effective_default_apps_preserves_default_apps_order() -> None:
+    cfg = DefaultConfig(default_apps=["a", "b", "c"])
+    assert cfg.effective_default_apps(True)[:3] == ["a", "b", "c"]
+
+
+def test_effective_default_apps_dedupes_when_already_listed() -> None:
+    cfg = DefaultConfig(default_apps=["oauth_provider", _STALWART])
+    apps = cfg.effective_default_apps(True)
+    # Stalwart already listed -> not appended twice, order preserved.
+    assert apps == ["oauth_provider", _STALWART, _BULWARK]
+    assert apps.count(_STALWART) == 1
+
+
+def test_effective_default_apps_dedupes_both_email_apps() -> None:
+    cfg = DefaultConfig(default_apps=[_BULWARK, _STALWART])
+    apps = cfg.effective_default_apps(True)
+    assert apps == [_BULWARK, _STALWART]
+
+
+def test_effective_default_apps_returns_a_copy() -> None:
+    # The returned list must not alias config.default_apps (callers mutate it).
+    cfg = DefaultConfig(default_apps=["oauth_provider"])
+    result = cfg.effective_default_apps(False)
+    result.append("mutated")
+    assert cfg.default_apps == ["oauth_provider"]
+
+
+# --- well-formed custom-domain validation ------------------------------------
+
+
+@pytest.mark.parametrize(
+    "domain",
+    [
+        "mail.mydomain.com",
+        "example.com",
+        "a.b.c.d.example.com",
+        "MAIL.MyDomain.COM",
+        "mail.mydomain.com.",
+        "xn--80ak6aa92e.com",  # punycode label
+        "mail-server.my-domain.io",
+        "a1.b2.example.com",
+    ],
+)
+def test_custom_domain_accepts_well_formed(domain: str) -> None:
+    cfg = DefaultConfig(email_custom_domain=domain)
+    assert cfg.email_custom_domain_normalized is not None
+
+
+@pytest.mark.parametrize(
+    "domain",
+    [
+        "not a domain",
+        "bad_domain!",
+        "singlelabel",
+        "-leadinghyphen.com",
+        "trailinghyphen-.com",
+        "double..dot.com",
+        "under_score.com",
+        "space in.com",
+        "a..b",
+        "-.com",
+    ],
+)
+def test_custom_domain_rejects_malformed(domain: str) -> None:
+    with pytest.raises(ValueError, match="not a well-formed domain"):
+        DefaultConfig(email_custom_domain=domain)
+
+
+def test_custom_domain_rejects_overlong_label() -> None:
+    # A DNS label may be at most 63 chars.
+    too_long = "a" * 64 + ".com"
+    with pytest.raises(ValueError, match="not a well-formed domain"):
+        DefaultConfig(email_custom_domain=too_long)
+
+
+def test_custom_domain_accepts_max_length_label() -> None:
+    exactly_63 = "a" * 63 + ".com"
+    cfg = DefaultConfig(email_custom_domain=exactly_63)
+    assert cfg.email_custom_domain_normalized == exactly_63
+
+
+# --- TOML round trip ----------------------------------------------------------
+
+
+def test_email_fields_round_trip_through_toml(tmp_path: Path) -> None:
+    cfg = DefaultConfig(
+        email_proxy_base_url="https://openhost.imbue.com",
+        email_dmarc_rua="dmarc-reports@example.com",
+        email_custom_domain="mail.mydomain.com",
+        public_ip="203.0.113.5",
+    )
+    out = tmp_path / "config.toml"
+    out.write_text(cfg.to_toml_str())
+    reloaded = DefaultConfig.from_toml(str(out))
+    assert reloaded.email_proxy_base_url == "https://openhost.imbue.com"
+    assert reloaded.email_dmarc_rua == "dmarc-reports@example.com"
+    assert reloaded.email_custom_domain == "mail.mydomain.com"
+    assert reloaded.email_mailbox_app_names == ["stalwart-email-server"]
+    assert reloaded.email_default_apps == [_STALWART, _BULWARK]
+
+
+def test_email_toml_omits_unset_none_fields() -> None:
+    # _to_toml_dict drops None-valued fields, so a config with no email set must
+    # not render the optional email keys at all.
+    rendered = DefaultConfig().to_toml_str()
+    section = tomllib.loads(rendered)["openhost"]
+    assert "email_proxy_base_url" not in section
+    assert "email_dmarc_rua" not in section
+    assert "email_custom_domain" not in section
+    # The list fields always have a (non-None) default, so they DO render.
+    assert section["email_mailbox_app_names"] == ["stalwart-email-server"]
+
+
+def test_email_toml_renders_set_fields() -> None:
+    cfg = DefaultConfig(email_proxy_base_url="https://p.test", email_custom_domain="mail.mydomain.com")
+    section = tomllib.loads(cfg.to_toml_str())["openhost"]
+    assert section["email_proxy_base_url"] == "https://p.test"
+    assert section["email_custom_domain"] == "mail.mydomain.com"

--- a/compute_space/src/compute_space/tests/test_email_enablement.py
+++ b/compute_space/src/compute_space/tests/test_email_enablement.py
@@ -1,0 +1,198 @@
+"""Tests for core.email.enablement (DB-based email enablement + identity).
+
+``email_enabled(config, db)`` is True iff three prerequisites are all present:
+the proxy URL (Config), the shared per-instance Imbue identity (DB settings table,
+with the deprecated cert_api_keycloak_* config fallback), and the public IP
+(Config).  ``resolve_email_identity`` is a thin wrapper over
+``get_instance_identity``.
+
+The ``db`` fixture (conftest) is an in-memory DB carrying the real schema, so the
+settings + domains tables exist.  These tests seed the identity via
+``set_instance_identity`` and toggle the Config prerequisites to assert the
+enablement truth table.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+import pytest
+
+from compute_space.config import CERT_PROVIDER_CERT_API
+from compute_space.config import DefaultConfig
+from compute_space.core.email.enablement import email_enabled
+from compute_space.core.email.enablement import resolve_email_identity
+from compute_space.core.identity_store import set_instance_identity
+from compute_space.core.tls.keycloak import KeycloakClientCredentials
+
+_PROXY = "https://openhost.imbue.com"
+_IP = "203.0.113.5"
+
+
+def _cred() -> KeycloakClientCredentials:
+    return KeycloakClientCredentials(
+        issuer_url="https://kc/realms/openhost-customers",
+        client_id="instance-alice",
+        client_secret="sekret",
+    )
+
+
+def _enabled_config() -> DefaultConfig:
+    return DefaultConfig(email_proxy_base_url=_PROXY, public_ip=_IP)
+
+
+# --- all prerequisites present -> enabled ------------------------------------
+
+
+def test_enabled_when_all_prereqs_present(db: sqlite3.Connection) -> None:
+    set_instance_identity(db, _cred())
+    assert email_enabled(_enabled_config(), db) is True
+
+
+# --- each prerequisite missing -> disabled -----------------------------------
+
+
+def test_disabled_when_proxy_url_missing(db: sqlite3.Connection) -> None:
+    set_instance_identity(db, _cred())
+    cfg = DefaultConfig(email_proxy_base_url=None, public_ip=_IP)
+    assert email_enabled(cfg, db) is False
+
+
+def test_disabled_when_public_ip_missing(db: sqlite3.Connection) -> None:
+    set_instance_identity(db, _cred())
+    cfg = DefaultConfig(email_proxy_base_url=_PROXY, public_ip=None)
+    assert email_enabled(cfg, db) is False
+
+
+def test_disabled_when_identity_missing(db: sqlite3.Connection) -> None:
+    # No identity seeded and no config fallback.
+    assert email_enabled(_enabled_config(), db) is False
+
+
+def test_disabled_when_only_proxy_present(db: sqlite3.Connection) -> None:
+    cfg = DefaultConfig(email_proxy_base_url=_PROXY)
+    assert email_enabled(cfg, db) is False
+
+
+def test_disabled_when_nothing_present(db: sqlite3.Connection) -> None:
+    assert email_enabled(DefaultConfig(), db) is False
+
+
+@pytest.mark.parametrize("drop", ["proxy", "identity", "public_ip"])
+def test_disabled_when_any_single_prereq_dropped(db: sqlite3.Connection, drop: str) -> None:
+    if drop != "identity":
+        set_instance_identity(db, _cred())
+    cfg = DefaultConfig(
+        email_proxy_base_url=None if drop == "proxy" else _PROXY,
+        public_ip=None if drop == "public_ip" else _IP,
+    )
+    assert email_enabled(cfg, db) is False
+
+
+def test_empty_string_proxy_is_disabled(db: sqlite3.Connection) -> None:
+    # An empty proxy URL is falsy -> email off (never "" truthy).
+    set_instance_identity(db, _cred())
+    cfg = DefaultConfig(email_proxy_base_url="", public_ip=_IP)
+    assert email_enabled(cfg, db) is False
+
+
+def test_empty_string_public_ip_is_disabled(db: sqlite3.Connection) -> None:
+    set_instance_identity(db, _cred())
+    cfg = DefaultConfig(email_proxy_base_url=_PROXY, public_ip="")
+    assert email_enabled(cfg, db) is False
+
+
+def test_email_enabled_returns_bool_not_truthy(db: sqlite3.Connection) -> None:
+    # email_enabled wraps its result in bool(); confirm the concrete type.
+    set_instance_identity(db, _cred())
+    result = email_enabled(_enabled_config(), db)
+    assert result is True
+    assert isinstance(result, bool)
+
+
+# --- identity source: settings table vs. cert_api config fallback ------------
+
+
+def test_identity_from_settings_table_enables(db: sqlite3.Connection) -> None:
+    set_instance_identity(db, _cred())
+    cfg = _enabled_config()
+    assert email_enabled(cfg, db) is True
+    assert resolve_email_identity(cfg, db) == _cred()
+
+
+def test_identity_from_cert_api_config_fallback_enables(db: sqlite3.Connection) -> None:
+    # No settings-table identity, but a pre-shared-identity instance carries the
+    # deprecated cert_api_keycloak_* fields in config; those satisfy enablement.
+    cfg = DefaultConfig(
+        email_proxy_base_url=_PROXY,
+        public_ip=_IP,
+        cert_provider=CERT_PROVIDER_CERT_API,
+        cert_api_base_url="https://cert-api.example.com",
+        cert_api_keycloak_issuer_url="https://kc/realms/openhost-customers",
+        cert_api_keycloak_client_id="instance-fallback",
+        cert_api_keycloak_client_secret="fallback-secret",
+    )
+    assert email_enabled(cfg, db) is True
+    cred = resolve_email_identity(cfg, db)
+    assert cred is not None
+    assert cred.client_id == "instance-fallback"
+
+
+def test_settings_identity_takes_precedence_over_config_fallback(db: sqlite3.Connection) -> None:
+    set_instance_identity(db, _cred())
+    cfg = DefaultConfig(
+        email_proxy_base_url=_PROXY,
+        public_ip=_IP,
+        cert_provider=CERT_PROVIDER_CERT_API,
+        cert_api_base_url="https://cert-api.example.com",
+        cert_api_keycloak_issuer_url="https://other/realms/x",
+        cert_api_keycloak_client_id="instance-config",
+        cert_api_keycloak_client_secret="config-secret",
+    )
+    cred = resolve_email_identity(cfg, db)
+    assert cred is not None
+    # Settings table wins.
+    assert cred.client_id == "instance-alice"
+
+
+def test_partial_cert_api_fallback_does_not_enable(db: sqlite3.Connection) -> None:
+    # Only two of three cert_api_keycloak_* fields set -> no resolvable identity.
+    cfg = DefaultConfig(
+        email_proxy_base_url=_PROXY,
+        public_ip=_IP,
+        cert_api_keycloak_issuer_url="https://kc/realms/openhost-customers",
+        cert_api_keycloak_client_id="instance-x",
+        cert_api_keycloak_client_secret=None,
+    )
+    assert email_enabled(cfg, db) is False
+
+
+# --- resolve_email_identity --------------------------------------------------
+
+
+def test_resolve_identity_returns_credentials(db: sqlite3.Connection) -> None:
+    set_instance_identity(db, _cred())
+    assert resolve_email_identity(_enabled_config(), db) == _cred()
+
+
+def test_resolve_identity_none_when_unset(db: sqlite3.Connection) -> None:
+    assert resolve_email_identity(_enabled_config(), db) is None
+
+
+def test_resolve_identity_ignores_proxy_and_public_ip(db: sqlite3.Connection) -> None:
+    # resolve_email_identity is purely about the credential; the proxy/public_ip
+    # prerequisites don't affect it (only email_enabled combines all three).
+    set_instance_identity(db, _cred())
+    cfg = DefaultConfig()  # no proxy, no public_ip
+    assert resolve_email_identity(cfg, db) == _cred()
+
+
+def test_resolve_identity_reflects_updated_credential(db: sqlite3.Connection) -> None:
+    set_instance_identity(db, _cred())
+    updated = KeycloakClientCredentials(
+        issuer_url="https://kc2/realms/openhost-customers",
+        client_id="instance-rotated",
+        client_secret="rotated",
+    )
+    set_instance_identity(db, updated)
+    assert resolve_email_identity(_enabled_config(), db) == updated

--- a/compute_space/src/compute_space/tests/test_email_provision.py
+++ b/compute_space/src/compute_space/tests/test_email_provision.py
@@ -90,7 +90,6 @@ class _FakeClient:
         self.requested.append(domain)
         target = domain or _ZONE
         return IdentityResult(
-            domain=target,
             verified=False,
             dkim_records=(DkimRecord(name=f"tok._domainkey.{target}", value="tok.dkim.amazonses.com"),),
         )
@@ -370,7 +369,6 @@ def test_custom_domain_error_does_not_prevent_primary(tmp_path: Path, monkeypatc
             if domain is not None:
                 raise EmailProxyError("custom domain identity failed")
             return IdentityResult(
-                domain=_ZONE,
                 verified=False,
                 dkim_records=(DkimRecord(name=f"tok._domainkey.{_ZONE}", value="tok.dkim.amazonses.com"),),
             )

--- a/compute_space/src/compute_space/tests/test_email_provision.py
+++ b/compute_space/src/compute_space/tests/test_email_provision.py
@@ -1,0 +1,384 @@
+"""Tests for core.email.provision.provision_email_records.
+
+Provisioning is a no-op unless email is enabled (proxy URL + Imbue identity in the
+DB + public IP).  When enabled it authenticates, asks the proxy to ensure the SES
+identity, and appends SPF/DMARC/MX/A/DKIM records into the primary zone file (and
+the custom-domain zone file when one is delegated).  It is best-effort: an
+EmailProxyError (or any exception) is logged and swallowed, never raised.
+
+The DB is a file-backed test DB with a seeded primary domain + Imbue identity
+(``_make_test_config`` + ``set_instance_identity``).  The proxy/token clients are
+monkeypatched with in-process fakes so no network is touched; the zone file lives
+under ``config.coredns_zonefile_path`` (the primary's legacy path).
+"""
+
+from __future__ import annotations
+
+from contextlib import closing
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from compute_space.config import Config
+from compute_space.core.email.provision import provision_email_records
+from compute_space.core.email.proxy_client import DkimRecord
+from compute_space.core.email.proxy_client import EmailProxyError
+from compute_space.core.email.proxy_client import IdentityResult
+from compute_space.core.identity_store import set_instance_identity
+from compute_space.core.tls.keycloak import KeycloakClientCredentials
+from compute_space.tests.conftest import _make_test_config
+from compute_space.tests.conftest import open_db
+
+_ZONE = "alice.example.com"
+_IP = "203.0.113.9"
+
+
+def _cred() -> KeycloakClientCredentials:
+    return KeycloakClientCredentials(
+        issuer_url="https://kc.test/realms/openhost-customers",
+        client_id="instance-alice",
+        client_secret="s3cr3t",
+    )
+
+
+def _write_zonefile(path: Path, origin: str = _ZONE, serial: int = 100) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        f"$ORIGIN {origin}.\n"
+        "$TTL 60\n"
+        f"@   IN SOA  ns.{_ZONE}. admin.{origin}. (\n"
+        f"    {serial}   ; serial\n"
+        "    3600  ; refresh\n"
+        "    600   ; retry\n"
+        "    86400 ; expire\n"
+        "    60    ; minimum\n"
+        ")\n"
+        f"@   IN NS   ns.{_ZONE}.\n"
+        "@   IN A    127.0.0.1\n"
+    )
+
+
+def _enabled_config(tmp_path: Path, **overrides: Any) -> Config:
+    cfg = _make_test_config(tmp_path, zone_domain=_ZONE, **overrides)
+    with closing(open_db(cfg)) as db:
+        set_instance_identity(db, _cred())
+    return cfg
+
+
+class _FakeTokenProvider:
+    def __enter__(self) -> _FakeTokenProvider:
+        return self
+
+    def __exit__(self, *a: object) -> None:
+        return None
+
+
+class _FakeClient:
+    """Records the domains it was asked for and returns one DKIM record per call."""
+
+    def __init__(self) -> None:
+        self.requested: list[str | None] = []
+
+    def __enter__(self) -> _FakeClient:
+        return self
+
+    def __exit__(self, *a: object) -> None:
+        return None
+
+    def ensure_identity(self, domain: str | None = None) -> IdentityResult:
+        self.requested.append(domain)
+        target = domain or _ZONE
+        return IdentityResult(
+            domain=target,
+            verified=False,
+            dkim_records=(DkimRecord(name=f"tok._domainkey.{target}", value="tok.dkim.amazonses.com"),),
+        )
+
+
+def _install_fakes(monkeypatch: pytest.MonkeyPatch, client: object) -> None:
+    monkeypatch.setattr(
+        "compute_space.core.email.provision.KeycloakTokenProvider.create",
+        classmethod(lambda cls, creds: _FakeTokenProvider()),
+    )
+    monkeypatch.setattr(
+        "compute_space.core.email.provision.EmailProxyClient.create",
+        classmethod(lambda cls, url, tp: client),
+    )
+
+
+# --- no-op when disabled -----------------------------------------------------
+
+
+def test_noop_when_email_disabled_leaves_zone_untouched(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    cfg = _make_test_config(tmp_path, zone_domain=_ZONE)  # no identity, no proxy, no public_ip
+    zonefile = cfg.coredns_zonefile_path
+    _write_zonefile(zonefile)
+    before = zonefile.read_text()
+
+    called = {"create": False}
+
+    def _mark_created(cls: object, /, *a: object, **k: object) -> object:
+        called["create"] = True
+        return object()
+
+    monkeypatch.setattr(
+        "compute_space.core.email.provision.EmailProxyClient.create",
+        classmethod(_mark_created),
+    )
+    with closing(open_db(cfg)) as db:
+        provision_email_records(cfg, db)
+
+    assert zonefile.read_text() == before
+    assert called["create"] is False
+
+
+def test_noop_when_identity_missing(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    # Proxy + public_ip set, but no Imbue identity -> still disabled -> no-op.
+    cfg = _make_test_config(tmp_path, zone_domain=_ZONE, email_proxy_base_url="https://proxy.test", public_ip=_IP)
+    zonefile = cfg.coredns_zonefile_path
+    _write_zonefile(zonefile)
+    before = zonefile.read_text()
+
+    client = _FakeClient()
+    _install_fakes(monkeypatch, client)
+    with closing(open_db(cfg)) as db:
+        provision_email_records(cfg, db)
+
+    assert zonefile.read_text() == before
+    assert client.requested == []
+
+
+# --- enabled: writes records into the primary zone ---------------------------
+
+
+def test_enabled_publishes_records_into_primary_zone(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    cfg = _enabled_config(tmp_path, email_proxy_base_url="https://proxy.test", public_ip=_IP)
+    zonefile = cfg.coredns_zonefile_path
+    _write_zonefile(zonefile)
+
+    client = _FakeClient()
+    _install_fakes(monkeypatch, client)
+    with closing(open_db(cfg)) as db:
+        provision_email_records(cfg, db)
+
+    content = zonefile.read_text()
+    # SPF authorizing SES (outbound).
+    assert "v=spf1 include:amazonses.com ~all" in content
+    # DMARC policy.
+    assert "_dmarc   IN TXT" in content
+    assert "v=DMARC1" in content
+    # Direct inbound: MX -> mail.<zone>, with an A record for it -> instance IP.
+    assert f"@   IN MX   10 mail.{_ZONE}." in content
+    assert f"mail.{_ZONE}.   IN A   {_IP}" in content
+    # DKIM CNAME.
+    assert f"tok._domainkey.{_ZONE}.   IN CNAME  tok.dkim.amazonses.com." in content
+
+
+def test_enabled_calls_ensure_identity_for_primary_with_no_request_domain(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # The built-in zone is requested with request_domain=None (the proxy scopes
+    # to the caller's own zone).
+    cfg = _enabled_config(tmp_path, email_proxy_base_url="https://proxy.test", public_ip=_IP)
+    _write_zonefile(cfg.coredns_zonefile_path)
+
+    client = _FakeClient()
+    _install_fakes(monkeypatch, client)
+    with closing(open_db(cfg)) as db:
+        provision_email_records(cfg, db)
+
+    assert client.requested == [None]
+
+
+def test_enabled_bumps_soa_serial(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    cfg = _enabled_config(tmp_path, email_proxy_base_url="https://proxy.test", public_ip=_IP)
+    _write_zonefile(cfg.coredns_zonefile_path, serial=100)
+
+    client = _FakeClient()
+    _install_fakes(monkeypatch, client)
+    with closing(open_db(cfg)) as db:
+        provision_email_records(cfg, db)
+
+    assert "101   ; serial" in cfg.coredns_zonefile_path.read_text()
+
+
+def test_enabled_publishes_dmarc_rua_when_set(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    cfg = _enabled_config(
+        tmp_path,
+        email_proxy_base_url="https://proxy.test",
+        public_ip=_IP,
+        email_dmarc_rua="reports@example.com",
+    )
+    _write_zonefile(cfg.coredns_zonefile_path)
+
+    client = _FakeClient()
+    _install_fakes(monkeypatch, client)
+    with closing(open_db(cfg)) as db:
+        provision_email_records(cfg, db)
+
+    assert "rua=mailto:reports@example.com" in cfg.coredns_zonefile_path.read_text()
+
+
+def test_enabled_no_ses_inbound_host(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    # Inbound is always direct-to-instance; the SES inbound host must never appear.
+    cfg = _enabled_config(tmp_path, email_proxy_base_url="https://proxy.test", public_ip=_IP)
+    _write_zonefile(cfg.coredns_zonefile_path)
+
+    client = _FakeClient()
+    _install_fakes(monkeypatch, client)
+    with closing(open_db(cfg)) as db:
+        provision_email_records(cfg, db)
+
+    assert "inbound-smtp" not in cfg.coredns_zonefile_path.read_text()
+
+
+# --- custom domain -----------------------------------------------------------
+
+
+def test_custom_domain_publishes_second_zone(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    cfg = _enabled_config(
+        tmp_path,
+        email_proxy_base_url="https://proxy.test",
+        public_ip=_IP,
+        email_custom_domain="mail.mydomain.com",
+    )
+    _write_zonefile(cfg.coredns_zonefile_path)
+    custom_zonefile = cfg.coredns_zonefile_path_for("mail.mydomain.com", False)
+    _write_zonefile(custom_zonefile, origin="mail.mydomain.com")
+
+    client = _FakeClient()
+    _install_fakes(monkeypatch, client)
+    with closing(open_db(cfg)) as db:
+        provision_email_records(cfg, db)
+
+    # Built-in zone requested with None; custom zone requested by name.
+    assert client.requested == [None, "mail.mydomain.com"]
+    custom_content = custom_zonefile.read_text()
+    # Custom zone gets its own records. mail.mydomain.com is already a mail host,
+    # so it is used as-is (not doubled to mail.mail.mydomain.com).
+    assert "@   IN MX   10 mail.mydomain.com." in custom_content
+    assert f"mail.mydomain.com.   IN A   {_IP}" in custom_content
+    assert "mail.mail." not in custom_content
+    assert "tok._domainkey.mail.mydomain.com.   IN CNAME  tok.dkim.amazonses.com." in custom_content
+
+
+def test_custom_domain_also_updates_primary_zone(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    cfg = _enabled_config(
+        tmp_path,
+        email_proxy_base_url="https://proxy.test",
+        public_ip=_IP,
+        email_custom_domain="mail.mydomain.com",
+    )
+    _write_zonefile(cfg.coredns_zonefile_path)
+    custom_zonefile = cfg.coredns_zonefile_path_for("mail.mydomain.com", False)
+    _write_zonefile(custom_zonefile, origin="mail.mydomain.com")
+
+    client = _FakeClient()
+    _install_fakes(monkeypatch, client)
+    with closing(open_db(cfg)) as db:
+        provision_email_records(cfg, db)
+
+    # Primary zone still got its own records too.
+    assert f"@   IN MX   10 mail.{_ZONE}." in cfg.coredns_zonefile_path.read_text()
+
+
+def test_no_custom_domain_only_touches_primary(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    cfg = _enabled_config(tmp_path, email_proxy_base_url="https://proxy.test", public_ip=_IP)
+    _write_zonefile(cfg.coredns_zonefile_path)
+
+    client = _FakeClient()
+    _install_fakes(monkeypatch, client)
+    with closing(open_db(cfg)) as db:
+        provision_email_records(cfg, db)
+
+    # Only the primary zone was requested; no custom-zone file was created.
+    assert client.requested == [None]
+    assert not cfg.zones_dir.exists() or list(cfg.zones_dir.glob("*.zone")) == []
+
+
+# --- best-effort error handling ----------------------------------------------
+
+
+def test_proxy_error_is_swallowed_and_zone_untouched(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    cfg = _enabled_config(tmp_path, email_proxy_base_url="https://proxy.test", public_ip=_IP)
+    zonefile = cfg.coredns_zonefile_path
+    _write_zonefile(zonefile)
+    before = zonefile.read_text()
+
+    class _FailingClient:
+        def __enter__(self) -> _FailingClient:
+            return self
+
+        def __exit__(self, *a: object) -> None:
+            return None
+
+        def ensure_identity(self, domain: str | None = None) -> IdentityResult:
+            raise EmailProxyError("proxy down")
+
+    _install_fakes(monkeypatch, _FailingClient())
+    with closing(open_db(cfg)) as db:
+        provision_email_records(cfg, db)  # must not raise
+
+    assert zonefile.read_text() == before
+
+
+def test_unexpected_exception_is_swallowed(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    cfg = _enabled_config(tmp_path, email_proxy_base_url="https://proxy.test", public_ip=_IP)
+    zonefile = cfg.coredns_zonefile_path
+    _write_zonefile(zonefile)
+    before = zonefile.read_text()
+
+    class _BoomClient:
+        def __enter__(self) -> _BoomClient:
+            return self
+
+        def __exit__(self, *a: object) -> None:
+            return None
+
+        def ensure_identity(self, domain: str | None = None) -> IdentityResult:
+            raise RuntimeError("unexpected")
+
+    _install_fakes(monkeypatch, _BoomClient())
+    with closing(open_db(cfg)) as db:
+        provision_email_records(cfg, db)  # must not raise
+
+    assert zonefile.read_text() == before
+
+
+def test_custom_domain_error_does_not_prevent_primary(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    # The primary zone is published first; a failure on the custom domain must not
+    # roll back the primary's records (best-effort, in order).
+    cfg = _enabled_config(
+        tmp_path,
+        email_proxy_base_url="https://proxy.test",
+        public_ip=_IP,
+        email_custom_domain="mail.mydomain.com",
+    )
+    _write_zonefile(cfg.coredns_zonefile_path)
+    custom_zonefile = cfg.coredns_zonefile_path_for("mail.mydomain.com", False)
+    _write_zonefile(custom_zonefile, origin="mail.mydomain.com")
+
+    class _CustomFailsClient:
+        def __enter__(self) -> _CustomFailsClient:
+            return self
+
+        def __exit__(self, *a: object) -> None:
+            return None
+
+        def ensure_identity(self, domain: str | None = None) -> IdentityResult:
+            if domain is not None:
+                raise EmailProxyError("custom domain identity failed")
+            return IdentityResult(
+                domain=_ZONE,
+                verified=False,
+                dkim_records=(DkimRecord(name=f"tok._domainkey.{_ZONE}", value="tok.dkim.amazonses.com"),),
+            )
+
+    _install_fakes(monkeypatch, _CustomFailsClient())
+    with closing(open_db(cfg)) as db:
+        provision_email_records(cfg, db)  # must not raise
+
+    # Primary got its records; custom zone did not.
+    assert f"@   IN MX   10 mail.{_ZONE}." in cfg.coredns_zonefile_path.read_text()
+    assert "IN MX" not in custom_zonefile.read_text()

--- a/compute_space/src/compute_space/tests/test_email_proxy_client.py
+++ b/compute_space/src/compute_space/tests/test_email_proxy_client.py
@@ -1,0 +1,274 @@
+"""Tests for core.email.proxy_client.EmailProxyClient.
+
+The client POSTs/GETs the email API's ``/api/email/identity`` endpoint with a
+Keycloak bearer and parses the response into an ``IdentityResult``.  HTTP is
+mocked with ``httpx.MockTransport`` so no network is touched; the client is built
+directly (bypassing ``create``) so the mock transport can be injected, with a
+``StaticTokenProvider`` supplying the bearer.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable
+
+import httpx
+import pytest
+
+from compute_space.core.email.proxy_client import DkimRecord
+from compute_space.core.email.proxy_client import EmailProxyClient
+from compute_space.core.email.proxy_client import EmailProxyError
+from compute_space.core.email.proxy_client import IdentityResult
+from compute_space.core.tls.keycloak import StaticTokenProvider
+
+_Handler = Callable[[httpx.Request], httpx.Response]
+
+
+def _client(handler: _Handler, token: str = "test-token") -> EmailProxyClient:
+    return EmailProxyClient(
+        base_url="https://proxy.test",
+        token_provider=StaticTokenProvider(token=token),
+        http_client=httpx.Client(transport=httpx.MockTransport(handler)),
+    )
+
+
+def _identity_body(domain: str = "alice.example.com", verified: bool = False) -> dict[str, object]:
+    return {
+        "domain": domain,
+        "verified": verified,
+        "dkim_records": [
+            {"name": "a._domainkey.alice.example.com", "value": "a.dkim.amazonses.com"},
+            {"name": "b._domainkey.alice.example.com", "value": "b.dkim.amazonses.com"},
+        ],
+    }
+
+
+# --- ensure_identity: parsing ------------------------------------------------
+
+
+def test_ensure_identity_parses_200() -> None:
+    client = _client(lambda req: httpx.Response(200, json=_identity_body()))
+    result = client.ensure_identity()
+    assert isinstance(result, IdentityResult)
+    assert result.domain == "alice.example.com"
+    assert result.verified is False
+    assert result.dkim_records == (
+        DkimRecord(name="a._domainkey.alice.example.com", value="a.dkim.amazonses.com"),
+        DkimRecord(name="b._domainkey.alice.example.com", value="b.dkim.amazonses.com"),
+    )
+
+
+def test_ensure_identity_accepts_201_created() -> None:
+    # 201 (identity just created) carries the same body as 200 and must NOT be
+    # treated as an error, or a freshly-created identity skips publishing records.
+    client = _client(lambda req: httpx.Response(201, json=_identity_body()))
+    result = client.ensure_identity()
+    assert result.domain == "alice.example.com"
+    assert len(result.dkim_records) == 2
+
+
+def test_ensure_identity_verified_true() -> None:
+    client = _client(lambda req: httpx.Response(200, json=_identity_body(verified=True)))
+    assert client.ensure_identity().verified is True
+
+
+def test_ensure_identity_verified_truthy_coerced_to_bool() -> None:
+    # verified is coerced with bool(); a truthy non-bool becomes True.
+    body = _identity_body()
+    body["verified"] = 1
+    client = _client(lambda req: httpx.Response(200, json=body))
+    result = client.ensure_identity()
+    assert result.verified is True
+    assert isinstance(result.verified, bool)
+
+
+def test_ensure_identity_missing_verified_defaults_false() -> None:
+    body = {"domain": "alice.example.com", "dkim_records": []}
+    client = _client(lambda req: httpx.Response(200, json=body))
+    assert client.ensure_identity().verified is False
+
+
+def test_ensure_identity_missing_dkim_records_defaults_empty() -> None:
+    body = {"domain": "alice.example.com", "verified": True}
+    client = _client(lambda req: httpx.Response(200, json=body))
+    assert client.ensure_identity().dkim_records == ()
+
+
+def test_ensure_identity_ignores_extra_fields() -> None:
+    body = _identity_body()
+    body["unexpected"] = "ignored"
+    client = _client(lambda req: httpx.Response(200, json=body))
+    assert client.ensure_identity().domain == "alice.example.com"
+
+
+def test_ensure_identity_missing_domain_raises_email_proxy_error() -> None:
+    # A 2xx with a malformed body (missing required "domain") surfaces as a clean
+    # EmailProxyError, not a raw KeyError.
+    body = {"verified": True, "dkim_records": []}
+    client = _client(lambda req: httpx.Response(200, json=body))
+    with pytest.raises(EmailProxyError, match="malformed"):
+        client.ensure_identity()
+
+
+def test_ensure_identity_malformed_dkim_record_raises_email_proxy_error() -> None:
+    body = {"domain": "d.com", "verified": False, "dkim_records": [{"name": "x"}]}
+    client = _client(lambda req: httpx.Response(200, json=body))
+    with pytest.raises(EmailProxyError, match="malformed"):
+        client.ensure_identity()
+
+
+# --- ensure_identity: request shape ------------------------------------------
+
+
+def test_ensure_identity_uses_post_to_identity_path() -> None:
+    seen: dict[str, object] = {}
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        seen["method"] = req.method
+        seen["path"] = req.url.path
+        return httpx.Response(200, json=_identity_body())
+
+    _client(handler).ensure_identity()
+    assert seen["method"] == "POST"
+    assert seen["path"] == "/api/email/identity"
+
+
+def test_ensure_identity_sends_bearer_header() -> None:
+    seen: dict[str, object] = {}
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        seen["auth"] = req.headers.get("Authorization")
+        return httpx.Response(200, json=_identity_body())
+
+    _client(handler, token="s3cr3t").ensure_identity()
+    assert seen["auth"] == "Bearer s3cr3t"
+
+
+def test_ensure_identity_no_domain_sends_empty_body() -> None:
+    seen: dict[str, object] = {}
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        seen["json"] = json.loads(req.content)
+        return httpx.Response(200, json=_identity_body())
+
+    _client(handler).ensure_identity()
+    # No domain -> {} body (empty JSON object).
+    assert seen["json"] == {}
+
+
+def test_ensure_identity_passes_domain_in_body() -> None:
+    seen: dict[str, object] = {}
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        seen["json"] = json.loads(req.content)
+        return httpx.Response(200, json=_identity_body(domain="mail.mydomain.com"))
+
+    _client(handler).ensure_identity(domain="mail.mydomain.com")
+    assert seen["json"] == {"domain": "mail.mydomain.com"}
+
+
+# --- ensure_identity: errors -------------------------------------------------
+
+
+def test_ensure_identity_non_2xx_raises_email_proxy_error() -> None:
+    client = _client(lambda req: httpx.Response(502, text="upstream boom"))
+    with pytest.raises(EmailProxyError, match="HTTP 502"):
+        client.ensure_identity()
+
+
+def test_ensure_identity_error_includes_response_text() -> None:
+    client = _client(lambda req: httpx.Response(400, text="bad domain"))
+    with pytest.raises(EmailProxyError, match="bad domain"):
+        client.ensure_identity()
+
+
+def test_ensure_identity_network_error_raises_email_proxy_error() -> None:
+    def handler(req: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("connection refused")
+
+    client = _client(handler)
+    with pytest.raises(EmailProxyError, match="email API unreachable"):
+        client.ensure_identity()
+
+
+# --- identity_status ---------------------------------------------------------
+
+
+def test_identity_status_uses_get() -> None:
+    seen: dict[str, object] = {}
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        seen["method"] = req.method
+        seen["path"] = req.url.path
+        return httpx.Response(200, json=_identity_body(verified=True))
+
+    result = _client(handler).identity_status()
+    assert seen["method"] == "GET"
+    assert seen["path"] == "/api/email/identity"
+    assert result.verified is True
+
+
+def test_identity_status_sends_bearer_header() -> None:
+    seen: dict[str, object] = {}
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        seen["auth"] = req.headers.get("Authorization")
+        return httpx.Response(200, json=_identity_body())
+
+    _client(handler, token="tok2").identity_status()
+    assert seen["auth"] == "Bearer tok2"
+
+
+def test_identity_status_passes_domain_as_query_param() -> None:
+    seen: dict[str, object] = {}
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        seen["query"] = dict(req.url.params)
+        return httpx.Response(200, json=_identity_body(domain="mail.mydomain.com"))
+
+    _client(handler).identity_status(domain="mail.mydomain.com")
+    assert seen["query"] == {"domain": "mail.mydomain.com"}
+
+
+def test_identity_status_no_domain_sends_no_query() -> None:
+    seen: dict[str, object] = {}
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        seen["query"] = dict(req.url.params)
+        return httpx.Response(200, json=_identity_body())
+
+    _client(handler).identity_status()
+    assert seen["query"] == {}
+
+
+def test_identity_status_non_2xx_raises() -> None:
+    client = _client(lambda req: httpx.Response(404, text="not found"))
+    with pytest.raises(EmailProxyError, match="HTTP 404"):
+        client.identity_status()
+
+
+def test_identity_status_network_error_raises() -> None:
+    def handler(req: httpx.Request) -> httpx.Response:
+        raise httpx.ReadTimeout("timed out")
+
+    client = _client(handler)
+    with pytest.raises(EmailProxyError, match="email API unreachable"):
+        client.identity_status()
+
+
+# --- create() / context manager ----------------------------------------------
+
+
+def test_create_strips_trailing_slash_from_base_url() -> None:
+    client = EmailProxyClient.create("https://proxy.test/", StaticTokenProvider(token="t"))
+    try:
+        assert client.base_url == "https://proxy.test"
+    finally:
+        client.http_client.close()
+
+
+def test_context_manager_closes_http_client() -> None:
+    client = _client(lambda req: httpx.Response(200, json=_identity_body()))
+    with client as c:
+        assert c is client
+    assert client.http_client.is_closed

--- a/compute_space/src/compute_space/tests/test_email_proxy_client.py
+++ b/compute_space/src/compute_space/tests/test_email_proxy_client.py
@@ -50,7 +50,6 @@ def test_ensure_identity_parses_200() -> None:
     client = _client(lambda req: httpx.Response(200, json=_identity_body()))
     result = client.ensure_identity()
     assert isinstance(result, IdentityResult)
-    assert result.domain == "alice.example.com"
     assert result.verified is False
     assert result.dkim_records == (
         DkimRecord(name="a._domainkey.alice.example.com", value="a.dkim.amazonses.com"),
@@ -63,7 +62,6 @@ def test_ensure_identity_accepts_201_created() -> None:
     # treated as an error, or a freshly-created identity skips publishing records.
     client = _client(lambda req: httpx.Response(201, json=_identity_body()))
     result = client.ensure_identity()
-    assert result.domain == "alice.example.com"
     assert len(result.dkim_records) == 2
 
 
@@ -98,16 +96,7 @@ def test_ensure_identity_ignores_extra_fields() -> None:
     body = _identity_body()
     body["unexpected"] = "ignored"
     client = _client(lambda req: httpx.Response(200, json=body))
-    assert client.ensure_identity().domain == "alice.example.com"
-
-
-def test_ensure_identity_missing_domain_raises_email_proxy_error() -> None:
-    # A 2xx with a malformed body (missing required "domain") surfaces as a clean
-    # EmailProxyError, not a raw KeyError.
-    body = {"verified": True, "dkim_records": []}
-    client = _client(lambda req: httpx.Response(200, json=body))
-    with pytest.raises(EmailProxyError, match="malformed"):
-        client.ensure_identity()
+    assert len(client.ensure_identity().dkim_records) == 2
 
 
 def test_ensure_identity_malformed_dkim_record_raises_email_proxy_error() -> None:

--- a/compute_space/src/compute_space/tests/test_email_relay_credential.py
+++ b/compute_space/src/compute_space/tests/test_email_relay_credential.py
@@ -147,9 +147,7 @@ def test_get_sends_bearer_to_relay_config_endpoint(db: sqlite3.Connection, monke
     assert seen["auth"] == "Bearer fake-token"
 
 
-def test_get_ignores_extra_response_fields(
-    db: sqlite3.Connection, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_get_ignores_extra_response_fields(db: sqlite3.Connection, monkeypatch: pytest.MonkeyPatch) -> None:
     # The credential only needs the four SMTP-login fields; any extra keys the
     # frontend returns (e.g. zone_domain) are ignored and don't break parsing.
     cfg = _seed_enabled(db)

--- a/compute_space/src/compute_space/tests/test_email_relay_credential.py
+++ b/compute_space/src/compute_space/tests/test_email_relay_credential.py
@@ -1,0 +1,272 @@
+"""Tests for core.email.relay_credential.RelayCredentialProvider.
+
+``get(db)`` returns None when email isn't enabled; otherwise it fetches the relay
+config from the frontend (bearer via the shared Imbue identity) and returns a
+``RelayCredential``, cached in-process with a TTL keyed on the identity/zone/
+custom-domain.  A fetch failure while email IS enabled raises
+``RelayCredentialError``.
+
+The in-memory ``db`` fixture (conftest) carries the real schema; these tests seed
+a primary domain + Imbue identity into it.  The Keycloak token provider is faked
+and ``httpx.Client`` is swapped for a MockTransport client, so no network is hit.
+The TTL is driven by an injected ``monotonic`` clock.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from collections.abc import Callable
+
+import httpx
+import pytest
+
+from compute_space.config import DefaultConfig
+from compute_space.core.domains import Domain
+from compute_space.core.domains import seed_domains
+from compute_space.core.email.relay_credential import _CACHE_TTL_SECONDS
+from compute_space.core.email.relay_credential import RelayCredential
+from compute_space.core.email.relay_credential import RelayCredentialError
+from compute_space.core.email.relay_credential import RelayCredentialProvider
+from compute_space.core.identity_store import set_instance_identity
+from compute_space.core.tls.keycloak import KeycloakClientCredentials
+
+_Handler = Callable[[httpx.Request], httpx.Response]
+_REAL_HTTPX_CLIENT = httpx.Client
+_ZONE = "alice.example.com"
+_PROXY = "https://openhost.imbue.com"
+_IP = "203.0.113.5"
+
+
+def _cred() -> KeycloakClientCredentials:
+    return KeycloakClientCredentials(
+        issuer_url="https://kc/realms/openhost-customers",
+        client_id="instance-alice",
+        client_secret="sekret",
+    )
+
+
+class _FakeTokenProvider:
+    def __enter__(self) -> _FakeTokenProvider:
+        return self
+
+    def __exit__(self, *a: object) -> None:
+        return None
+
+    def get_token(self) -> str:
+        return "fake-token"
+
+
+def _install_transport(monkeypatch: pytest.MonkeyPatch, handler: _Handler) -> None:
+    """Fake the token provider and route relay-config HTTP through a mock transport."""
+    monkeypatch.setattr(
+        "compute_space.core.email.relay_credential.KeycloakTokenProvider.create",
+        classmethod(lambda cls, creds: _FakeTokenProvider()),
+    )
+    monkeypatch.setattr(
+        "compute_space.core.email.relay_credential.httpx.Client",
+        lambda *a, **k: _REAL_HTTPX_CLIENT(transport=httpx.MockTransport(handler)),
+    )
+
+
+def _seed_enabled(db: sqlite3.Connection, custom_domain: str | None = None) -> DefaultConfig:
+    seed_domains(db, Domain(name=_ZONE, tls=True), [])
+    set_instance_identity(db, _cred())
+    return DefaultConfig(email_proxy_base_url=_PROXY, public_ip=_IP, email_custom_domain=custom_domain)
+
+
+def _relay_body(**overrides: object) -> dict[str, object]:
+    body: dict[str, object] = {
+        "configured": True,
+        "smtp_relay_host": "smtp.openhost.imbue.com",
+        "smtp_relay_port": 465,
+        "smtp_relay_user": _ZONE,
+        "smtp_relay_password": "hmac-derived-pw",
+        "zone_domain": _ZONE,
+    }
+    body.update(overrides)
+    return body
+
+
+# --- disabled ----------------------------------------------------------------
+
+
+def test_get_none_when_email_disabled(db: sqlite3.Connection) -> None:
+    # No identity/proxy/public_ip -> email off -> None (not an error).
+    seed_domains(db, Domain(name=_ZONE, tls=True), [])
+    provider = RelayCredentialProvider(config=DefaultConfig())
+    assert provider.get(db) is None
+
+
+def test_get_none_when_identity_missing(db: sqlite3.Connection) -> None:
+    seed_domains(db, Domain(name=_ZONE, tls=True), [])
+    provider = RelayCredentialProvider(config=DefaultConfig(email_proxy_base_url=_PROXY, public_ip=_IP))
+    assert provider.get(db) is None
+
+
+def test_get_none_does_not_fetch_when_disabled(db: sqlite3.Connection, monkeypatch: pytest.MonkeyPatch) -> None:
+    seed_domains(db, Domain(name=_ZONE, tls=True), [])
+    called = {"fetch": False}
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        called["fetch"] = True
+        return httpx.Response(200, json=_relay_body())
+
+    _install_transport(monkeypatch, handler)
+    provider = RelayCredentialProvider(config=DefaultConfig())
+    assert provider.get(db) is None
+    assert called["fetch"] is False
+
+
+# --- enabled: successful fetch -----------------------------------------------
+
+
+def test_get_returns_credential_when_enabled(db: sqlite3.Connection, monkeypatch: pytest.MonkeyPatch) -> None:
+    cfg = _seed_enabled(db)
+    _install_transport(monkeypatch, lambda req: httpx.Response(200, json=_relay_body()))
+    cred = RelayCredentialProvider(config=cfg).get(db)
+    assert cred == RelayCredential(
+        smtp_relay_host="smtp.openhost.imbue.com",
+        smtp_relay_port=465,
+        smtp_relay_user=_ZONE,
+        smtp_relay_password="hmac-derived-pw",
+        zone_domain=_ZONE,
+        custom_domain=None,
+    )
+
+
+def test_get_sends_bearer_to_relay_config_endpoint(db: sqlite3.Connection, monkeypatch: pytest.MonkeyPatch) -> None:
+    cfg = _seed_enabled(db)
+    seen: dict[str, object] = {}
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        seen["path"] = req.url.path
+        seen["auth"] = req.headers.get("Authorization")
+        return httpx.Response(200, json=_relay_body())
+
+    _install_transport(monkeypatch, handler)
+    RelayCredentialProvider(config=cfg).get(db)
+    assert seen["path"] == "/api/email/relay-config"
+    assert seen["auth"] == "Bearer fake-token"
+
+
+def test_get_carries_custom_domain_through(db: sqlite3.Connection, monkeypatch: pytest.MonkeyPatch) -> None:
+    cfg = _seed_enabled(db, custom_domain="mail.mydomain.com")
+    _install_transport(monkeypatch, lambda req: httpx.Response(200, json=_relay_body()))
+    cred = RelayCredentialProvider(config=cfg).get(db)
+    assert cred is not None
+    assert cred.custom_domain == "mail.mydomain.com"
+
+
+def test_get_falls_back_to_zone_when_zone_domain_absent(
+    db: sqlite3.Connection, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    cfg = _seed_enabled(db)
+    body = _relay_body()
+    del body["zone_domain"]
+    _install_transport(monkeypatch, lambda req: httpx.Response(200, json=body))
+    cred = RelayCredentialProvider(config=cfg).get(db)
+    assert cred is not None
+    assert cred.zone_domain == _ZONE
+
+
+def test_get_coerces_port_to_int(db: sqlite3.Connection, monkeypatch: pytest.MonkeyPatch) -> None:
+    cfg = _seed_enabled(db)
+    _install_transport(monkeypatch, lambda req: httpx.Response(200, json=_relay_body(smtp_relay_port="587")))
+    cred = RelayCredentialProvider(config=cfg).get(db)
+    assert cred is not None
+    assert cred.smtp_relay_port == 587
+
+
+# --- TTL cache ---------------------------------------------------------------
+
+
+def test_cache_reused_within_ttl(db: sqlite3.Connection, monkeypatch: pytest.MonkeyPatch) -> None:
+    cfg = _seed_enabled(db)
+    calls = {"n": 0}
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        calls["n"] += 1
+        return httpx.Response(200, json=_relay_body())
+
+    _install_transport(monkeypatch, handler)
+    clock = {"t": 1000.0}
+    provider = RelayCredentialProvider(config=cfg, monotonic=lambda: clock["t"])
+    first = provider.get(db)
+    second = provider.get(db)
+    assert first is second
+    assert calls["n"] == 1
+
+
+def test_cache_refetches_after_ttl_expiry(db: sqlite3.Connection, monkeypatch: pytest.MonkeyPatch) -> None:
+    cfg = _seed_enabled(db)
+    calls = {"n": 0}
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        calls["n"] += 1
+        return httpx.Response(200, json=_relay_body())
+
+    _install_transport(monkeypatch, handler)
+    clock = {"t": 1000.0}
+    provider = RelayCredentialProvider(config=cfg, monotonic=lambda: clock["t"])
+    provider.get(db)
+    clock["t"] = 1000.0 + _CACHE_TTL_SECONDS + 1
+    provider.get(db)
+    assert calls["n"] == 2
+
+
+def test_cache_refetches_when_identity_rotates(db: sqlite3.Connection, monkeypatch: pytest.MonkeyPatch) -> None:
+    cfg = _seed_enabled(db)
+    calls = {"n": 0}
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        calls["n"] += 1
+        return httpx.Response(200, json=_relay_body())
+
+    _install_transport(monkeypatch, handler)
+    clock = {"t": 1000.0}
+    provider = RelayCredentialProvider(config=cfg, monotonic=lambda: clock["t"])
+    provider.get(db)
+    # Rotate the identity (still within TTL) -> cache key changes -> refetch.
+    set_instance_identity(
+        db,
+        KeycloakClientCredentials(issuer_url="https://kc/realms/x", client_id="rotated", client_secret="new"),
+    )
+    provider.get(db)
+    assert calls["n"] == 2
+
+
+# --- error behavior (probed against the real implementation) -----------------
+
+
+def test_http_error_status_raises_relay_credential_error(
+    db: sqlite3.Connection, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    cfg = _seed_enabled(db)
+    _install_transport(monkeypatch, lambda req: httpx.Response(500, text="boom"))
+    with pytest.raises(RelayCredentialError, match="HTTP 500"):
+        RelayCredentialProvider(config=cfg).get(db)
+
+
+def test_network_error_raises_relay_credential_error(db: sqlite3.Connection, monkeypatch: pytest.MonkeyPatch) -> None:
+    def handler(req: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("refused")
+
+    cfg = _seed_enabled(db)
+    _install_transport(monkeypatch, handler)
+    with pytest.raises(RelayCredentialError, match="relay-config fetch failed"):
+        RelayCredentialProvider(config=cfg).get(db)
+
+
+def test_not_configured_response_raises(db: sqlite3.Connection, monkeypatch: pytest.MonkeyPatch) -> None:
+    cfg = _seed_enabled(db)
+    _install_transport(monkeypatch, lambda req: httpx.Response(200, json={"configured": False}))
+    with pytest.raises(RelayCredentialError, match="not configured"):
+        RelayCredentialProvider(config=cfg).get(db)
+
+
+def test_malformed_body_raises(db: sqlite3.Connection, monkeypatch: pytest.MonkeyPatch) -> None:
+    # configured True but missing required fields -> malformed error.
+    cfg = _seed_enabled(db)
+    _install_transport(monkeypatch, lambda req: httpx.Response(200, json={"configured": True}))
+    with pytest.raises(RelayCredentialError, match="malformed"):
+        RelayCredentialProvider(config=cfg).get(db)

--- a/compute_space/src/compute_space/tests/test_email_relay_credential.py
+++ b/compute_space/src/compute_space/tests/test_email_relay_credential.py
@@ -129,8 +129,6 @@ def test_get_returns_credential_when_enabled(db: sqlite3.Connection, monkeypatch
         smtp_relay_port=465,
         smtp_relay_user=_ZONE,
         smtp_relay_password="hmac-derived-pw",
-        zone_domain=_ZONE,
-        custom_domain=None,
     )
 
 
@@ -149,24 +147,20 @@ def test_get_sends_bearer_to_relay_config_endpoint(db: sqlite3.Connection, monke
     assert seen["auth"] == "Bearer fake-token"
 
 
-def test_get_carries_custom_domain_through(db: sqlite3.Connection, monkeypatch: pytest.MonkeyPatch) -> None:
-    cfg = _seed_enabled(db, custom_domain="mail.mydomain.com")
-    _install_transport(monkeypatch, lambda req: httpx.Response(200, json=_relay_body()))
-    cred = RelayCredentialProvider(config=cfg).get(db)
-    assert cred is not None
-    assert cred.custom_domain == "mail.mydomain.com"
-
-
-def test_get_falls_back_to_zone_when_zone_domain_absent(
+def test_get_ignores_extra_response_fields(
     db: sqlite3.Connection, monkeypatch: pytest.MonkeyPatch
 ) -> None:
+    # The credential only needs the four SMTP-login fields; any extra keys the
+    # frontend returns (e.g. zone_domain) are ignored and don't break parsing.
     cfg = _seed_enabled(db)
     body = _relay_body()
-    del body["zone_domain"]
+    body["zone_domain"] = "ignored.example.com"
+    body["custom_domain"] = "also-ignored.example.com"
     _install_transport(monkeypatch, lambda req: httpx.Response(200, json=body))
     cred = RelayCredentialProvider(config=cfg).get(db)
     assert cred is not None
-    assert cred.zone_domain == _ZONE
+    assert cred.smtp_relay_host == "smtp.openhost.imbue.com"
+    assert not hasattr(cred, "zone_domain")
 
 
 def test_get_coerces_port_to_int(db: sqlite3.Connection, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/compute_space/src/compute_space/tests/test_email_relay_route.py
+++ b/compute_space/src/compute_space/tests/test_email_relay_route.py
@@ -1,0 +1,275 @@
+"""Route tests for the email API endpoints in web/routes/api/system.py.
+
+Covered here:
+  * ``GET /api/email/relay-config`` (guard ``require_app_auth``, scoped to
+    ``config.email_mailbox_app_names``): an authenticated app NOT in that list is
+    rejected; the mailbox app gets ``configured=false`` when email is disabled;
+    the mailbox app gets the credential when email is enabled (relay fetch stubbed).
+  * ``GET /api/email/custom-domain`` (guard ``require_owner_auth``): owner-only,
+    surfaces the delegation record when a custom domain is set, else unconfigured.
+
+The endpoints are exercised through a minimal Litestar app carrying just
+``system_routes`` against a file-backed test DB, mirroring test_installer_route /
+test_connect_routes.  App auth is a bearer token resolved against a seeded
+``apps`` + ``app_tokens`` row; owner auth is a session cookie for a seeded user.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import sqlite3
+from collections.abc import Iterator
+from contextlib import closing
+from pathlib import Path
+from typing import Any
+
+import bcrypt
+import pytest
+from litestar import Litestar
+from litestar.di import Provide
+from litestar.testing import TestClient
+
+import compute_space.web.routes.api.system as sys_mod
+from compute_space.config import provide_config
+from compute_space.config import set_active_config
+from compute_space.core.auth.auth import SESSION_COOKIE_NAME
+from compute_space.core.auth.auth import create_session
+from compute_space.core.email.relay_credential import RelayCredential
+from compute_space.core.email.relay_credential import RelayCredentialError
+from compute_space.core.identity_store import set_instance_identity
+from compute_space.core.tls.keycloak import KeycloakClientCredentials
+from compute_space.db import init_db
+from compute_space.db import provide_db
+from compute_space.tests.conftest import _make_test_config
+from compute_space.tests.conftest import open_db
+from compute_space.web.routes.api.system import system_routes
+
+_ZONE = "alice.example.com"
+_PROXY = "https://openhost.imbue.com"
+_IP = "203.0.113.5"
+_MAILBOX_TOKEN = "mailbox-app-token"
+_OTHER_TOKEN = "other-app-token"
+
+
+def _cred() -> KeycloakClientCredentials:
+    return KeycloakClientCredentials(
+        issuer_url="https://kc/realms/openhost-customers",
+        client_id="instance-alice",
+        client_secret="sekret",
+    )
+
+
+@pytest.fixture(autouse=True)
+def _reset_relay_providers() -> Iterator[None]:
+    # The route memoizes providers in a module-global dict; clear it between tests
+    # so a stubbed provider from one test can't leak into another.
+    sys_mod._relay_providers.clear()
+    yield
+    sys_mod._relay_providers.clear()
+
+
+@pytest.fixture
+def cfg(tmp_path: Path) -> Any:
+    cfg = _make_test_config(tmp_path, port=20800, zone_domain=_ZONE)
+    init_db(cfg.db_path)  # point get_db() (used by require_app_auth) at this DB
+    return cfg
+
+
+def _make_app() -> Litestar:
+    return Litestar(
+        route_handlers=[system_routes],
+        dependencies={
+            "config": Provide(provide_config, sync_to_thread=False),
+            "db": Provide(provide_db),
+        },
+        openapi_config=None,
+    )
+
+
+@pytest.fixture
+def client(cfg: Any) -> Iterator[TestClient[Litestar]]:
+    with TestClient(app=_make_app()) as c:
+        yield c
+
+
+def _seed_app(cfg: Any, name: str, app_id: str, token: str) -> None:
+    conn = sqlite3.connect(cfg.db_path)
+    try:
+        conn.execute(
+            """INSERT INTO apps (app_id, name, version, repo_path, local_port, status, installed_by)
+               VALUES (?, ?, ?, ?, ?, ?, NULL)""",
+            (app_id, name, "0.0.0", f"/tmp/{name}", 19700, "running"),
+        )
+        token_hash = hashlib.sha256(token.encode()).hexdigest()
+        conn.execute("INSERT INTO app_tokens (app_id, token_hash) VALUES (?, ?)", (app_id, token_hash))
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def _seed_mailbox_app(cfg: Any) -> None:
+    _seed_app(cfg, "stalwart-email-server", "MailboxApp01", _MAILBOX_TOKEN)
+
+
+def _seed_other_app(cfg: Any) -> None:
+    _seed_app(cfg, "some-other-app", "OtherApp001", _OTHER_TOKEN)
+
+
+def _seed_identity(cfg: Any) -> None:
+    with closing(open_db(cfg)) as db:
+        set_instance_identity(db, _cred())
+
+
+def _app_headers(token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _owner_cookie(cfg: Any) -> dict[str, str]:
+    pw_hash = bcrypt.hashpw(b"secretpass1", bcrypt.gensalt()).decode()
+    conn = sqlite3.connect(cfg.db_path)
+    conn.row_factory = sqlite3.Row
+    try:
+        cur = conn.execute("INSERT INTO users (username, password_hash) VALUES (?, ?)", ("owner", pw_hash))
+        assert cur.lastrowid is not None
+        token = create_session(cur.lastrowid, conn)
+        conn.commit()
+    finally:
+        conn.close()
+    return {SESSION_COOKIE_NAME: token}
+
+
+# --- relay-config: auth + scoping --------------------------------------------
+
+
+def test_relay_config_requires_app_auth(client: TestClient[Litestar]) -> None:
+    assert client.get("/api/email/relay-config").status_code == 401
+
+
+def test_relay_config_rejects_unknown_bearer(client: TestClient[Litestar]) -> None:
+    resp = client.get("/api/email/relay-config", headers=_app_headers("not-a-real-token"))
+    assert resp.status_code == 401
+
+
+def test_relay_config_rejects_non_mailbox_app(cfg: Any, client: TestClient[Litestar]) -> None:
+    # An authenticated app whose name is NOT in email_mailbox_app_names is refused.
+    _seed_other_app(cfg)
+    resp = client.get("/api/email/relay-config", headers=_app_headers(_OTHER_TOKEN))
+    assert resp.status_code == 401
+
+
+def test_relay_config_mailbox_app_unconfigured_when_email_off(cfg: Any, client: TestClient[Litestar]) -> None:
+    # The mailbox app is allowed through the scope check, but email is off (no
+    # identity/proxy/public_ip) -> configured=false with null fields.
+    _seed_mailbox_app(cfg)
+    resp = client.get("/api/email/relay-config", headers=_app_headers(_MAILBOX_TOKEN))
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["configured"] is False
+    assert body["smtp_relay_password"] is None
+    assert body["smtp_relay_host"] is None
+
+
+def test_relay_config_returns_credential_to_mailbox_app(
+    cfg: Any, client: TestClient[Litestar], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Email enabled + a stubbed provider returning a credential.
+    _seed_mailbox_app(cfg)
+    _seed_identity(cfg)
+    cfg_enabled = cfg.evolve(email_proxy_base_url=_PROXY, public_ip=_IP)
+
+    set_active_config(cfg_enabled)
+
+    cred = RelayCredential(
+        smtp_relay_host="smtp.openhost.imbue.com",
+        smtp_relay_port=465,
+        smtp_relay_user=_ZONE,
+        smtp_relay_password="hmac-pw",
+        zone_domain=_ZONE,
+        custom_domain=None,
+    )
+
+    class _StubProvider:
+        def get(self, db: sqlite3.Connection) -> RelayCredential:
+            return cred
+
+    monkeypatch.setattr(sys_mod, "get_relay_credential_provider", lambda config: _StubProvider())
+    resp = client.get("/api/email/relay-config", headers=_app_headers(_MAILBOX_TOKEN))
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["configured"] is True
+    assert body["smtp_relay_host"] == "smtp.openhost.imbue.com"
+    assert body["smtp_relay_port"] == 465
+    assert body["smtp_relay_password"] == "hmac-pw"
+    assert body["zone_domain"] == _ZONE
+
+
+def test_relay_config_unconfigured_when_provider_returns_none(
+    cfg: Any, client: TestClient[Litestar], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _seed_mailbox_app(cfg)
+    _seed_identity(cfg)
+    cfg_enabled = cfg.evolve(email_proxy_base_url=_PROXY, public_ip=_IP)
+
+    set_active_config(cfg_enabled)
+
+    class _NoneProvider:
+        def get(self, db: sqlite3.Connection) -> RelayCredential | None:
+            return None
+
+    monkeypatch.setattr(sys_mod, "get_relay_credential_provider", lambda config: _NoneProvider())
+    resp = client.get("/api/email/relay-config", headers=_app_headers(_MAILBOX_TOKEN))
+    assert resp.status_code == 200
+    assert resp.json()["configured"] is False
+
+
+def test_relay_config_unconfigured_on_credential_error(
+    cfg: Any, client: TestClient[Litestar], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # A RelayCredentialError while email is enabled degrades to unconfigured
+    # (logged, not surfaced as a 500 to the mailbox app).
+
+    _seed_mailbox_app(cfg)
+    _seed_identity(cfg)
+    cfg_enabled = cfg.evolve(email_proxy_base_url=_PROXY, public_ip=_IP)
+
+    set_active_config(cfg_enabled)
+
+    class _ErrorProvider:
+        def get(self, db: sqlite3.Connection) -> RelayCredential:
+            raise RelayCredentialError("frontend down")
+
+    monkeypatch.setattr(sys_mod, "get_relay_credential_provider", lambda config: _ErrorProvider())
+    resp = client.get("/api/email/relay-config", headers=_app_headers(_MAILBOX_TOKEN))
+    assert resp.status_code == 200
+    assert resp.json()["configured"] is False
+
+
+# --- custom-domain: owner auth -----------------------------------------------
+
+
+def test_custom_domain_requires_owner_auth(client: TestClient[Litestar]) -> None:
+    assert client.get("/api/email/custom-domain").status_code == 401
+
+
+def test_custom_domain_unconfigured_when_unset(cfg: Any, client: TestClient[Litestar]) -> None:
+    resp = client.get("/api/email/custom-domain", cookies=_owner_cookie(cfg))
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["configured"] is False
+    assert body["domain"] is None
+    assert body["display_line"] is None
+
+
+def test_custom_domain_returns_delegation_record_when_set(cfg: Any, client: TestClient[Litestar]) -> None:
+    cfg_custom = cfg.evolve(email_custom_domain="mail.mydomain.com")
+
+    set_active_config(cfg_custom)
+    resp = client.get("/api/email/custom-domain", cookies=_owner_cookie(cfg))
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["configured"] is True
+    assert body["domain"] == "mail.mydomain.com"
+    assert body["record_name"] == "mail.mydomain.com"
+    assert body["record_type"] == "NS"
+    assert body["record_value"] == f"ns.{_ZONE}"
+    assert body["display_line"] == f"mail.mydomain.com   NS   ns.{_ZONE}"

--- a/compute_space/src/compute_space/tests/test_email_relay_route.py
+++ b/compute_space/src/compute_space/tests/test_email_relay_route.py
@@ -1,25 +1,19 @@
-"""Route tests for the email API endpoints in web/routes/api/system.py.
+"""Route tests for the owner-facing email API in web/routes/api/system.py.
 
-Covered here:
-  * ``GET /api/email/relay-config`` (guard ``require_app_auth``, scoped to
-    ``config.email_mailbox_app_names``): an authenticated app NOT in that list is
-    rejected; the mailbox app gets ``configured=false`` when email is disabled;
-    the mailbox app gets the credential when email is enabled (relay fetch stubbed).
-  * ``GET /api/email/custom-domain`` (guard ``require_owner_auth``): owner-only,
-    surfaces the delegation record when a custom domain is set, else unconfigured.
+Covers ``GET /api/email/custom-domain`` (guard ``require_owner_auth``): owner
+only, surfaces the NS delegation record when a custom mail domain is set, else
+unconfigured. (Outbound send is no longer an HTTP route: apps relay through the
+router's SMTP submission listener, tested in test_email_smtp_service.py.)
 
-The endpoints are exercised through a minimal Litestar app carrying just
-``system_routes`` against a file-backed test DB, mirroring test_installer_route /
-test_connect_routes.  App auth is a bearer token resolved against a seeded
-``apps`` + ``app_tokens`` row; owner auth is a session cookie for a seeded user.
+The endpoint is exercised through a minimal Litestar app carrying just
+``system_routes`` against a file-backed test DB. Owner auth is a session cookie
+for a seeded user.
 """
 
 from __future__ import annotations
 
-import hashlib
 import sqlite3
 from collections.abc import Iterator
-from contextlib import closing
 from pathlib import Path
 from typing import Any
 
@@ -29,49 +23,22 @@ from litestar import Litestar
 from litestar.di import Provide
 from litestar.testing import TestClient
 
-import compute_space.web.routes.api.system as sys_mod
 from compute_space.config import provide_config
 from compute_space.config import set_active_config
 from compute_space.core.auth.auth import SESSION_COOKIE_NAME
 from compute_space.core.auth.auth import create_session
-from compute_space.core.email.relay_credential import RelayCredential
-from compute_space.core.email.relay_credential import RelayCredentialError
-from compute_space.core.identity_store import set_instance_identity
-from compute_space.core.tls.keycloak import KeycloakClientCredentials
 from compute_space.db import init_db
 from compute_space.db import provide_db
 from compute_space.tests.conftest import _make_test_config
-from compute_space.tests.conftest import open_db
 from compute_space.web.routes.api.system import system_routes
 
 _ZONE = "alice.example.com"
-_PROXY = "https://openhost.imbue.com"
-_IP = "203.0.113.5"
-_MAILBOX_TOKEN = "mailbox-app-token"
-_OTHER_TOKEN = "other-app-token"
-
-
-def _cred() -> KeycloakClientCredentials:
-    return KeycloakClientCredentials(
-        issuer_url="https://kc/realms/openhost-customers",
-        client_id="instance-alice",
-        client_secret="sekret",
-    )
-
-
-@pytest.fixture(autouse=True)
-def _reset_relay_providers() -> Iterator[None]:
-    # The route memoizes providers in a module-global dict; clear it between tests
-    # so a stubbed provider from one test can't leak into another.
-    sys_mod._relay_providers.clear()
-    yield
-    sys_mod._relay_providers.clear()
 
 
 @pytest.fixture
 def cfg(tmp_path: Path) -> Any:
     cfg = _make_test_config(tmp_path, port=20800, zone_domain=_ZONE)
-    init_db(cfg.db_path)  # point get_db() (used by require_app_auth) at this DB
+    init_db(cfg.db_path)  # point get_db() (used by the owner-auth guard) at this DB
     return cfg
 
 
@@ -92,38 +59,6 @@ def client(cfg: Any) -> Iterator[TestClient[Litestar]]:
         yield c
 
 
-def _seed_app(cfg: Any, name: str, app_id: str, token: str) -> None:
-    conn = sqlite3.connect(cfg.db_path)
-    try:
-        conn.execute(
-            """INSERT INTO apps (app_id, name, version, repo_path, local_port, status, installed_by)
-               VALUES (?, ?, ?, ?, ?, ?, NULL)""",
-            (app_id, name, "0.0.0", f"/tmp/{name}", 19700, "running"),
-        )
-        token_hash = hashlib.sha256(token.encode()).hexdigest()
-        conn.execute("INSERT INTO app_tokens (app_id, token_hash) VALUES (?, ?)", (app_id, token_hash))
-        conn.commit()
-    finally:
-        conn.close()
-
-
-def _seed_mailbox_app(cfg: Any) -> None:
-    _seed_app(cfg, "stalwart-email-server", "MailboxApp01", _MAILBOX_TOKEN)
-
-
-def _seed_other_app(cfg: Any) -> None:
-    _seed_app(cfg, "some-other-app", "OtherApp001", _OTHER_TOKEN)
-
-
-def _seed_identity(cfg: Any) -> None:
-    with closing(open_db(cfg)) as db:
-        set_instance_identity(db, _cred())
-
-
-def _app_headers(token: str) -> dict[str, str]:
-    return {"Authorization": f"Bearer {token}"}
-
-
 def _owner_cookie(cfg: Any) -> dict[str, str]:
     pw_hash = bcrypt.hashpw(b"secretpass1", bcrypt.gensalt()).decode()
     conn = sqlite3.connect(cfg.db_path)
@@ -136,112 +71,6 @@ def _owner_cookie(cfg: Any) -> dict[str, str]:
     finally:
         conn.close()
     return {SESSION_COOKIE_NAME: token}
-
-
-# --- relay-config: auth + scoping --------------------------------------------
-
-
-def test_relay_config_requires_app_auth(client: TestClient[Litestar]) -> None:
-    assert client.get("/api/email/relay-config").status_code == 401
-
-
-def test_relay_config_rejects_unknown_bearer(client: TestClient[Litestar]) -> None:
-    resp = client.get("/api/email/relay-config", headers=_app_headers("not-a-real-token"))
-    assert resp.status_code == 401
-
-
-def test_relay_config_rejects_non_mailbox_app(cfg: Any, client: TestClient[Litestar]) -> None:
-    # An authenticated app whose name is NOT in email_mailbox_app_names is refused.
-    _seed_other_app(cfg)
-    resp = client.get("/api/email/relay-config", headers=_app_headers(_OTHER_TOKEN))
-    assert resp.status_code == 401
-
-
-def test_relay_config_mailbox_app_unconfigured_when_email_off(cfg: Any, client: TestClient[Litestar]) -> None:
-    # The mailbox app is allowed through the scope check, but email is off (no
-    # identity/proxy/public_ip) -> configured=false with null fields.
-    _seed_mailbox_app(cfg)
-    resp = client.get("/api/email/relay-config", headers=_app_headers(_MAILBOX_TOKEN))
-    assert resp.status_code == 200
-    body = resp.json()
-    assert body["configured"] is False
-    assert body["smtp_relay_password"] is None
-    assert body["smtp_relay_host"] is None
-
-
-def test_relay_config_returns_credential_to_mailbox_app(
-    cfg: Any, client: TestClient[Litestar], monkeypatch: pytest.MonkeyPatch
-) -> None:
-    # Email enabled + a stubbed provider returning a credential.
-    _seed_mailbox_app(cfg)
-    _seed_identity(cfg)
-    cfg_enabled = cfg.evolve(email_proxy_base_url=_PROXY, public_ip=_IP)
-
-    set_active_config(cfg_enabled)
-
-    cred = RelayCredential(
-        smtp_relay_host="smtp.openhost.imbue.com",
-        smtp_relay_port=465,
-        smtp_relay_user=_ZONE,
-        smtp_relay_password="hmac-pw",
-        zone_domain=_ZONE,
-        custom_domain=None,
-    )
-
-    class _StubProvider:
-        def get(self, db: sqlite3.Connection) -> RelayCredential:
-            return cred
-
-    monkeypatch.setattr(sys_mod, "get_relay_credential_provider", lambda config: _StubProvider())
-    resp = client.get("/api/email/relay-config", headers=_app_headers(_MAILBOX_TOKEN))
-    assert resp.status_code == 200
-    body = resp.json()
-    assert body["configured"] is True
-    assert body["smtp_relay_host"] == "smtp.openhost.imbue.com"
-    assert body["smtp_relay_port"] == 465
-    assert body["smtp_relay_password"] == "hmac-pw"
-    assert body["zone_domain"] == _ZONE
-
-
-def test_relay_config_unconfigured_when_provider_returns_none(
-    cfg: Any, client: TestClient[Litestar], monkeypatch: pytest.MonkeyPatch
-) -> None:
-    _seed_mailbox_app(cfg)
-    _seed_identity(cfg)
-    cfg_enabled = cfg.evolve(email_proxy_base_url=_PROXY, public_ip=_IP)
-
-    set_active_config(cfg_enabled)
-
-    class _NoneProvider:
-        def get(self, db: sqlite3.Connection) -> RelayCredential | None:
-            return None
-
-    monkeypatch.setattr(sys_mod, "get_relay_credential_provider", lambda config: _NoneProvider())
-    resp = client.get("/api/email/relay-config", headers=_app_headers(_MAILBOX_TOKEN))
-    assert resp.status_code == 200
-    assert resp.json()["configured"] is False
-
-
-def test_relay_config_unconfigured_on_credential_error(
-    cfg: Any, client: TestClient[Litestar], monkeypatch: pytest.MonkeyPatch
-) -> None:
-    # A RelayCredentialError while email is enabled degrades to unconfigured
-    # (logged, not surfaced as a 500 to the mailbox app).
-
-    _seed_mailbox_app(cfg)
-    _seed_identity(cfg)
-    cfg_enabled = cfg.evolve(email_proxy_base_url=_PROXY, public_ip=_IP)
-
-    set_active_config(cfg_enabled)
-
-    class _ErrorProvider:
-        def get(self, db: sqlite3.Connection) -> RelayCredential:
-            raise RelayCredentialError("frontend down")
-
-    monkeypatch.setattr(sys_mod, "get_relay_credential_provider", lambda config: _ErrorProvider())
-    resp = client.get("/api/email/relay-config", headers=_app_headers(_MAILBOX_TOKEN))
-    assert resp.status_code == 200
-    assert resp.json()["configured"] is False
 
 
 # --- custom-domain: owner auth -----------------------------------------------
@@ -272,4 +101,3 @@ def test_custom_domain_returns_delegation_record_when_set(cfg: Any, client: Test
     assert body["record_name"] == "mail.mydomain.com"
     assert body["record_type"] == "NS"
     assert body["record_value"] == f"ns.{_ZONE}"
-    assert body["display_line"] == f"mail.mydomain.com   NS   ns.{_ZONE}"

--- a/compute_space/src/compute_space/tests/test_email_smtp_service.py
+++ b/compute_space/src/compute_space/tests/test_email_smtp_service.py
@@ -171,8 +171,6 @@ def _cred() -> RelayCredential:
         smtp_relay_port=465,
         smtp_relay_user=_ZONE,
         smtp_relay_password="hmac-pw",
-        zone_domain=_ZONE,
-        custom_domain=None,
     )
 
 

--- a/compute_space/src/compute_space/tests/test_email_smtp_service.py
+++ b/compute_space/src/compute_space/tests/test_email_smtp_service.py
@@ -1,0 +1,240 @@
+"""Tests for the router-mediated outbound email SMTP service.
+
+The router runs a local SMTP submission listener that apps relay through. An app
+authenticates with SMTP AUTH (username = app name, password = OPENHOST_APP_TOKEN),
+must hold the ``email`` v2 service ``send`` grant, and the router then relays the
+message to the Imbue smarthost with the per-instance relay credential attached
+(the app never sees it).
+
+These tests exercise the auth resolution, the grant check, the Authenticator
+callback, and the handler's DATA relay path (smarthost call stubbed).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import sqlite3
+from contextlib import closing
+from pathlib import Path
+from typing import Any
+
+import pytest
+from aiosmtpd.smtp import LoginPassword
+
+from compute_space.core.auth.permissions_v2 import grant_permission_v2
+from compute_space.core.email import smtp_service
+from compute_space.core.email.relay_credential import RelayCredential
+from compute_space.core.email.relay_credential import RelayCredentialError
+from compute_space.core.email.service import EMAIL_GRANT_SEND
+from compute_space.core.email.service import EMAIL_SERVICE_URL
+from compute_space.core.identity_store import set_instance_identity
+from compute_space.core.tls.keycloak import KeycloakClientCredentials
+from compute_space.db import init_db
+from compute_space.tests.conftest import _make_test_config
+from compute_space.tests.conftest import open_db
+
+_ZONE = "alice.example.com"
+_PROXY = "https://openhost.imbue.com"
+_IP = "203.0.113.5"
+_TOKEN = "sender-app-token"
+
+
+def _cred_identity() -> KeycloakClientCredentials:
+    return KeycloakClientCredentials(
+        issuer_url="https://kc/realms/openhost-customers",
+        client_id="instance-alice",
+        client_secret="sekret",
+    )
+
+
+@pytest.fixture
+def cfg(tmp_path: Path) -> Any:
+    cfg = _make_test_config(tmp_path, port=20900, zone_domain=_ZONE)
+    init_db(cfg.db_path)  # point get_db() at this DB (used by the auth/grant helpers)
+    return cfg
+
+
+def _seed_app(cfg: Any, name: str, app_id: str, token: str) -> None:
+    conn = sqlite3.connect(cfg.db_path)
+    try:
+        conn.execute(
+            """INSERT INTO apps (app_id, name, version, repo_path, local_port, status, installed_by)
+               VALUES (?, ?, ?, ?, ?, ?, NULL)""",
+            (app_id, name, "0.0.0", f"/tmp/{name}", 19700, "running"),
+        )
+        token_hash = hashlib.sha256(token.encode()).hexdigest()
+        conn.execute("INSERT INTO app_tokens (app_id, token_hash) VALUES (?, ?)", (app_id, token_hash))
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def _grant_send(app_id: str) -> None:
+    grant_permission_v2(app_id, EMAIL_SERVICE_URL, EMAIL_GRANT_SEND)
+
+
+# --- auth resolution ---------------------------------------------------------
+
+
+def test_auth_resolves_app_id_for_valid_token(cfg: Any) -> None:
+    _seed_app(cfg, "mailer", "MailerApp01", _TOKEN)
+    assert smtp_service._authenticated_app_id("mailer", _TOKEN) == "MailerApp01"
+
+
+def test_auth_rejects_unknown_token(cfg: Any) -> None:
+    _seed_app(cfg, "mailer", "MailerApp01", _TOKEN)
+    assert smtp_service._authenticated_app_id("mailer", "wrong-token") is None
+
+
+def test_auth_rejects_name_token_mismatch(cfg: Any) -> None:
+    # Valid token, but the claimed username is a different app.
+    _seed_app(cfg, "mailer", "MailerApp01", _TOKEN)
+    assert smtp_service._authenticated_app_id("someone-else", _TOKEN) is None
+
+
+# --- grant check -------------------------------------------------------------
+
+
+def test_app_may_send_requires_grant(cfg: Any) -> None:
+    _seed_app(cfg, "mailer", "MailerApp01", _TOKEN)
+    assert smtp_service._app_may_send("MailerApp01") is False
+    _grant_send("MailerApp01")
+    assert smtp_service._app_may_send("MailerApp01") is True
+
+
+def test_app_may_send_ignores_other_service_grant(cfg: Any) -> None:
+    _seed_app(cfg, "mailer", "MailerApp01", _TOKEN)
+    grant_permission_v2("MailerApp01", "github.com/other/service", "send")
+    assert smtp_service._app_may_send("MailerApp01") is False
+
+
+# --- Authenticator callback --------------------------------------------------
+
+
+def _auth(cfg: Any, login: str, password: str) -> Any:
+    # aiosmtpd passes a LoginPassword; only .login/.password are read.
+    authnr = smtp_service.EmailServiceAuthenticator()
+    data = LoginPassword(login.encode(), password.encode())
+    return authnr(None, None, None, "LOGIN", data)  # type: ignore[arg-type]
+
+
+def test_authenticator_success_binds_app_id(cfg: Any) -> None:
+    _seed_app(cfg, "mailer", "MailerApp01", _TOKEN)
+    _grant_send("MailerApp01")
+    result = _auth(cfg, "mailer", _TOKEN)
+    assert result.success is True
+    assert result.auth_data == "MailerApp01"
+
+
+def test_authenticator_fails_without_grant(cfg: Any) -> None:
+    _seed_app(cfg, "mailer", "MailerApp01", _TOKEN)
+    result = _auth(cfg, "mailer", _TOKEN)
+    assert result.success is False
+
+
+def test_authenticator_fails_bad_token(cfg: Any) -> None:
+    _seed_app(cfg, "mailer", "MailerApp01", _TOKEN)
+    _grant_send("MailerApp01")
+    result = _auth(cfg, "mailer", "nope")
+    assert result.success is False
+
+
+# --- handler DATA relay ------------------------------------------------------
+
+
+class _Envelope:
+    def __init__(self, mail_from: str, rcpts: list[str], content: bytes) -> None:
+        self.mail_from = mail_from
+        self.rcpt_tos = rcpts
+        self.content = content
+        self.original_content = content
+
+
+class _Session:
+    def __init__(self, auth_data: object) -> None:
+        self.auth_data = auth_data
+
+
+def _enable_email(cfg: Any) -> Any:
+    with closing(open_db(cfg)) as db:
+        set_instance_identity(db, _cred_identity())
+    return cfg.evolve(email_proxy_base_url=_PROXY, public_ip=_IP)
+
+
+async def _run_data(handler: smtp_service.EmailServiceHandler, session: Any, envelope: Any) -> str:
+    return await handler.handle_DATA(None, session, envelope)  # type: ignore[arg-type]
+
+
+def _cred() -> RelayCredential:
+    return RelayCredential(
+        smtp_relay_host="smtp.openhost.imbue.com",
+        smtp_relay_port=465,
+        smtp_relay_user=_ZONE,
+        smtp_relay_password="hmac-pw",
+        zone_domain=_ZONE,
+        custom_domain=None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_handle_data_relays_with_injected_credential(cfg: Any, monkeypatch: pytest.MonkeyPatch) -> None:
+    cfg_enabled = _enable_email(cfg)
+    handler = smtp_service.EmailServiceHandler(cfg_enabled)
+
+    # Stub the credential fetch and capture the smarthost relay call.
+    monkeypatch.setattr(handler, "_fetch_credential", lambda: _cred())
+    seen: dict[str, Any] = {}
+
+    def _fake_relay(cred: RelayCredential, raw: bytes, frm: str, tos: list[str]) -> None:
+        seen["cred"] = cred
+        seen["raw"] = raw
+        seen["from"] = frm
+        seen["tos"] = tos
+
+    monkeypatch.setattr(smtp_service, "_relay_to_smarthost", _fake_relay)
+
+    env = _Envelope("me@alice.example.com", ["dest@example.net"], b"Subject: hi\r\n\r\nbody")
+    result = await _run_data(handler, _Session("MailerApp01"), env)
+    assert result.startswith("250")
+    # The app never provided the credential; the router injected it.
+    assert seen["cred"].smtp_relay_password == "hmac-pw"
+    assert seen["from"] == "me@alice.example.com"
+    assert seen["tos"] == ["dest@example.net"]
+
+
+@pytest.mark.asyncio
+async def test_handle_data_requires_auth(cfg: Any) -> None:
+    handler = smtp_service.EmailServiceHandler(_enable_email(cfg))
+    env = _Envelope("me@alice.example.com", ["d@example.net"], b"x")
+    # No bound app_id on the session -> rejected.
+    result = await _run_data(handler, _Session(None), env)
+    assert result.startswith("530")
+
+
+@pytest.mark.asyncio
+async def test_handle_data_unconfigured_when_no_credential(cfg: Any, monkeypatch: pytest.MonkeyPatch) -> None:
+    handler = smtp_service.EmailServiceHandler(_enable_email(cfg))
+    monkeypatch.setattr(handler, "_fetch_credential", lambda: None)
+    env = _Envelope("me@alice.example.com", ["d@example.net"], b"x")
+    result = await _run_data(handler, _Session("MailerApp01"), env)
+    assert result.startswith("451")
+
+
+@pytest.mark.asyncio
+async def test_handle_data_no_recipients(cfg: Any, monkeypatch: pytest.MonkeyPatch) -> None:
+    handler = smtp_service.EmailServiceHandler(_enable_email(cfg))
+    monkeypatch.setattr(handler, "_fetch_credential", lambda: _cred())
+    env = _Envelope("me@alice.example.com", [], b"x")
+    result = await _run_data(handler, _Session("MailerApp01"), env)
+    assert result.startswith("554")
+
+
+def test_fetch_credential_swallows_error(cfg: Any, monkeypatch: pytest.MonkeyPatch) -> None:
+    handler = smtp_service.EmailServiceHandler(_enable_email(cfg))
+
+    class _ErrProvider:
+        def get(self, db: sqlite3.Connection) -> RelayCredential:
+            raise RelayCredentialError("frontend down")
+
+    monkeypatch.setattr(smtp_service, "get_relay_credential_provider", lambda config: _ErrProvider())
+    assert handler._fetch_credential() is None

--- a/compute_space/src/compute_space/tests/test_security_ports.py
+++ b/compute_space/src/compute_space/tests/test_security_ports.py
@@ -13,6 +13,7 @@ from unittest import mock
 import pytest
 
 from compute_space.core.auth import security_audit as security
+from compute_space.core.email.service import ROUTER_SMTP_PORT
 
 _SS_FORMAT = "LISTEN  0  4096  {addr}  *:*"
 
@@ -34,6 +35,15 @@ def _classify(ports, port: int) -> str | None:
         if entry["port"] == port:
             return entry["classification"]
     return None
+
+
+def test_router_email_smtp_port_classified_secure(fake_ss) -> None:
+    """The router's outbound-email SMTP listener (ROUTER_SMTP_PORT) binds
+    127.0.0.1 + the container gateway only; it must be classified ``secure``
+    so the audit doesn't flag every email-enabled instance."""
+    fake_ss([f"127.0.0.1:{ROUTER_SMTP_PORT}", f"10.200.0.1:{ROUTER_SMTP_PORT}"])
+    ports = security.list_listening_ports(db=None)
+    assert _classify(ports, ROUTER_SMTP_PORT) == "secure"
 
 
 def test_juicefs_pprof_loopback_classified_secure(fake_ss) -> None:

--- a/compute_space/src/compute_space/web/routes/api/system.py
+++ b/compute_space/src/compute_space/web/routes/api/system.py
@@ -3,17 +3,21 @@ import os
 import secrets
 import sqlite3
 import subprocess
+import threading
 from datetime import UTC
 from datetime import datetime
 from datetime import timedelta
+from typing import Any
 
 import attr
 from litestar import MediaType
+from litestar import Request
 from litestar import Response
 from litestar import Router
 from litestar import delete
 from litestar import get
 from litestar import post
+from litestar.exceptions import NotAuthorizedException
 
 from compute_space import OPENHOST_PROJECT_DIR
 from compute_space.config import Config
@@ -24,17 +28,53 @@ from compute_space.core.auth.security_audit import list_listening_ports
 from compute_space.core.containers import drop_docker_build_cache
 from compute_space.core.diagnostics import PlatformDiagnostics
 from compute_space.core.diagnostics import collect_platform_diagnostics
+from compute_space.core.domains import primary_domain
+from compute_space.core.email.enablement import email_enabled
+from compute_space.core.email.relay_credential import RelayCredentialError
+from compute_space.core.email.relay_credential import RelayCredentialProvider
 from compute_space.core.git_ops import get_branch_name
 from compute_space.core.git_ops import get_head_sha
 from compute_space.core.git_ops import is_dirty
 from compute_space.core.logging import get_log_path
+from compute_space.core.logging import logger
 from compute_space.core.storage import is_guard_paused
 from compute_space.core.storage import set_guard_paused
 from compute_space.core.storage import storage_status
 from compute_space.core.updates import is_shutdown_pending
+from compute_space.web.auth.auth import require_app_auth
 from compute_space.web.auth.auth import require_owner_auth
+from compute_space.web.auth.auth import verify_app_auth
 
 DEFAULT_TOKEN_EXPIRY_HOURS: float = 8.0
+
+
+# Process-wide relay-credential provider (caches the frontend-fetched credential
+# with a short TTL). Keyed on the config values that determine the credential
+# rather than on id(config): provide_config() hands each request a freshly-built
+# Config object, so an id()-based key would never hit — defeating the TTL cache
+# (refetching from the frontend on every request) and leaking a provider per
+# request. The identity/zone the credential also depends on are sourced live from
+# the DB and keyed inside the provider itself (RelayCredentialProvider.get).
+_relay_providers: dict[tuple[object, ...], RelayCredentialProvider] = {}
+_relay_providers_lock = threading.Lock()
+
+
+def _relay_provider_key(config: Config) -> tuple[object, ...]:
+    """A stable key over the config fields the relay credential depends on."""
+    return (
+        config.email_proxy_base_url,
+        config.email_custom_domain_normalized,
+    )
+
+
+def get_relay_credential_provider(config: Config) -> RelayCredentialProvider:
+    key = _relay_provider_key(config)
+    with _relay_providers_lock:
+        provider = _relay_providers.get(key)
+        if provider is None:
+            provider = RelayCredentialProvider(config=config)
+            _relay_providers[key] = provider
+        return provider
 
 
 # ─── attrs models ──────────────────────────────────────────────────────────
@@ -113,6 +153,40 @@ class SshStatusResponse:
 class DropCacheOk:
     ok: bool  # always True
     output: str
+
+
+@attr.s(auto_attribs=True, frozen=True)
+class EmailRelayConfigResponse:
+    """SMTP smarthost relay config the mailbox app uses to send outbound mail.
+
+    Returned only to the mailbox app (scoped by app name); the relay password is a
+    per-instance secret and is deliberately NOT injected into every app's env.
+    ``configured`` is False when email/relay isn't set up on this instance.
+    """
+
+    configured: bool
+    smtp_relay_host: str | None
+    smtp_relay_port: int | None
+    smtp_relay_user: str | None
+    smtp_relay_password: str | None
+    zone_domain: str | None
+    custom_domain: str | None
+
+
+@attr.s(auto_attribs=True, frozen=True)
+class CustomEmailDomainResponse:
+    """Owner-facing view of the custom mail domain and the single NS record to add.
+
+    ``configured`` is False when no custom mail domain is set on this instance, in
+    which case the record fields are None.
+    """
+
+    configured: bool
+    domain: str | None
+    record_name: str | None
+    record_type: str | None
+    record_value: str | None
+    display_line: str | None
 
 
 @attr.s(auto_attribs=True, frozen=True)
@@ -336,6 +410,86 @@ async def api_diagnostics(
     return Response(content=diagnostics, status_code=200, media_type=MediaType.JSON, headers=headers)
 
 
+@get("/api/email/relay-config", guards=[require_app_auth], sync_to_thread=True)
+def email_relay_config(
+    request: Request[Any, Any, Any], db: sqlite3.Connection, config: Config
+) -> Response[EmailRelayConfigResponse]:
+    """Return the SMTP smarthost relay config for the mailbox app.
+
+    Scoped: the request must be authenticated as an app (OPENHOST_APP_TOKEN), and
+    that app must be one of ``config.email_mailbox_app_names``. The relay host/port
+    + per-instance credential are fetched at runtime from the frontend (never baked
+    into this instance's config), then handed only to the mailbox app.
+    """
+    app_id = verify_app_auth(request)
+    row = db.execute("SELECT name FROM apps WHERE app_id = ?", (app_id,)).fetchone()
+    app_name = row["name"] if row is not None else None
+    if app_name not in config.email_mailbox_app_names:
+        raise NotAuthorizedException(detail="app is not authorized to fetch email relay config")
+
+    unconfigured = Response(
+        content=EmailRelayConfigResponse(
+            configured=False,
+            smtp_relay_host=None,
+            smtp_relay_port=None,
+            smtp_relay_user=None,
+            smtp_relay_password=None,
+            zone_domain=None,
+            custom_domain=None,
+        ),
+        media_type=MediaType.JSON,
+    )
+    if not email_enabled(config, db):
+        return unconfigured
+    try:
+        cred = get_relay_credential_provider(config).get(db)
+    except RelayCredentialError as e:
+        logger.warning(f"relay-config: could not fetch credential from frontend: {e}")
+        return unconfigured
+    if cred is None:
+        return unconfigured
+    return Response(
+        content=EmailRelayConfigResponse(
+            configured=True,
+            smtp_relay_host=cred.smtp_relay_host,
+            smtp_relay_port=cred.smtp_relay_port,
+            smtp_relay_user=cred.smtp_relay_user,
+            smtp_relay_password=cred.smtp_relay_password,
+            zone_domain=cred.zone_domain,
+            custom_domain=cred.custom_domain,
+        ),
+        media_type=MediaType.JSON,
+    )
+
+
+@get("/api/email/custom-domain", guards=[require_owner_auth], sync_to_thread=False)
+def custom_email_domain(db: sqlite3.Connection, config: Config) -> CustomEmailDomainResponse:
+    """Return the owner's custom mail domain and the single NS record to delegate it.
+
+    The owner sets this once at their registrar; the instance's nameserver host
+    (ns.<zone>) already resolves to the instance IP, so this one record is all
+    that is required for the custom domain to work.
+    """
+    record = config.custom_domain_delegation_record(primary_domain(db).name_no_port)
+    if record is None:
+        return CustomEmailDomainResponse(
+            configured=False,
+            domain=None,
+            record_name=None,
+            record_type=None,
+            record_value=None,
+            display_line=None,
+        )
+    return CustomEmailDomainResponse(
+        configured=True,
+        domain=config.email_custom_domain_normalized,
+        record_name=record.name,
+        record_type=record.record_type,
+        record_value=record.value,
+        display_line=record.as_display_line(),
+    )
+
+
 @post("/restart_router", status_code=200, guards=[require_owner_auth], sync_to_thread=False)
 def restart_router() -> OkResponse:
     """Restart the router systemd service to pick up code changes."""
@@ -368,6 +522,8 @@ system_routes = Router(
         drop_docker_cache,
         api_version,
         api_diagnostics,
+        email_relay_config,
+        custom_email_domain,
         restart_router,
     ],
 )

--- a/compute_space/src/compute_space/web/routes/api/system.py
+++ b/compute_space/src/compute_space/web/routes/api/system.py
@@ -3,21 +3,17 @@ import os
 import secrets
 import sqlite3
 import subprocess
-import threading
 from datetime import UTC
 from datetime import datetime
 from datetime import timedelta
-from typing import Any
 
 import attr
 from litestar import MediaType
-from litestar import Request
 from litestar import Response
 from litestar import Router
 from litestar import delete
 from litestar import get
 from litestar import post
-from litestar.exceptions import NotAuthorizedException
 
 from compute_space import OPENHOST_PROJECT_DIR
 from compute_space.config import Config
@@ -29,52 +25,17 @@ from compute_space.core.containers import drop_docker_build_cache
 from compute_space.core.diagnostics import PlatformDiagnostics
 from compute_space.core.diagnostics import collect_platform_diagnostics
 from compute_space.core.domains import primary_domain
-from compute_space.core.email.enablement import email_enabled
-from compute_space.core.email.relay_credential import RelayCredentialError
-from compute_space.core.email.relay_credential import RelayCredentialProvider
 from compute_space.core.git_ops import get_branch_name
 from compute_space.core.git_ops import get_head_sha
 from compute_space.core.git_ops import is_dirty
 from compute_space.core.logging import get_log_path
-from compute_space.core.logging import logger
 from compute_space.core.storage import is_guard_paused
 from compute_space.core.storage import set_guard_paused
 from compute_space.core.storage import storage_status
 from compute_space.core.updates import is_shutdown_pending
-from compute_space.web.auth.auth import require_app_auth
 from compute_space.web.auth.auth import require_owner_auth
-from compute_space.web.auth.auth import verify_app_auth
 
 DEFAULT_TOKEN_EXPIRY_HOURS: float = 8.0
-
-
-# Process-wide relay-credential provider (caches the frontend-fetched credential
-# with a short TTL). Keyed on the config values that determine the credential
-# rather than on id(config): provide_config() hands each request a freshly-built
-# Config object, so an id()-based key would never hit — defeating the TTL cache
-# (refetching from the frontend on every request) and leaking a provider per
-# request. The identity/zone the credential also depends on are sourced live from
-# the DB and keyed inside the provider itself (RelayCredentialProvider.get).
-_relay_providers: dict[tuple[object, ...], RelayCredentialProvider] = {}
-_relay_providers_lock = threading.Lock()
-
-
-def _relay_provider_key(config: Config) -> tuple[object, ...]:
-    """A stable key over the config fields the relay credential depends on."""
-    return (
-        config.email_proxy_base_url,
-        config.email_custom_domain_normalized,
-    )
-
-
-def get_relay_credential_provider(config: Config) -> RelayCredentialProvider:
-    key = _relay_provider_key(config)
-    with _relay_providers_lock:
-        provider = _relay_providers.get(key)
-        if provider is None:
-            provider = RelayCredentialProvider(config=config)
-            _relay_providers[key] = provider
-        return provider
 
 
 # ─── attrs models ──────────────────────────────────────────────────────────
@@ -153,24 +114,6 @@ class SshStatusResponse:
 class DropCacheOk:
     ok: bool  # always True
     output: str
-
-
-@attr.s(auto_attribs=True, frozen=True)
-class EmailRelayConfigResponse:
-    """SMTP smarthost relay config the mailbox app uses to send outbound mail.
-
-    Returned only to the mailbox app (scoped by app name); the relay password is a
-    per-instance secret and is deliberately NOT injected into every app's env.
-    ``configured`` is False when email/relay isn't set up on this instance.
-    """
-
-    configured: bool
-    smtp_relay_host: str | None
-    smtp_relay_port: int | None
-    smtp_relay_user: str | None
-    smtp_relay_password: str | None
-    zone_domain: str | None
-    custom_domain: str | None
 
 
 @attr.s(auto_attribs=True, frozen=True)
@@ -410,58 +353,6 @@ async def api_diagnostics(
     return Response(content=diagnostics, status_code=200, media_type=MediaType.JSON, headers=headers)
 
 
-@get("/api/email/relay-config", guards=[require_app_auth], sync_to_thread=True)
-def email_relay_config(
-    request: Request[Any, Any, Any], db: sqlite3.Connection, config: Config
-) -> Response[EmailRelayConfigResponse]:
-    """Return the SMTP smarthost relay config for the mailbox app.
-
-    Scoped: the request must be authenticated as an app (OPENHOST_APP_TOKEN), and
-    that app must be one of ``config.email_mailbox_app_names``. The relay host/port
-    + per-instance credential are fetched at runtime from the frontend (never baked
-    into this instance's config), then handed only to the mailbox app.
-    """
-    app_id = verify_app_auth(request)
-    row = db.execute("SELECT name FROM apps WHERE app_id = ?", (app_id,)).fetchone()
-    app_name = row["name"] if row is not None else None
-    if app_name not in config.email_mailbox_app_names:
-        raise NotAuthorizedException(detail="app is not authorized to fetch email relay config")
-
-    unconfigured = Response(
-        content=EmailRelayConfigResponse(
-            configured=False,
-            smtp_relay_host=None,
-            smtp_relay_port=None,
-            smtp_relay_user=None,
-            smtp_relay_password=None,
-            zone_domain=None,
-            custom_domain=None,
-        ),
-        media_type=MediaType.JSON,
-    )
-    if not email_enabled(config, db):
-        return unconfigured
-    try:
-        cred = get_relay_credential_provider(config).get(db)
-    except RelayCredentialError as e:
-        logger.warning(f"relay-config: could not fetch credential from frontend: {e}")
-        return unconfigured
-    if cred is None:
-        return unconfigured
-    return Response(
-        content=EmailRelayConfigResponse(
-            configured=True,
-            smtp_relay_host=cred.smtp_relay_host,
-            smtp_relay_port=cred.smtp_relay_port,
-            smtp_relay_user=cred.smtp_relay_user,
-            smtp_relay_password=cred.smtp_relay_password,
-            zone_domain=cred.zone_domain,
-            custom_domain=cred.custom_domain,
-        ),
-        media_type=MediaType.JSON,
-    )
-
-
 @get("/api/email/custom-domain", guards=[require_owner_auth], sync_to_thread=False)
 def custom_email_domain(db: sqlite3.Connection, config: Config) -> CustomEmailDomainResponse:
     """Return the owner's custom mail domain and the single NS record to delegate it.
@@ -522,7 +413,6 @@ system_routes = Router(
         drop_docker_cache,
         api_version,
         api_diagnostics,
-        email_relay_config,
         custom_email_domain,
         restart_router,
     ],

--- a/compute_space/src/compute_space/web/start.py
+++ b/compute_space/src/compute_space/web/start.py
@@ -29,7 +29,10 @@ from compute_space.core.dns import set_active_coredns
 from compute_space.core.dns import start_coredns
 from compute_space.core.domains import Domain
 from compute_space.core.domains import effective_domains
+from compute_space.core.email.enablement import email_enabled
 from compute_space.core.email.provision import provision_email_records
+from compute_space.core.email.smtp_service import ROUTER_SMTP_PORT
+from compute_space.core.email.smtp_service import start_email_smtp_service
 from compute_space.core.first_boot import owner_exists
 from compute_space.core.first_boot import seed_first_boot
 from compute_space.core.logging import logger
@@ -165,6 +168,15 @@ def main() -> None:
         # No-op unless email is enabled; best-effort (never blocks boot).
         if config.coredns_enabled:
             provision_email_records(config, db)
+
+        # Router-mediated outbound email: start the local SMTP submission listener
+        # apps relay through (permissioned via the 'email' v2 service). Only when
+        # email is enabled; binds loopback + the container gateway, never public.
+        if email_enabled(config, db):
+            smtp_hosts = ["127.0.0.1"]
+            if config.host != "0.0.0.0":
+                smtp_hosts.append("10.200.0.1")
+            start_email_smtp_service(config, hosts=smtp_hosts, port=ROUTER_SMTP_PORT)
 
         # Caddy reverse proxy. mainly for TLS termination, but also some other features.
         # The acquired file cert covers the primary domain (a wildcard for it);

--- a/compute_space/src/compute_space/web/start.py
+++ b/compute_space/src/compute_space/web/start.py
@@ -29,6 +29,7 @@ from compute_space.core.dns import set_active_coredns
 from compute_space.core.dns import start_coredns
 from compute_space.core.domains import Domain
 from compute_space.core.domains import effective_domains
+from compute_space.core.email.provision import provision_email_records
 from compute_space.core.first_boot import owner_exists
 from compute_space.core.first_boot import seed_first_boot
 from compute_space.core.logging import logger
@@ -159,6 +160,11 @@ def main() -> None:
 
         if domains[0].tls:  # primary is a TLS domain
             _ensure_tls_cert(config, db)
+
+        # Publish email DNS records into the (freshly regenerated) CoreDNS zone(s).
+        # No-op unless email is enabled; best-effort (never blocks boot).
+        if config.coredns_enabled:
+            provision_email_records(config, db)
 
         # Caddy reverse proxy. mainly for TLS termination, but also some other features.
         # The acquired file cert covers the primary domain (a wildcard for it);

--- a/openhost_system_agent/src/openhost_system_agent/migrations/registry.py
+++ b/openhost_system_agent/src/openhost_system_agent/migrations/registry.py
@@ -11,6 +11,9 @@ from openhost_system_agent.migrations.versions.v0004_pixi_version import Migrati
 from openhost_system_agent.migrations.versions.v0005_pixi_ownership_failsafe import Migration0005PixiOwnershipFailsafe
 from openhost_system_agent.migrations.versions.v0006_journald_size_cap import Migration0006JournaldSizeCap
 from openhost_system_agent.migrations.versions.v0007_seed_domains_and_scrub import Migration0007SeedDomainsAndScrub
+from openhost_system_agent.migrations.versions.v0008_seed_imbue_identity_and_scrub import (
+    Migration0008SeedImbueIdentityAndScrub,
+)
 
 # Numbered migrations in apply order. Versions MUST start at 2 and be
 # contiguous. v1 is the baseline produced by ansible setup.yml.
@@ -21,6 +24,7 @@ REGISTRY: list[SystemMigration] = [
     Migration0005PixiOwnershipFailsafe(),
     Migration0006JournaldSizeCap(),
     Migration0007SeedDomainsAndScrub(),
+    Migration0008SeedImbueIdentityAndScrub(),
 ]
 
 

--- a/openhost_system_agent/src/openhost_system_agent/migrations/versions/v0008_seed_imbue_identity_and_scrub.py
+++ b/openhost_system_agent/src/openhost_system_agent/migrations/versions/v0008_seed_imbue_identity_and_scrub.py
@@ -1,0 +1,155 @@
+"""v8: migrate an OLD instance's per-instance Keycloak credential from ``config.toml`` into the
+router DB ``settings`` table, then scrub the now-captured ``cert_api_keycloak_*`` lines.
+
+Before the shared-identity work, an instance's per-instance credential lived in ``config.toml`` as
+``cert_api_keycloak_issuer_url`` / ``cert_api_keycloak_client_id`` / ``cert_api_keycloak_client_secret``
+(cert-api's auth). The new model stores one shared credential in the DB ``settings`` table
+(``imbue_identity_*`` keys), which every Imbue service (cert-api, email, ...) reads. New instances get
+it seeded from ``first_boot.toml``; this migration moves an upgraded instance's existing credential
+into the same store so the DB is the single source of truth — after which the read-time config
+fallback in the router can eventually be removed.
+
+This is the **old-instance (upgrade)** path, mirroring v7 (domains + claim token). Fresh installs never
+carry ``cert_api_keycloak_*`` (they seed ``imbue_identity_*`` via first_boot), so this is a no-op
+capture for them and just scrubs on a later update. It runs as root during ``openhost update``, before
+the router restarts, so it does the capture itself (a scrub-only migration would strip the credential
+before the router's runtime resolver could fall back to it).
+
+stdlib only: agent migrations run before ``pixi install``, so this can't import the router's code.
+The ``settings`` schema is a frozen snapshot kept byte-compatible with the router's v13 migration so a
+``CREATE TABLE IF NOT EXISTS`` here is a no-op after the router (or v7) created it.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import sqlite3
+import tomllib
+from contextlib import closing
+from pathlib import Path
+
+from openhost_system_agent.migrations.base import SystemMigration
+
+# Router paths (mirror the openhost.service Environment + the data-dir layout).
+_DATA_DIR = "/home/host/.openhost/local_compute_space"
+CONFIG_TOML_PATH = f"{_DATA_DIR}/config.toml"
+DB_PATH = f"{_DATA_DIR}/persistent_data/openhost/router.db"
+
+# Frozen copy of the v13 ``settings`` schema. MUST stay byte-compatible with the router's v13 migration
+# so its CREATE-IF-NOT-EXISTS is a no-op after this migration (or v7) has created the table.
+_SCHEMA = """
+CREATE TABLE IF NOT EXISTS settings (
+    key   TEXT PRIMARY KEY,
+    value TEXT
+);
+"""
+
+# The three config-file assignment lines the credential lives on (whole line, incl. its newline). Once
+# captured into the settings table they are DB-sourced, so their config-file copies are scrubbed.
+_CAPTURED_LINE_RE = re.compile(
+    r"(?m)^[ \t]*cert_api_keycloak_(?:issuer_url|client_id|client_secret)[ \t]*=.*(?:\r?\n|$)"
+)
+
+# settings keys — MUST match compute_space.core.identity_store's IMBUE_IDENTITY_* constants.
+_ISSUER_KEY = "imbue_identity_issuer_url"
+_CLIENT_ID_KEY = "imbue_identity_client_id"
+_CLIENT_SECRET_KEY = "imbue_identity_client_secret"
+
+
+def _seed_imbue_identity(db: sqlite3.Connection, openhost: dict[str, object]) -> bool:
+    """Move ``cert_api_keycloak_*`` into ``settings`` as the shared ``imbue_identity_*`` credential.
+
+    Only seeds when all three parts are present in config AND the settings table has no credential yet
+    (so a later Connect/first-boot value is never clobbered). Returns True iff it seeded (the caller
+    only scrubs config when the capture succeeded, so a partial credential is never lost).
+    """
+    already = db.execute(
+        "SELECT 1 FROM settings WHERE key IN (?, ?, ?) LIMIT 1",
+        (_ISSUER_KEY, _CLIENT_ID_KEY, _CLIENT_SECRET_KEY),
+    ).fetchone()
+    if already is not None:
+        return False
+    issuer = str(openhost.get("cert_api_keycloak_issuer_url", "")).strip()
+    client_id = str(openhost.get("cert_api_keycloak_client_id", "")).strip()
+    client_secret = str(openhost.get("cert_api_keycloak_client_secret", "")).strip()
+    if not (issuer and client_id and client_secret):
+        return False
+    db.executemany(
+        "INSERT INTO settings (key, value) VALUES (?, ?)",
+        [(_ISSUER_KEY, issuer), (_CLIENT_ID_KEY, client_id), (_CLIENT_SECRET_KEY, client_secret)],
+    )
+    return True
+
+
+def _scrub_captured_config(config_path: str) -> None:
+    """Remove the now-captured ``cert_api_keycloak_*`` lines from ``config.toml``, preserving the file's
+    owner/mode (this runs as root, so a naive rewrite would leave it root-owned)."""
+    p = Path(config_path)
+    try:
+        original = p.read_text()
+    except OSError:
+        return
+    scrubbed = _CAPTURED_LINE_RE.sub("", original)
+    if scrubbed == original:
+        return
+    st = p.stat()
+    tmp = p.with_name(p.name + ".tmp")
+    tmp.write_text(scrubbed)
+    os.chown(tmp, st.st_uid, st.st_gid)
+    os.chmod(tmp, st.st_mode & 0o777)
+    os.replace(tmp, p)
+
+
+def migrate(config_path: str = CONFIG_TOML_PATH, db_path: str = DB_PATH) -> None:
+    """Capture ``cert_api_keycloak_*`` into the router DB settings table, then scrub those lines from
+    ``config.toml``. Idempotent; a no-op if there's no router DB yet or nothing to capture, and it only
+    scrubs the config once the credential is safely in the DB."""
+    if not Path(db_path).exists():
+        return  # the router hasn't created its DB yet — it'll seed from first_boot at first boot
+    try:
+        with open(config_path, "rb") as f:
+            openhost = tomllib.load(f).get("openhost", {})
+    except FileNotFoundError:
+        return  # no config to capture; a malformed one must fail loud so the migration retries
+    if not isinstance(openhost, dict):
+        return
+
+    # timeout: the old router is still running during the update, so the DB may be briefly locked.
+    with closing(sqlite3.connect(db_path, timeout=30)) as db:
+        db.executescript(_SCHEMA)  # frozen v13 settings schema (no-op if already created)
+        seeded = _seed_imbue_identity(db, openhost)
+        db.commit()
+
+    # Any WAL/SHM files touched here must stay owned by the router's user, not root.
+    if Path(db_path).exists():
+        st = os.stat(db_path)
+        for suffix in ("-wal", "-shm"):
+            sidecar = Path(db_path + suffix)
+            if sidecar.exists():
+                os.chown(sidecar, st.st_uid, st.st_gid)
+
+    # Only scrub once the credential is captured (in the DB now, or from a prior run). If the settings
+    # table already holds an imbue_identity_* credential, the config copy is redundant and safe to drop.
+    if seeded or _identity_in_settings(db_path):
+        _scrub_captured_config(config_path)
+
+
+def _identity_in_settings(db_path: str) -> bool:
+    """True if the settings table already holds all three imbue_identity_* parts."""
+    try:
+        with closing(sqlite3.connect(db_path, timeout=30)) as db:
+            rows = db.execute(
+                "SELECT key FROM settings WHERE key IN (?, ?, ?)",
+                (_ISSUER_KEY, _CLIENT_ID_KEY, _CLIENT_SECRET_KEY),
+            ).fetchall()
+        return {r[0] for r in rows} == {_ISSUER_KEY, _CLIENT_ID_KEY, _CLIENT_SECRET_KEY}
+    except sqlite3.OperationalError:
+        return False
+
+
+class Migration0008SeedImbueIdentityAndScrub(SystemMigration):
+    version = 8
+
+    def up(self) -> None:
+        migrate()

--- a/openhost_system_agent/src/openhost_system_agent/tests/test_migration_seed_imbue_identity_and_scrub.py
+++ b/openhost_system_agent/src/openhost_system_agent/tests/test_migration_seed_imbue_identity_and_scrub.py
@@ -1,0 +1,187 @@
+"""Tests for the v8 migration: the OLD-instance (upgrade) capture of the config-file
+``cert_api_keycloak_*`` credential into the router DB ``settings`` table as the shared
+``imbue_identity_*`` credential, followed by scrubbing those lines from config.toml.
+
+Stdlib-only + self-contained (runs before ``pixi install``). We drive ``migrate()`` against a temp DB
++ config.toml and assert it seeds the settings table and scrubs the file — and that it never clobbers
+an existing DB credential or loses a partial one.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import tomllib
+from pathlib import Path
+
+from openhost_system_agent.migrations.versions.v0008_seed_imbue_identity_and_scrub import _CLIENT_ID_KEY
+from openhost_system_agent.migrations.versions.v0008_seed_imbue_identity_and_scrub import _CLIENT_SECRET_KEY
+from openhost_system_agent.migrations.versions.v0008_seed_imbue_identity_and_scrub import _ISSUER_KEY
+from openhost_system_agent.migrations.versions.v0008_seed_imbue_identity_and_scrub import _SCHEMA
+from openhost_system_agent.migrations.versions.v0008_seed_imbue_identity_and_scrub import migrate
+
+_FULL_CONFIG = (
+    "[openhost]\n"
+    'host = "127.0.0.1"\n'
+    "port = 8080\n"
+    'cert_provider = "cert_api"\n'
+    'cert_api_base_url = "https://cert.example.com"\n'
+    'cert_api_keycloak_issuer_url = "https://kc.example.com/realms/openhost-customers"\n'
+    'cert_api_keycloak_client_id = "instance-alice"\n'
+    'cert_api_keycloak_client_secret = "s3cr3t"\n'
+)
+
+
+def _db_with_settings(path: Path) -> None:
+    """A router DB that already has the settings table (as v7/v13 would create it)."""
+    conn = sqlite3.connect(path)
+    conn.executescript(_SCHEMA)
+    conn.commit()
+    conn.close()
+
+
+def _settings(db_path: Path) -> dict[str, str]:
+    conn = sqlite3.connect(db_path)
+    try:
+        return {k: v for k, v in conn.execute("SELECT key, value FROM settings")}
+    finally:
+        conn.close()
+
+
+def _openhost(config_path: Path) -> dict[str, object]:
+    with open(config_path, "rb") as f:
+        section = tomllib.load(f).get("openhost", {})
+    return section if isinstance(section, dict) else {}
+
+
+# --- happy path ---------------------------------------------------------------
+
+
+def test_captures_credential_into_settings_then_scrubs(tmp_path: Path) -> None:
+    config = tmp_path / "config.toml"
+    config.write_text(_FULL_CONFIG)
+    db = tmp_path / "router.db"
+    _db_with_settings(db)
+
+    migrate(str(config), str(db))
+
+    s = _settings(db)
+    assert s[_ISSUER_KEY] == "https://kc.example.com/realms/openhost-customers"
+    assert s[_CLIENT_ID_KEY] == "instance-alice"
+    assert s[_CLIENT_SECRET_KEY] == "s3cr3t"
+    # The cert_api_keycloak_* lines are scrubbed from config...
+    oh = _openhost(config)
+    assert "cert_api_keycloak_issuer_url" not in oh
+    assert "cert_api_keycloak_client_id" not in oh
+    assert "cert_api_keycloak_client_secret" not in oh
+    # ...but everything else is preserved.
+    assert oh["cert_provider"] == "cert_api"
+    assert oh["cert_api_base_url"] == "https://cert.example.com"
+    assert oh["host"] == "127.0.0.1"
+
+
+def test_idempotent(tmp_path: Path) -> None:
+    config = tmp_path / "config.toml"
+    config.write_text(_FULL_CONFIG)
+    db = tmp_path / "router.db"
+    _db_with_settings(db)
+
+    migrate(str(config), str(db))
+    first = _settings(db)
+    first_config = config.read_text()
+    # Second run: config no longer has the keys, settings already populated -> no change.
+    migrate(str(config), str(db))
+    assert _settings(db) == first
+    assert config.read_text() == first_config
+
+
+# --- do-not-clobber / do-not-lose ---------------------------------------------
+
+
+def test_does_not_clobber_existing_settings_credential(tmp_path: Path) -> None:
+    # An instance that already has an imbue_identity_* credential (e.g. from Connect) must keep it,
+    # and its config copy is redundant -> still scrubbed.
+    config = tmp_path / "config.toml"
+    config.write_text(_FULL_CONFIG)
+    db = tmp_path / "router.db"
+    _db_with_settings(db)
+    conn = sqlite3.connect(db)
+    conn.executemany(
+        "INSERT INTO settings (key, value) VALUES (?, ?)",
+        [(_ISSUER_KEY, "existing-iss"), (_CLIENT_ID_KEY, "existing-id"), (_CLIENT_SECRET_KEY, "existing-sec")],
+    )
+    conn.commit()
+    conn.close()
+
+    migrate(str(config), str(db))
+
+    s = _settings(db)
+    assert s[_CLIENT_SECRET_KEY] == "existing-sec"  # not clobbered by the config value
+    # config copy is redundant, so it is scrubbed.
+    assert "cert_api_keycloak_client_secret" not in _openhost(config)
+
+
+def test_partial_credential_not_seeded_and_not_scrubbed(tmp_path: Path) -> None:
+    # If config has only 2 of the 3 parts (a typo), seed nothing and DO NOT scrub -> nothing is lost.
+    config = tmp_path / "config.toml"
+    config.write_text(
+        "[openhost]\n"
+        'cert_api_keycloak_issuer_url = "https://kc/realms/oh"\n'
+        'cert_api_keycloak_client_id = "instance-x"\n'
+    )
+    db = tmp_path / "router.db"
+    _db_with_settings(db)
+
+    migrate(str(config), str(db))
+
+    assert _settings(db) == {}  # nothing seeded
+    oh = _openhost(config)
+    assert oh["cert_api_keycloak_issuer_url"] == "https://kc/realms/oh"  # preserved (not scrubbed)
+    assert oh["cert_api_keycloak_client_id"] == "instance-x"
+
+
+# --- no-ops -------------------------------------------------------------------
+
+
+def test_no_db_is_noop(tmp_path: Path) -> None:
+    config = tmp_path / "config.toml"
+    config.write_text(_FULL_CONFIG)
+    db = tmp_path / "router.db"  # does not exist
+    migrate(str(config), str(db))
+    # config untouched; no db created.
+    assert "cert_api_keycloak_issuer_url" in _openhost(config)
+    assert not db.exists()
+
+
+def test_no_config_keys_is_noop(tmp_path: Path) -> None:
+    # A fresh install (no cert_api_keycloak_*) -> nothing to capture, nothing to scrub.
+    config = tmp_path / "config.toml"
+    config.write_text('[openhost]\nhost = "127.0.0.1"\nport = 8080\n')
+    db = tmp_path / "router.db"
+    _db_with_settings(db)
+
+    migrate(str(config), str(db))
+
+    assert _settings(db) == {}
+    assert config.read_text() == '[openhost]\nhost = "127.0.0.1"\nport = 8080\n'
+
+
+def test_missing_config_is_noop(tmp_path: Path) -> None:
+    db = tmp_path / "router.db"
+    _db_with_settings(db)
+    migrate(str(tmp_path / "nope.toml"), str(db))
+    assert _settings(db) == {}
+
+
+def test_creates_settings_table_if_absent(tmp_path: Path) -> None:
+    # An older DB without the settings table: the migration's frozen CREATE handles it.
+    config = tmp_path / "config.toml"
+    config.write_text(_FULL_CONFIG)
+    db = tmp_path / "router.db"
+    conn = sqlite3.connect(db)
+    conn.execute("CREATE TABLE users (username TEXT PRIMARY KEY)")  # some table so the file exists
+    conn.commit()
+    conn.close()
+
+    migrate(str(config), str(db))
+
+    assert _settings(db)[_CLIENT_ID_KEY] == "instance-alice"

--- a/pixi.lock
+++ b/pixi.lock
@@ -1,8 +1,24 @@
 version: 7
 platforms:
-- name: linux-64
-- name: linux-aarch64
 - name: osx-arm64
+  virtual-packages:
+  - __unix=0=0
+  - __osx=13.0
+  - __archspec=0=m1
+- name: p1
+  subdir: linux-64
+  virtual-packages:
+  - __linux=6.8
+  - __glibc=2.39
+  - __unix=0=0
+  - __archspec=0=x86_64
+- name: p2
+  subdir: linux-aarch64
+  virtual-packages:
+  - __linux=6.8
+  - __glibc=2.39
+  - __unix=0=0
+  - __archspec=0=aarch64
 environments:
   default:
     channels:
@@ -10,7 +26,108 @@ environments:
     indexes:
     - https://pypi.org/simple
     packages:
-      linux-64:
+      osx-arm64:
+      - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-types-0.7.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/anyio-4.14.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.5.20-hbd8a1cb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2026.5.20-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.4.1-pyhc90fa1f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/faker-40.23.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/h11-0.16.0-pyhcf101f3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.3.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/httpcore-1.0.9-pyh29332c3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/httpx-0.28.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.18-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/litestar-2.24.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/litestar-htmx-0.5.0-pyhe01879c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-4.2.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/multipart-1.3.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/polyfactory-3.3.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.20.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-tzdata-2026.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.12-8_cp312.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rich-15.0.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rich-click-1.9.8-pyh8f84b5b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/sniffio-1.3.1-pyhd8ed1ab_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.15.0-h396c80c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-hd037594_9.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/caddy-2.11.4-hf76c51c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/icu-78.3-hef89b57_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.8.1-hf6b4638_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.5.2-hcf2aa1b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblzma-5.8.3-h8088a28_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.53.2-h1ae2325_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.3.2-h8088a28_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/msgspec-0.21.1-py312h2bbb03f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/multidict-6.7.1-py312h43af8aa_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.6-h1d4f5a5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.6.3-hd24854e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.12.13-h8561d8f_0_cpython.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyyaml-6.0.3-py312h04c11ed_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/readline-8.3-h46df422_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-h010d191_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/yaml-0.2.5-h925e9cb_3.conda
+      - pypi: ./
+      - pypi: https://files.pythonhosted.org/packages/00/e9/1e1fd7fae559bfd07704991e9a59dd1349b72423c904256c073ce88a9940/pyflakes-3.1.0-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/0c/29/0348de65b8cc732daa3e33e67806420b2ae89bdce2b04af740289c5c6c8c/loguru-0.7.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/0c/eb/4fc8d0a7110eb5fc9cc161723a34a8a6c200ce3b4fbf681bc86feee22308/charset_normalizer-3.4.7-cp312-cp312-macosx_10_13_universal2.whl
+      - pypi: https://files.pythonhosted.org/packages/13/66/67b54f12fc0c5b2dc6fd0c04ea4cf1e7fc4a9843de680a22070d1fd77901/boto3-1.43.31-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/14/2f/967ba146e6d58cf6a652da73885f52fc68001525b4197effc174321d70b4/jmespath-1.1.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/20/7a/1c6e3562dfd8950adbb11ffbc65d21e7c89d01a6e4f137fa981056de25c5/gitpython-3.1.50-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/27/1a/1f68f9ba0c207934b35b86a8ca3aad8395a3d6dd7921c0686e23853ff5a9/mccabe-0.7.0-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/2c/58/ca301544e1fa93ed4f80d724bf5b194f6e4b945841c5bfd555878eea9fcb/referencing-0.37.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/34/90/0200184d2124484f918054751ef997ed6409cb05b7e8dcbf5a22da4c4748/pyrfc3339-2.1.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/40/1e/9771421ac2286eaab95b8575b0cb701ae3663abf8b5e1f64f1fd90d0a673/websockets-16.0-cp312-cp312-macosx_11_0_arm64.whl
+      - pypi: https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/46/5f/4c174edad94f82de888ac00a5ddd8d07b35609b6c94f0bdf4d74af57703e/s3transfer-0.19.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/4f/d3/a8b22fa575b297cd6e3e3b0155c7e25db170edf1c74783d6a31a2490b8d9/argon2_cffi-25.1.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/54/18/1dd71c9b43192ab83f1d531ad6002dc81108ac36c475f79fb7a295abe2f4/pyopenssl-26.3.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/5d/ba/2af136406e1c3839aea9ecadc2f6be2bcd1eff255bd451dd39bcf302c47a/bcrypt-5.0.0-cp39-abi3-macosx_10_12_universal2.whl
+      - pypi: https://files.pythonhosted.org/packages/5e/5f/82c8074f7e84978129347c2c6ec8b6c59f3584ff1a20bc3c940a3e061790/priority-2.0.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/64/b4/17d4b0b2a2dc85a6df63d1157e028ed19f90d4cd97c36717afef2bc2f395/attrs-26.1.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/69/90/f63fb5873511e014207a475e2bb4e8b2e570d655b00ac19a9a0ca0a385ee/jsonschema-4.26.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/80/56/60547f7801b97c67e97491dc3d9ade9fbccbd0325058fd3dfcb2f5d98d90/cattrs-26.1.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/85/c8/b156c2087c70f10c71ccc874c3e2cf484240775c818a006686553f61bd2a/cappa-0.32.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/8b/9e/d01ef2bed8e995bbdeeb5307a571729a10545de4a6f8f06d9175fc7a1978/typed_settings-25.3.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/93/35/850277d1b17b206bd10874c8a9a3f52e059452fb49bb0d22cbb908f6038b/hypercorn-0.18.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/96/c0/271f3e1e3502a8decb8ee5c680dbed2d8dc2cd504f5e20f7ed491d5f37e1/atpublic-7.0.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/9a/81/7e4e08678a1f98521201c3079f77db69fb552acd56067661f8c2f534a718/markupsafe-3.0.3-cp312-cp312-macosx_11_0_arm64.whl
+      - pypi: https://files.pythonhosted.org/packages/9b/22/adf66990e63584a68dfb50c24f48a125c07b1699899381c8151e63ed458c/cryptography-49.0.0-cp311-abi3-macosx_11_0_arm64.whl
+      - pypi: https://files.pythonhosted.org/packages/9d/76/f789f7a86709c6b087c5a2f52f911838cad707cc613162401badc665acfe/setuptools-82.0.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/9e/c9/b2622292ea83fbb4ec318f5b9ab867d0a28ab43c5717bb85b0a5f6b3b0a4/networkx-3.6.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a0/61/5c78b91c3143ed5c14207f463aecfc8f9dbb5092fb2869baf37c273b2705/gitdb-4.0.12-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a3/43/35e3f136343aef451e545ce8c38d36c2f93c0ed88703db8b64ba2b205c68/rpds_py-2026.5.1-cp312-cp312-macosx_11_0_arm64.whl
+      - pypi: https://files.pythonhosted.org/packages/a3/5e/ecf12fdb62546d64385c158514e9b2b671f7832108ef2ecd2020ce0af2d1/pyjwt-2.13.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a4/f5/10b68b7b1544245097b2a1b8238f66f2fc6dcaeb24ba5d917f52bd2eed4f/wsproto-1.3.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a5/69/6da5581c6a7fede7dc261bf4e67d6adca4196f176b43288b55b3db395b6e/mdit_py_plugins-0.6.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a9/4e/0463faa15aa5c618691f8c959bb0c40b215f5883175e3daa0f15f3b3e5a9/diskimage_builder-3.42.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/b0/24/bbf7175ffc47cb3d3e1eb523ddb23272968359dfcf2e1294707a2bf12fc4/flake8-6.1.0-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/b1/90/a998c550d0ddd07e38605bb5c455d00fcc177a800ff9cc3dafdcb3dd7b56/pycodestyle-2.11.1-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/b3/c5/30de077e06f7ffc3fe21d45ce26b8088816227b678a7157f6b9e080ff2db/type_lens-0.2.6-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/b6/02/d297943bcacf05e4f2a94ab6f462831dc20158614e5d067c35d4e63b9acb/argon2_cffi_bindings-25.1.0-cp39-abi3-macosx_11_0_arm64.whl
+      - pypi: https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/ba/47/5eb27f6f065170380bd4bd782177a2f1f67e721d6b3fa7de18c492f52917/acme-5.6.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/c0/db/61efa0d08a99f897ef98256b03e563092d36cc38dc4ebe4a85020fe40b31/pbr-7.0.3-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/c1/d4/59e74daffcb57a07668852eeeb6035af9f32cbfd7a1d2511f17d2fe6a738/smmap-5.0.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/c7/18/c86eb8e0202e32dd3df50d43d7ff9854f8e0603945ff398974c1d91ac1ef/tomli_w-1.2.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/d2/1e/da5fdcb8438008d3c53a0c6de6a40cb10bdb7e02a6e034aef79bc2b66800/botocore-1.43.31-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/df/a2/781b623f57358e360d62cdd7a8c681f074a71d445418a776eef0aadb4ab4/cffi-2.0.0-cp312-cp312-macosx_11_0_arm64.whl
+      - pypi: https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/ec/39/d401756df60a8344848477d54fdf4ce0f50531f6149f3b8eaae9c06ae3dc/aiosmtpd-1.4.6-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/f5/ac/19f9941c74add59d17694930ec8105d5eddeee4ce56dd8632b765ca16d6c/stevedore-5.8.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/f8/b2/b5caed897fbb1cc286c62c01feca977e08d99a17230ff3055b9a98eccf1d/josepy-2.2.0-py3-none-any.whl
+      p1:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hda65f42_9.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/caddy-2.11.4-hfc2019e_0.conda
@@ -88,7 +205,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.15.0-h396c80c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
-      - pypi: .
+      - pypi: ./
       - pypi: https://files.pythonhosted.org/packages/00/e9/1e1fd7fae559bfd07704991e9a59dd1349b72423c904256c073ce88a9940/pyflakes-3.1.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/09/52/94108adfdd6e2ddf58be64f959a0b9c7d4ef2fa71086c38356d22dc501ea/argon2_cffi_bindings-25.1.0-cp39-abi3-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/0c/29/0348de65b8cc732daa3e33e67806420b2ae89bdce2b04af740289c5c6c8c/loguru-0.7.3-py3-none-any.whl
@@ -116,6 +233,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/85/c8/b156c2087c70f10c71ccc874c3e2cf484240775c818a006686553f61bd2a/cappa-0.32.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/8b/9e/d01ef2bed8e995bbdeeb5307a571729a10545de4a6f8f06d9175fc7a1978/typed_settings-25.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/93/35/850277d1b17b206bd10874c8a9a3f52e059452fb49bb0d22cbb908f6038b/hypercorn-0.18.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/96/c0/271f3e1e3502a8decb8ee5c680dbed2d8dc2cd504f5e20f7ed491d5f37e1/atpublic-7.0.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/9d/76/f789f7a86709c6b087c5a2f52f911838cad707cc613162401badc665acfe/setuptools-82.0.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/9e/c9/b2622292ea83fbb4ec318f5b9ab867d0a28ab43c5717bb85b0a5f6b3b0a4/networkx-3.6.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a0/61/5c78b91c3143ed5c14207f463aecfc8f9dbb5092fb2869baf37c273b2705/gitdb-4.0.12-py3-none-any.whl
@@ -136,11 +254,12 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/d2/1e/da5fdcb8438008d3c53a0c6de6a40cb10bdb7e02a6e034aef79bc2b66800/botocore-1.43.31-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d4/8d/5e43d9584b3b3591a6f9b68f755a4da879a59712981ef5ad2a0ac1379f7a/bcrypt-5.0.0-cp39-abi3-manylinux_2_34_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/ec/39/d401756df60a8344848477d54fdf4ce0f50531f6149f3b8eaae9c06ae3dc/aiosmtpd-1.4.6-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f4/1e/2c9096fc19d5fd084b0184ca2b651e659aa0a37e6fdbecf6ece47f147fe1/rpds_py-2026.5.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/f5/ac/19f9941c74add59d17694930ec8105d5eddeee4ce56dd8632b765ca16d6c/stevedore-5.8.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f8/b2/b5caed897fbb1cc286c62c01feca977e08d99a17230ff3055b9a98eccf1d/josepy-2.2.0-py3-none-any.whl
-      linux-aarch64:
+      p2:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/_openmp_mutex-4.5-20_gnu.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/bzip2-1.0.8-h4777abc_9.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/caddy-2.11.4-h22914b5_0.conda
@@ -219,7 +338,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.15.0-h396c80c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
-      - pypi: .
+      - pypi: ./
       - pypi: https://files.pythonhosted.org/packages/00/e9/1e1fd7fae559bfd07704991e9a59dd1349b72423c904256c073ce88a9940/pyflakes-3.1.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/0c/29/0348de65b8cc732daa3e33e67806420b2ae89bdce2b04af740289c5c6c8c/loguru-0.7.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl
@@ -245,6 +364,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/85/c8/b156c2087c70f10c71ccc874c3e2cf484240775c818a006686553f61bd2a/cappa-0.32.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/8b/9e/d01ef2bed8e995bbdeeb5307a571729a10545de4a6f8f06d9175fc7a1978/typed_settings-25.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/93/35/850277d1b17b206bd10874c8a9a3f52e059452fb49bb0d22cbb908f6038b/hypercorn-0.18.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/96/c0/271f3e1e3502a8decb8ee5c680dbed2d8dc2cd504f5e20f7ed491d5f37e1/atpublic-7.0.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/97/bb/21c36b7dbbafc85d2d480cd65df02a1dc93bf76d97147605a8e27ff9409d/websockets-16.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/9d/76/f789f7a86709c6b087c5a2f52f911838cad707cc613162401badc665acfe/setuptools-82.0.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/9e/c9/b2622292ea83fbb4ec318f5b9ab867d0a28ab43c5717bb85b0a5f6b3b0a4/networkx-3.6.1-py3-none-any.whl
@@ -266,11 +386,18 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/c7/18/c86eb8e0202e32dd3df50d43d7ff9854f8e0603945ff398974c1d91ac1ef/tomli_w-1.2.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d5/72/12b5f8d3865bf0f87cf1404d8c374e7487dcf097a1c91c436e72e6badd83/cffi-2.0.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/ec/39/d401756df60a8344848477d54fdf4ce0f50531f6149f3b8eaae9c06ae3dc/aiosmtpd-1.4.6-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f1/de/1155cade4db5fb1121b66d9936b5e958b663db446752d47acc56ad5d380a/botocore-1.43.39-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f5/ac/19f9941c74add59d17694930ec8105d5eddeee4ce56dd8632b765ca16d6c/stevedore-5.8.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f8/b2/b5caed897fbb1cc286c62c01feca977e08d99a17230ff3055b9a98eccf1d/josepy-2.2.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f8/e3/0fadc706008ac9d7b9b5be6dc767c05f9d3e5df51744ce4cc9605de7b9f4/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl
+  dev:
+    channels:
+    - url: https://conda.anaconda.org/conda-forge/
+    indexes:
+    - https://pypi.org/simple
+    packages:
       osx-arm64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-types-0.7.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/anyio-4.14.0-pyhcf101f3_0.conda
@@ -318,42 +445,76 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/readline-8.3-h46df422_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-h010d191_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/yaml-0.2.5-h925e9cb_3.conda
-      - pypi: .
+      - pypi: ./
+      - pypi: https://files.pythonhosted.org/packages/00/15/b92b4e1d88d02c6eff9733c9eea21846ab435cc4d813d84ccc5d335955df/graphql_core-3.2.11-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/00/e9/1e1fd7fae559bfd07704991e9a59dd1349b72423c904256c073ce88a9940/pyflakes-3.1.0-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/02/08/9c41fb51ab5b43eb21674aff13df270e8ba6c4b29c8624e328dc7a9482af/distlib-0.4.3-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/03/e2/08a497ef684b88559c9cc5f4ad53a37e7b99e727094a86d6ea32536d5d3c/pytest_asyncio-1.4.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/0b/b3/b7f770114b7d0ac92d0f76e8d93c2780844a70488a90e91821927850da86/mypy-2.1.0-cp312-cp312-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/0c/29/0348de65b8cc732daa3e33e67806420b2ae89bdce2b04af740289c5c6c8c/loguru-0.7.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/0c/eb/4fc8d0a7110eb5fc9cc161723a34a8a6c200ce3b4fbf681bc86feee22308/charset_normalizer-3.4.7-cp312-cp312-macosx_10_13_universal2.whl
+      - pypi: https://files.pythonhosted.org/packages/13/37/a065dc3bd6e49423a6532c642ca7378d3f467b1ef44c2800c937af7f9739/filelock-3.29.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/13/66/67b54f12fc0c5b2dc6fd0c04ea4cf1e7fc4a9843de680a22070d1fd77901/boto3-1.43.31-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/14/2f/967ba146e6d58cf6a652da73885f52fc68001525b4197effc174321d70b4/jmespath-1.1.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/17/44/635a8d2add845c9a2d99a93a379df77f7e70829f0a1d7d5a6998b61f9d01/hypothesis_jsonschema-0.23.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/1a/82/a70006589557f267f15bd384c0642ad49f0d97b690c3a05b166b9dcbad3b/python_discovery-1.4.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/1c/bc/b139710a3b6018f7fb2b9508b35c8af564e61bf2bf4fa619d088f3e16f85/types_requests-2.33.0.20260518-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/1e/21/949c004d730d610dac63bcf5964f2585e98aa7bd44ff570ef8844472e76b/harfile-0.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/20/7a/1c6e3562dfd8950adbb11ffbc65d21e7c89d01a6e4f137fa981056de25c5/gitpython-3.1.50-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/25/44/f5209b889a344b1331a103aec4e9f906c7f67f9295fd287fdaa818179d95/starlette_testclient-0.4.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/26/0a/bd3d18a582f273d6c843d16bb9e22e9e16365ff7991e92f18f798e9f1224/ast_serialize-0.5.0-cp39-abi3-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/27/1a/1f68f9ba0c207934b35b86a8ca3aad8395a3d6dd7921c0686e23853ff5a9/mccabe-0.7.0-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/2a/7d/e6fb3a653e2b1696d0e5ce9c1151f95dce7d628f1c4f98c8854272898ceb/jsonschema_rs-0.46.5-cp310-abi3-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl
+      - pypi: https://files.pythonhosted.org/packages/2a/93/2d896b5fd3d79b4cadd8882c06650e66d003f465c9d12c488d92853dff78/junit_xml-1.9-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/2b/77/2b5ea2e5e343fd7f74ba9c50a282d7cb66d1be3d12bd647510338d78fcf1/pyrate_limiter-4.4.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/2c/02/3623e6169bed617ed1e2d372f7c69f92ec28d54c4dfc997055c8578ec148/virtualenv-21.5.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2c/58/ca301544e1fa93ed4f80d724bf5b194f6e4b945841c5bfd555878eea9fcb/referencing-0.37.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/34/90/0200184d2124484f918054751ef997ed6409cb05b7e8dcbf5a22da4c4748/pyrfc3339-2.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/40/1e/9771421ac2286eaab95b8575b0cb701ae3663abf8b5e1f64f1fd90d0a673/websockets-16.0-cp312-cp312-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/46/5f/4c174edad94f82de888ac00a5ddd8d07b35609b6c94f0bdf4d74af57703e/s3transfer-0.19.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/4f/d3/a8b22fa575b297cd6e3e3b0155c7e25db170edf1c74783d6a31a2490b8d9/argon2_cffi-25.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/54/18/1dd71c9b43192ab83f1d531ad6002dc81108ac36c475f79fb7a295abe2f4/pyopenssl-26.3.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/58/3e/9e4b29a509fadec889dcd1f115fcc30655fd5296bd00198dcd8a0ea78d64/hypothesis_graphql-0.13.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/59/7b/e1d32ae8a3ed937ec2be3721c5f728b13d731a0b7c6442e0b3bec5094ac0/playwright-1.60.0-py3-none-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/5d/ba/2af136406e1c3839aea9ecadc2f6be2bcd1eff255bd451dd39bcf302c47a/bcrypt-5.0.0-cp39-abi3-macosx_10_12_universal2.whl
       - pypi: https://files.pythonhosted.org/packages/5e/5f/82c8074f7e84978129347c2c6ec8b6c59f3584ff1a20bc3c940a3e061790/priority-2.0.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/64/b4/17d4b0b2a2dc85a6df63d1157e028ed19f90d4cd97c36717afef2bc2f395/attrs-26.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/69/90/f63fb5873511e014207a475e2bb4e8b2e570d655b00ac19a9a0ca0a385ee/jsonschema-4.26.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/7a/24/8493538fa4f62f982686398a5b8f68008138a75086abdea19ade64bf4255/librt-0.11.0-cp312-cp312-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/80/56/60547f7801b97c67e97491dc3d9ade9fbccbd0325058fd3dfcb2f5d98d90/cattrs-26.1.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/80/6e/4b28b62ecb6aae56769c34a8ff1d661473ec1e9519e2d5f8b2c150086b26/pre_commit-4.6.0-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/81/e6/cd9575ac904136b3cbf7aa7ee819ef86eedb7274e46f230e94ea4342e729/platformdirs-4.10.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/85/c8/b156c2087c70f10c71ccc874c3e2cf484240775c818a006686553f61bd2a/cappa-0.32.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/88/b2/d0896bdcdc8d28a7fc5717c305f1a861c26e18c05047949fb371034d98bd/nodeenv-1.10.0-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/8b/5a/ba30a81239b909821b3153e303e7def45178bf353da4f72380e6c5e8793b/pytest-9.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/8b/9e/d01ef2bed8e995bbdeeb5307a571729a10545de4a6f8f06d9175fc7a1978/typed_settings-25.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/93/35/850277d1b17b206bd10874c8a9a3f52e059452fb49bb0d22cbb908f6038b/hypercorn-0.18.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/93/8c/2e650f2afeb7ee576912636c23ddb621c91ac6a98e66dc8d29c3c69446e1/werkzeug-3.1.8-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/94/84/d9273cd09688070a6523c4aee4663a8538721b2b755c4962aafae0011e72/identify-2.6.19-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/96/c0/271f3e1e3502a8decb8ee5c680dbed2d8dc2cd504f5e20f7ed491d5f37e1/atpublic-7.0.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/98/1c/b00940ab9eb8ede7897443b771987f2f4a76f06be02f1b3f01eb7567e24a/pytest_base_url-2.1.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/9a/30/fee1cf04e753f5ea914d39195df68ff6a1f2001aa6e8c9608fcc694428f9/schemathesis-4.21.8-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/9a/81/7e4e08678a1f98521201c3079f77db69fb552acd56067661f8c2f534a718/markupsafe-3.0.3-cp312-cp312-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/9b/22/adf66990e63584a68dfb50c24f48a125c07b1699899381c8151e63ed458c/cryptography-49.0.0-cp311-abi3-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/9d/76/f789f7a86709c6b087c5a2f52f911838cad707cc613162401badc665acfe/setuptools-82.0.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/9e/c9/b2622292ea83fbb4ec318f5b9ab867d0a28ab43c5717bb85b0a5f6b3b0a4/networkx-3.6.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a0/61/5c78b91c3143ed5c14207f463aecfc8f9dbb5092fb2869baf37c273b2705/gitdb-4.0.12-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a0/c4/b4d4827c93ef43c01f599ef31453ccc1c132b353284fc6c87d535c233129/pyee-13.0.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a2/23/ce3a543935a01e478349e82f6c1440776f92d4cb346662c4d81574878fed/hypothesis-6.155.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a3/43/35e3f136343aef451e545ce8c38d36c2f93c0ed88703db8b64ba2b205c68/rpds_py-2026.5.1-cp312-cp312-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/a3/5e/ecf12fdb62546d64385c158514e9b2b671f7832108ef2ecd2020ce0af2d1/pyjwt-2.13.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a4/62/02da182e544a51a5c3ccf4b03ab79df279f9c60c5e82d5e8bec7ca26ac11/python_slugify-8.0.4-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a4/f5/10b68b7b1544245097b2a1b8238f66f2fc6dcaeb24ba5d917f52bd2eed4f/wsproto-1.3.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a5/69/6da5581c6a7fede7dc261bf4e67d6adca4196f176b43288b55b3db395b6e/mdit_py_plugins-0.6.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a6/a5/c0b6468d3824fe3fde30dbb5e1f687b291608f9473681bbf7dabbf5a87d7/text_unidecode-1.3-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a9/4e/0463faa15aa5c618691f8c959bb0c40b215f5883175e3daa0f15f3b3e5a9/diskimage_builder-3.42.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b0/24/bbf7175ffc47cb3d3e1eb523ddb23272968359dfcf2e1294707a2bf12fc4/flake8-6.1.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b1/90/a998c550d0ddd07e38605bb5c455d00fcc177a800ff9cc3dafdcb3dd7b56/pycodestyle-2.11.1-py2.py3-none-any.whl
@@ -363,20 +524,24 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/ba/47/5eb27f6f065170380bd4bd782177a2f1f67e721d6b3fa7de18c492f52917/acme-5.6.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c0/db/61efa0d08a99f897ef98256b03e563092d36cc38dc4ebe4a85020fe40b31/pbr-7.0.3-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c1/d4/59e74daffcb57a07668852eeeb6035af9f32cbfd7a1d2511f17d2fe6a738/smmap-5.0.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/c4/37/4549f149c9797c21b32c2683c33522af22522099de128b2406672526d005/greenlet-3.5.1-cp312-cp312-macosx_11_0_universal2.whl
+      - pypi: https://files.pythonhosted.org/packages/c4/8f/533075f00aaf19b07c5cd6aa6e5d89424b06b3b3f4583bfa9c640a079059/ruff-0.15.5-py3-none-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/c7/18/c86eb8e0202e32dd3df50d43d7ff9854f8e0603945ff398974c1d91ac1ef/tomli_w-1.2.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d2/1e/da5fdcb8438008d3c53a0c6de6a40cb10bdb7e02a6e034aef79bc2b66800/botocore-1.43.31-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/d7/c1/eb8f9debc45d3b7918a32ab756658a0904732f75e555402972246b0b8e71/tenacity-9.1.4-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/df/a2/781b623f57358e360d62cdd7a8c681f074a71d445418a776eef0aadb4ab4/cffi-2.0.0-cp312-cp312-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/ec/39/d401756df60a8344848477d54fdf4ce0f50531f6149f3b8eaae9c06ae3dc/aiosmtpd-1.4.6-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/ec/bb/2799cc2ede3ed41131f8975621e7213dfc7ef4acbbaadfa440f32500c370/starlette-1.3.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/f1/d9/7fb5aa316bc299258e68c73ba3bddbc499654a07f151cba08f6153988714/pathspec-1.1.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f5/ac/19f9941c74add59d17694930ec8105d5eddeee4ce56dd8632b765ca16d6c/stevedore-5.8.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f8/b2/b5caed897fbb1cc286c62c01feca977e08d99a17230ff3055b9a98eccf1d/josepy-2.2.0-py3-none-any.whl
-  dev:
-    channels:
-    - url: https://conda.anaconda.org/conda-forge/
-    indexes:
-    - https://pypi.org/simple
-    packages:
-      linux-64:
+      - pypi: https://files.pythonhosted.org/packages/fa/b6/3127540ecdf1464a00e5a01ee60a1b09175f6913f0644ac748494d9c4b21/pytest_timeout-2.4.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/fe/71/1c545fac6a9054b52b3771238fb2dc6e8f1d0ccec116e1c7786ec191887c/pytest_playwright-0.8.0-py3-none-any.whl
+      p1:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hda65f42_9.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/caddy-2.11.4-hfc2019e_0.conda
@@ -455,7 +620,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.15.0-h396c80c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
-      - pypi: .
+      - pypi: ./
       - pypi: https://files.pythonhosted.org/packages/00/15/b92b4e1d88d02c6eff9733c9eea21846ab435cc4d813d84ccc5d335955df/graphql_core-3.2.11-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/00/e9/1e1fd7fae559bfd07704991e9a59dd1349b72423c904256c073ce88a9940/pyflakes-3.1.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/02/08/9c41fb51ab5b43eb21674aff13df270e8ba6c4b29c8624e328dc7a9482af/distlib-0.4.3-py2.py3-none-any.whl
@@ -507,6 +672,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/93/35/850277d1b17b206bd10874c8a9a3f52e059452fb49bb0d22cbb908f6038b/hypercorn-0.18.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/93/8c/2e650f2afeb7ee576912636c23ddb621c91ac6a98e66dc8d29c3c69446e1/werkzeug-3.1.8-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/94/84/d9273cd09688070a6523c4aee4663a8538721b2b755c4962aafae0011e72/identify-2.6.19-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/96/c0/271f3e1e3502a8decb8ee5c680dbed2d8dc2cd504f5e20f7ed491d5f37e1/atpublic-7.0.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/98/1c/b00940ab9eb8ede7897443b771987f2f4a76f06be02f1b3f01eb7567e24a/pytest_base_url-2.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/9a/30/fee1cf04e753f5ea914d39195df68ff6a1f2001aa6e8c9608fcc694428f9/schemathesis-4.21.8-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/9d/76/f789f7a86709c6b087c5a2f52f911838cad707cc613162401badc665acfe/setuptools-82.0.1-py3-none-any.whl
@@ -541,6 +707,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/d7/c1/eb8f9debc45d3b7918a32ab756658a0904732f75e555402972246b0b8e71/tenacity-9.1.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/ec/39/d401756df60a8344848477d54fdf4ce0f50531f6149f3b8eaae9c06ae3dc/aiosmtpd-1.4.6-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ec/bb/2799cc2ede3ed41131f8975621e7213dfc7ef4acbbaadfa440f32500c370/starlette-1.3.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f1/d9/7fb5aa316bc299258e68c73ba3bddbc499654a07f151cba08f6153988714/pathspec-1.1.1-py3-none-any.whl
@@ -549,7 +716,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/f8/b2/b5caed897fbb1cc286c62c01feca977e08d99a17230ff3055b9a98eccf1d/josepy-2.2.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fa/b6/3127540ecdf1464a00e5a01ee60a1b09175f6913f0644ac748494d9c4b21/pytest_timeout-2.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fe/71/1c545fac6a9054b52b3771238fb2dc6e8f1d0ccec116e1c7786ec191887c/pytest_playwright-0.8.0-py3-none-any.whl
-      linux-aarch64:
+      p2:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/_openmp_mutex-4.5-20_gnu.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/bzip2-1.0.8-h4777abc_9.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/caddy-2.11.4-h22914b5_0.conda
@@ -628,7 +795,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.15.0-h396c80c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
-      - pypi: .
+      - pypi: ./
       - pypi: https://files.pythonhosted.org/packages/00/15/b92b4e1d88d02c6eff9733c9eea21846ab435cc4d813d84ccc5d335955df/graphql_core-3.2.11-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/00/e9/1e1fd7fae559bfd07704991e9a59dd1349b72423c904256c073ce88a9940/pyflakes-3.1.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/01/f8/c151e196d4f397ed9436a071e52666c70a2f021138dea828b0a461e245db/hypothesis-6.155.7-py3-none-any.whl
@@ -681,6 +848,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/93/35/850277d1b17b206bd10874c8a9a3f52e059452fb49bb0d22cbb908f6038b/hypercorn-0.18.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/93/8c/2e650f2afeb7ee576912636c23ddb621c91ac6a98e66dc8d29c3c69446e1/werkzeug-3.1.8-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/94/84/d9273cd09688070a6523c4aee4663a8538721b2b755c4962aafae0011e72/identify-2.6.19-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/96/c0/271f3e1e3502a8decb8ee5c680dbed2d8dc2cd504f5e20f7ed491d5f37e1/atpublic-7.0.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/97/bb/21c36b7dbbafc85d2d480cd65df02a1dc93bf76d97147605a8e27ff9409d/websockets-16.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/98/1c/b00940ab9eb8ede7897443b771987f2f4a76f06be02f1b3f01eb7567e24a/pytest_base_url-2.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/9d/76/f789f7a86709c6b087c5a2f52f911838cad707cc613162401badc665acfe/setuptools-82.0.1-py3-none-any.whl
@@ -711,6 +879,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/d5/72/12b5f8d3865bf0f87cf1404d8c374e7487dcf097a1c91c436e72e6badd83/cffi-2.0.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/ec/39/d401756df60a8344848477d54fdf4ce0f50531f6149f3b8eaae9c06ae3dc/aiosmtpd-1.4.6-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ec/bb/2799cc2ede3ed41131f8975621e7213dfc7ef4acbbaadfa440f32500c370/starlette-1.3.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f1/d9/7fb5aa316bc299258e68c73ba3bddbc499654a07f151cba08f6153988714/pathspec-1.1.1-py3-none-any.whl
@@ -718,147 +887,6 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/f5/ac/19f9941c74add59d17694930ec8105d5eddeee4ce56dd8632b765ca16d6c/stevedore-5.8.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f8/b2/b5caed897fbb1cc286c62c01feca977e08d99a17230ff3055b9a98eccf1d/josepy-2.2.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f8/e3/0fadc706008ac9d7b9b5be6dc767c05f9d3e5df51744ce4cc9605de7b9f4/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl
-      - pypi: https://files.pythonhosted.org/packages/fa/b6/3127540ecdf1464a00e5a01ee60a1b09175f6913f0644ac748494d9c4b21/pytest_timeout-2.4.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/fe/71/1c545fac6a9054b52b3771238fb2dc6e8f1d0ccec116e1c7786ec191887c/pytest_playwright-0.8.0-py3-none-any.whl
-      osx-arm64:
-      - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-types-0.7.0-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/anyio-4.14.0-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.5.20-hbd8a1cb_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2026.5.20-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.4.1-pyhc90fa1f_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/faker-40.23.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/h11-0.16.0-pyhcf101f3_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.3.0-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/httpcore-1.0.9-pyh29332c3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/httpx-0.28.1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.1.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.18-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/litestar-2.24.0-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/litestar-htmx-0.5.0-pyhe01879c_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-4.2.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/multipart-1.3.1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/polyfactory-3.3.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.20.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/python-tzdata-2026.2-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.12-8_cp312.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/rich-15.0.0-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/rich-click-1.9.8-pyh8f84b5b_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/sniffio-1.3.1-pyhd8ed1ab_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.15.0-h396c80c_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-hd037594_9.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/caddy-2.11.4-hf76c51c_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/icu-78.3-hef89b57_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.8.1-hf6b4638_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.5.2-hcf2aa1b_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblzma-5.8.3-h8088a28_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.53.2-h1ae2325_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.3.2-h8088a28_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/msgspec-0.21.1-py312h2bbb03f_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/multidict-6.7.1-py312h43af8aa_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.6-h1d4f5a5_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.6.3-hd24854e_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.12.13-h8561d8f_0_cpython.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyyaml-6.0.3-py312h04c11ed_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/readline-8.3-h46df422_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-h010d191_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/yaml-0.2.5-h925e9cb_3.conda
-      - pypi: .
-      - pypi: https://files.pythonhosted.org/packages/00/15/b92b4e1d88d02c6eff9733c9eea21846ab435cc4d813d84ccc5d335955df/graphql_core-3.2.11-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/00/e9/1e1fd7fae559bfd07704991e9a59dd1349b72423c904256c073ce88a9940/pyflakes-3.1.0-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/02/08/9c41fb51ab5b43eb21674aff13df270e8ba6c4b29c8624e328dc7a9482af/distlib-0.4.3-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/03/e2/08a497ef684b88559c9cc5f4ad53a37e7b99e727094a86d6ea32536d5d3c/pytest_asyncio-1.4.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/0b/b3/b7f770114b7d0ac92d0f76e8d93c2780844a70488a90e91821927850da86/mypy-2.1.0-cp312-cp312-macosx_11_0_arm64.whl
-      - pypi: https://files.pythonhosted.org/packages/0c/29/0348de65b8cc732daa3e33e67806420b2ae89bdce2b04af740289c5c6c8c/loguru-0.7.3-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/0c/eb/4fc8d0a7110eb5fc9cc161723a34a8a6c200ce3b4fbf681bc86feee22308/charset_normalizer-3.4.7-cp312-cp312-macosx_10_13_universal2.whl
-      - pypi: https://files.pythonhosted.org/packages/13/37/a065dc3bd6e49423a6532c642ca7378d3f467b1ef44c2800c937af7f9739/filelock-3.29.4-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/13/66/67b54f12fc0c5b2dc6fd0c04ea4cf1e7fc4a9843de680a22070d1fd77901/boto3-1.43.31-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/14/2f/967ba146e6d58cf6a652da73885f52fc68001525b4197effc174321d70b4/jmespath-1.1.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/17/44/635a8d2add845c9a2d99a93a379df77f7e70829f0a1d7d5a6998b61f9d01/hypothesis_jsonschema-0.23.1-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/1a/82/a70006589557f267f15bd384c0642ad49f0d97b690c3a05b166b9dcbad3b/python_discovery-1.4.2-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/1c/bc/b139710a3b6018f7fb2b9508b35c8af564e61bf2bf4fa619d088f3e16f85/types_requests-2.33.0.20260518-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/1e/21/949c004d730d610dac63bcf5964f2585e98aa7bd44ff570ef8844472e76b/harfile-0.5.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/20/7a/1c6e3562dfd8950adbb11ffbc65d21e7c89d01a6e4f137fa981056de25c5/gitpython-3.1.50-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/25/44/f5209b889a344b1331a103aec4e9f906c7f67f9295fd287fdaa818179d95/starlette_testclient-0.4.1-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/26/0a/bd3d18a582f273d6c843d16bb9e22e9e16365ff7991e92f18f798e9f1224/ast_serialize-0.5.0-cp39-abi3-macosx_11_0_arm64.whl
-      - pypi: https://files.pythonhosted.org/packages/27/1a/1f68f9ba0c207934b35b86a8ca3aad8395a3d6dd7921c0686e23853ff5a9/mccabe-0.7.0-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/2a/7d/e6fb3a653e2b1696d0e5ce9c1151f95dce7d628f1c4f98c8854272898ceb/jsonschema_rs-0.46.5-cp310-abi3-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl
-      - pypi: https://files.pythonhosted.org/packages/2a/93/2d896b5fd3d79b4cadd8882c06650e66d003f465c9d12c488d92853dff78/junit_xml-1.9-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/2b/77/2b5ea2e5e343fd7f74ba9c50a282d7cb66d1be3d12bd647510338d78fcf1/pyrate_limiter-4.4.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/2c/02/3623e6169bed617ed1e2d372f7c69f92ec28d54c4dfc997055c8578ec148/virtualenv-21.5.1-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/2c/58/ca301544e1fa93ed4f80d724bf5b194f6e4b945841c5bfd555878eea9fcb/referencing-0.37.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/34/90/0200184d2124484f918054751ef997ed6409cb05b7e8dcbf5a22da4c4748/pyrfc3339-2.1.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/40/1e/9771421ac2286eaab95b8575b0cb701ae3663abf8b5e1f64f1fd90d0a673/websockets-16.0-cp312-cp312-macosx_11_0_arm64.whl
-      - pypi: https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/46/5f/4c174edad94f82de888ac00a5ddd8d07b35609b6c94f0bdf4d74af57703e/s3transfer-0.19.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/4f/d3/a8b22fa575b297cd6e3e3b0155c7e25db170edf1c74783d6a31a2490b8d9/argon2_cffi-25.1.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/54/18/1dd71c9b43192ab83f1d531ad6002dc81108ac36c475f79fb7a295abe2f4/pyopenssl-26.3.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/58/3e/9e4b29a509fadec889dcd1f115fcc30655fd5296bd00198dcd8a0ea78d64/hypothesis_graphql-0.13.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/59/7b/e1d32ae8a3ed937ec2be3721c5f728b13d731a0b7c6442e0b3bec5094ac0/playwright-1.60.0-py3-none-macosx_11_0_arm64.whl
-      - pypi: https://files.pythonhosted.org/packages/5d/ba/2af136406e1c3839aea9ecadc2f6be2bcd1eff255bd451dd39bcf302c47a/bcrypt-5.0.0-cp39-abi3-macosx_10_12_universal2.whl
-      - pypi: https://files.pythonhosted.org/packages/5e/5f/82c8074f7e84978129347c2c6ec8b6c59f3584ff1a20bc3c940a3e061790/priority-2.0.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/64/b4/17d4b0b2a2dc85a6df63d1157e028ed19f90d4cd97c36717afef2bc2f395/attrs-26.1.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/69/90/f63fb5873511e014207a475e2bb4e8b2e570d655b00ac19a9a0ca0a385ee/jsonschema-4.26.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/7a/24/8493538fa4f62f982686398a5b8f68008138a75086abdea19ade64bf4255/librt-0.11.0-cp312-cp312-macosx_11_0_arm64.whl
-      - pypi: https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/80/56/60547f7801b97c67e97491dc3d9ade9fbccbd0325058fd3dfcb2f5d98d90/cattrs-26.1.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/80/6e/4b28b62ecb6aae56769c34a8ff1d661473ec1e9519e2d5f8b2c150086b26/pre_commit-4.6.0-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/81/e6/cd9575ac904136b3cbf7aa7ee819ef86eedb7274e46f230e94ea4342e729/platformdirs-4.10.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/85/c8/b156c2087c70f10c71ccc874c3e2cf484240775c818a006686553f61bd2a/cappa-0.32.1-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/88/b2/d0896bdcdc8d28a7fc5717c305f1a861c26e18c05047949fb371034d98bd/nodeenv-1.10.0-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/8b/5a/ba30a81239b909821b3153e303e7def45178bf353da4f72380e6c5e8793b/pytest-9.1.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/8b/9e/d01ef2bed8e995bbdeeb5307a571729a10545de4a6f8f06d9175fc7a1978/typed_settings-25.3.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/93/35/850277d1b17b206bd10874c8a9a3f52e059452fb49bb0d22cbb908f6038b/hypercorn-0.18.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/93/8c/2e650f2afeb7ee576912636c23ddb621c91ac6a98e66dc8d29c3c69446e1/werkzeug-3.1.8-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/94/84/d9273cd09688070a6523c4aee4663a8538721b2b755c4962aafae0011e72/identify-2.6.19-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/98/1c/b00940ab9eb8ede7897443b771987f2f4a76f06be02f1b3f01eb7567e24a/pytest_base_url-2.1.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/9a/30/fee1cf04e753f5ea914d39195df68ff6a1f2001aa6e8c9608fcc694428f9/schemathesis-4.21.8-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/9a/81/7e4e08678a1f98521201c3079f77db69fb552acd56067661f8c2f534a718/markupsafe-3.0.3-cp312-cp312-macosx_11_0_arm64.whl
-      - pypi: https://files.pythonhosted.org/packages/9b/22/adf66990e63584a68dfb50c24f48a125c07b1699899381c8151e63ed458c/cryptography-49.0.0-cp311-abi3-macosx_11_0_arm64.whl
-      - pypi: https://files.pythonhosted.org/packages/9d/76/f789f7a86709c6b087c5a2f52f911838cad707cc613162401badc665acfe/setuptools-82.0.1-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/9e/c9/b2622292ea83fbb4ec318f5b9ab867d0a28ab43c5717bb85b0a5f6b3b0a4/networkx-3.6.1-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/a0/61/5c78b91c3143ed5c14207f463aecfc8f9dbb5092fb2869baf37c273b2705/gitdb-4.0.12-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/a0/c4/b4d4827c93ef43c01f599ef31453ccc1c132b353284fc6c87d535c233129/pyee-13.0.1-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/a2/23/ce3a543935a01e478349e82f6c1440776f92d4cb346662c4d81574878fed/hypothesis-6.155.3-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/a3/43/35e3f136343aef451e545ce8c38d36c2f93c0ed88703db8b64ba2b205c68/rpds_py-2026.5.1-cp312-cp312-macosx_11_0_arm64.whl
-      - pypi: https://files.pythonhosted.org/packages/a3/5e/ecf12fdb62546d64385c158514e9b2b671f7832108ef2ecd2020ce0af2d1/pyjwt-2.13.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/a4/62/02da182e544a51a5c3ccf4b03ab79df279f9c60c5e82d5e8bec7ca26ac11/python_slugify-8.0.4-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/a4/f5/10b68b7b1544245097b2a1b8238f66f2fc6dcaeb24ba5d917f52bd2eed4f/wsproto-1.3.2-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/a5/69/6da5581c6a7fede7dc261bf4e67d6adca4196f176b43288b55b3db395b6e/mdit_py_plugins-0.6.1-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/a6/a5/c0b6468d3824fe3fde30dbb5e1f687b291608f9473681bbf7dabbf5a87d7/text_unidecode-1.3-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/a9/4e/0463faa15aa5c618691f8c959bb0c40b215f5883175e3daa0f15f3b3e5a9/diskimage_builder-3.42.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/b0/24/bbf7175ffc47cb3d3e1eb523ddb23272968359dfcf2e1294707a2bf12fc4/flake8-6.1.0-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/b1/90/a998c550d0ddd07e38605bb5c455d00fcc177a800ff9cc3dafdcb3dd7b56/pycodestyle-2.11.1-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/b3/c5/30de077e06f7ffc3fe21d45ce26b8088816227b678a7157f6b9e080ff2db/type_lens-0.2.6-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/b6/02/d297943bcacf05e4f2a94ab6f462831dc20158614e5d067c35d4e63b9acb/argon2_cffi_bindings-25.1.0-cp39-abi3-macosx_11_0_arm64.whl
-      - pypi: https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/ba/47/5eb27f6f065170380bd4bd782177a2f1f67e721d6b3fa7de18c492f52917/acme-5.6.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/c0/db/61efa0d08a99f897ef98256b03e563092d36cc38dc4ebe4a85020fe40b31/pbr-7.0.3-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/c1/d4/59e74daffcb57a07668852eeeb6035af9f32cbfd7a1d2511f17d2fe6a738/smmap-5.0.3-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/c4/37/4549f149c9797c21b32c2683c33522af22522099de128b2406672526d005/greenlet-3.5.1-cp312-cp312-macosx_11_0_universal2.whl
-      - pypi: https://files.pythonhosted.org/packages/c4/8f/533075f00aaf19b07c5cd6aa6e5d89424b06b3b3f4583bfa9c640a079059/ruff-0.15.5-py3-none-macosx_11_0_arm64.whl
-      - pypi: https://files.pythonhosted.org/packages/c7/18/c86eb8e0202e32dd3df50d43d7ff9854f8e0603945ff398974c1d91ac1ef/tomli_w-1.2.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/d2/1e/da5fdcb8438008d3c53a0c6de6a40cb10bdb7e02a6e034aef79bc2b66800/botocore-1.43.31-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/d7/c1/eb8f9debc45d3b7918a32ab756658a0904732f75e555402972246b0b8e71/tenacity-9.1.4-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/df/a2/781b623f57358e360d62cdd7a8c681f074a71d445418a776eef0aadb4ab4/cffi-2.0.0-cp312-cp312-macosx_11_0_arm64.whl
-      - pypi: https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/ec/bb/2799cc2ede3ed41131f8975621e7213dfc7ef4acbbaadfa440f32500c370/starlette-1.3.1-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/f1/d9/7fb5aa316bc299258e68c73ba3bddbc499654a07f151cba08f6153988714/pathspec-1.1.1-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/f5/ac/19f9941c74add59d17694930ec8105d5eddeee4ce56dd8632b765ca16d6c/stevedore-5.8.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/f8/b2/b5caed897fbb1cc286c62c01feca977e08d99a17230ff3055b9a98eccf1d/josepy-2.2.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fa/b6/3127540ecdf1464a00e5a01ee60a1b09175f6913f0644ac748494d9c4b21/pytest_timeout-2.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fe/71/1c545fac6a9054b52b3771238fb2dc6e8f1d0ccec116e1c7786ec191887c/pytest_playwright-0.8.0-py3-none-any.whl
 packages:
@@ -2804,11 +2832,12 @@ packages:
   purls: []
   size: 83386
   timestamp: 1753484079473
-- pypi: .
+- pypi: ./
   name: openhost
   requires_dist:
   - pyjwt[crypto]
   - acme>=5.4.0
+  - aiosmtpd
   - argon2-cffi
   - attrs
   - bcrypt>=4.1
@@ -3625,6 +3654,11 @@ packages:
   requires_dist:
   - ukkonen ; extra == 'license'
   requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/96/c0/271f3e1e3502a8decb8ee5c680dbed2d8dc2cd504f5e20f7ed491d5f37e1/atpublic-7.0.0-py3-none-any.whl
+  name: atpublic
+  version: 7.0.0
+  sha256: 6702bd9e7245eb4e8220a3e222afcef7f87412154732271ee7deee4433b72b4b
+  requires_python: '>=3.10'
 - pypi: https://files.pythonhosted.org/packages/97/bb/21c36b7dbbafc85d2d480cd65df02a1dc93bf76d97147605a8e27ff9409d/websockets-16.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl
   name: websockets
   version: '16.0'
@@ -4222,6 +4256,14 @@ packages:
   name: packaging
   version: '26.2'
   sha256: 5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e
+  requires_python: '>=3.8'
+- pypi: https://files.pythonhosted.org/packages/ec/39/d401756df60a8344848477d54fdf4ce0f50531f6149f3b8eaae9c06ae3dc/aiosmtpd-1.4.6-py3-none-any.whl
+  name: aiosmtpd
+  version: 1.4.6
+  sha256: 72c99179ba5aa9ae0abbda6994668239b64a5ce054471955fe75f581d2592475
+  requires_dist:
+  - atpublic
+  - attrs
   requires_python: '>=3.8'
 - pypi: https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl
   name: python-dateutil

--- a/pixi.lock
+++ b/pixi.lock
@@ -1,24 +1,8 @@
 version: 7
 platforms:
+- name: linux-64
+- name: linux-aarch64
 - name: osx-arm64
-  virtual-packages:
-  - __unix=0=0
-  - __osx=13.0
-  - __archspec=0=m1
-- name: p1
-  subdir: linux-64
-  virtual-packages:
-  - __linux=6.8
-  - __glibc=2.39
-  - __unix=0=0
-  - __archspec=0=x86_64
-- name: p2
-  subdir: linux-aarch64
-  virtual-packages:
-  - __linux=6.8
-  - __glibc=2.39
-  - __unix=0=0
-  - __archspec=0=aarch64
 environments:
   default:
     channels:
@@ -26,108 +10,7 @@ environments:
     indexes:
     - https://pypi.org/simple
     packages:
-      osx-arm64:
-      - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-types-0.7.0-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/anyio-4.14.0-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.5.20-hbd8a1cb_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2026.5.20-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.4.1-pyhc90fa1f_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/faker-40.23.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/h11-0.16.0-pyhcf101f3_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.3.0-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/httpcore-1.0.9-pyh29332c3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/httpx-0.28.1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.1.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.18-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/litestar-2.24.0-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/litestar-htmx-0.5.0-pyhe01879c_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-4.2.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/multipart-1.3.1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/polyfactory-3.3.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.20.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/python-tzdata-2026.2-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.12-8_cp312.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/rich-15.0.0-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/rich-click-1.9.8-pyh8f84b5b_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/sniffio-1.3.1-pyhd8ed1ab_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.15.0-h396c80c_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-hd037594_9.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/caddy-2.11.4-hf76c51c_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/icu-78.3-hef89b57_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.8.1-hf6b4638_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.5.2-hcf2aa1b_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblzma-5.8.3-h8088a28_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.53.2-h1ae2325_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.3.2-h8088a28_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/msgspec-0.21.1-py312h2bbb03f_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/multidict-6.7.1-py312h43af8aa_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.6-h1d4f5a5_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.6.3-hd24854e_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.12.13-h8561d8f_0_cpython.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyyaml-6.0.3-py312h04c11ed_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/readline-8.3-h46df422_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-h010d191_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/yaml-0.2.5-h925e9cb_3.conda
-      - pypi: ./
-      - pypi: https://files.pythonhosted.org/packages/00/e9/1e1fd7fae559bfd07704991e9a59dd1349b72423c904256c073ce88a9940/pyflakes-3.1.0-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/0c/29/0348de65b8cc732daa3e33e67806420b2ae89bdce2b04af740289c5c6c8c/loguru-0.7.3-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/0c/eb/4fc8d0a7110eb5fc9cc161723a34a8a6c200ce3b4fbf681bc86feee22308/charset_normalizer-3.4.7-cp312-cp312-macosx_10_13_universal2.whl
-      - pypi: https://files.pythonhosted.org/packages/13/66/67b54f12fc0c5b2dc6fd0c04ea4cf1e7fc4a9843de680a22070d1fd77901/boto3-1.43.31-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/14/2f/967ba146e6d58cf6a652da73885f52fc68001525b4197effc174321d70b4/jmespath-1.1.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/20/7a/1c6e3562dfd8950adbb11ffbc65d21e7c89d01a6e4f137fa981056de25c5/gitpython-3.1.50-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/27/1a/1f68f9ba0c207934b35b86a8ca3aad8395a3d6dd7921c0686e23853ff5a9/mccabe-0.7.0-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/2c/58/ca301544e1fa93ed4f80d724bf5b194f6e4b945841c5bfd555878eea9fcb/referencing-0.37.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/34/90/0200184d2124484f918054751ef997ed6409cb05b7e8dcbf5a22da4c4748/pyrfc3339-2.1.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/40/1e/9771421ac2286eaab95b8575b0cb701ae3663abf8b5e1f64f1fd90d0a673/websockets-16.0-cp312-cp312-macosx_11_0_arm64.whl
-      - pypi: https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/46/5f/4c174edad94f82de888ac00a5ddd8d07b35609b6c94f0bdf4d74af57703e/s3transfer-0.19.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/4f/d3/a8b22fa575b297cd6e3e3b0155c7e25db170edf1c74783d6a31a2490b8d9/argon2_cffi-25.1.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/54/18/1dd71c9b43192ab83f1d531ad6002dc81108ac36c475f79fb7a295abe2f4/pyopenssl-26.3.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/5d/ba/2af136406e1c3839aea9ecadc2f6be2bcd1eff255bd451dd39bcf302c47a/bcrypt-5.0.0-cp39-abi3-macosx_10_12_universal2.whl
-      - pypi: https://files.pythonhosted.org/packages/5e/5f/82c8074f7e84978129347c2c6ec8b6c59f3584ff1a20bc3c940a3e061790/priority-2.0.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/64/b4/17d4b0b2a2dc85a6df63d1157e028ed19f90d4cd97c36717afef2bc2f395/attrs-26.1.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/69/90/f63fb5873511e014207a475e2bb4e8b2e570d655b00ac19a9a0ca0a385ee/jsonschema-4.26.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/80/56/60547f7801b97c67e97491dc3d9ade9fbccbd0325058fd3dfcb2f5d98d90/cattrs-26.1.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/85/c8/b156c2087c70f10c71ccc874c3e2cf484240775c818a006686553f61bd2a/cappa-0.32.1-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/8b/9e/d01ef2bed8e995bbdeeb5307a571729a10545de4a6f8f06d9175fc7a1978/typed_settings-25.3.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/93/35/850277d1b17b206bd10874c8a9a3f52e059452fb49bb0d22cbb908f6038b/hypercorn-0.18.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/96/c0/271f3e1e3502a8decb8ee5c680dbed2d8dc2cd504f5e20f7ed491d5f37e1/atpublic-7.0.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/9a/81/7e4e08678a1f98521201c3079f77db69fb552acd56067661f8c2f534a718/markupsafe-3.0.3-cp312-cp312-macosx_11_0_arm64.whl
-      - pypi: https://files.pythonhosted.org/packages/9b/22/adf66990e63584a68dfb50c24f48a125c07b1699899381c8151e63ed458c/cryptography-49.0.0-cp311-abi3-macosx_11_0_arm64.whl
-      - pypi: https://files.pythonhosted.org/packages/9d/76/f789f7a86709c6b087c5a2f52f911838cad707cc613162401badc665acfe/setuptools-82.0.1-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/9e/c9/b2622292ea83fbb4ec318f5b9ab867d0a28ab43c5717bb85b0a5f6b3b0a4/networkx-3.6.1-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/a0/61/5c78b91c3143ed5c14207f463aecfc8f9dbb5092fb2869baf37c273b2705/gitdb-4.0.12-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/a3/43/35e3f136343aef451e545ce8c38d36c2f93c0ed88703db8b64ba2b205c68/rpds_py-2026.5.1-cp312-cp312-macosx_11_0_arm64.whl
-      - pypi: https://files.pythonhosted.org/packages/a3/5e/ecf12fdb62546d64385c158514e9b2b671f7832108ef2ecd2020ce0af2d1/pyjwt-2.13.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/a4/f5/10b68b7b1544245097b2a1b8238f66f2fc6dcaeb24ba5d917f52bd2eed4f/wsproto-1.3.2-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/a5/69/6da5581c6a7fede7dc261bf4e67d6adca4196f176b43288b55b3db395b6e/mdit_py_plugins-0.6.1-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/a9/4e/0463faa15aa5c618691f8c959bb0c40b215f5883175e3daa0f15f3b3e5a9/diskimage_builder-3.42.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/b0/24/bbf7175ffc47cb3d3e1eb523ddb23272968359dfcf2e1294707a2bf12fc4/flake8-6.1.0-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/b1/90/a998c550d0ddd07e38605bb5c455d00fcc177a800ff9cc3dafdcb3dd7b56/pycodestyle-2.11.1-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/b3/c5/30de077e06f7ffc3fe21d45ce26b8088816227b678a7157f6b9e080ff2db/type_lens-0.2.6-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/b6/02/d297943bcacf05e4f2a94ab6f462831dc20158614e5d067c35d4e63b9acb/argon2_cffi_bindings-25.1.0-cp39-abi3-macosx_11_0_arm64.whl
-      - pypi: https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/ba/47/5eb27f6f065170380bd4bd782177a2f1f67e721d6b3fa7de18c492f52917/acme-5.6.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/c0/db/61efa0d08a99f897ef98256b03e563092d36cc38dc4ebe4a85020fe40b31/pbr-7.0.3-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/c1/d4/59e74daffcb57a07668852eeeb6035af9f32cbfd7a1d2511f17d2fe6a738/smmap-5.0.3-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/c7/18/c86eb8e0202e32dd3df50d43d7ff9854f8e0603945ff398974c1d91ac1ef/tomli_w-1.2.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/d2/1e/da5fdcb8438008d3c53a0c6de6a40cb10bdb7e02a6e034aef79bc2b66800/botocore-1.43.31-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/df/a2/781b623f57358e360d62cdd7a8c681f074a71d445418a776eef0aadb4ab4/cffi-2.0.0-cp312-cp312-macosx_11_0_arm64.whl
-      - pypi: https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/ec/39/d401756df60a8344848477d54fdf4ce0f50531f6149f3b8eaae9c06ae3dc/aiosmtpd-1.4.6-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/f5/ac/19f9941c74add59d17694930ec8105d5eddeee4ce56dd8632b765ca16d6c/stevedore-5.8.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/f8/b2/b5caed897fbb1cc286c62c01feca977e08d99a17230ff3055b9a98eccf1d/josepy-2.2.0-py3-none-any.whl
-      p1:
+      linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hda65f42_9.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/caddy-2.11.4-hfc2019e_0.conda
@@ -259,7 +142,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/f4/1e/2c9096fc19d5fd084b0184ca2b651e659aa0a37e6fdbecf6ece47f147fe1/rpds_py-2026.5.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/f5/ac/19f9941c74add59d17694930ec8105d5eddeee4ce56dd8632b765ca16d6c/stevedore-5.8.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f8/b2/b5caed897fbb1cc286c62c01feca977e08d99a17230ff3055b9a98eccf1d/josepy-2.2.0-py3-none-any.whl
-      p2:
+      linux-aarch64:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/_openmp_mutex-4.5-20_gnu.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/bzip2-1.0.8-h4777abc_9.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/caddy-2.11.4-h22914b5_0.conda
@@ -392,12 +275,6 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/f5/ac/19f9941c74add59d17694930ec8105d5eddeee4ce56dd8632b765ca16d6c/stevedore-5.8.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f8/b2/b5caed897fbb1cc286c62c01feca977e08d99a17230ff3055b9a98eccf1d/josepy-2.2.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f8/e3/0fadc706008ac9d7b9b5be6dc767c05f9d3e5df51744ce4cc9605de7b9f4/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl
-  dev:
-    channels:
-    - url: https://conda.anaconda.org/conda-forge/
-    indexes:
-    - https://pypi.org/simple
-    packages:
       osx-arm64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-types-0.7.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/anyio-4.14.0-pyhcf101f3_0.conda
@@ -446,75 +323,42 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-h010d191_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/yaml-0.2.5-h925e9cb_3.conda
       - pypi: ./
-      - pypi: https://files.pythonhosted.org/packages/00/15/b92b4e1d88d02c6eff9733c9eea21846ab435cc4d813d84ccc5d335955df/graphql_core-3.2.11-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/00/e9/1e1fd7fae559bfd07704991e9a59dd1349b72423c904256c073ce88a9940/pyflakes-3.1.0-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/02/08/9c41fb51ab5b43eb21674aff13df270e8ba6c4b29c8624e328dc7a9482af/distlib-0.4.3-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/03/e2/08a497ef684b88559c9cc5f4ad53a37e7b99e727094a86d6ea32536d5d3c/pytest_asyncio-1.4.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/0b/b3/b7f770114b7d0ac92d0f76e8d93c2780844a70488a90e91821927850da86/mypy-2.1.0-cp312-cp312-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/0c/29/0348de65b8cc732daa3e33e67806420b2ae89bdce2b04af740289c5c6c8c/loguru-0.7.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/0c/eb/4fc8d0a7110eb5fc9cc161723a34a8a6c200ce3b4fbf681bc86feee22308/charset_normalizer-3.4.7-cp312-cp312-macosx_10_13_universal2.whl
-      - pypi: https://files.pythonhosted.org/packages/13/37/a065dc3bd6e49423a6532c642ca7378d3f467b1ef44c2800c937af7f9739/filelock-3.29.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/13/66/67b54f12fc0c5b2dc6fd0c04ea4cf1e7fc4a9843de680a22070d1fd77901/boto3-1.43.31-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/14/2f/967ba146e6d58cf6a652da73885f52fc68001525b4197effc174321d70b4/jmespath-1.1.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/17/44/635a8d2add845c9a2d99a93a379df77f7e70829f0a1d7d5a6998b61f9d01/hypothesis_jsonschema-0.23.1-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/1a/82/a70006589557f267f15bd384c0642ad49f0d97b690c3a05b166b9dcbad3b/python_discovery-1.4.2-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/1c/bc/b139710a3b6018f7fb2b9508b35c8af564e61bf2bf4fa619d088f3e16f85/types_requests-2.33.0.20260518-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/1e/21/949c004d730d610dac63bcf5964f2585e98aa7bd44ff570ef8844472e76b/harfile-0.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/20/7a/1c6e3562dfd8950adbb11ffbc65d21e7c89d01a6e4f137fa981056de25c5/gitpython-3.1.50-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/25/44/f5209b889a344b1331a103aec4e9f906c7f67f9295fd287fdaa818179d95/starlette_testclient-0.4.1-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/26/0a/bd3d18a582f273d6c843d16bb9e22e9e16365ff7991e92f18f798e9f1224/ast_serialize-0.5.0-cp39-abi3-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/27/1a/1f68f9ba0c207934b35b86a8ca3aad8395a3d6dd7921c0686e23853ff5a9/mccabe-0.7.0-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/2a/7d/e6fb3a653e2b1696d0e5ce9c1151f95dce7d628f1c4f98c8854272898ceb/jsonschema_rs-0.46.5-cp310-abi3-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl
-      - pypi: https://files.pythonhosted.org/packages/2a/93/2d896b5fd3d79b4cadd8882c06650e66d003f465c9d12c488d92853dff78/junit_xml-1.9-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/2b/77/2b5ea2e5e343fd7f74ba9c50a282d7cb66d1be3d12bd647510338d78fcf1/pyrate_limiter-4.4.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/2c/02/3623e6169bed617ed1e2d372f7c69f92ec28d54c4dfc997055c8578ec148/virtualenv-21.5.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2c/58/ca301544e1fa93ed4f80d724bf5b194f6e4b945841c5bfd555878eea9fcb/referencing-0.37.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/34/90/0200184d2124484f918054751ef997ed6409cb05b7e8dcbf5a22da4c4748/pyrfc3339-2.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/40/1e/9771421ac2286eaab95b8575b0cb701ae3663abf8b5e1f64f1fd90d0a673/websockets-16.0-cp312-cp312-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/46/5f/4c174edad94f82de888ac00a5ddd8d07b35609b6c94f0bdf4d74af57703e/s3transfer-0.19.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/4f/d3/a8b22fa575b297cd6e3e3b0155c7e25db170edf1c74783d6a31a2490b8d9/argon2_cffi-25.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/54/18/1dd71c9b43192ab83f1d531ad6002dc81108ac36c475f79fb7a295abe2f4/pyopenssl-26.3.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/58/3e/9e4b29a509fadec889dcd1f115fcc30655fd5296bd00198dcd8a0ea78d64/hypothesis_graphql-0.13.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/59/7b/e1d32ae8a3ed937ec2be3721c5f728b13d731a0b7c6442e0b3bec5094ac0/playwright-1.60.0-py3-none-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/5d/ba/2af136406e1c3839aea9ecadc2f6be2bcd1eff255bd451dd39bcf302c47a/bcrypt-5.0.0-cp39-abi3-macosx_10_12_universal2.whl
       - pypi: https://files.pythonhosted.org/packages/5e/5f/82c8074f7e84978129347c2c6ec8b6c59f3584ff1a20bc3c940a3e061790/priority-2.0.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/64/b4/17d4b0b2a2dc85a6df63d1157e028ed19f90d4cd97c36717afef2bc2f395/attrs-26.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/69/90/f63fb5873511e014207a475e2bb4e8b2e570d655b00ac19a9a0ca0a385ee/jsonschema-4.26.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/7a/24/8493538fa4f62f982686398a5b8f68008138a75086abdea19ade64bf4255/librt-0.11.0-cp312-cp312-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/80/56/60547f7801b97c67e97491dc3d9ade9fbccbd0325058fd3dfcb2f5d98d90/cattrs-26.1.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/80/6e/4b28b62ecb6aae56769c34a8ff1d661473ec1e9519e2d5f8b2c150086b26/pre_commit-4.6.0-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/81/e6/cd9575ac904136b3cbf7aa7ee819ef86eedb7274e46f230e94ea4342e729/platformdirs-4.10.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/85/c8/b156c2087c70f10c71ccc874c3e2cf484240775c818a006686553f61bd2a/cappa-0.32.1-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/88/b2/d0896bdcdc8d28a7fc5717c305f1a861c26e18c05047949fb371034d98bd/nodeenv-1.10.0-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/8b/5a/ba30a81239b909821b3153e303e7def45178bf353da4f72380e6c5e8793b/pytest-9.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/8b/9e/d01ef2bed8e995bbdeeb5307a571729a10545de4a6f8f06d9175fc7a1978/typed_settings-25.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/93/35/850277d1b17b206bd10874c8a9a3f52e059452fb49bb0d22cbb908f6038b/hypercorn-0.18.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/93/8c/2e650f2afeb7ee576912636c23ddb621c91ac6a98e66dc8d29c3c69446e1/werkzeug-3.1.8-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/94/84/d9273cd09688070a6523c4aee4663a8538721b2b755c4962aafae0011e72/identify-2.6.19-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/96/c0/271f3e1e3502a8decb8ee5c680dbed2d8dc2cd504f5e20f7ed491d5f37e1/atpublic-7.0.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/98/1c/b00940ab9eb8ede7897443b771987f2f4a76f06be02f1b3f01eb7567e24a/pytest_base_url-2.1.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/9a/30/fee1cf04e753f5ea914d39195df68ff6a1f2001aa6e8c9608fcc694428f9/schemathesis-4.21.8-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/9a/81/7e4e08678a1f98521201c3079f77db69fb552acd56067661f8c2f534a718/markupsafe-3.0.3-cp312-cp312-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/9b/22/adf66990e63584a68dfb50c24f48a125c07b1699899381c8151e63ed458c/cryptography-49.0.0-cp311-abi3-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/9d/76/f789f7a86709c6b087c5a2f52f911838cad707cc613162401badc665acfe/setuptools-82.0.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/9e/c9/b2622292ea83fbb4ec318f5b9ab867d0a28ab43c5717bb85b0a5f6b3b0a4/networkx-3.6.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a0/61/5c78b91c3143ed5c14207f463aecfc8f9dbb5092fb2869baf37c273b2705/gitdb-4.0.12-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/a0/c4/b4d4827c93ef43c01f599ef31453ccc1c132b353284fc6c87d535c233129/pyee-13.0.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/a2/23/ce3a543935a01e478349e82f6c1440776f92d4cb346662c4d81574878fed/hypothesis-6.155.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a3/43/35e3f136343aef451e545ce8c38d36c2f93c0ed88703db8b64ba2b205c68/rpds_py-2026.5.1-cp312-cp312-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/a3/5e/ecf12fdb62546d64385c158514e9b2b671f7832108ef2ecd2020ce0af2d1/pyjwt-2.13.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/a4/62/02da182e544a51a5c3ccf4b03ab79df279f9c60c5e82d5e8bec7ca26ac11/python_slugify-8.0.4-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a4/f5/10b68b7b1544245097b2a1b8238f66f2fc6dcaeb24ba5d917f52bd2eed4f/wsproto-1.3.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a5/69/6da5581c6a7fede7dc261bf4e67d6adca4196f176b43288b55b3db395b6e/mdit_py_plugins-0.6.1-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/a6/a5/c0b6468d3824fe3fde30dbb5e1f687b291608f9473681bbf7dabbf5a87d7/text_unidecode-1.3-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a9/4e/0463faa15aa5c618691f8c959bb0c40b215f5883175e3daa0f15f3b3e5a9/diskimage_builder-3.42.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b0/24/bbf7175ffc47cb3d3e1eb523ddb23272968359dfcf2e1294707a2bf12fc4/flake8-6.1.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b1/90/a998c550d0ddd07e38605bb5c455d00fcc177a800ff9cc3dafdcb3dd7b56/pycodestyle-2.11.1-py2.py3-none-any.whl
@@ -524,24 +368,21 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/ba/47/5eb27f6f065170380bd4bd782177a2f1f67e721d6b3fa7de18c492f52917/acme-5.6.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c0/db/61efa0d08a99f897ef98256b03e563092d36cc38dc4ebe4a85020fe40b31/pbr-7.0.3-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c1/d4/59e74daffcb57a07668852eeeb6035af9f32cbfd7a1d2511f17d2fe6a738/smmap-5.0.3-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/c4/37/4549f149c9797c21b32c2683c33522af22522099de128b2406672526d005/greenlet-3.5.1-cp312-cp312-macosx_11_0_universal2.whl
-      - pypi: https://files.pythonhosted.org/packages/c4/8f/533075f00aaf19b07c5cd6aa6e5d89424b06b3b3f4583bfa9c640a079059/ruff-0.15.5-py3-none-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/c7/18/c86eb8e0202e32dd3df50d43d7ff9854f8e0603945ff398974c1d91ac1ef/tomli_w-1.2.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d2/1e/da5fdcb8438008d3c53a0c6de6a40cb10bdb7e02a6e034aef79bc2b66800/botocore-1.43.31-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/d7/c1/eb8f9debc45d3b7918a32ab756658a0904732f75e555402972246b0b8e71/tenacity-9.1.4-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/df/a2/781b623f57358e360d62cdd7a8c681f074a71d445418a776eef0aadb4ab4/cffi-2.0.0-cp312-cp312-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ec/39/d401756df60a8344848477d54fdf4ce0f50531f6149f3b8eaae9c06ae3dc/aiosmtpd-1.4.6-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/ec/bb/2799cc2ede3ed41131f8975621e7213dfc7ef4acbbaadfa440f32500c370/starlette-1.3.1-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/f1/d9/7fb5aa316bc299258e68c73ba3bddbc499654a07f151cba08f6153988714/pathspec-1.1.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f5/ac/19f9941c74add59d17694930ec8105d5eddeee4ce56dd8632b765ca16d6c/stevedore-5.8.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f8/b2/b5caed897fbb1cc286c62c01feca977e08d99a17230ff3055b9a98eccf1d/josepy-2.2.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/fa/b6/3127540ecdf1464a00e5a01ee60a1b09175f6913f0644ac748494d9c4b21/pytest_timeout-2.4.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/fe/71/1c545fac6a9054b52b3771238fb2dc6e8f1d0ccec116e1c7786ec191887c/pytest_playwright-0.8.0-py3-none-any.whl
-      p1:
+  dev:
+    channels:
+    - url: https://conda.anaconda.org/conda-forge/
+    indexes:
+    - https://pypi.org/simple
+    packages:
+      linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hda65f42_9.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/caddy-2.11.4-hfc2019e_0.conda
@@ -716,7 +557,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/f8/b2/b5caed897fbb1cc286c62c01feca977e08d99a17230ff3055b9a98eccf1d/josepy-2.2.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fa/b6/3127540ecdf1464a00e5a01ee60a1b09175f6913f0644ac748494d9c4b21/pytest_timeout-2.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fe/71/1c545fac6a9054b52b3771238fb2dc6e8f1d0ccec116e1c7786ec191887c/pytest_playwright-0.8.0-py3-none-any.whl
-      p2:
+      linux-aarch64:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/_openmp_mutex-4.5-20_gnu.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/bzip2-1.0.8-h4777abc_9.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/caddy-2.11.4-h22914b5_0.conda
@@ -887,6 +728,149 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/f5/ac/19f9941c74add59d17694930ec8105d5eddeee4ce56dd8632b765ca16d6c/stevedore-5.8.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f8/b2/b5caed897fbb1cc286c62c01feca977e08d99a17230ff3055b9a98eccf1d/josepy-2.2.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f8/e3/0fadc706008ac9d7b9b5be6dc767c05f9d3e5df51744ce4cc9605de7b9f4/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl
+      - pypi: https://files.pythonhosted.org/packages/fa/b6/3127540ecdf1464a00e5a01ee60a1b09175f6913f0644ac748494d9c4b21/pytest_timeout-2.4.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/fe/71/1c545fac6a9054b52b3771238fb2dc6e8f1d0ccec116e1c7786ec191887c/pytest_playwright-0.8.0-py3-none-any.whl
+      osx-arm64:
+      - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-types-0.7.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/anyio-4.14.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.5.20-hbd8a1cb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2026.5.20-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.4.1-pyhc90fa1f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/faker-40.23.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/h11-0.16.0-pyhcf101f3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.3.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/httpcore-1.0.9-pyh29332c3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/httpx-0.28.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.18-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/litestar-2.24.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/litestar-htmx-0.5.0-pyhe01879c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-4.2.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/multipart-1.3.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/polyfactory-3.3.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.20.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-tzdata-2026.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.12-8_cp312.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rich-15.0.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rich-click-1.9.8-pyh8f84b5b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/sniffio-1.3.1-pyhd8ed1ab_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.15.0-h396c80c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-hd037594_9.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/caddy-2.11.4-hf76c51c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/icu-78.3-hef89b57_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.8.1-hf6b4638_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.5.2-hcf2aa1b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblzma-5.8.3-h8088a28_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.53.2-h1ae2325_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.3.2-h8088a28_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/msgspec-0.21.1-py312h2bbb03f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/multidict-6.7.1-py312h43af8aa_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.6-h1d4f5a5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.6.3-hd24854e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.12.13-h8561d8f_0_cpython.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyyaml-6.0.3-py312h04c11ed_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/readline-8.3-h46df422_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-h010d191_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/yaml-0.2.5-h925e9cb_3.conda
+      - pypi: ./
+      - pypi: https://files.pythonhosted.org/packages/00/15/b92b4e1d88d02c6eff9733c9eea21846ab435cc4d813d84ccc5d335955df/graphql_core-3.2.11-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/00/e9/1e1fd7fae559bfd07704991e9a59dd1349b72423c904256c073ce88a9940/pyflakes-3.1.0-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/02/08/9c41fb51ab5b43eb21674aff13df270e8ba6c4b29c8624e328dc7a9482af/distlib-0.4.3-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/03/e2/08a497ef684b88559c9cc5f4ad53a37e7b99e727094a86d6ea32536d5d3c/pytest_asyncio-1.4.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/0b/b3/b7f770114b7d0ac92d0f76e8d93c2780844a70488a90e91821927850da86/mypy-2.1.0-cp312-cp312-macosx_11_0_arm64.whl
+      - pypi: https://files.pythonhosted.org/packages/0c/29/0348de65b8cc732daa3e33e67806420b2ae89bdce2b04af740289c5c6c8c/loguru-0.7.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/0c/eb/4fc8d0a7110eb5fc9cc161723a34a8a6c200ce3b4fbf681bc86feee22308/charset_normalizer-3.4.7-cp312-cp312-macosx_10_13_universal2.whl
+      - pypi: https://files.pythonhosted.org/packages/13/37/a065dc3bd6e49423a6532c642ca7378d3f467b1ef44c2800c937af7f9739/filelock-3.29.4-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/13/66/67b54f12fc0c5b2dc6fd0c04ea4cf1e7fc4a9843de680a22070d1fd77901/boto3-1.43.31-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/14/2f/967ba146e6d58cf6a652da73885f52fc68001525b4197effc174321d70b4/jmespath-1.1.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/17/44/635a8d2add845c9a2d99a93a379df77f7e70829f0a1d7d5a6998b61f9d01/hypothesis_jsonschema-0.23.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/1a/82/a70006589557f267f15bd384c0642ad49f0d97b690c3a05b166b9dcbad3b/python_discovery-1.4.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/1c/bc/b139710a3b6018f7fb2b9508b35c8af564e61bf2bf4fa619d088f3e16f85/types_requests-2.33.0.20260518-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/1e/21/949c004d730d610dac63bcf5964f2585e98aa7bd44ff570ef8844472e76b/harfile-0.5.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/20/7a/1c6e3562dfd8950adbb11ffbc65d21e7c89d01a6e4f137fa981056de25c5/gitpython-3.1.50-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/25/44/f5209b889a344b1331a103aec4e9f906c7f67f9295fd287fdaa818179d95/starlette_testclient-0.4.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/26/0a/bd3d18a582f273d6c843d16bb9e22e9e16365ff7991e92f18f798e9f1224/ast_serialize-0.5.0-cp39-abi3-macosx_11_0_arm64.whl
+      - pypi: https://files.pythonhosted.org/packages/27/1a/1f68f9ba0c207934b35b86a8ca3aad8395a3d6dd7921c0686e23853ff5a9/mccabe-0.7.0-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/2a/7d/e6fb3a653e2b1696d0e5ce9c1151f95dce7d628f1c4f98c8854272898ceb/jsonschema_rs-0.46.5-cp310-abi3-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl
+      - pypi: https://files.pythonhosted.org/packages/2a/93/2d896b5fd3d79b4cadd8882c06650e66d003f465c9d12c488d92853dff78/junit_xml-1.9-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/2b/77/2b5ea2e5e343fd7f74ba9c50a282d7cb66d1be3d12bd647510338d78fcf1/pyrate_limiter-4.4.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/2c/02/3623e6169bed617ed1e2d372f7c69f92ec28d54c4dfc997055c8578ec148/virtualenv-21.5.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/2c/58/ca301544e1fa93ed4f80d724bf5b194f6e4b945841c5bfd555878eea9fcb/referencing-0.37.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/34/90/0200184d2124484f918054751ef997ed6409cb05b7e8dcbf5a22da4c4748/pyrfc3339-2.1.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/40/1e/9771421ac2286eaab95b8575b0cb701ae3663abf8b5e1f64f1fd90d0a673/websockets-16.0-cp312-cp312-macosx_11_0_arm64.whl
+      - pypi: https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/46/5f/4c174edad94f82de888ac00a5ddd8d07b35609b6c94f0bdf4d74af57703e/s3transfer-0.19.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/4f/d3/a8b22fa575b297cd6e3e3b0155c7e25db170edf1c74783d6a31a2490b8d9/argon2_cffi-25.1.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/54/18/1dd71c9b43192ab83f1d531ad6002dc81108ac36c475f79fb7a295abe2f4/pyopenssl-26.3.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/58/3e/9e4b29a509fadec889dcd1f115fcc30655fd5296bd00198dcd8a0ea78d64/hypothesis_graphql-0.13.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/59/7b/e1d32ae8a3ed937ec2be3721c5f728b13d731a0b7c6442e0b3bec5094ac0/playwright-1.60.0-py3-none-macosx_11_0_arm64.whl
+      - pypi: https://files.pythonhosted.org/packages/5d/ba/2af136406e1c3839aea9ecadc2f6be2bcd1eff255bd451dd39bcf302c47a/bcrypt-5.0.0-cp39-abi3-macosx_10_12_universal2.whl
+      - pypi: https://files.pythonhosted.org/packages/5e/5f/82c8074f7e84978129347c2c6ec8b6c59f3584ff1a20bc3c940a3e061790/priority-2.0.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/64/b4/17d4b0b2a2dc85a6df63d1157e028ed19f90d4cd97c36717afef2bc2f395/attrs-26.1.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/69/90/f63fb5873511e014207a475e2bb4e8b2e570d655b00ac19a9a0ca0a385ee/jsonschema-4.26.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/7a/24/8493538fa4f62f982686398a5b8f68008138a75086abdea19ade64bf4255/librt-0.11.0-cp312-cp312-macosx_11_0_arm64.whl
+      - pypi: https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/80/56/60547f7801b97c67e97491dc3d9ade9fbccbd0325058fd3dfcb2f5d98d90/cattrs-26.1.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/80/6e/4b28b62ecb6aae56769c34a8ff1d661473ec1e9519e2d5f8b2c150086b26/pre_commit-4.6.0-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/81/e6/cd9575ac904136b3cbf7aa7ee819ef86eedb7274e46f230e94ea4342e729/platformdirs-4.10.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/85/c8/b156c2087c70f10c71ccc874c3e2cf484240775c818a006686553f61bd2a/cappa-0.32.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/88/b2/d0896bdcdc8d28a7fc5717c305f1a861c26e18c05047949fb371034d98bd/nodeenv-1.10.0-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/8b/5a/ba30a81239b909821b3153e303e7def45178bf353da4f72380e6c5e8793b/pytest-9.1.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/8b/9e/d01ef2bed8e995bbdeeb5307a571729a10545de4a6f8f06d9175fc7a1978/typed_settings-25.3.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/93/35/850277d1b17b206bd10874c8a9a3f52e059452fb49bb0d22cbb908f6038b/hypercorn-0.18.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/93/8c/2e650f2afeb7ee576912636c23ddb621c91ac6a98e66dc8d29c3c69446e1/werkzeug-3.1.8-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/94/84/d9273cd09688070a6523c4aee4663a8538721b2b755c4962aafae0011e72/identify-2.6.19-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/96/c0/271f3e1e3502a8decb8ee5c680dbed2d8dc2cd504f5e20f7ed491d5f37e1/atpublic-7.0.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/98/1c/b00940ab9eb8ede7897443b771987f2f4a76f06be02f1b3f01eb7567e24a/pytest_base_url-2.1.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/9a/30/fee1cf04e753f5ea914d39195df68ff6a1f2001aa6e8c9608fcc694428f9/schemathesis-4.21.8-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/9a/81/7e4e08678a1f98521201c3079f77db69fb552acd56067661f8c2f534a718/markupsafe-3.0.3-cp312-cp312-macosx_11_0_arm64.whl
+      - pypi: https://files.pythonhosted.org/packages/9b/22/adf66990e63584a68dfb50c24f48a125c07b1699899381c8151e63ed458c/cryptography-49.0.0-cp311-abi3-macosx_11_0_arm64.whl
+      - pypi: https://files.pythonhosted.org/packages/9d/76/f789f7a86709c6b087c5a2f52f911838cad707cc613162401badc665acfe/setuptools-82.0.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/9e/c9/b2622292ea83fbb4ec318f5b9ab867d0a28ab43c5717bb85b0a5f6b3b0a4/networkx-3.6.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a0/61/5c78b91c3143ed5c14207f463aecfc8f9dbb5092fb2869baf37c273b2705/gitdb-4.0.12-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a0/c4/b4d4827c93ef43c01f599ef31453ccc1c132b353284fc6c87d535c233129/pyee-13.0.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a2/23/ce3a543935a01e478349e82f6c1440776f92d4cb346662c4d81574878fed/hypothesis-6.155.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a3/43/35e3f136343aef451e545ce8c38d36c2f93c0ed88703db8b64ba2b205c68/rpds_py-2026.5.1-cp312-cp312-macosx_11_0_arm64.whl
+      - pypi: https://files.pythonhosted.org/packages/a3/5e/ecf12fdb62546d64385c158514e9b2b671f7832108ef2ecd2020ce0af2d1/pyjwt-2.13.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a4/62/02da182e544a51a5c3ccf4b03ab79df279f9c60c5e82d5e8bec7ca26ac11/python_slugify-8.0.4-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a4/f5/10b68b7b1544245097b2a1b8238f66f2fc6dcaeb24ba5d917f52bd2eed4f/wsproto-1.3.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a5/69/6da5581c6a7fede7dc261bf4e67d6adca4196f176b43288b55b3db395b6e/mdit_py_plugins-0.6.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a6/a5/c0b6468d3824fe3fde30dbb5e1f687b291608f9473681bbf7dabbf5a87d7/text_unidecode-1.3-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a9/4e/0463faa15aa5c618691f8c959bb0c40b215f5883175e3daa0f15f3b3e5a9/diskimage_builder-3.42.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/b0/24/bbf7175ffc47cb3d3e1eb523ddb23272968359dfcf2e1294707a2bf12fc4/flake8-6.1.0-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/b1/90/a998c550d0ddd07e38605bb5c455d00fcc177a800ff9cc3dafdcb3dd7b56/pycodestyle-2.11.1-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/b3/c5/30de077e06f7ffc3fe21d45ce26b8088816227b678a7157f6b9e080ff2db/type_lens-0.2.6-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/b6/02/d297943bcacf05e4f2a94ab6f462831dc20158614e5d067c35d4e63b9acb/argon2_cffi_bindings-25.1.0-cp39-abi3-macosx_11_0_arm64.whl
+      - pypi: https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/ba/47/5eb27f6f065170380bd4bd782177a2f1f67e721d6b3fa7de18c492f52917/acme-5.6.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/c0/db/61efa0d08a99f897ef98256b03e563092d36cc38dc4ebe4a85020fe40b31/pbr-7.0.3-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/c1/d4/59e74daffcb57a07668852eeeb6035af9f32cbfd7a1d2511f17d2fe6a738/smmap-5.0.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/c4/37/4549f149c9797c21b32c2683c33522af22522099de128b2406672526d005/greenlet-3.5.1-cp312-cp312-macosx_11_0_universal2.whl
+      - pypi: https://files.pythonhosted.org/packages/c4/8f/533075f00aaf19b07c5cd6aa6e5d89424b06b3b3f4583bfa9c640a079059/ruff-0.15.5-py3-none-macosx_11_0_arm64.whl
+      - pypi: https://files.pythonhosted.org/packages/c7/18/c86eb8e0202e32dd3df50d43d7ff9854f8e0603945ff398974c1d91ac1ef/tomli_w-1.2.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/d2/1e/da5fdcb8438008d3c53a0c6de6a40cb10bdb7e02a6e034aef79bc2b66800/botocore-1.43.31-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/d7/c1/eb8f9debc45d3b7918a32ab756658a0904732f75e555402972246b0b8e71/tenacity-9.1.4-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/df/a2/781b623f57358e360d62cdd7a8c681f074a71d445418a776eef0aadb4ab4/cffi-2.0.0-cp312-cp312-macosx_11_0_arm64.whl
+      - pypi: https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/ec/39/d401756df60a8344848477d54fdf4ce0f50531f6149f3b8eaae9c06ae3dc/aiosmtpd-1.4.6-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/ec/bb/2799cc2ede3ed41131f8975621e7213dfc7ef4acbbaadfa440f32500c370/starlette-1.3.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/f1/d9/7fb5aa316bc299258e68c73ba3bddbc499654a07f151cba08f6153988714/pathspec-1.1.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/f5/ac/19f9941c74add59d17694930ec8105d5eddeee4ce56dd8632b765ca16d6c/stevedore-5.8.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/f8/b2/b5caed897fbb1cc286c62c01feca977e08d99a17230ff3055b9a98eccf1d/josepy-2.2.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fa/b6/3127540ecdf1464a00e5a01ee60a1b09175f6913f0644ac748494d9c4b21/pytest_timeout-2.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fe/71/1c545fac6a9054b52b3771238fb2dc6e8f1d0ccec116e1c7786ec191887c/pytest_playwright-0.8.0-py3-none-any.whl
 packages:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,7 @@ requires-python = ">=3.12"
 dependencies = [
     "PyJWT[crypto]",
     "acme>=5.4.0",
+    "aiosmtpd",
     "argon2-cffi",
     "attrs",
     "bcrypt>=4.1",

--- a/services/email/README.md
+++ b/services/email/README.md
@@ -1,0 +1,55 @@
+# OpenHost Email Service
+
+Outbound email sending, provided by OpenHost itself (not a provider app).
+
+**Service URL:** `github.com/imbue-openhost/openhost/services/email`
+
+## What it does
+
+Any app that wants to send mail requests this service's `send` permission. The
+router runs a local SMTP submission listener; the app relays its message there,
+and the router attaches the instance's relay credential and forwards the message
+to the Imbue email proxy smarthost. The app never sees the relay credential.
+
+This is spoken over SMTP (not the HTTP V2 service-call proxy) because the natural
+clients are mail servers (e.g. Stalwart), which relay through an SMTP smarthost.
+Permissioning is the same as every other service: a manifest-declared grant that
+the owner approves at install.
+
+## Consuming it
+
+Declare the consume in your `openhost.toml`:
+
+```toml
+[[services.v2.consumes]]
+service = "github.com/imbue-openhost/openhost/services/email"
+shortname = "email"
+version = ">=0.1.0"
+grants = ["send"]
+```
+
+## Permission grant format
+
+- `"send"` — permission to send outbound mail through the instance's relay.
+
+## Sending
+
+The router injects two env vars into every app:
+
+- `OPENHOST_SMTP_HOST` — the router SMTP submission host (reachable from the app)
+- `OPENHOST_SMTP_PORT` — the router SMTP submission port
+
+Connect to `OPENHOST_SMTP_HOST:OPENHOST_SMTP_PORT` and authenticate with SMTP
+AUTH:
+
+- username = your app name (`OPENHOST_APP_NAME`)
+- password = your app token (`OPENHOST_APP_TOKEN`)
+
+The router validates the token, checks the `send` grant, then relays the message
+to the Imbue smarthost with the per-instance credential attached. From/To
+envelope addresses are preserved; the message body is forwarded verbatim (SES
+signs DKIM downstream).
+
+The listener is bound only to loopback and the container gateway (never a public
+interface). Inbound mail is unaffected: it is delivered directly to the mailbox
+server, not through this service.

--- a/services/email/openhost_service.toml
+++ b/services/email/openhost_service.toml
@@ -1,0 +1,3 @@
+[service]
+name = "email"
+description = "Outbound email sending, relayed by the router over SMTP submission"


### PR DESCRIPTION
Adds email to OpenHost instances on the shared Imbue identity. Inbound is delivered directly to the instance's mail server (MX -> mail.<zone> -> instance IP, Stalwart on :25), never touching Imbue infra. Outbound is a router-mediated service.

Outbound as an OpenHost service:
- Email is an "email" v2 service (github.com/imbue-openhost/openhost/services/email), permissioned like any other service. Apps request the "send" grant in their manifest.
- The router runs a local SMTP submission listener (loopback + container gateway only, never public). Apps relay to it with SMTP AUTH (username = app name, password = their OPENHOST_APP_TOKEN).
- The router checks the grant, attaches the per-instance relay credential, and forwards to the Imbue SES smarthost. The app never sees the relay credential.
- Replaces the old app-scoped path: the /api/email/relay-config route and email_mailbox_app_names allowlist are removed.

Other pieces:
- CoreDNS publishing of SPF/DKIM/DMARC + direct-inbound MX/A; scoped ACME-challenge clear so cert renewal never wipes email records.
- Startup provisioning of the SES identity + DKIM (best-effort, no-op when email off).
- Mailbox (Stalwart) + webmail (Bulwark) auto-deployed when email is enabled. Owner-facing /api/email/custom-domain (BYO domain via one NS record).
- Carries system-agent migration v9 (moves any pre-existing cert_api_keycloak_* config into the settings table); belongs to the shared-identity work, included here because email depends on it.

Companion (must land in lockstep): openhost-stalwart-email-server#12.

Verification: unit tests (auth, grant, SMTP relay path) + full suite + ruff/mypy + vet clean; 50 live full-process e2e; real Stalwart-path with confirmed inbox delivery.

