### PR TITLE
Add configurable swap file (default 16 GiB) with settings-page control

### DIFF
--- a/ansible/local_setup.yml
+++ b/ansible/local_setup.yml
@@ -25,6 +25,7 @@
     - import_tasks: tasks/apt_packages.yml
     - import_tasks: tasks/containers.yml
     - import_tasks: tasks/journald.yml
+    - import_tasks: tasks/swap.yml
 
 - name: Dev environment
   hosts: localhost

--- a/ansible/prebake.yml
+++ b/ansible/prebake.yml
@@ -43,6 +43,7 @@
     - import_tasks: tasks/apt_packages.yml
     - import_tasks: tasks/containers.yml
     - import_tasks: tasks/journald.yml
+    - import_tasks: tasks/swap.yml
 
 - name: Dev environment
   hosts: all

--- a/ansible/setup.yml
+++ b/ansible/setup.yml
@@ -37,6 +37,7 @@
     - import_tasks: tasks/apt_packages.yml
     - import_tasks: tasks/containers.yml
     - import_tasks: tasks/journald.yml
+    - import_tasks: tasks/swap.yml
 
 - name: Dev environment
   hosts: all

--- a/ansible/tasks/swap.yml
+++ b/ansible/tasks/swap.yml
@@ -1,0 +1,49 @@
+---
+# Provision a swap file so small instances don't OOM-kill apps under memory
+# pressure.  A swap file gives the kernel somewhere to spill cold pages, trading
+# disk for resilience.  Runs with become: yes.
+#
+# Behaviorally mirrors the openhost_system_agent v7 migration
+# (v0007_swap_file.py), which provisions the same default-sized swap file on
+# hosts provisioned before swap existed.  Both create the file only when it is
+# absent, so an owner who later resizes swap from the settings page is never
+# shrunk back to the default on a re-provision.  The default size here is kept
+# in sync with DEFAULT_SWAP_SIZE_GIB in openhost_system_agent/swap.py; a test
+# enforces this.
+
+- name: Check for existing swap file
+  stat:
+    path: /swapfile
+  register: swapfile_stat
+
+- name: Create swap file
+  command: fallocate -l {{ swap_size_gb | default(16) }}G /swapfile
+  when: not swapfile_stat.stat.exists
+
+- name: Secure swap file permissions
+  file:
+    path: /swapfile
+    mode: "0600"
+    owner: root
+    group: root
+  when: not swapfile_stat.stat.exists
+
+- name: Format swap file
+  command: mkswap /swapfile
+  when: not swapfile_stat.stat.exists
+
+# Persist across reboots.  lineinfile keeps this dependency-free and idempotent,
+# and the line is byte-identical to the fstab entry the swap module writes.
+- name: Persist swap in fstab
+  lineinfile:
+    path: /etc/fstab
+    regexp: '^/swapfile\s'
+    line: "/swapfile none swap sw 0 0"
+    state: present
+
+- name: Enable swap
+  command: swapon /swapfile
+  when: not swapfile_stat.stat.exists
+  register: swapon_result
+  changed_when: swapon_result.rc == 0
+  failed_when: swapon_result.rc != 0 and 'already active' not in swapon_result.stderr

--- a/compute_space/src/compute_space/core/system_agent.py
+++ b/compute_space/src/compute_space/core/system_agent.py
@@ -10,6 +10,7 @@ from openhost_system_agent.protocol import DiffResult
 from openhost_system_agent.protocol import FetchResult
 from openhost_system_agent.protocol import MigrationStatus
 from openhost_system_agent.protocol import RemoteInfo
+from openhost_system_agent.protocol import SwapStatus
 
 
 class SystemAgentError(Exception):
@@ -97,3 +98,16 @@ def system_agent_get_remote() -> RemoteInfo:
 @async_wrap
 def system_agent_status() -> MigrationStatus:
     return _call_system_agent_sync(MigrationStatus, "status")
+
+
+@async_wrap
+def system_agent_get_swap() -> SwapStatus:
+    return _call_system_agent_sync(SwapStatus, "swap", "get")
+
+
+@async_wrap
+def system_agent_set_swap(size_gib: int) -> SwapStatus:
+    # Resizing recreates the swap file (fallocate/mkswap/swapon), which for a
+    # large size can take a little while, so allow more headroom than a plain
+    # status call.
+    return _call_system_agent_sync(SwapStatus, "swap", "set", str(size_gib), timeout=600)

--- a/compute_space/src/compute_space/tests/test_settings_swap.py
+++ b/compute_space/src/compute_space/tests/test_settings_swap.py
@@ -1,0 +1,95 @@
+"""Tests for the /api/settings/swap get + set handlers.
+
+Like test_settings_host_prep.py, we call the Litestar handlers' underlying
+coroutines via ``handler.fn(...)`` and drive the system agent through fakes, so
+the routing layer and the privileged agent are both out of scope.
+"""
+
+from __future__ import annotations
+
+import pytest
+from litestar.exceptions import HTTPException
+
+import compute_space.web.routes.api.settings as settings_mod
+from compute_space.core.system_agent import SystemAgentError
+from openhost_system_agent.protocol import SwapStatus
+
+
+@pytest.mark.asyncio
+async def test_get_swap_returns_status(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def fake_get() -> SwapStatus:
+        return SwapStatus(size_bytes=16 * 1024**3, path="/swapfile", active=True)
+
+    monkeypatch.setattr(settings_mod, "system_agent_get_swap", fake_get)
+
+    result = await settings_mod.get_swap.fn()
+
+    assert result.size_bytes == 16 * 1024**3
+    assert result.active is True
+
+
+@pytest.mark.asyncio
+async def test_get_swap_agent_error_is_500(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def fake_get() -> SwapStatus:
+        raise SystemAgentError("agent down")
+
+    monkeypatch.setattr(settings_mod, "system_agent_get_swap", fake_get)
+
+    with pytest.raises(HTTPException) as excinfo:
+        await settings_mod.get_swap.fn()
+    assert excinfo.value.status_code == 500
+    assert "agent down" in (excinfo.value.detail or "")
+
+
+@pytest.mark.asyncio
+async def test_set_swap_applies_valid_size(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured = {"size": None}
+
+    async def fake_set(size_gib: int) -> SwapStatus:
+        captured["size"] = size_gib
+        return SwapStatus(size_bytes=size_gib * 1024**3, path="/swapfile", active=True)
+
+    monkeypatch.setattr(settings_mod, "system_agent_set_swap", fake_set)
+
+    result = await settings_mod.set_swap.fn(settings_mod.SetSwapRequest(size_gib=32))
+
+    assert captured["size"] == 32
+    assert result.size_bytes == 32 * 1024**3
+
+
+@pytest.mark.asyncio
+async def test_set_swap_rejects_out_of_range_before_calling_agent(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def boom(size_gib: int) -> SwapStatus:
+        raise AssertionError("agent must not run for an out-of-range size")
+
+    monkeypatch.setattr(settings_mod, "system_agent_set_swap", boom)
+
+    with pytest.raises(HTTPException) as excinfo:
+        await settings_mod.set_swap.fn(settings_mod.SetSwapRequest(size_gib=99999))
+    assert excinfo.value.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_set_swap_allows_zero_to_disable(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def fake_set(size_gib: int) -> SwapStatus:
+        return SwapStatus(size_bytes=0, path="/swapfile", active=False)
+
+    monkeypatch.setattr(settings_mod, "system_agent_set_swap", fake_set)
+
+    result = await settings_mod.set_swap.fn(settings_mod.SetSwapRequest(size_gib=0))
+
+    assert result.size_bytes == 0
+    assert result.active is False
+
+
+@pytest.mark.asyncio
+async def test_set_swap_agent_error_is_500(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def fake_set(size_gib: int) -> SwapStatus:
+        raise SystemAgentError("mkswap failed")
+
+    monkeypatch.setattr(settings_mod, "system_agent_set_swap", fake_set)
+
+    with pytest.raises(HTTPException) as excinfo:
+        await settings_mod.set_swap.fn(settings_mod.SetSwapRequest(size_gib=8))
+    assert excinfo.value.status_code == 500
+    assert "mkswap failed" in (excinfo.value.detail or "")

--- a/compute_space/src/compute_space/web/routes/api/settings.py
+++ b/compute_space/src/compute_space/web/routes/api/settings.py
@@ -18,12 +18,17 @@ from compute_space.core.system_agent import SystemAgentError
 from compute_space.core.system_agent import system_agent_apply
 from compute_space.core.system_agent import system_agent_fetch
 from compute_space.core.system_agent import system_agent_get_remote
+from compute_space.core.system_agent import system_agent_get_swap
 from compute_space.core.system_agent import system_agent_set_remote
+from compute_space.core.system_agent import system_agent_set_swap
 from compute_space.core.system_agent import system_agent_status
 from compute_space.core.updates import trigger_restart
 from compute_space.core.util import not_blank
 from compute_space.web.auth.auth import require_owner_auth
 from openhost_system_agent.protocol import RemoteInfo
+from openhost_system_agent.protocol import SwapStatus
+from openhost_system_agent.swap import MAX_SWAP_SIZE_GIB
+from openhost_system_agent.swap import MIN_SWAP_SIZE_GIB
 
 # --- request / response types -----------------------------------------------
 
@@ -189,6 +194,32 @@ async def change_password(data: ChangePasswordRequest, db: sqlite3.Connection) -
     return ChangePasswordResponse(ok=True)
 
 
+@attr.s(auto_attribs=True, frozen=True)
+class SetSwapRequest:
+    size_gib: int
+
+
+@get("/api/settings/swap", guards=[require_owner_auth])
+async def get_swap() -> SwapStatus:
+    try:
+        return await system_agent_get_swap()
+    except SystemAgentError as e:
+        raise HTTPException(detail=str(e), status_code=500) from e
+
+
+@post("/api/settings/swap", status_code=200, guards=[require_owner_auth])
+async def set_swap(data: SetSwapRequest) -> SwapStatus:
+    if not MIN_SWAP_SIZE_GIB <= data.size_gib <= MAX_SWAP_SIZE_GIB:
+        raise HTTPException(
+            detail=f"Swap size must be between {MIN_SWAP_SIZE_GIB} and {MAX_SWAP_SIZE_GIB} GiB.",
+            status_code=400,
+        )
+    try:
+        return await system_agent_set_swap(data.size_gib)
+    except SystemAgentError as e:
+        raise HTTPException(detail=str(e), status_code=500) from e
+
+
 @get("/api/settings/owner_username", guards=[require_owner_auth])
 async def get_owner_username(db: sqlite3.Connection) -> OwnerUsernameResponse:
     return OwnerUsernameResponse(username=read_owner_username(db))
@@ -220,6 +251,8 @@ api_settings_routes = Router(
         apply_update,
         restart_compute_space,
         change_password,
+        get_swap,
+        set_swap,
         get_owner_username,
         set_owner_username,
     ],

--- a/compute_space/src/compute_space/web/static/js/settings.js
+++ b/compute_space/src/compute_space/web/static/js/settings.js
@@ -319,6 +319,98 @@ async function setOwnerUsername() {
   }
 }
 
+// ─── Swap ───
+
+let savedSwapGib = null;
+
+function _renderSwapCurrent(data) {
+  const current = document.getElementById('swap-current');
+  if (data.size_bytes > 0) {
+    current.className = 'hint';
+    current.textContent = 'Current: ' + formatBytes(data.size_bytes)
+      + (data.active ? ' (active).' : ' (present but not enabled).');
+  } else {
+    current.className = 'hint';
+    current.textContent = 'No swap file configured.';
+  }
+}
+
+async function loadSwap() {
+  const input = document.getElementById('swap-size');
+  const btn = document.getElementById('set-swap-btn');
+  const current = document.getElementById('swap-current');
+  try {
+    const resp = await fetch('/api/settings/swap');
+    if (!resp.ok) throw new Error('failed to load swap');
+    const data = await resp.json();
+    savedSwapGib = Math.round(data.size_bytes / 1073741824);
+    input.value = savedSwapGib;
+    input.placeholder = '16';
+    input.disabled = false;
+    btn.disabled = true;
+    _renderSwapCurrent(data);
+    input.addEventListener('input', () => {
+      const v = input.value.trim();
+      btn.disabled = v === '' || Number(v) === savedSwapGib;
+    });
+  } catch (e) {
+    input.placeholder = '';
+    current.className = 'error';
+    current.textContent = 'Failed to load swap status. Reload the page to retry.';
+  }
+}
+
+async function setSwap() {
+  clearError();
+  const input = document.getElementById('swap-size');
+  const btn = document.getElementById('set-swap-btn');
+  const msg = document.getElementById('swap-msg');
+  const current = document.getElementById('swap-current');
+  const v = input.value.trim();
+  if (v === '') return;
+
+  const sizeGib = Number(v);
+  if (!Number.isInteger(sizeGib) || sizeGib < 0) {
+    msg.textContent = 'Enter a whole number of GiB (0 or more).';
+    msg.className = 'error';
+    msg.style.color = '';
+    msg.style.display = '';
+    return;
+  }
+
+  btn.disabled = true;
+  msg.style.display = 'none';
+  current.className = 'hint';
+  current.textContent = 'Applying (this can take a moment for large sizes)…';
+
+  try {
+    const resp = await fetch('/api/settings/swap', {
+      method: 'POST',
+      headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify({size_gib: sizeGib}),
+    });
+    if (!resp.ok) {
+      const err = await resp.json();
+      throw new Error(err.detail || 'failed to set swap size');
+    }
+    const data = await resp.json();
+    savedSwapGib = Math.round(data.size_bytes / 1073741824);
+    input.value = savedSwapGib;
+    _renderSwapCurrent(data);
+    msg.textContent = 'Saved.';
+    msg.className = '';
+    msg.style.color = '#080';
+    msg.style.display = '';
+    setTimeout(() => { msg.style.display = 'none'; }, 4000);
+  } catch (e) {
+    msg.textContent = e.message;
+    msg.className = 'error';
+    msg.style.color = '';
+    msg.style.display = '';
+    btn.disabled = false;
+  }
+}
+
 function escSettingsHtml(s) {
   var d = document.createElement('div');
   d.textContent = (s == null) ? '' : String(s);
@@ -653,3 +745,4 @@ checkForUpdates();
 updateSshStatus();
 setInterval(updateSshStatus, 5000);
 loadArchiveBackend();
+loadSwap();

--- a/compute_space/src/compute_space/web/templates/settings.html
+++ b/compute_space/src/compute_space/web/templates/settings.html
@@ -96,6 +96,20 @@
   <div class="muted">Loading&hellip;</div>
 </div>
 
+<h2 class="section-title">Swap</h2>
+<p class="hint">Swap gives the kernel disk-backed memory to spill cold pages to, so apps are less likely to be killed when the instance runs low on RAM. Larger swap uses more disk. Set to <code>0</code> to disable swap.</p>
+<table class="form-table">
+  <tr>
+    <th><label for="swap-size">Swap size (GiB)</label></th>
+    <td>
+      <input type="number" id="swap-size" min="0" max="256" step="1" style="width:6em;" placeholder="Loading…" disabled>
+      <button onclick="setSwap()" class="btn btn-primary" id="set-swap-btn" disabled>Save</button>
+      <p class="hint" id="swap-current">Loading&hellip;</p>
+      <p id="swap-msg" style="display:none;"></p>
+    </td>
+  </tr>
+</table>
+
 <h2 class="section-title">Maintenance</h2>
 <table class="form-table">
   <tr>

--- a/openhost_system_agent/src/openhost_system_agent/cli.py
+++ b/openhost_system_agent/src/openhost_system_agent/cli.py
@@ -9,6 +9,8 @@ import attrs
 import cappa
 
 from openhost_system_agent.status import get_migration_status
+from openhost_system_agent.swap import get_swap_status
+from openhost_system_agent.swap import resize_swapfile
 from openhost_system_agent.update import apply_update
 from openhost_system_agent.update import fetch_updates
 from openhost_system_agent.update import get_remote_info
@@ -76,13 +78,34 @@ class StatusCmd:
         _output(get_migration_status())
 
 
+@cappa.command(name="swap", help="Manage the host swap file.")
+@attrs.define
+class SwapCmd:
+    @cappa.command(name="get", help="Report the swap file's size and whether it is active.")
+    def get(self) -> None:
+        try:
+            _output(get_swap_status())
+        except Exception as e:
+            _error(str(e))
+
+    @cappa.command(name="set", help="Resize the swap file (GiB; 0 disables swap).")
+    def set(
+        self,
+        size_gib: Annotated[int, cappa.Arg(help="Swap size in GiB (0 disables swap)")],
+    ) -> None:
+        try:
+            _output(resize_swapfile(size_gib))
+        except Exception as e:
+            _error(str(e))
+
+
 @cappa.command(
     name="openhost_system_agent",
     help="OpenHost system agent — host-level updates and migrations.",
 )
 @attrs.define
 class SystemAgent:
-    subcommand: cappa.Subcommands[UpdateCmd | StatusCmd]
+    subcommand: cappa.Subcommands[UpdateCmd | StatusCmd | SwapCmd]
 
 
 def main() -> None:

--- a/openhost_system_agent/src/openhost_system_agent/migrations/registry.py
+++ b/openhost_system_agent/src/openhost_system_agent/migrations/registry.py
@@ -10,6 +10,7 @@ from openhost_system_agent.migrations.versions.v0003_remove_obsolete_hairpin_nat
 from openhost_system_agent.migrations.versions.v0004_pixi_version import Migration0004PixiVersion
 from openhost_system_agent.migrations.versions.v0005_pixi_ownership_failsafe import Migration0005PixiOwnershipFailsafe
 from openhost_system_agent.migrations.versions.v0006_journald_size_cap import Migration0006JournaldSizeCap
+from openhost_system_agent.migrations.versions.v0007_swap_file import Migration0007SwapFile
 
 # Numbered migrations in apply order. Versions MUST start at 2 and be
 # contiguous. v1 is the baseline produced by ansible setup.yml.
@@ -19,6 +20,7 @@ REGISTRY: list[SystemMigration] = [
     Migration0004PixiVersion(),
     Migration0005PixiOwnershipFailsafe(),
     Migration0006JournaldSizeCap(),
+    Migration0007SwapFile(),
 ]
 
 

--- a/openhost_system_agent/src/openhost_system_agent/migrations/versions/v0007_swap_file.py
+++ b/openhost_system_agent/src/openhost_system_agent/migrations/versions/v0007_swap_file.py
@@ -1,0 +1,25 @@
+"""Provision a swap file on existing hosts.
+
+Small instances run out of RAM under memory pressure and get apps OOM-killed. A
+swap file gives the kernel somewhere to spill cold pages. Fresh hosts get one
+from ``ansible/tasks/swap.yml``; this migration applies the same default-sized
+swap file to hosts provisioned before swap existed.
+
+Idempotent and non-destructive: ``ensure_swapfile(create_only=True)`` creates
+the default-sized file only when the host has none, so a host whose owner later
+resized swap from the settings page is never shrunk back to the default when
+this migration re-runs.
+"""
+
+from __future__ import annotations
+
+from openhost_system_agent.migrations.base import SystemMigration
+from openhost_system_agent.swap import DEFAULT_SWAP_SIZE_GIB
+from openhost_system_agent.swap import ensure_swapfile
+
+
+class Migration0007SwapFile(SystemMigration):
+    version = 7
+
+    def up(self) -> None:
+        ensure_swapfile(DEFAULT_SWAP_SIZE_GIB, create_only=True)

--- a/openhost_system_agent/src/openhost_system_agent/protocol.py
+++ b/openhost_system_agent/src/openhost_system_agent/protocol.py
@@ -34,6 +34,16 @@ class RemoteInfo:
 
 
 @attr.s(auto_attribs=True, frozen=True)
+class SwapStatus:
+    # On-disk size of the managed swap file (the configured size, which survives
+    # a swapoff). 0 when no swap file is present.
+    size_bytes: int
+    path: str
+    # Whether the swap file is currently swapped on and available to the kernel.
+    active: bool
+
+
+@attr.s(auto_attribs=True, frozen=True)
 class MigrationStatus:
     ok: bool
     reason: str

--- a/openhost_system_agent/src/openhost_system_agent/swap.py
+++ b/openhost_system_agent/src/openhost_system_agent/swap.py
@@ -1,0 +1,159 @@
+"""Manage the host swap file.
+
+Small instances run out of RAM under memory pressure and get apps OOM-killed. A
+swap file gives the kernel somewhere to spill cold pages, trading disk for
+resilience. OpenHost provisions a default-sized swap file on every host (ansible
+on fresh hosts, the v7 migration on already-provisioned ones) and lets the owner
+resize it from the settings page.
+
+This module is the single source of truth for the swap file's location, its
+default size, and the create/resize/inspect logic. It is root-only: only root
+can mkswap/swapon and edit /etc/fstab.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+from openhost_system_agent.protocol import SwapStatus
+
+#: Where the swap file lives. /swapfile is the conventional location on a
+#: single-volume host.
+SWAP_PATH = "/swapfile"
+
+#: Default swap size provisioned on every host. Kept in sync with the ansible
+#: task's ``swap_size_gb`` default (a test enforces this).
+DEFAULT_SWAP_SIZE_GIB = 16
+
+#: Guardrails for owner-chosen sizes. 0 disables swap entirely; the upper bound
+#: keeps a fat-fingered value from trying to fill the disk.
+MIN_SWAP_SIZE_GIB = 0
+MAX_SWAP_SIZE_GIB = 256
+
+_FSTAB_PATH = "/etc/fstab"
+# The fstab entry that makes the swap file persist across reboots.
+_FSTAB_LINE = f"{SWAP_PATH} none swap sw 0 0"
+
+
+def _require_root() -> None:
+    if os.geteuid() != 0:
+        raise RuntimeError("swap operations must be run as root")
+
+
+def _run(*cmd: str, check: bool = True) -> subprocess.CompletedProcess[str]:
+    """Run *cmd*, raising RuntimeError with the captured stderr on failure.
+
+    We surface stderr rather than letting a bare CalledProcessError bubble up so
+    a failed mkswap/swapon is debuggable from the migration log or the CLI's
+    JSON error, instead of showing only an exit code.
+    """
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    if check and result.returncode != 0:
+        raise RuntimeError(f"{' '.join(cmd)} failed (exit {result.returncode}): {result.stderr.strip()}")
+    return result
+
+
+def _active_swap_bytes() -> int:
+    """Bytes of *our* swap file currently swapped on, else 0.
+
+    Reads /proc/swaps and matches the swap file path; other swap devices are
+    ignored so the number reflects the file this module manages.
+    """
+    try:
+        text = Path("/proc/swaps").read_text()
+    except FileNotFoundError:
+        return 0
+    for line in text.splitlines()[1:]:
+        parts = line.split()
+        # /proc/swaps columns: Filename Type Size Used Priority (Size in KiB).
+        if len(parts) >= 3 and parts[0] == SWAP_PATH:
+            return int(parts[2]) * 1024
+    return 0
+
+
+def get_swap_status() -> SwapStatus:
+    """Report the managed swap file's size and whether it is swapped on.
+
+    ``size_bytes`` is the on-disk file size (the configured size, which survives
+    a swapoff); ``active`` reflects whether it is currently in use.
+    """
+    path = Path(SWAP_PATH)
+    size_bytes = path.stat().st_size if path.exists() else 0
+    return SwapStatus(size_bytes=size_bytes, path=SWAP_PATH, active=_active_swap_bytes() > 0)
+
+
+def _set_fstab_entry(present: bool) -> None:
+    """Ensure the swap fstab line is present or absent. Idempotent.
+
+    Rewrites /etc/fstab dropping any existing entry for our swap path, then
+    appends the canonical line when *present*. Only lines whose first field is
+    exactly the swap path are removed, so operator entries and comments survive.
+    """
+    path = Path(_FSTAB_PATH)
+    lines = path.read_text().splitlines() if path.exists() else []
+    kept = [line for line in lines if line.split()[:1] != [SWAP_PATH]]
+    if present:
+        kept.append(_FSTAB_LINE)
+    path.write_text("\n".join(kept) + "\n")
+
+
+def _create_and_enable(size_gib: int) -> None:
+    """(Re)create the swap file at *size_gib* GiB and swap it on.
+
+    fallocate is near-instant but produces a file some filesystems refuse to
+    swap on; if mkswap/swapon rejects it we fall back to dd, which writes real
+    zeroed blocks. Any prior swap file is swapped off and removed first so this
+    is safe to call for both initial creation and resizing.
+    """
+    _run("swapoff", SWAP_PATH, check=False)
+    Path(SWAP_PATH).unlink(missing_ok=True)
+    try:
+        _run("fallocate", "-l", f"{size_gib}G", SWAP_PATH)
+        os.chmod(SWAP_PATH, 0o600)
+        _run("mkswap", SWAP_PATH)
+        _run("swapon", SWAP_PATH)
+        return
+    except RuntimeError:
+        _run("swapoff", SWAP_PATH, check=False)
+        Path(SWAP_PATH).unlink(missing_ok=True)
+    _run("dd", "if=/dev/zero", f"of={SWAP_PATH}", "bs=1M", f"count={size_gib * 1024}")
+    os.chmod(SWAP_PATH, 0o600)
+    _run("mkswap", SWAP_PATH)
+    _run("swapon", SWAP_PATH)
+
+
+def resize_swapfile(size_gib: int) -> SwapStatus:
+    """Set the swap file to *size_gib* GiB, enabling it and persisting it in
+    /etc/fstab. ``size_gib`` of 0 disables swap and removes the file. Root-only,
+    idempotent, safe to call repeatedly.
+    """
+    _require_root()
+    if not MIN_SWAP_SIZE_GIB <= size_gib <= MAX_SWAP_SIZE_GIB:
+        raise ValueError(f"swap size must be between {MIN_SWAP_SIZE_GIB} and {MAX_SWAP_SIZE_GIB} GiB, got {size_gib}")
+    if size_gib == 0:
+        _run("swapoff", SWAP_PATH, check=False)
+        Path(SWAP_PATH).unlink(missing_ok=True)
+        _set_fstab_entry(present=False)
+    else:
+        _create_and_enable(size_gib)
+        _set_fstab_entry(present=True)
+    return get_swap_status()
+
+
+def ensure_swapfile(size_gib: int = DEFAULT_SWAP_SIZE_GIB, *, create_only: bool = True) -> SwapStatus:
+    """Provision the swap file if the host has none. Root-only, idempotent.
+
+    Used by fresh-host provisioning (ansible) and the v7 migration on existing
+    hosts. With ``create_only`` (the default) an existing swap file is left at
+    its current size so a re-provision or re-run never shrinks an owner-
+    customized value; it still re-enables a present-but-swapped-off file and
+    re-asserts the fstab entry so the file actually gets used.
+    """
+    _require_root()
+    if create_only and Path(SWAP_PATH).exists():
+        _run("swapon", SWAP_PATH, check=False)
+        _set_fstab_entry(present=True)
+        return get_swap_status()
+    return resize_swapfile(size_gib)

--- a/openhost_system_agent/src/openhost_system_agent/tests/test_migration_swap.py
+++ b/openhost_system_agent/src/openhost_system_agent/tests/test_migration_swap.py
@@ -1,0 +1,46 @@
+"""Tests for the v7 migration that provisions a swap file on existing hosts.
+
+The migration delegates to ``ensure_swapfile``; we assert it calls it in the
+non-destructive create-only mode with the default size, and that the default
+size stays in sync with the ansible task that provisions fresh hosts.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from openhost_system_agent.migrations.versions.v0007_swap_file import Migration0007SwapFile
+from openhost_system_agent.swap import DEFAULT_SWAP_SIZE_GIB
+
+_PREFIX = "openhost_system_agent.migrations.versions.v0007_swap_file"
+
+
+def test_provisions_default_swap_create_only(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[dict[str, Any]] = []
+
+    def fake_ensure(size_gib: int, *, create_only: bool = True) -> None:
+        calls.append({"size_gib": size_gib, "create_only": create_only})
+
+    monkeypatch.setattr(f"{_PREFIX}.ensure_swapfile", fake_ensure)
+
+    Migration0007SwapFile().up()
+
+    # Default-sized and non-destructive: an owner-resized swap file is not
+    # shrunk back to the default when this migration re-runs.
+    assert calls == [{"size_gib": DEFAULT_SWAP_SIZE_GIB, "create_only": True}]
+
+
+def test_default_size_matches_ansible_task() -> None:
+    # The migration (existing hosts) and the ansible task (fresh hosts) must
+    # provision the same default swap size so a host looks the same however it
+    # was set up.
+    repo_root = Path(__file__).resolve().parents[4]
+    task = (repo_root / "ansible" / "tasks" / "swap.yml").read_text()
+
+    match = re.search(r"swap_size_gb\s*\|\s*default\((\d+)\)", task)
+    assert match is not None, "ansible swap.yml must define a swap_size_gb default"
+    assert int(match.group(1)) == DEFAULT_SWAP_SIZE_GIB

--- a/openhost_system_agent/src/openhost_system_agent/tests/test_swap.py
+++ b/openhost_system_agent/src/openhost_system_agent/tests/test_swap.py
@@ -1,0 +1,174 @@
+"""Tests for the swap-file management module.
+
+Real mkswap/swapon and /etc/fstab edits need root and a real host, so we drive
+the logic through fakes: a recording ``subprocess.run`` and a no-op ``chmod``,
+with SWAP_PATH / _FSTAB_PATH pointed at tmp files.  This asserts the command
+sequence, the fallback path, the create-only guard, and fstab idempotency
+without touching the host.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+import openhost_system_agent.swap as swap
+from openhost_system_agent.protocol import SwapStatus
+
+
+@pytest.fixture
+def fake_host(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> list[list[str]]:
+    """Run swap ops as fake-root with recorded commands and a tmp swap path.
+
+    Returns the list that accumulates each ``subprocess.run`` argv so tests can
+    assert on the command sequence.
+    """
+    calls: list[list[str]] = []
+
+    def fake_run(cmd: list[str], **kwargs: Any) -> subprocess.CompletedProcess[str]:
+        calls.append(cmd)
+        return subprocess.CompletedProcess(cmd, 0, "", "")
+
+    monkeypatch.setattr(swap, "SWAP_PATH", str(tmp_path / "swapfile"))
+    monkeypatch.setattr("openhost_system_agent.swap.os.geteuid", lambda: 0)
+    monkeypatch.setattr("openhost_system_agent.swap.os.chmod", lambda *a, **k: None)
+    monkeypatch.setattr("openhost_system_agent.swap.subprocess.run", fake_run)
+    return calls
+
+
+def _cmds(calls: list[list[str]]) -> list[str]:
+    return [c[0] for c in calls]
+
+
+def test_requires_root(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("openhost_system_agent.swap.os.geteuid", lambda: 1000)
+    with pytest.raises(RuntimeError, match="must be run as root"):
+        swap.resize_swapfile(8)
+
+
+def test_resize_rejects_out_of_range(fake_host: list[list[str]]) -> None:
+    with pytest.raises(ValueError, match="between"):
+        swap.resize_swapfile(swap.MAX_SWAP_SIZE_GIB + 1)
+    # Nothing should have run before validation failed.
+    assert fake_host == []
+
+
+def test_resize_creates_and_persists(fake_host: list[list[str]], monkeypatch: pytest.MonkeyPatch) -> None:
+    fstab: dict[str, bool] = {}
+    monkeypatch.setattr(swap, "_set_fstab_entry", lambda present: fstab.update(present=present))
+    monkeypatch.setattr(
+        swap, "get_swap_status", lambda: SwapStatus(size_bytes=8 * 1024**3, path=swap.SWAP_PATH, active=True)
+    )
+
+    result = swap.resize_swapfile(8)
+
+    assert "fallocate" in _cmds(fake_host)
+    assert "mkswap" in _cmds(fake_host)
+    assert "swapon" in _cmds(fake_host)
+    assert fstab == {"present": True}
+    assert result.active is True
+
+
+def test_resize_zero_disables_and_removes(fake_host: list[list[str]], monkeypatch: pytest.MonkeyPatch) -> None:
+    fstab: dict[str, bool] = {}
+    monkeypatch.setattr(swap, "_set_fstab_entry", lambda present: fstab.update(present=present))
+    monkeypatch.setattr(swap, "get_swap_status", lambda: SwapStatus(size_bytes=0, path=swap.SWAP_PATH, active=False))
+
+    # A leftover swap file should be removed.
+    Path(swap.SWAP_PATH).write_text("stale")
+
+    swap.resize_swapfile(0)
+
+    assert _cmds(fake_host) == ["swapoff"]
+    assert not Path(swap.SWAP_PATH).exists()
+    assert fstab == {"present": False}
+
+
+def test_create_falls_back_to_dd_when_fallocate_unswappable(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    # First swapon attempt (fallocate path) fails; the dd path must then run.
+    calls: list[list[str]] = []
+    seen_swapon = {"n": 0}
+
+    def fake_run(cmd: list[str], **kwargs: Any) -> subprocess.CompletedProcess[str]:
+        calls.append(cmd)
+        if cmd[0] == "swapon":
+            seen_swapon["n"] += 1
+            if seen_swapon["n"] == 1:
+                return subprocess.CompletedProcess(cmd, 1, "", "swapon: invalid argument")
+        return subprocess.CompletedProcess(cmd, 0, "", "")
+
+    monkeypatch.setattr(swap, "SWAP_PATH", str(tmp_path / "swapfile"))
+    monkeypatch.setattr("openhost_system_agent.swap.os.geteuid", lambda: 0)
+    monkeypatch.setattr("openhost_system_agent.swap.os.chmod", lambda *a, **k: None)
+    monkeypatch.setattr("openhost_system_agent.swap.subprocess.run", fake_run)
+
+    swap._create_and_enable(8)
+
+    assert "dd" in _cmds(calls)
+    # swapon attempted twice: once on the fallocate path, once after dd.
+    assert seen_swapon["n"] == 2
+
+
+def test_ensure_create_only_keeps_existing_size(fake_host: list[list[str]], monkeypatch: pytest.MonkeyPatch) -> None:
+    # An existing swap file must not be recreated (which would resize it).
+    Path(swap.SWAP_PATH).write_text("existing swap")
+
+    def boom(size_gib: int) -> SwapStatus:
+        raise AssertionError("resize must not run when a swap file already exists")
+
+    monkeypatch.setattr(swap, "resize_swapfile", boom)
+    monkeypatch.setattr(swap, "_set_fstab_entry", lambda present: None)
+    monkeypatch.setattr(swap, "get_swap_status", lambda: SwapStatus(size_bytes=99, path=swap.SWAP_PATH, active=True))
+
+    swap.ensure_swapfile(swap.DEFAULT_SWAP_SIZE_GIB, create_only=True)
+
+    # It re-enables the present file rather than recreating it.
+    assert _cmds(fake_host) == ["swapon"]
+
+
+def test_ensure_creates_when_absent(fake_host: list[list[str]], monkeypatch: pytest.MonkeyPatch) -> None:
+    called: dict[str, int | None] = {"size": None}
+
+    def fake_resize(size_gib: int) -> SwapStatus:
+        called["size"] = size_gib
+        return SwapStatus(size_bytes=size_gib * 1024**3, path=swap.SWAP_PATH, active=True)
+
+    monkeypatch.setattr(swap, "resize_swapfile", fake_resize)
+
+    swap.ensure_swapfile(swap.DEFAULT_SWAP_SIZE_GIB, create_only=True)
+
+    assert called["size"] == swap.DEFAULT_SWAP_SIZE_GIB
+
+
+def test_set_fstab_entry_is_idempotent(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    fstab = tmp_path / "fstab"
+    fstab.write_text("UUID=abc / ext4 defaults 0 1\n")
+    monkeypatch.setattr(swap, "_FSTAB_PATH", str(fstab))
+
+    swap._set_fstab_entry(present=True)
+    swap._set_fstab_entry(present=True)
+    text = fstab.read_text()
+
+    # Operator's root entry survives; our line appears exactly once.
+    assert "UUID=abc / ext4 defaults 0 1" in text
+    assert text.count(swap._FSTAB_LINE) == 1
+
+    swap._set_fstab_entry(present=False)
+    assert swap._FSTAB_LINE not in fstab.read_text()
+    assert "UUID=abc / ext4 defaults 0 1" in fstab.read_text()
+
+
+def test_get_swap_status_reports_file_size(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    swapfile = tmp_path / "swapfile"
+    swapfile.write_bytes(b"\0" * 4096)
+    monkeypatch.setattr(swap, "SWAP_PATH", str(swapfile))
+    monkeypatch.setattr(swap, "_active_swap_bytes", lambda: 0)
+
+    status = swap.get_swap_status()
+
+    assert status.size_bytes == 4096
+    assert status.path == str(swapfile)
+    assert status.active is False


### PR DESCRIPTION
## Why

Several users have run into the memory limits of their instances, with apps getting OOM-killed under memory pressure. This provisions a **default 16 GiB swap file** on every host and lets the owner resize it from the settings page.

## Approach

Follows OpenHost's established system-config pattern — every host-level knob is configured in two mirrored places (ansible for fresh hosts, a `openhost_system_agent` migration for already-provisioned ones). The owner-facing resize goes through the root-run `openhost_system_agent` CLI rather than shelling out from the web app directly, so the privileged logic is shared with the migration and unit-tested.

**Source of truth is the swap file itself** (its on-disk size + `/etc/fstab` entry) — no new DB/config store; `get` reads live state.

## Changes

- **`openhost_system_agent/swap.py`** — single source of truth for swap path/default size and root-only create/resize/inspect logic. fallocate with a dd fallback, fstab persistence, `swapoff`+recreate on resize, `0` disables swap, bounds 0–256 GiB.
- **`SwapStatus`** protocol type + **`swap get` / `swap set <gib>`** CLI subcommands.
- **`ansible/tasks/swap.yml`** (create-if-absent) wired into `setup.yml`, `local_setup.yml`, `prebake.yml`; **`v0007_swap_file`** migration for existing hosts — non-destructive, so an owner-resized swap is never shrunk back to the default.
- **`GET`/`POST /api/settings/swap`** (owner-guarded, validated) + a **Swap** section in the settings page (`settings.html` / `settings.js`), mirroring the existing git-remote control.
- **Tests** (17): swap module logic (command sequence, dd fallback, create-only guard, fstab idempotency, root guard), the migration + a test asserting the ansible default stays in sync with `DEFAULT_SWAP_SIZE_GIB`, and the API handlers.

## Notes / decisions

- Swappiness left at the Ubuntu default (60 — already enough for the kernel to use swap under pressure). Happy to add a `vm.swappiness` sysctl knob if wanted.
- Swap path is `/swapfile`; `0` disables swap.

## Verification

- `openhost_system_agent` suite: 123 passed. compute_space settings/route/app suite: 311 passed.
- ruff + mypy clean (pre-commit).
- CLI `--help` confirms `swap get` / `swap set` parse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)