### PR TITLE
Add configurable swap file (default 16 GiB)

### DIFF
--- a/ansible/local_setup.yml
+++ b/ansible/local_setup.yml
@@ -25,6 +25,7 @@
     - import_tasks: tasks/apt_packages.yml
     - import_tasks: tasks/containers.yml
     - import_tasks: tasks/journald.yml
+    - import_tasks: tasks/swap.yml
 
 - name: Dev environment
   hosts: localhost

--- a/ansible/prebake.yml
+++ b/ansible/prebake.yml
@@ -43,6 +43,7 @@
     - import_tasks: tasks/apt_packages.yml
     - import_tasks: tasks/containers.yml
     - import_tasks: tasks/journald.yml
+    - import_tasks: tasks/swap.yml
 
 - name: Dev environment
   hosts: all

--- a/ansible/setup.yml
+++ b/ansible/setup.yml
@@ -37,6 +37,7 @@
     - import_tasks: tasks/apt_packages.yml
     - import_tasks: tasks/containers.yml
     - import_tasks: tasks/journald.yml
+    - import_tasks: tasks/swap.yml
 
 - name: Dev environment
   hosts: all

--- a/ansible/tasks/swap.yml
+++ b/ansible/tasks/swap.yml
@@ -1,0 +1,49 @@
+---
+# Provision a swap file so small instances don't OOM-kill apps under memory
+# pressure.  A swap file gives the kernel somewhere to spill cold pages, trading
+# disk for resilience.  Runs with become: yes.
+#
+# Behaviorally mirrors the openhost_system_agent v7 migration
+# (v0007_swap_file.py), which provisions the same default-sized swap file on
+# hosts provisioned before swap existed.  Both create the file only when it is
+# absent, so an owner who later resizes swap from the settings page is never
+# shrunk back to the default on a re-provision.  The default size here is kept
+# in sync with DEFAULT_SWAP_SIZE_GIB in openhost_system_agent/swap.py; a test
+# enforces this.
+
+- name: Check for existing swap file
+  stat:
+    path: /swapfile
+  register: swapfile_stat
+
+- name: Create swap file
+  command: fallocate -l {{ swap_size_gb | default(16) }}G /swapfile
+  when: not swapfile_stat.stat.exists
+
+- name: Secure swap file permissions
+  file:
+    path: /swapfile
+    mode: "0600"
+    owner: root
+    group: root
+  when: not swapfile_stat.stat.exists
+
+- name: Format swap file
+  command: mkswap /swapfile
+  when: not swapfile_stat.stat.exists
+
+# Persist across reboots.  lineinfile keeps this dependency-free and idempotent,
+# and the line is byte-identical to the fstab entry the swap module writes.
+- name: Persist swap in fstab
+  lineinfile:
+    path: /etc/fstab
+    regexp: '^/swapfile\s'
+    line: "/swapfile none swap sw 0 0"
+    state: present
+
+- name: Enable swap
+  command: swapon /swapfile
+  when: not swapfile_stat.stat.exists
+  register: swapon_result
+  changed_when: swapon_result.rc == 0
+  failed_when: swapon_result.rc != 0 and 'already active' not in swapon_result.stderr

--- a/ansible/tasks/swap.yml
+++ b/ansible/tasks/swap.yml
@@ -3,8 +3,8 @@
 # pressure.  A swap file gives the kernel somewhere to spill cold pages, trading
 # disk for resilience.  Runs with become: yes.
 #
-# Behaviorally mirrors the openhost_system_agent v7 migration
-# (v0007_swap_file.py), which provisions the same default-sized swap file on
+# Behaviorally mirrors the openhost_system_agent v9 migration
+# (v0009_swap_file.py), which provisions the same default-sized swap file on
 # hosts provisioned before swap existed.  Both create the file only when it is
 # absent, so an owner who later resizes swap from the settings page is never
 # shrunk back to the default on a re-provision.  The default size here is kept

--- a/openhost_system_agent/src/openhost_system_agent/cli.py
+++ b/openhost_system_agent/src/openhost_system_agent/cli.py
@@ -10,6 +10,8 @@ import cappa
 
 from openhost_system_agent.migrations.runner import apply_system_migrations
 from openhost_system_agent.status import get_migration_status
+from openhost_system_agent.swap import get_swap_status
+from openhost_system_agent.swap import resize_swapfile
 from openhost_system_agent.update import apply_update
 from openhost_system_agent.update import fetch_updates
 from openhost_system_agent.update import get_remote_info
@@ -88,13 +90,34 @@ class StatusCmd:
         _output(get_migration_status())
 
 
+@cappa.command(name="swap", help="Manage the host swap file.")
+@attrs.define
+class SwapCmd:
+    @cappa.command(name="get", help="Report the swap file's size and whether it is active.")
+    def get(self) -> None:
+        try:
+            _output(get_swap_status())
+        except Exception as e:
+            _error(str(e))
+
+    @cappa.command(name="set", help="Resize the swap file (GiB; 0 disables swap).")
+    def set(
+        self,
+        size_gib: Annotated[int, cappa.Arg(help="Swap size in GiB (0 disables swap)")],
+    ) -> None:
+        try:
+            _output(resize_swapfile(size_gib))
+        except Exception as e:
+            _error(str(e))
+
+
 @cappa.command(
     name="openhost_system_agent",
     help="OpenHost system agent — host-level updates and migrations.",
 )
 @attrs.define
 class SystemAgent:
-    subcommand: cappa.Subcommands[UpdateCmd | StatusCmd]
+    subcommand: cappa.Subcommands[UpdateCmd | StatusCmd | SwapCmd]
 
 
 def main() -> None:

--- a/openhost_system_agent/src/openhost_system_agent/migrations/registry.py
+++ b/openhost_system_agent/src/openhost_system_agent/migrations/registry.py
@@ -12,6 +12,7 @@ from openhost_system_agent.migrations.versions.v0005_pixi_ownership_failsafe imp
 from openhost_system_agent.migrations.versions.v0006_journald_size_cap import Migration0006JournaldSizeCap
 from openhost_system_agent.migrations.versions.v0007_seed_domains_and_scrub import Migration0007SeedDomainsAndScrub
 from openhost_system_agent.migrations.versions.v0008_restart_on_failure import Migration0008RestartOnFailure
+from openhost_system_agent.migrations.versions.v0009_swap_file import Migration0009SwapFile
 
 # Numbered migrations in apply order. Versions MUST start at 2 and be
 # contiguous. v1 is the baseline produced by ansible setup.yml.
@@ -23,6 +24,7 @@ REGISTRY: list[SystemMigration] = [
     Migration0006JournaldSizeCap(),
     Migration0007SeedDomainsAndScrub(),
     Migration0008RestartOnFailure(),
+    Migration0009SwapFile(),
 ]
 
 

--- a/openhost_system_agent/src/openhost_system_agent/migrations/versions/v0009_swap_file.py
+++ b/openhost_system_agent/src/openhost_system_agent/migrations/versions/v0009_swap_file.py
@@ -1,0 +1,25 @@
+"""Provision a swap file on existing hosts.
+
+Small instances run out of RAM under memory pressure and get apps OOM-killed. A
+swap file gives the kernel somewhere to spill cold pages. Fresh hosts get one
+from ``ansible/tasks/swap.yml``; this migration applies the same default-sized
+swap file to hosts provisioned before swap existed.
+
+Idempotent and non-destructive: ``ensure_swapfile(create_only=True)`` creates
+the default-sized file only when the host has none, so a host whose owner later
+resized swap (e.g. ``sudo openhost_system_agent swap set 32``) is never shrunk
+back to the default when this migration re-runs.
+"""
+
+from __future__ import annotations
+
+from openhost_system_agent.migrations.base import SystemMigration
+from openhost_system_agent.swap import DEFAULT_SWAP_SIZE_GIB
+from openhost_system_agent.swap import ensure_swapfile
+
+
+class Migration0009SwapFile(SystemMigration):
+    version = 9
+
+    def up(self) -> None:
+        ensure_swapfile(DEFAULT_SWAP_SIZE_GIB, create_only=True)

--- a/openhost_system_agent/src/openhost_system_agent/protocol.py
+++ b/openhost_system_agent/src/openhost_system_agent/protocol.py
@@ -34,6 +34,16 @@ class RemoteInfo:
 
 
 @attr.s(auto_attribs=True, frozen=True)
+class SwapStatus:
+    # On-disk size of the managed swap file (the configured size, which survives
+    # a swapoff). 0 when no swap file is present.
+    size_bytes: int
+    path: str
+    # Whether the swap file is currently swapped on and available to the kernel.
+    active: bool
+
+
+@attr.s(auto_attribs=True, frozen=True)
 class MigrationStatus:
     ok: bool
     reason: str

--- a/openhost_system_agent/src/openhost_system_agent/swap.py
+++ b/openhost_system_agent/src/openhost_system_agent/swap.py
@@ -1,0 +1,159 @@
+"""Manage the host swap file.
+
+Small instances run out of RAM under memory pressure and get apps OOM-killed. A
+swap file gives the kernel somewhere to spill cold pages, trading disk for
+resilience. OpenHost provisions a default-sized swap file on every host (ansible
+on fresh hosts, the v7 migration on already-provisioned ones) and lets the owner
+resize it from the settings page.
+
+This module is the single source of truth for the swap file's location, its
+default size, and the create/resize/inspect logic. It is root-only: only root
+can mkswap/swapon and edit /etc/fstab.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+from openhost_system_agent.protocol import SwapStatus
+
+#: Where the swap file lives. /swapfile is the conventional location on a
+#: single-volume host.
+SWAP_PATH = "/swapfile"
+
+#: Default swap size provisioned on every host. Kept in sync with the ansible
+#: task's ``swap_size_gb`` default (a test enforces this).
+DEFAULT_SWAP_SIZE_GIB = 16
+
+#: Guardrails for owner-chosen sizes. 0 disables swap entirely; the upper bound
+#: keeps a fat-fingered value from trying to fill the disk.
+MIN_SWAP_SIZE_GIB = 0
+MAX_SWAP_SIZE_GIB = 256
+
+_FSTAB_PATH = "/etc/fstab"
+# The fstab entry that makes the swap file persist across reboots.
+_FSTAB_LINE = f"{SWAP_PATH} none swap sw 0 0"
+
+
+def _require_root() -> None:
+    if os.geteuid() != 0:
+        raise RuntimeError("swap operations must be run as root")
+
+
+def _run(*cmd: str, check: bool = True) -> subprocess.CompletedProcess[str]:
+    """Run *cmd*, raising RuntimeError with the captured stderr on failure.
+
+    We surface stderr rather than letting a bare CalledProcessError bubble up so
+    a failed mkswap/swapon is debuggable from the migration log or the CLI's
+    JSON error, instead of showing only an exit code.
+    """
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    if check and result.returncode != 0:
+        raise RuntimeError(f"{' '.join(cmd)} failed (exit {result.returncode}): {result.stderr.strip()}")
+    return result
+
+
+def _active_swap_bytes() -> int:
+    """Bytes of *our* swap file currently swapped on, else 0.
+
+    Reads /proc/swaps and matches the swap file path; other swap devices are
+    ignored so the number reflects the file this module manages.
+    """
+    try:
+        text = Path("/proc/swaps").read_text()
+    except FileNotFoundError:
+        return 0
+    for line in text.splitlines()[1:]:
+        parts = line.split()
+        # /proc/swaps columns: Filename Type Size Used Priority (Size in KiB).
+        if len(parts) >= 3 and parts[0] == SWAP_PATH:
+            return int(parts[2]) * 1024
+    return 0
+
+
+def get_swap_status() -> SwapStatus:
+    """Report the managed swap file's size and whether it is swapped on.
+
+    ``size_bytes`` is the on-disk file size (the configured size, which survives
+    a swapoff); ``active`` reflects whether it is currently in use.
+    """
+    path = Path(SWAP_PATH)
+    size_bytes = path.stat().st_size if path.exists() else 0
+    return SwapStatus(size_bytes=size_bytes, path=SWAP_PATH, active=_active_swap_bytes() > 0)
+
+
+def _set_fstab_entry(present: bool) -> None:
+    """Ensure the swap fstab line is present or absent. Idempotent.
+
+    Rewrites /etc/fstab dropping any existing entry for our swap path, then
+    appends the canonical line when *present*. Only lines whose first field is
+    exactly the swap path are removed, so operator entries and comments survive.
+    """
+    path = Path(_FSTAB_PATH)
+    lines = path.read_text().splitlines() if path.exists() else []
+    kept = [line for line in lines if line.split()[:1] != [SWAP_PATH]]
+    if present:
+        kept.append(_FSTAB_LINE)
+    path.write_text("\n".join(kept) + "\n")
+
+
+def _create_and_enable(size_gib: int) -> None:
+    """(Re)create the swap file at *size_gib* GiB and swap it on.
+
+    fallocate is near-instant but produces a file some filesystems refuse to
+    swap on; if mkswap/swapon rejects it we fall back to dd, which writes real
+    zeroed blocks. Any prior swap file is swapped off and removed first so this
+    is safe to call for both initial creation and resizing.
+    """
+    _run("swapoff", SWAP_PATH, check=False)
+    Path(SWAP_PATH).unlink(missing_ok=True)
+    try:
+        _run("fallocate", "-l", f"{size_gib}G", SWAP_PATH)
+        os.chmod(SWAP_PATH, 0o600)
+        _run("mkswap", SWAP_PATH)
+        _run("swapon", SWAP_PATH)
+        return
+    except RuntimeError:
+        _run("swapoff", SWAP_PATH, check=False)
+        Path(SWAP_PATH).unlink(missing_ok=True)
+    _run("dd", "if=/dev/zero", f"of={SWAP_PATH}", "bs=1M", f"count={size_gib * 1024}")
+    os.chmod(SWAP_PATH, 0o600)
+    _run("mkswap", SWAP_PATH)
+    _run("swapon", SWAP_PATH)
+
+
+def resize_swapfile(size_gib: int) -> SwapStatus:
+    """Set the swap file to *size_gib* GiB, enabling it and persisting it in
+    /etc/fstab. ``size_gib`` of 0 disables swap and removes the file. Root-only,
+    idempotent, safe to call repeatedly.
+    """
+    _require_root()
+    if not MIN_SWAP_SIZE_GIB <= size_gib <= MAX_SWAP_SIZE_GIB:
+        raise ValueError(f"swap size must be between {MIN_SWAP_SIZE_GIB} and {MAX_SWAP_SIZE_GIB} GiB, got {size_gib}")
+    if size_gib == 0:
+        _run("swapoff", SWAP_PATH, check=False)
+        Path(SWAP_PATH).unlink(missing_ok=True)
+        _set_fstab_entry(present=False)
+    else:
+        _create_and_enable(size_gib)
+        _set_fstab_entry(present=True)
+    return get_swap_status()
+
+
+def ensure_swapfile(size_gib: int = DEFAULT_SWAP_SIZE_GIB, *, create_only: bool = True) -> SwapStatus:
+    """Provision the swap file if the host has none. Root-only, idempotent.
+
+    Used by fresh-host provisioning (ansible) and the v7 migration on existing
+    hosts. With ``create_only`` (the default) an existing swap file is left at
+    its current size so a re-provision or re-run never shrinks an owner-
+    customized value; it still re-enables a present-but-swapped-off file and
+    re-asserts the fstab entry so the file actually gets used.
+    """
+    _require_root()
+    if create_only and Path(SWAP_PATH).exists():
+        _run("swapon", SWAP_PATH, check=False)
+        _set_fstab_entry(present=True)
+        return get_swap_status()
+    return resize_swapfile(size_gib)

--- a/openhost_system_agent/src/openhost_system_agent/swap.py
+++ b/openhost_system_agent/src/openhost_system_agent/swap.py
@@ -3,7 +3,7 @@
 Small instances run out of RAM under memory pressure and get apps OOM-killed. A
 swap file gives the kernel somewhere to spill cold pages, trading disk for
 resilience. OpenHost provisions a default-sized swap file on every host (ansible
-on fresh hosts, the v7 migration on already-provisioned ones) and lets the owner
+on fresh hosts, the v9 migration on already-provisioned ones) and lets the owner
 resize it from the settings page.
 
 This module is the single source of truth for the swap file's location, its
@@ -40,6 +40,19 @@ _FSTAB_LINE = f"{SWAP_PATH} none swap sw 0 0"
 def _require_root() -> None:
     if os.geteuid() != 0:
         raise RuntimeError("swap operations must be run as root")
+
+
+def _running_in_container() -> bool:
+    """True when we're running inside a container, where swap can't be provisioned.
+
+    Swap is a host-kernel resource: a container shares the host kernel and can't
+    ``swapon`` (it's namespaced away and needs real-host CAP_SYS_ADMIN), while a
+    multi-GiB backing file would just burn the container's writable layer. Both
+    podman and Docker drop a marker file at container start; either means we are
+    inside a container and must skip swap provisioning. Real VPS/bare-metal hosts
+    — the only place swap actually applies — have neither marker.
+    """
+    return Path("/run/.containerenv").exists() or Path("/.dockerenv").exists()
 
 
 def _run(*cmd: str, check: bool = True) -> subprocess.CompletedProcess[str]:
@@ -145,13 +158,21 @@ def resize_swapfile(size_gib: int) -> SwapStatus:
 def ensure_swapfile(size_gib: int = DEFAULT_SWAP_SIZE_GIB, *, create_only: bool = True) -> SwapStatus:
     """Provision the swap file if the host has none. Root-only, idempotent.
 
-    Used by fresh-host provisioning (ansible) and the v7 migration on existing
+    Used by fresh-host provisioning (ansible) and the v9 migration on existing
     hosts. With ``create_only`` (the default) an existing swap file is left at
     its current size so a re-provision or re-run never shrinks an owner-
     customized value; it still re-enables a present-but-swapped-off file and
     re-asserts the fstab entry so the file actually gets used.
+
+    No-op inside a container: swap can't be enabled there and creating the
+    backing file would just fill the container's disk, so this reports whatever
+    swap the host already exposes without touching anything. This is why running
+    the system-agent migrations inside a (test) container doesn't try to
+    fallocate a multi-GiB file.
     """
     _require_root()
+    if _running_in_container():
+        return get_swap_status()
     if create_only and Path(SWAP_PATH).exists():
         _run("swapon", SWAP_PATH, check=False)
         _set_fstab_entry(present=True)

--- a/openhost_system_agent/src/openhost_system_agent/tests/test_migration_swap.py
+++ b/openhost_system_agent/src/openhost_system_agent/tests/test_migration_swap.py
@@ -1,0 +1,46 @@
+"""Tests for the v9 migration that provisions a swap file on existing hosts.
+
+The migration delegates to ``ensure_swapfile``; we assert it calls it in the
+non-destructive create-only mode with the default size, and that the default
+size stays in sync with the ansible task that provisions fresh hosts.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from openhost_system_agent.migrations.versions.v0009_swap_file import Migration0009SwapFile
+from openhost_system_agent.swap import DEFAULT_SWAP_SIZE_GIB
+
+_PREFIX = "openhost_system_agent.migrations.versions.v0009_swap_file"
+
+
+def test_provisions_default_swap_create_only(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[dict[str, Any]] = []
+
+    def fake_ensure(size_gib: int, *, create_only: bool = True) -> None:
+        calls.append({"size_gib": size_gib, "create_only": create_only})
+
+    monkeypatch.setattr(f"{_PREFIX}.ensure_swapfile", fake_ensure)
+
+    Migration0009SwapFile().up()
+
+    # Default-sized and non-destructive: an owner-resized swap file is not
+    # shrunk back to the default when this migration re-runs.
+    assert calls == [{"size_gib": DEFAULT_SWAP_SIZE_GIB, "create_only": True}]
+
+
+def test_default_size_matches_ansible_task() -> None:
+    # The migration (existing hosts) and the ansible task (fresh hosts) must
+    # provision the same default swap size so a host looks the same however it
+    # was set up.
+    repo_root = Path(__file__).resolve().parents[4]
+    task = (repo_root / "ansible" / "tasks" / "swap.yml").read_text()
+
+    match = re.search(r"swap_size_gb\s*\|\s*default\((\d+)\)", task)
+    assert match is not None, "ansible swap.yml must define a swap_size_gb default"
+    assert int(match.group(1)) == DEFAULT_SWAP_SIZE_GIB

--- a/openhost_system_agent/src/openhost_system_agent/tests/test_swap.py
+++ b/openhost_system_agent/src/openhost_system_agent/tests/test_swap.py
@@ -36,6 +36,9 @@ def fake_host(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> list[list[str]
     monkeypatch.setattr("openhost_system_agent.swap.os.geteuid", lambda: 0)
     monkeypatch.setattr("openhost_system_agent.swap.os.chmod", lambda *a, **k: None)
     monkeypatch.setattr("openhost_system_agent.swap.subprocess.run", fake_run)
+    # These tests exercise the real host path; keep them stable even when the
+    # suite itself happens to run inside a container.
+    monkeypatch.setattr(swap, "_running_in_container", lambda: False)
     return calls
 
 
@@ -141,6 +144,35 @@ def test_ensure_creates_when_absent(fake_host: list[list[str]], monkeypatch: pyt
     swap.ensure_swapfile(swap.DEFAULT_SWAP_SIZE_GIB, create_only=True)
 
     assert called["size"] == swap.DEFAULT_SWAP_SIZE_GIB
+
+
+def test_ensure_is_noop_in_container(fake_host: list[list[str]], monkeypatch: pytest.MonkeyPatch) -> None:
+    # Inside a container swap can't be enabled and a multi-GiB backing file would
+    # just fill the disk, so provisioning must do nothing but report status. This
+    # is what keeps the container migration test from fallocating a 16 GiB file.
+    monkeypatch.setattr(swap, "_running_in_container", lambda: True)
+
+    def boom(size_gib: int) -> SwapStatus:
+        raise AssertionError("resize must not run inside a container")
+
+    monkeypatch.setattr(swap, "resize_swapfile", boom)
+    monkeypatch.setattr(swap, "get_swap_status", lambda: SwapStatus(size_bytes=0, path=swap.SWAP_PATH, active=False))
+
+    status = swap.ensure_swapfile(swap.DEFAULT_SWAP_SIZE_GIB, create_only=True)
+
+    assert _cmds(fake_host) == []
+    assert status.active is False
+
+
+def test_running_in_container_detects_marker(monkeypatch: pytest.MonkeyPatch) -> None:
+    # No container markers on disk -> we're on a real host.
+    monkeypatch.setattr("pathlib.Path.exists", lambda self: False)
+    assert swap._running_in_container() is False
+
+    # podman/Docker drop a marker file; either one means we're in a container.
+    for marker in ("/run/.containerenv", "/.dockerenv"):
+        monkeypatch.setattr("pathlib.Path.exists", lambda self, m=marker: str(self) == m)
+        assert swap._running_in_container() is True
 
 
 def test_set_fstab_entry_is_idempotent(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:

--- a/openhost_system_agent/src/openhost_system_agent/tests/test_swap.py
+++ b/openhost_system_agent/src/openhost_system_agent/tests/test_swap.py
@@ -1,0 +1,174 @@
+"""Tests for the swap-file management module.
+
+Real mkswap/swapon and /etc/fstab edits need root and a real host, so we drive
+the logic through fakes: a recording ``subprocess.run`` and a no-op ``chmod``,
+with SWAP_PATH / _FSTAB_PATH pointed at tmp files.  This asserts the command
+sequence, the fallback path, the create-only guard, and fstab idempotency
+without touching the host.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+import openhost_system_agent.swap as swap
+from openhost_system_agent.protocol import SwapStatus
+
+
+@pytest.fixture
+def fake_host(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> list[list[str]]:
+    """Run swap ops as fake-root with recorded commands and a tmp swap path.
+
+    Returns the list that accumulates each ``subprocess.run`` argv so tests can
+    assert on the command sequence.
+    """
+    calls: list[list[str]] = []
+
+    def fake_run(cmd: list[str], **kwargs: Any) -> subprocess.CompletedProcess[str]:
+        calls.append(cmd)
+        return subprocess.CompletedProcess(cmd, 0, "", "")
+
+    monkeypatch.setattr(swap, "SWAP_PATH", str(tmp_path / "swapfile"))
+    monkeypatch.setattr("openhost_system_agent.swap.os.geteuid", lambda: 0)
+    monkeypatch.setattr("openhost_system_agent.swap.os.chmod", lambda *a, **k: None)
+    monkeypatch.setattr("openhost_system_agent.swap.subprocess.run", fake_run)
+    return calls
+
+
+def _cmds(calls: list[list[str]]) -> list[str]:
+    return [c[0] for c in calls]
+
+
+def test_requires_root(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("openhost_system_agent.swap.os.geteuid", lambda: 1000)
+    with pytest.raises(RuntimeError, match="must be run as root"):
+        swap.resize_swapfile(8)
+
+
+def test_resize_rejects_out_of_range(fake_host: list[list[str]]) -> None:
+    with pytest.raises(ValueError, match="between"):
+        swap.resize_swapfile(swap.MAX_SWAP_SIZE_GIB + 1)
+    # Nothing should have run before validation failed.
+    assert fake_host == []
+
+
+def test_resize_creates_and_persists(fake_host: list[list[str]], monkeypatch: pytest.MonkeyPatch) -> None:
+    fstab: dict[str, bool] = {}
+    monkeypatch.setattr(swap, "_set_fstab_entry", lambda present: fstab.update(present=present))
+    monkeypatch.setattr(
+        swap, "get_swap_status", lambda: SwapStatus(size_bytes=8 * 1024**3, path=swap.SWAP_PATH, active=True)
+    )
+
+    result = swap.resize_swapfile(8)
+
+    assert "fallocate" in _cmds(fake_host)
+    assert "mkswap" in _cmds(fake_host)
+    assert "swapon" in _cmds(fake_host)
+    assert fstab == {"present": True}
+    assert result.active is True
+
+
+def test_resize_zero_disables_and_removes(fake_host: list[list[str]], monkeypatch: pytest.MonkeyPatch) -> None:
+    fstab: dict[str, bool] = {}
+    monkeypatch.setattr(swap, "_set_fstab_entry", lambda present: fstab.update(present=present))
+    monkeypatch.setattr(swap, "get_swap_status", lambda: SwapStatus(size_bytes=0, path=swap.SWAP_PATH, active=False))
+
+    # A leftover swap file should be removed.
+    Path(swap.SWAP_PATH).write_text("stale")
+
+    swap.resize_swapfile(0)
+
+    assert _cmds(fake_host) == ["swapoff"]
+    assert not Path(swap.SWAP_PATH).exists()
+    assert fstab == {"present": False}
+
+
+def test_create_falls_back_to_dd_when_fallocate_unswappable(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    # First swapon attempt (fallocate path) fails; the dd path must then run.
+    calls: list[list[str]] = []
+    seen_swapon = {"n": 0}
+
+    def fake_run(cmd: list[str], **kwargs: Any) -> subprocess.CompletedProcess[str]:
+        calls.append(cmd)
+        if cmd[0] == "swapon":
+            seen_swapon["n"] += 1
+            if seen_swapon["n"] == 1:
+                return subprocess.CompletedProcess(cmd, 1, "", "swapon: invalid argument")
+        return subprocess.CompletedProcess(cmd, 0, "", "")
+
+    monkeypatch.setattr(swap, "SWAP_PATH", str(tmp_path / "swapfile"))
+    monkeypatch.setattr("openhost_system_agent.swap.os.geteuid", lambda: 0)
+    monkeypatch.setattr("openhost_system_agent.swap.os.chmod", lambda *a, **k: None)
+    monkeypatch.setattr("openhost_system_agent.swap.subprocess.run", fake_run)
+
+    swap._create_and_enable(8)
+
+    assert "dd" in _cmds(calls)
+    # swapon attempted twice: once on the fallocate path, once after dd.
+    assert seen_swapon["n"] == 2
+
+
+def test_ensure_create_only_keeps_existing_size(fake_host: list[list[str]], monkeypatch: pytest.MonkeyPatch) -> None:
+    # An existing swap file must not be recreated (which would resize it).
+    Path(swap.SWAP_PATH).write_text("existing swap")
+
+    def boom(size_gib: int) -> SwapStatus:
+        raise AssertionError("resize must not run when a swap file already exists")
+
+    monkeypatch.setattr(swap, "resize_swapfile", boom)
+    monkeypatch.setattr(swap, "_set_fstab_entry", lambda present: None)
+    monkeypatch.setattr(swap, "get_swap_status", lambda: SwapStatus(size_bytes=99, path=swap.SWAP_PATH, active=True))
+
+    swap.ensure_swapfile(swap.DEFAULT_SWAP_SIZE_GIB, create_only=True)
+
+    # It re-enables the present file rather than recreating it.
+    assert _cmds(fake_host) == ["swapon"]
+
+
+def test_ensure_creates_when_absent(fake_host: list[list[str]], monkeypatch: pytest.MonkeyPatch) -> None:
+    called: dict[str, int | None] = {"size": None}
+
+    def fake_resize(size_gib: int) -> SwapStatus:
+        called["size"] = size_gib
+        return SwapStatus(size_bytes=size_gib * 1024**3, path=swap.SWAP_PATH, active=True)
+
+    monkeypatch.setattr(swap, "resize_swapfile", fake_resize)
+
+    swap.ensure_swapfile(swap.DEFAULT_SWAP_SIZE_GIB, create_only=True)
+
+    assert called["size"] == swap.DEFAULT_SWAP_SIZE_GIB
+
+
+def test_set_fstab_entry_is_idempotent(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    fstab = tmp_path / "fstab"
+    fstab.write_text("UUID=abc / ext4 defaults 0 1\n")
+    monkeypatch.setattr(swap, "_FSTAB_PATH", str(fstab))
+
+    swap._set_fstab_entry(present=True)
+    swap._set_fstab_entry(present=True)
+    text = fstab.read_text()
+
+    # Operator's root entry survives; our line appears exactly once.
+    assert "UUID=abc / ext4 defaults 0 1" in text
+    assert text.count(swap._FSTAB_LINE) == 1
+
+    swap._set_fstab_entry(present=False)
+    assert swap._FSTAB_LINE not in fstab.read_text()
+    assert "UUID=abc / ext4 defaults 0 1" in fstab.read_text()
+
+
+def test_get_swap_status_reports_file_size(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    swapfile = tmp_path / "swapfile"
+    swapfile.write_bytes(b"\0" * 4096)
+    monkeypatch.setattr(swap, "SWAP_PATH", str(swapfile))
+    monkeypatch.setattr(swap, "_active_swap_bytes", lambda: 0)
+
+    status = swap.get_swap_status()
+
+    assert status.size_bytes == 4096
+    assert status.path == str(swapfile)
+    assert status.active is False


### PR DESCRIPTION
## Why

Several users have run into the memory limits of their instances, with apps getting OOM-killed under memory pressure. This provisions a **default 16 GiB swap file** on every host so the kernel has somewhere to spill cold pages.

> Supersedes #277, which also added a settings-page control. Per feedback, resizing swap is an operator-level action — anyone who wants to change it can SSH in — so this PR drops the UI and keeps only the provisioning + an operator CLI.

## Approach

Follows OpenHost's established system-config pattern — every host-level knob is configured in two mirrored places (ansible for fresh hosts, an `openhost_system_agent` migration for already-provisioned ones). The privileged logic lives in the root-run `openhost_system_agent`.

**Source of truth is the swap file itself** (its on-disk size + `/etc/fstab` entry) — no new config store.

## Changes

- **`openhost_system_agent/swap.py`** — single source of truth for swap path/default size and root-only create/resize/inspect logic. fallocate with a dd fallback, fstab persistence, `swapoff`+recreate on resize, `0` disables swap, bounds 0–256 GiB.
- **`SwapStatus`** protocol type + **`swap get` / `swap set <gib>`** CLI subcommands, so an operator can resize over SSH: `sudo openhost_system_agent swap set 32`.
- **`ansible/tasks/swap.yml`** (create-if-absent) wired into `setup.yml`, `local_setup.yml`, `prebake.yml`; **`v0009_swap_file`** migration for existing hosts — non-destructive, so an operator-resized swap is never shrunk back to the default.
- **Tests**: swap module logic (command sequence, dd fallback, create-only guard, fstab idempotency, root guard), the migration + a test asserting the ansible default stays in sync with `DEFAULT_SWAP_SIZE_GIB`.

## Notes / decisions

- No settings-page UI (dropped from #277).
- Swappiness left at the Ubuntu default (60 — already enough for the kernel to use swap under pressure).
- Swap path is `/swapfile`; `0` disables swap.

## Verification

- `openhost_system_agent` suite: 137 passed.
- ruff + mypy clean (pre-commit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)