### PR TITLE
Auto-restart openhost.service on failure with a bounded crash limiter

### DIFF
--- a/ansible/templates/openhost.service.j2
+++ b/ansible/templates/openhost.service.j2
@@ -10,6 +10,14 @@ Description=OpenHost Compute Space
 # a hardcoded UID and the value differs across cloud providers.
 After=network-online.target user@{{ host_uid }}.service
 Wants=network-online.target user@{{ host_uid }}.service
+# Crash limiter for Restart=on-failure (see [Service]): if the service fails more
+# than StartLimitBurst times within StartLimitIntervalSec, systemd stops retrying
+# and leaves it `failed` (recover with `systemctl reset-failed openhost`). This
+# both stops a broken build from flapping forever and caps how fast a persistent
+# cert-acquisition crash could hit an ACME endpoint. Successful exits (code 0 and
+# the update-flow's SuccessExitStatus=42) do not count toward the burst.
+StartLimitIntervalSec=1800
+StartLimitBurst=5
 
 [Service]
 Type=simple
@@ -39,13 +47,37 @@ Environment=DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/{{ host_uid }}/bus
 # broken) pixi env.
 ExecStartPre=-+/usr/local/bin/openhost-reclaim-pixi
 ExecStart=/home/host/.pixi/bin/pixi run python -m compute_space
-# Don't auto-restart on crash (can blow through certbot rate limits).
-# RestartForceExitStatus=42 overrides Restart=no for exit code 42 only,
-# which is used by the self-update flow to trigger a clean restart.
-Restart=no
+# Auto-restart on crash, but rate-limited. compute_space is the parent of the
+# in-process CoreDNS + Caddy children (see core/dns.py, core/caddy.py), so when
+# it dies they die with it and the instance loses authoritative DNS *and* HTTP/S
+# at once — including its own nameserver, so nothing about the box resolves.
+# Recovering from a transient crash (OOM, a bad request path, etc.) without a
+# human rebooting is worth far more than staying dark.
+#
+# The historical reason this was Restart=no was ACME rate limits: instances used
+# to carry a shared Let's Encrypt account key and re-ran cert acquisition on every
+# boot, so a crash loop could burn the account's weekly quota. That risk is now
+# bounded on two fronts: (1) a boot with a valid cached cert on disk makes zero
+# ACME calls (_ensure_tls_cert short-circuits on CertStatus.OK, see web/start.py);
+# (2) managed instances no longer hold an account key at all — they get certs from
+# the server-side openhost-cert-api broker (Google Trust Services, not LE). The
+# StartLimit below is the backstop for the remaining window (BYO-ACME + a missing
+# cert): at most StartLimitBurst acquisition attempts per StartLimitIntervalSec,
+# which is nowhere near any CA's rate limit.
+#
+# RestartForceExitStatus=42 keeps the self-update clean-restart path working (the
+# update flow exits 42 on purpose; see updates.py RESTART_EXIT_CODE). Because 42
+# is also SuccessExitStatus, an update restart is a "success" exit and does NOT
+# count against StartLimitBurst — only genuine failures do — so frequent updates
+# can't trip the crash limiter.
+Restart=on-failure
 RestartForceExitStatus=42
 SuccessExitStatus=42
-RestartSec=3
+# Wait between restarts so a fast crash loop can't spin the CPU or race ACME.
+RestartSec=30
+# Give up (unit enters `failed`) after 5 failures inside a 30-minute window, so a
+# genuinely broken build stops flapping and a persistent cert-acquisition crash
+# can make at most ~5 ACME attempts per half hour. StartLimit* live in [Unit].
 # this will kill other processes in the group (eg caddy etc) after the main process exits
 TimeoutStopSec=5
 

--- a/compute_space/src/compute_space/tests/test_systemd_unit.py
+++ b/compute_space/src/compute_space/tests/test_systemd_unit.py
@@ -2,11 +2,14 @@
 
 The unit is a Jinja2 template (``ansible/templates/openhost.service.j2``) with a
 single ``host_uid`` variable, installed verbatim by
-``ansible/tasks/install_openhost_units.yml``. There is no ansible-side test
-harness in this repo, so these tests render the template directly and pin the
-behaviors we care about — chiefly the crash-restart policy, which is what keeps
-an instance (and its own authoritative DNS) from staying dark after a transient
-compute_space crash.
+``ansible/tasks/install_openhost_units.yml`` on fresh provisioning. The same
+directives are also emitted by ``build_openhost_service_unit`` in the system
+agent, which rewrites the installed unit during self-update migrations (see the
+system-agent ``test_service_unit.py`` for the builder side and the byte-for-byte
+directive agreement between the two). These tests render the ansible template
+directly and pin the behaviors we care about — chiefly the crash-restart policy,
+which is what keeps an instance (and its own authoritative DNS) from staying dark
+after a transient compute_space crash.
 """
 
 from __future__ import annotations

--- a/compute_space/src/compute_space/tests/test_systemd_unit.py
+++ b/compute_space/src/compute_space/tests/test_systemd_unit.py
@@ -1,0 +1,100 @@
+"""Render + assert invariants on the ``openhost.service`` systemd unit template.
+
+The unit is a Jinja2 template (``ansible/templates/openhost.service.j2``) with a
+single ``host_uid`` variable, installed verbatim by
+``ansible/tasks/install_openhost_units.yml``. There is no ansible-side test
+harness in this repo, so these tests render the template directly and pin the
+behaviors we care about — chiefly the crash-restart policy, which is what keeps
+an instance (and its own authoritative DNS) from staying dark after a transient
+compute_space crash.
+"""
+
+from __future__ import annotations
+
+import configparser
+from pathlib import Path
+
+import pytest
+from jinja2 import Environment
+from jinja2 import FileSystemLoader
+from jinja2 import StrictUndefined
+
+# tests/ -> compute_space/ -> src/ -> compute_space/ -> repo root
+_REPO_ROOT = Path(__file__).resolve().parents[4]
+_TEMPLATE_DIR = _REPO_ROOT / "ansible" / "templates"
+_TEMPLATE_NAME = "openhost.service.j2"
+
+_FAKE_HOST_UID = "1001"
+
+
+def _render_unit() -> str:
+    # StrictUndefined so a forgotten variable raises instead of rendering blank —
+    # a blank host_uid would silently produce a broken /run/user/ path.
+    env = Environment(loader=FileSystemLoader(str(_TEMPLATE_DIR)), undefined=StrictUndefined)
+    return env.get_template(_TEMPLATE_NAME).render(host_uid=_FAKE_HOST_UID)
+
+
+def _parse_unit(text: str) -> configparser.ConfigParser:
+    # systemd unit files are INI-ish; configparser reads them well enough for
+    # single-valued directives, which is all we assert here. allow_no_value for
+    # comment-only lines; strict=False since systemd permits repeated keys.
+    parser = configparser.ConfigParser(allow_no_value=True, strict=False, interpolation=None)
+    # Preserve case: systemd directive names are case-sensitive (Restart, not restart).
+    parser.optionxform = str  # type: ignore[assignment,method-assign]
+    parser.read_string(text)
+    return parser
+
+
+@pytest.fixture(scope="module")
+def unit_text() -> str:
+    return _render_unit()
+
+
+@pytest.fixture(scope="module")
+def unit(unit_text: str) -> configparser.ConfigParser:
+    return _parse_unit(unit_text)
+
+
+def test_template_renders_with_host_uid(unit_text: str) -> None:
+    # The one template variable must be substituted everywhere it appears.
+    assert "{{" not in unit_text and "{%" not in unit_text
+    assert f"user@{_FAKE_HOST_UID}.service" in unit_text
+    assert f"/run/user/{_FAKE_HOST_UID}" in unit_text
+
+
+def test_restart_policy_is_on_failure(unit: configparser.ConfigParser) -> None:
+    # The crux of this change: a transient crash must auto-recover rather than
+    # leave the instance (and its authoritative DNS) dark until a human reboots.
+    assert unit.get("Service", "Restart") == "on-failure"
+
+
+def test_update_flow_exit_42_still_restarts_cleanly(unit: configparser.ConfigParser) -> None:
+    # The self-update flow exits 42 on purpose (updates.py RESTART_EXIT_CODE).
+    # It must be both a forced-restart status (so Restart=on-failure honors it)
+    # and a success status (so it never counts toward the crash burst limit).
+    assert unit.get("Service", "RestartForceExitStatus") == "42"
+    assert unit.get("Service", "SuccessExitStatus") == "42"
+
+
+def test_crash_limiter_is_bounded(unit: configparser.ConfigParser) -> None:
+    # StartLimit* must live in [Unit] (systemd ignores them in [Service]) and be
+    # finite so a persistent cert-acquisition crash can hit an ACME endpoint at
+    # most StartLimitBurst times per interval.
+    burst = int(unit.get("Unit", "StartLimitBurst"))
+    interval = int(unit.get("Unit", "StartLimitIntervalSec"))
+    assert burst > 0
+    assert interval > 0
+    # Sanity bound: keep the worst-case ACME attempt rate low.
+    assert burst <= 10
+
+
+def test_restart_is_delayed(unit: configparser.ConfigParser) -> None:
+    # A non-trivial RestartSec keeps a fast crash loop from spinning the CPU and
+    # from racing ACME orders back-to-back within the burst window.
+    assert int(unit.get("Service", "RestartSec")) >= 5
+
+
+def test_stop_reaps_child_processes(unit: configparser.ConfigParser) -> None:
+    # CoreDNS + Caddy run as in-process children; a bounded TimeoutStopSec ensures
+    # systemd kills the whole cgroup on stop so they don't linger on :53/:80/:443.
+    assert int(unit.get("Service", "TimeoutStopSec")) > 0

--- a/openhost_system_agent/src/openhost_system_agent/migrations/registry.py
+++ b/openhost_system_agent/src/openhost_system_agent/migrations/registry.py
@@ -11,6 +11,7 @@ from openhost_system_agent.migrations.versions.v0004_pixi_version import Migrati
 from openhost_system_agent.migrations.versions.v0005_pixi_ownership_failsafe import Migration0005PixiOwnershipFailsafe
 from openhost_system_agent.migrations.versions.v0006_journald_size_cap import Migration0006JournaldSizeCap
 from openhost_system_agent.migrations.versions.v0007_seed_domains_and_scrub import Migration0007SeedDomainsAndScrub
+from openhost_system_agent.migrations.versions.v0008_restart_on_failure import Migration0008RestartOnFailure
 
 # Numbered migrations in apply order. Versions MUST start at 2 and be
 # contiguous. v1 is the baseline produced by ansible setup.yml.
@@ -21,6 +22,7 @@ REGISTRY: list[SystemMigration] = [
     Migration0005PixiOwnershipFailsafe(),
     Migration0006JournaldSizeCap(),
     Migration0007SeedDomainsAndScrub(),
+    Migration0008RestartOnFailure(),
 ]
 
 

--- a/openhost_system_agent/src/openhost_system_agent/migrations/versions/v0002_baseline.py
+++ b/openhost_system_agent/src/openhost_system_agent/migrations/versions/v0002_baseline.py
@@ -61,6 +61,13 @@ def build_openhost_service_unit(host_uid: int) -> str:
         "Description=OpenHost Compute Space\n"
         f"After=network-online.target user@{host_uid}.service\n"
         f"Wants=network-online.target user@{host_uid}.service\n"
+        # Crash limiter for Restart=on-failure (see below): after StartLimitBurst
+        # failures within StartLimitIntervalSec systemd stops retrying and leaves
+        # the unit `failed`. Bounds how fast a persistent cert-acquisition crash
+        # could hit an ACME endpoint; successful exits (0 and the update-flow's
+        # SuccessExitStatus=42) don't count. StartLimit* MUST live in [Unit].
+        "StartLimitIntervalSec=1800\n"
+        "StartLimitBurst=5\n"
         "\n"
         "[Service]\n"
         "Type=simple\n"
@@ -73,10 +80,20 @@ def build_openhost_service_unit(host_uid: int) -> str:
         f"Environment=DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/{host_uid}/bus\n"
         + RECLAIM_EXEC_START_PRE
         + "ExecStart=/home/host/.pixi/bin/pixi run python -m compute_space\n"
-        "Restart=no\n"
+        # Auto-restart on crash (bounded by StartLimit* above). compute_space is
+        # the parent of the in-process CoreDNS + Caddy children, so when it dies
+        # they die with it and the instance loses authoritative DNS *and* HTTP/S
+        # at once — including its own nameserver. The old Restart=no left that
+        # dark until a human rebooted. The historical ACME-quota reason no longer
+        # applies: a boot with a valid cached cert makes zero ACME calls, and
+        # managed instances get certs from the server-side cert-api broker, not a
+        # local account key. RestartForceExitStatus=42 keeps the self-update
+        # clean-restart working; because 42 is also SuccessExitStatus it doesn't
+        # count toward the crash burst. Kept in sync with the ansible template.
+        "Restart=on-failure\n"
         "RestartForceExitStatus=42\n"
         "SuccessExitStatus=42\n"
-        "RestartSec=3\n"
+        "RestartSec=30\n"
         "TimeoutStopSec=5\n"
         "\n"
         "[Install]\n"

--- a/openhost_system_agent/src/openhost_system_agent/migrations/versions/v0008_restart_on_failure.py
+++ b/openhost_system_agent/src/openhost_system_agent/migrations/versions/v0008_restart_on_failure.py
@@ -1,0 +1,42 @@
+"""Rewrite openhost.service to auto-restart on failure (was Restart=no).
+
+compute_space is the parent of the in-process CoreDNS + Caddy children, so when
+it exits they exit with it and the instance loses authoritative DNS *and*
+HTTP/S at once — including its own nameserver, so nothing about the box
+resolves.  With the old ``Restart=no`` a transient crash left the instance dark
+until a human rebooted.  ``build_openhost_service_unit`` now emits
+``Restart=on-failure`` with a bounded ``StartLimitBurst``/``StartLimitIntervalSec``
+crash limiter; fresh hosts get it from the baseline and the ansible template,
+but hosts provisioned before this change still have the old unit on disk.
+
+This migration rewrites the installed unit to the current
+``build_openhost_service_unit`` output and reloads systemd so existing hosts
+pick up the new policy on their next self-update — without waiting for a full
+re-provision.  It does NOT restart openhost: ``daemon-reload`` makes the new
+policy authoritative for the *next* start, and the update flow restarts the
+service at the end of the apply walk anyway (see apply_after_checkout.main).
+
+Idempotent: writing the same unit and reloading systemd is safe to repeat.  The
+written unit is byte-identical to what the baseline migration and the ansible
+template produce (all three go through ``build_openhost_service_unit`` / the
+matching template), so a host looks the same however it was set up.
+"""
+
+from __future__ import annotations
+
+from openhost_system_agent.migrations.base import SystemMigration
+from openhost_system_agent.migrations.helpers import get_host_uid
+from openhost_system_agent.migrations.helpers import run
+from openhost_system_agent.migrations.helpers import write_file
+from openhost_system_agent.migrations.versions.v0002_baseline import OPENHOST_SERVICE_PATH
+from openhost_system_agent.migrations.versions.v0002_baseline import build_openhost_service_unit
+
+
+class Migration0008RestartOnFailure(SystemMigration):
+    version = 8
+
+    def up(self) -> None:
+        write_file(OPENHOST_SERVICE_PATH, build_openhost_service_unit(get_host_uid()), mode=0o644)
+        # Make the rewritten unit authoritative for the next start. The apply
+        # walk restarts openhost at the end, so we don't restart here.
+        run("systemctl", "daemon-reload")

--- a/openhost_system_agent/src/openhost_system_agent/tests/test_migration_restart_on_failure.py
+++ b/openhost_system_agent/src/openhost_system_agent/tests/test_migration_restart_on_failure.py
@@ -1,0 +1,55 @@
+"""Tests for the v8 migration that rewrites openhost.service to Restart=on-failure.
+
+The migration exists so hosts provisioned before the restart-policy change pick
+up the new unit on their next self-update, not only on a full re-provision.  It
+writes the current ``build_openhost_service_unit`` output to the installed unit
+path and reloads systemd; we drive it through fakes to assert exactly that.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from openhost_system_agent.migrations.versions import v0008_restart_on_failure
+from openhost_system_agent.migrations.versions.v0002_baseline import OPENHOST_SERVICE_PATH
+from openhost_system_agent.migrations.versions.v0002_baseline import build_openhost_service_unit
+from openhost_system_agent.migrations.versions.v0008_restart_on_failure import Migration0008RestartOnFailure
+
+_PREFIX = "openhost_system_agent.migrations.versions.v0008_restart_on_failure"
+
+
+def test_rewrites_unit_and_reloads(monkeypatch: pytest.MonkeyPatch) -> None:
+    written: dict[str, Any] = {}
+    run_calls: list[tuple[str, ...]] = []
+
+    def fake_write_file(path: str, content: str, *, mode: int = 0o600) -> None:
+        written["path"] = path
+        written["content"] = content
+        written["mode"] = mode
+
+    def fake_run(*cmd: str) -> None:
+        run_calls.append(cmd)
+
+    monkeypatch.setattr(f"{_PREFIX}.write_file", fake_write_file)
+    monkeypatch.setattr(f"{_PREFIX}.run", fake_run)
+    monkeypatch.setattr(f"{_PREFIX}.get_host_uid", lambda: 1001)
+
+    Migration0008RestartOnFailure().up()
+
+    # World-readable unit at the canonical path, exactly the shared builder's output.
+    assert written["path"] == OPENHOST_SERVICE_PATH
+    assert written["mode"] == 0o644
+    assert written["content"] == build_openhost_service_unit(1001)
+    assert "Restart=on-failure\n" in written["content"]
+
+    # systemd is reloaded so the new unit is authoritative for the next start.
+    assert ("systemctl", "daemon-reload") in run_calls
+    # It must NOT restart openhost itself — the apply walk does that at the end;
+    # a mid-migration restart would kill the running apply process.
+    assert not any(c[:2] == ("systemctl", "restart") for c in run_calls)
+
+
+def test_migration_version_is_eight() -> None:
+    assert v0008_restart_on_failure.Migration0008RestartOnFailure.version == 8

--- a/openhost_system_agent/src/openhost_system_agent/tests/test_service_unit.py
+++ b/openhost_system_agent/src/openhost_system_agent/tests/test_service_unit.py
@@ -2,10 +2,37 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from jinja2 import Environment
+from jinja2 import FileSystemLoader
+from jinja2 import StrictUndefined
+
 from openhost_system_agent.migrations.versions.v0002_baseline import RECLAIM_EXEC_START_PRE
 from openhost_system_agent.migrations.versions.v0002_baseline import RECLAIM_SCRIPT
 from openhost_system_agent.migrations.versions.v0002_baseline import RECLAIM_SCRIPT_PATH
 from openhost_system_agent.migrations.versions.v0002_baseline import build_openhost_service_unit
+
+
+def _effective_directives(unit_text: str) -> list[str]:
+    """Non-comment, non-blank lines — the directives systemd actually acts on."""
+    out: list[str] = []
+    for line in unit_text.splitlines():
+        stripped = line.strip()
+        if stripped and not stripped.startswith("#"):
+            out.append(stripped)
+    return out
+
+
+def test_ansible_template_and_builder_agree_on_directives() -> None:
+    """The ansible template (fresh provisioning) and build_openhost_service_unit
+    (migrations) must produce the same systemd directives so a host looks the
+    same however it was set up. Comments may differ; directives may not."""
+    repo_root = Path(__file__).resolve().parents[4]
+    env = Environment(
+        loader=FileSystemLoader(str(repo_root / "ansible" / "templates")),
+        undefined=StrictUndefined,
+    )
+    rendered_j2 = env.get_template("openhost.service.j2").render(host_uid="1001")
+    assert _effective_directives(rendered_j2) == _effective_directives(build_openhost_service_unit(1001))
 
 
 class TestOpenhostServiceUnit:
@@ -32,6 +59,25 @@ class TestOpenhostServiceUnit:
         unit = build_openhost_service_unit(4242)
         assert "XDG_RUNTIME_DIR=/run/user/4242" in unit
         assert "user@4242.service" in unit
+
+    def test_restarts_on_failure_with_a_bounded_crash_limiter(self) -> None:
+        unit = build_openhost_service_unit(1001)
+        # Auto-restart on crash so a transient compute_space failure doesn't take
+        # the instance (and its own authoritative DNS) dark until a human reboots.
+        assert "Restart=on-failure\n" in unit
+        assert "Restart=no" not in unit
+        # StartLimit* MUST live in [Unit]; systemd ignores them in [Service].
+        assert unit.index("StartLimitBurst=5") < unit.index("[Service]")
+        assert "StartLimitIntervalSec=1800\n" in unit
+        # A non-trivial backoff so a crash loop can't spin the CPU or race ACME.
+        assert "RestartSec=30\n" in unit
+
+    def test_self_update_exit_42_is_a_restarting_success(self) -> None:
+        unit = build_openhost_service_unit(1001)
+        # 42 (updates.py RESTART_EXIT_CODE) must force a restart *and* count as a
+        # success, so update restarts work and don't consume the crash burst.
+        assert "RestartForceExitStatus=42\n" in unit
+        assert "SuccessExitStatus=42\n" in unit
 
 
 class TestReclaimScript:


### PR DESCRIPTION
Changes openhost.service from Restart=no to Restart=on-failure with a bounded StartLimitBurst=5 per StartLimitIntervalSec=1800 and RestartSec=30 backoff.

Motivation: compute_space is the parent of the in-process CoreDNS and Caddy children, so when it dies they die with it and the instance loses authoritative DNS and HTTP/S at once, including its own nameserver, so nothing about the box resolves. With Restart=no this stayed dark until a human rebooted. This was observed in production on a user instance whose compute_space had exited and did not come back until a manual reboot.

The original Restart=no was for ACME rate limits, since instances used to carry a shared Lets Encrypt account key and re-ran cert acquisition on every boot, so a crash loop could burn the account weekly quota. That risk is now bounded: a boot with a valid cached cert makes zero ACME calls, since _ensure_tls_cert short-circuits on CertStatus.OK; and managed instances no longer hold an account key at all, since they get certs from the server-side openhost-cert-api broker backed by Google Trust Services. The StartLimit is the backstop for the remaining BYO-ACME plus missing-cert window: at most 5 attempts per 30 minutes.

The self-update clean-restart path is preserved. exit 42 is both RestartForceExitStatus and SuccessExitStatus, so an update restart still happens and counts as success, not a failure, so it does not consume the crash burst.

The unit is defined in two places that must agree: the ansible template for fresh provisioning, and build_openhost_service_unit in the system agent, which the migration framework uses to rewrite the installed unit. Both are updated, and a test asserts they emit the same directives.

Existing hosts: a new v0008 system-agent migration rewrites the installed unit and reloads systemd, so hosts provisioned before this change pick up the new policy on their next self-update rather than needing a full re-provision. It does not restart openhost itself; daemon-reload makes the new policy authoritative for the next start, and the apply walk restarts the service at the end.

Testing. Unit tests: added system-agent tests for the new policy in build_openhost_service_unit, the directive agreement between the template and the builder, and the v0008 migration writing the unit and reloading without restarting; added a compute_space test that renders the template and pins the policy; full system-agent suite passes. Ruff and mypy clean.

End-to-end on real Hetzner instances via vm-manager:
- Fresh install on this branch: verified the deployed unit and effective systemd properties, then SIGKILLed the main process and confirmed auto-recovery in about 30s with CoreDNS and Caddy listeners restored and DNS resolving again. Caddy loaded the cached cert with no ACME call on restart. Deterministic probes confirmed exit-42 restarts as success and a persistent exit-1 stops after the burst and enters failed.
- Upgrade path: provisioned on main (unit had Restart=no, migration version 1), pinned the remote to this branch, and ran update apply. The migration walk applied v1 through v8 including v0008, the on-disk unit became Restart=on-failure with the StartLimit and RestartSec, systemd loaded it, and a SIGKILL of the main process auto-recovered with DNS resolving again.

vet ran clean across parallel API and agentic runs on both the template-only change and the system-agent migration change.