### PR TITLE
Add build_memory_mb limit for the app image build step

### DIFF
--- a/apps/test_app/openhost.toml
+++ b/apps/test_app/openhost.toml
@@ -19,4 +19,8 @@ grants = [{ key = "TEST_SECRET" }]
 
 [resources]
 memory_mb = 64
+# The running app is tiny (64 MB), but `pip install aiohttp` needs far more
+# than that to build. build_memory_mb defaults to memory_mb, so the build
+# must opt into a higher cap explicitly or it gets OOM-killed.
+build_memory_mb = 1024
 cpu_cores = 0.1

--- a/compute_space/src/compute_space/core/apps.py
+++ b/compute_space/src/compute_space/core/apps.py
@@ -564,6 +564,7 @@ def deploy_app_background(
                     repo_path,
                     manifest.container_image,
                     temp_data_dir=config.temporary_data_dir,
+                    memory_mb=manifest.effective_build_memory_mb,
                 )
                 break
             except RuntimeError as e:
@@ -811,6 +812,7 @@ def start_app_process(app_id: str, db: sqlite3.Connection, config: Config) -> No
         app_row["repo_path"],
         manifest.container_image,
         temp_data_dir=config.temporary_data_dir,
+        memory_mb=manifest.effective_build_memory_mb,
     )
     container_id = run_container(
         app_name,

--- a/compute_space/src/compute_space/core/containers.py
+++ b/compute_space/src/compute_space/core/containers.py
@@ -192,7 +192,13 @@ def build_image(
         dockerfile_path,
     ]
     if memory_mb is not None:
+        # Cap build RAM at the app's declared limit for isolation, but allow
+        # unlimited swap (the host has a large swap file). A build that needs
+        # more than memory_mb then spills to swap instead of OOM-killing —
+        # keeping most builds working even with a small memory_mb, without
+        # letting a "small" app hog host RAM. --memory-swap=-1 requires --memory.
         cmd.append(f"--memory={memory_mb}m")
+        cmd.append("--memory-swap=-1")
     cmd.append(repo_path)
     logger.info("Building container image: %s", " ".join(cmd))
 

--- a/compute_space/src/compute_space/core/containers.py
+++ b/compute_space/src/compute_space/core/containers.py
@@ -174,8 +174,13 @@ def build_image(
     repo_path: str,
     dockerfile_rel_path: str,
     temp_data_dir: str | None = None,
+    memory_mb: int | None = None,
 ) -> str:
-    """Build the container image for an app.  Returns the image tag."""
+    """Build the container image for an app.  Returns the image tag.
+
+    ``memory_mb`` caps the memory available to the build via podman's
+    ``--memory`` flag; None leaves the build unconstrained.
+    """
     image_tag = f"openhost-{app_name}:latest"
     dockerfile_path = os.path.join(repo_path, dockerfile_rel_path)
     cmd = [
@@ -185,8 +190,10 @@ def build_image(
         image_tag,
         "-f",
         dockerfile_path,
-        repo_path,
     ]
+    if memory_mb is not None:
+        cmd.append(f"--memory={memory_mb}m")
+    cmd.append(repo_path)
     logger.info("Building container image: %s", " ".join(cmd))
 
     if temp_data_dir:

--- a/compute_space/src/compute_space/core/manifest.py
+++ b/compute_space/src/compute_space/core/manifest.py
@@ -164,8 +164,9 @@ class AppManifest:
     # [resources]
     memory_mb: int = 128
     # Memory limit for the image *build* step (podman build --memory).
-    # None means "use memory_mb" — the build gets the same limit as the
-    # running container unless the app opts into a different value.
+    # None means the build is unconstrained. Builds (pip installs, native
+    # compilation) routinely need far more memory than the running app, so
+    # we do NOT default this to the runtime memory_mb — an app must opt in.
     build_memory_mb: int | None = None
     cpu_cores: float = 0.1
     gpu: bool = False
@@ -194,9 +195,14 @@ class AppManifest:
     raw_toml: str = ""
 
     @property
-    def effective_build_memory_mb(self) -> int:
-        """Memory limit to apply to the image build, defaulting to memory_mb."""
-        return self.build_memory_mb if self.build_memory_mb is not None else self.memory_mb
+    def effective_build_memory_mb(self) -> int | None:
+        """Memory limit to apply to the image build, or None to leave it unconstrained.
+
+        The build is only capped when the app explicitly sets
+        ``build_memory_mb``; it deliberately does not fall back to the runtime
+        ``memory_mb``, which is typically far too small for the build step.
+        """
+        return self.build_memory_mb
 
 
 def _validate_devices(devices: list[Any]) -> list[str]:

--- a/compute_space/src/compute_space/core/manifest.py
+++ b/compute_space/src/compute_space/core/manifest.py
@@ -164,9 +164,10 @@ class AppManifest:
     # [resources]
     memory_mb: int = 128
     # Memory limit for the image *build* step (podman build --memory).
-    # None means the build is unconstrained. Builds (pip installs, native
-    # compilation) routinely need far more memory than the running app, so
-    # we do NOT default this to the runtime memory_mb — an app must opt in.
+    # None falls back to the app's runtime memory_mb: an app that declares a
+    # small memory footprint must not be able to consume far more during its
+    # build and trigger the OOM killer against other apps. A build that
+    # genuinely needs more memory must declare it here up front.
     build_memory_mb: int | None = None
     cpu_cores: float = 0.1
     gpu: bool = False
@@ -195,14 +196,16 @@ class AppManifest:
     raw_toml: str = ""
 
     @property
-    def effective_build_memory_mb(self) -> int | None:
-        """Memory limit to apply to the image build, or None to leave it unconstrained.
+    def effective_build_memory_mb(self) -> int:
+        """Memory limit to apply to the image build.
 
-        The build is only capped when the app explicitly sets
-        ``build_memory_mb``; it deliberately does not fall back to the runtime
-        ``memory_mb``, which is typically far too small for the build step.
+        Falls back to the runtime ``memory_mb`` when ``build_memory_mb`` is
+        unset, so a build can never exceed the app's declared memory footprint
+        — otherwise a "small" app could grab far more at build time and trip
+        the OOM killer against other apps. A build that genuinely needs more
+        must raise it explicitly via ``build_memory_mb``.
         """
-        return self.build_memory_mb
+        return self.build_memory_mb if self.build_memory_mb is not None else self.memory_mb
 
 
 def _validate_devices(devices: list[Any]) -> list[str]:

--- a/compute_space/src/compute_space/core/manifest.py
+++ b/compute_space/src/compute_space/core/manifest.py
@@ -163,6 +163,10 @@ class AppManifest:
 
     # [resources]
     memory_mb: int = 128
+    # Memory limit for the image *build* step (podman build --memory).
+    # None means "use memory_mb" — the build gets the same limit as the
+    # running container unless the app opts into a different value.
+    build_memory_mb: int | None = None
     cpu_cores: float = 0.1
     gpu: bool = False
 
@@ -188,6 +192,11 @@ class AppManifest:
     hidden: bool = False
 
     raw_toml: str = ""
+
+    @property
+    def effective_build_memory_mb(self) -> int:
+        """Memory limit to apply to the image build, defaulting to memory_mb."""
+        return self.build_memory_mb if self.build_memory_mb is not None else self.memory_mb
 
 
 def _validate_devices(devices: list[Any]) -> list[str]:
@@ -429,6 +438,7 @@ def parse_manifest_from_string(raw_text: str) -> AppManifest:
         public_paths=routing.get("public_paths", []),
         links=_parse_links(data.get("links", [])),
         memory_mb=resources.get("memory_mb", 128),
+        build_memory_mb=resources.get("build_memory_mb"),
         cpu_cores=_parse_cpu_cores(resources, app_name),
         gpu=resources.get("gpu", False),
         sqlite_dbs=data_section.get("sqlite", []),

--- a/compute_space/src/compute_space/tests/test_containers.py
+++ b/compute_space/src/compute_space/tests/test_containers.py
@@ -65,6 +65,42 @@ def test_build_image_uses_podman_build(monkeypatch: pytest.MonkeyPatch) -> None:
     ]
 
 
+def test_build_image_applies_memory_limit(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[list[str]] = []
+
+    def fake_run(cmd, capture_output, text, timeout):  # type: ignore[no-untyped-def]
+        calls.append(cmd)
+        return _FakeCompleted(0, stdout="")
+
+    _patch_subprocess_run(monkeypatch, fake_run)
+
+    build_image("myapp", "/tmp/repo", "Dockerfile", temp_data_dir=None, memory_mb=512)
+    # --memory is passed to `podman build`, before the build context path.
+    assert calls[0] == [
+        "podman",
+        "build",
+        "-t",
+        "openhost-myapp:latest",
+        "-f",
+        "/tmp/repo/Dockerfile",
+        "--memory=512m",
+        "/tmp/repo",
+    ]
+
+
+def test_build_image_omits_memory_flag_when_unset(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[list[str]] = []
+
+    def fake_run(cmd, capture_output, text, timeout):  # type: ignore[no-untyped-def]
+        calls.append(cmd)
+        return _FakeCompleted(0, stdout="")
+
+    _patch_subprocess_run(monkeypatch, fake_run)
+
+    build_image("myapp", "/tmp/repo", "Dockerfile", temp_data_dir=None)
+    assert not any(arg.startswith("--memory") for arg in calls[0])
+
+
 @pytest.mark.parametrize(
     "fragment",
     [

--- a/compute_space/src/compute_space/tests/test_containers.py
+++ b/compute_space/src/compute_space/tests/test_containers.py
@@ -75,7 +75,9 @@ def test_build_image_applies_memory_limit(monkeypatch: pytest.MonkeyPatch) -> No
     _patch_subprocess_run(monkeypatch, fake_run)
 
     build_image("myapp", "/tmp/repo", "Dockerfile", temp_data_dir=None, memory_mb=512)
-    # --memory is passed to `podman build`, before the build context path.
+    # --memory caps build RAM; --memory-swap=-1 allows unlimited swap so a
+    # build that needs more spills to swap instead of OOMing. Both go to
+    # `podman build`, before the build context path.
     assert calls[0] == [
         "podman",
         "build",
@@ -84,6 +86,7 @@ def test_build_image_applies_memory_limit(monkeypatch: pytest.MonkeyPatch) -> No
         "-f",
         "/tmp/repo/Dockerfile",
         "--memory=512m",
+        "--memory-swap=-1",
         "/tmp/repo",
     ]
 
@@ -98,6 +101,7 @@ def test_build_image_omits_memory_flag_when_unset(monkeypatch: pytest.MonkeyPatc
     _patch_subprocess_run(monkeypatch, fake_run)
 
     build_image("myapp", "/tmp/repo", "Dockerfile", temp_data_dir=None)
+    # No memory limit → neither --memory nor --memory-swap is passed.
     assert not any(arg.startswith("--memory") for arg in calls[0])
 
 

--- a/compute_space/src/compute_space/tests/test_manifest.py
+++ b/compute_space/src/compute_space/tests/test_manifest.py
@@ -33,11 +33,11 @@ class TestDefaults:
         manifest = parse_manifest_from_string(MINIMAL)
         assert manifest.memory_mb == 128
 
-    def test_build_memory_defaults_to_memory_mb(self):
-        """Unset build_memory_mb falls back to the runtime memory limit."""
+    def test_build_memory_unset_leaves_build_unconstrained(self):
+        """Unset build_memory_mb does NOT fall back to memory_mb; the build is uncapped."""
         manifest = parse_manifest_from_string(MINIMAL + "\n[resources]\nmemory_mb = 256\n")
         assert manifest.build_memory_mb is None
-        assert manifest.effective_build_memory_mb == 256
+        assert manifest.effective_build_memory_mb is None
 
     def test_gpu_default_is_false(self):
         manifest = parse_manifest_from_string(MINIMAL)

--- a/compute_space/src/compute_space/tests/test_manifest.py
+++ b/compute_space/src/compute_space/tests/test_manifest.py
@@ -33,6 +33,12 @@ class TestDefaults:
         manifest = parse_manifest_from_string(MINIMAL)
         assert manifest.memory_mb == 128
 
+    def test_build_memory_defaults_to_memory_mb(self):
+        """Unset build_memory_mb falls back to the runtime memory limit."""
+        manifest = parse_manifest_from_string(MINIMAL + "\n[resources]\nmemory_mb = 256\n")
+        assert manifest.build_memory_mb is None
+        assert manifest.effective_build_memory_mb == 256
+
     def test_gpu_default_is_false(self):
         manifest = parse_manifest_from_string(MINIMAL)
         assert manifest.gpu is False
@@ -101,6 +107,12 @@ class TestExplicitValues:
         toml = MINIMAL + "\n[resources]\nmemory_mb = 256\n"
         manifest = parse_manifest_from_string(toml)
         assert manifest.memory_mb == 256
+
+    def test_build_memory_mb_explicit_overrides_memory_mb(self):
+        toml = MINIMAL + "\n[resources]\nmemory_mb = 256\nbuild_memory_mb = 1024\n"
+        manifest = parse_manifest_from_string(toml)
+        assert manifest.build_memory_mb == 1024
+        assert manifest.effective_build_memory_mb == 1024
 
     def test_public_paths_explicit(self):
         toml = MINIMAL + '\n[routing]\npublic_paths = ["/api"]\n'

--- a/compute_space/src/compute_space/tests/test_manifest.py
+++ b/compute_space/src/compute_space/tests/test_manifest.py
@@ -33,11 +33,11 @@ class TestDefaults:
         manifest = parse_manifest_from_string(MINIMAL)
         assert manifest.memory_mb == 128
 
-    def test_build_memory_unset_leaves_build_unconstrained(self):
-        """Unset build_memory_mb does NOT fall back to memory_mb; the build is uncapped."""
+    def test_build_memory_unset_falls_back_to_memory_mb(self):
+        """Unset build_memory_mb caps the build at the runtime memory_mb."""
         manifest = parse_manifest_from_string(MINIMAL + "\n[resources]\nmemory_mb = 256\n")
         assert manifest.build_memory_mb is None
-        assert manifest.effective_build_memory_mb is None
+        assert manifest.effective_build_memory_mb == 256
 
     def test_gpu_default_is_false(self):
         manifest = parse_manifest_from_string(MINIMAL)

--- a/docs/src/manifest_spec.md
+++ b/docs/src/manifest_spec.md
@@ -57,7 +57,7 @@ User-facing links the app advertises for paths on its own URL that aren't the ba
 | Field | Type | Required | Default | Description |
 |-------|------|----------|---------|-------------|
 | `memory_mb` | integer | no | 128 | Max memory in MB |
-| `build_memory_mb` | integer | no | unlimited | Memory limit (MB) for the image build step (`podman build --memory`). Unset means the build is unconstrained — builds usually need more memory than the running app. |
+| `build_memory_mb` | integer | no | `memory_mb` | Memory limit (MB) for the image build step (`podman build --memory`). Defaults to the app's `memory_mb` so a build can't exceed the declared footprint; a build that needs more must set this explicitly. |
 | `cpu_cores` | float | no | 0.1 | CPU allocation in cores (1.0 = 1 core) |
 | `gpu` | boolean | no | false | Whether GPU access is needed |
 

--- a/docs/src/manifest_spec.md
+++ b/docs/src/manifest_spec.md
@@ -57,6 +57,7 @@ User-facing links the app advertises for paths on its own URL that aren't the ba
 | Field | Type | Required | Default | Description |
 |-------|------|----------|---------|-------------|
 | `memory_mb` | integer | no | 128 | Max memory in MB |
+| `build_memory_mb` | integer | no | `memory_mb` | Memory limit (MB) for the image build step (`podman build --memory`). Defaults to `memory_mb`. |
 | `cpu_cores` | float | no | 0.1 | CPU allocation in cores (1.0 = 1 core) |
 | `gpu` | boolean | no | false | Whether GPU access is needed |
 

--- a/docs/src/manifest_spec.md
+++ b/docs/src/manifest_spec.md
@@ -57,7 +57,7 @@ User-facing links the app advertises for paths on its own URL that aren't the ba
 | Field | Type | Required | Default | Description |
 |-------|------|----------|---------|-------------|
 | `memory_mb` | integer | no | 128 | Max memory in MB |
-| `build_memory_mb` | integer | no | `memory_mb` | Memory limit (MB) for the image build step (`podman build --memory`). Defaults to `memory_mb`. |
+| `build_memory_mb` | integer | no | unlimited | Memory limit (MB) for the image build step (`podman build --memory`). Unset means the build is unconstrained — builds usually need more memory than the running app. |
 | `cpu_cores` | float | no | 0.1 | CPU allocation in cores (1.0 = 1 core) |
 | `gpu` | boolean | no | false | Whether GPU access is needed |
 


### PR DESCRIPTION
## What

Cap the real memory available to the app image **build** step (`podman build --memory`).

- Defaults to the app's runtime `memory_mb`, so behaviour is unchanged for existing apps.
- Optional `build_memory_mb` key under `[resources]` in `openhost.toml` overrides it independently — e.g. a big build that needs more RAM than the running container.
- Still allows for unlimited use of swap, so after https://github.com/imbue-openhost/openhost/pull/279 it shouldn't cause any builds to start failing, just slow down.

## Changes

- **manifest**: new `build_memory_mb: int | None` field + `effective_build_memory_mb` property that falls back to `memory_mb`.
- **`build_image`**: accepts `memory_mb` and appends `--memory=<n>m` (omitted when `None`).
- Both `build_image` callers (initial deploy + reload) pass `manifest.effective_build_memory_mb`. Each parses the manifest fresh from the repo.
- Docs (`manifest_spec.md`) + manifest/containers tests.

## Notes / decisions

- Named the key `build_memory_mb` for parallelism with the existing runtime key `memory_mb` (the issue said "something like build_memory_limit").
- Not persisted in the `apps` db row — it's a build-time-only value re-read from the manifest each build.
- No value validation; trusting podman's `--memory` to behave.

## Testing

Full `compute_space` suite: 965 passed, 43 skipped. New tests cover the `--memory` flag (present/absent) and the `memory_mb` fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)