### PR TITLE
Openhost -> Cloud in a Bottle Renaming

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Openhost
+# Cloud in a Bottle
 
 Your corner of the cloud.
 
@@ -6,15 +6,15 @@ Deploy, use, and share any app on a server you control. Built on the idea that m
 
 [![License: AGPL-3.0](https://img.shields.io/badge/License-AGPL%20v3-blue.svg)](https://www.gnu.org/licenses/agpl-3.0)
 
-> **Early access.** Openhost is in active beta. We want you to try it and share feedback! Note that no password recovery exists yet and we don't hold keys to your instance so we can't reset it. Response time on issues and PRs may be slow as we're heads-down on the core product.
+> **Early access.** Cloud in a Bottle is in active beta. We want you to try it and share feedback! Note that no password recovery exists yet and we don't hold keys to your instance so we can't reset it. Response time on issues and PRs may be slow as we're heads-down on the core product.
 
 
 
-## Why Openhost
+## Why Cloud in a Bottle
 
 Most people have no access to the cloud that isn't mediated by a company with different incentives than theirs. Open source web software exists but running it somewhere means fighting infrastructure that most people don't want to touch.
 
-Openhost is the project our team needed and couldn't find: a corner of the cloud that's genuinely yours. Where apps install as easily as on your phone, and the data lives on hardware you control.
+Cloud in a Bottle is the project our team needed and couldn't find: a corner of the cloud that's genuinely yours. Where apps install as easily as on your phone, and the data lives on hardware you control.
 
 ## What people deploy
 
@@ -25,7 +25,7 @@ Openhost is the project our team needed and couldn't find: a corner of the cloud
 
 ## Managed hosting
 
-If you'd rather not run your own server, [Openhost](https://openhost.imbue.com/plans) provisions one for you: your SSH key, your data, your instance. We just set you up with everything you need to get going, and then it's all yours from there.
+If you'd rather not run your own server, [Cloud in a Bottle](https://openhost.imbue.com/plans) provisions one for you: your SSH key, your data, your instance. We just set you up with everything you need to get going, and then it's all yours from there.
 
 ---
 
@@ -200,7 +200,7 @@ The user-facing manual lives in `docs/src/` and is served at `https://<zone>/doc
 
 ## Agent skill
 
-An agent skill that gives an AI coding agent context for deploying and debugging apps on Openhost via the `oh` CLI. Install with:
+An agent skill that gives an AI coding agent context for deploying and debugging apps on Cloud in a Bottle via the `oh` CLI. Install with:
 
 ```bash
 npx skills add imbue-openhost/openhost --skill openhost-context
@@ -213,13 +213,13 @@ uv tool install "oh @ git+https://github.com/imbue-openhost/openhost.git#subdire
 oh instance login
 ```
 
-Once set up, ask your coding agent to package any existing project for Openhost and deploy it directly — no manual manifest editing required.
+Once set up, ask your coding agent to package any existing project for Cloud in a Bottle and deploy it directly — no manual manifest editing required.
 
 ---
 
 ## License
 
-Openhost is provided under the [AGPL-3.0 license](LICENSE).
+Cloud in a Bottle is provided under the [AGPL-3.0 license](LICENSE).
 
 We may move to a different license in the future — something like a [fair source license](https://fair.io/licenses/) — with the intent that personal use will always be unrestricted, while commercial use may be scoped to support a sustainable project.
 

--- a/ansible/templates/openhost-juicefs.service.j2
+++ b/ansible/templates/openhost-juicefs.service.j2
@@ -1,5 +1,5 @@
 [Unit]
-Description=OpenHost JuiceFS Archive Mount
+Description=Cloud in a Bottle JuiceFS Archive Mount
 After=network-online.target
 Wants=network-online.target
 # Start before the main service so the FUSE mount is ready when

--- a/ansible/templates/openhost.service.j2
+++ b/ansible/templates/openhost.service.j2
@@ -1,5 +1,5 @@
 [Unit]
-Description=OpenHost Compute Space
+Description=Cloud in a Bottle Compute Space
 # The user-session bus from ``user@{{ host_uid }}.service`` must be up
 # before we start, otherwise rootless podman's systemd cgroup manager
 # can't talk to it and builds fail with "Interactive authentication

--- a/compute_space/src/compute_space/config.py
+++ b/compute_space/src/compute_space/config.py
@@ -90,7 +90,7 @@ class Config:
     # Each entry is either:
     #   - a bare dirname under apps_dir (vendored builtin, e.g. "secrets_v2"), or
     #   - a remote git URL the router will clone on first boot
-    #     (e.g. "https://github.com/imbue-openhost/bottle-catalog").
+    #     (e.g. "https://github.com/imbue-openhost/app-catalog").
     # Remote URLs are dispatched through the same clone path as
     # /api/add_app and do not need to be present on disk ahead of time.
     default_apps: list[str]
@@ -351,7 +351,7 @@ class DefaultConfig(Config):
             "https://github.com/imbue-openhost/secrets",
             "https://github.com/imbue-openhost/bottled-filestash",
             "oauth_provider",
-            "https://github.com/imbue-openhost/bottle-catalog",
+            "https://github.com/imbue-openhost/app-catalog",
             "https://github.com/imbue-openhost/backup",
             "https://github.com/imbue-openhost/bottled-community-chat",
         ]

--- a/compute_space/src/compute_space/config.py
+++ b/compute_space/src/compute_space/config.py
@@ -90,7 +90,7 @@ class Config:
     # Each entry is either:
     #   - a bare dirname under apps_dir (vendored builtin, e.g. "secrets_v2"), or
     #   - a remote git URL the router will clone on first boot
-    #     (e.g. "https://github.com/imbue-openhost/bottled-catalog").
+    #     (e.g. "https://github.com/imbue-openhost/bottle-catalog").
     # Remote URLs are dispatched through the same clone path as
     # /api/add_app and do not need to be present on disk ahead of time.
     default_apps: list[str]
@@ -351,8 +351,8 @@ class DefaultConfig(Config):
             "https://github.com/imbue-openhost/secrets",
             "https://github.com/imbue-openhost/bottled-filestash",
             "oauth_provider",
-            "https://github.com/imbue-openhost/bottled-catalog",
-            "https://github.com/imbue-openhost/bottled-backup",
+            "https://github.com/imbue-openhost/bottle-catalog",
+            "https://github.com/imbue-openhost/backup",
             "https://github.com/imbue-openhost/bottled-community-chat",
         ]
     )

--- a/compute_space/src/compute_space/config.py
+++ b/compute_space/src/compute_space/config.py
@@ -90,7 +90,7 @@ class Config:
     # Each entry is either:
     #   - a bare dirname under apps_dir (vendored builtin, e.g. "secrets_v2"), or
     #   - a remote git URL the router will clone on first boot
-    #     (e.g. "https://github.com/imbue-openhost/openhost-catalog").
+    #     (e.g. "https://github.com/imbue-openhost/bottled-catalog").
     # Remote URLs are dispatched through the same clone path as
     # /api/add_app and do not need to be present on disk ahead of time.
     default_apps: list[str]
@@ -349,11 +349,11 @@ class DefaultConfig(Config):
     default_apps: list[str] = attr.Factory(
         lambda: [
             "https://github.com/imbue-openhost/secrets",
-            "https://github.com/imbue-openhost/openhost-filestash",
+            "https://github.com/imbue-openhost/bottled-filestash",
             "oauth_provider",
-            "https://github.com/imbue-openhost/openhost-catalog",
-            "https://github.com/imbue-openhost/openhost-backup",
-            "https://github.com/imbue-openhost/openhost-community-chat",
+            "https://github.com/imbue-openhost/bottled-catalog",
+            "https://github.com/imbue-openhost/bottled-backup",
+            "https://github.com/imbue-openhost/bottled-community-chat",
         ]
     )
 

--- a/compute_space/src/compute_space/core/default_apps.py
+++ b/compute_space/src/compute_space/core/default_apps.py
@@ -6,7 +6,7 @@ Each entry in ``config.default_apps`` is either:
   ``"file_browser"``) — copied from disk, same as the original
   default-apps behavior.
 - A remote git URL (e.g.
-  ``"https://github.com/imbue-openhost/bottle-catalog"``) — cloned
+  ``"https://github.com/imbue-openhost/app-catalog"``) — cloned
   on demand via the same path used by ``/api/add_app``.  The repo
   does not need to be present on disk ahead of time.
 """

--- a/compute_space/src/compute_space/core/default_apps.py
+++ b/compute_space/src/compute_space/core/default_apps.py
@@ -6,7 +6,7 @@ Each entry in ``config.default_apps`` is either:
   ``"file_browser"``) — copied from disk, same as the original
   default-apps behavior.
 - A remote git URL (e.g.
-  ``"https://github.com/imbue-openhost/bottled-catalog"``) — cloned
+  ``"https://github.com/imbue-openhost/bottle-catalog"``) — cloned
   on demand via the same path used by ``/api/add_app``.  The repo
   does not need to be present on disk ahead of time.
 """

--- a/compute_space/src/compute_space/core/default_apps.py
+++ b/compute_space/src/compute_space/core/default_apps.py
@@ -6,7 +6,7 @@ Each entry in ``config.default_apps`` is either:
   ``"file_browser"``) — copied from disk, same as the original
   default-apps behavior.
 - A remote git URL (e.g.
-  ``"https://github.com/imbue-openhost/openhost-catalog"``) — cloned
+  ``"https://github.com/imbue-openhost/bottled-catalog"``) — cloned
   on demand via the same path used by ``/api/add_app``.  The repo
   does not need to be present on disk ahead of time.
 """

--- a/compute_space/src/compute_space/core/org_rename.py
+++ b/compute_space/src/compute_space/core/org_rename.py
@@ -18,11 +18,12 @@ versioned migration so that it lands inert (see ``NEW_ORG``) and activates for
 the whole fleet on the release that accompanies the rename.  It is idempotent,
 and it never raises: a boot must not fail because a rewrite did not apply.
 
-Sequencing matters and is the reason ``NEW_ORG`` ships empty.  Rewriting before
-the org is actually renamed would point instances at an owner that does not
-exist yet, which is strictly worse than the redirect dependency it is meant to
-remove.  Set ``NEW_ORG`` only in the release that ships with (or after) the
-rename.
+Sequencing matters, and is why the owner name and the decision to act on it are
+separate constants.  ``NEW_ORG`` is settled data; ``ORG_RENAME_COMPLETE`` is the
+switch.  Rewriting before the org is actually renamed would point instances at
+an owner that does not exist yet, which is strictly worse than the redirect
+dependency it is meant to remove.  Flip ``ORG_RENAME_COMPLETE`` only in the
+release that ships with (or after) the rename.
 """
 
 import sqlite3
@@ -37,10 +38,24 @@ from compute_space.core.logging import logger
 # The owner every currently-deployed instance has persisted.
 OLD_ORG = "imbue-openhost"
 
-# The owner to move to.  Empty disables the reconcile entirely, which is the
-# correct state until the org has actually been renamed -- see the module
-# docstring.  The name itself is still pending sign-off.
-NEW_ORG = ""
+# The owner to move to.  Decided; the GitHub org has not been renamed yet.
+NEW_ORG = "cloud-in-a-bottle"
+
+# The activation switch, deliberately separate from the name above.  While this
+# is False the reconcile is a total no-op, which is the correct state until the
+# org has actually been renamed: rewriting early would point instances at an
+# owner that does not resolve.  Flip this in the release that ships with (or
+# after) the rename.
+ORG_RENAME_COMPLETE = False
+
+
+def enabled() -> bool:
+    """True when persisted owners should be rewritten.
+
+    Read at call time so flipping ``ORG_RENAME_COMPLETE`` (and patching it in
+    tests) takes effect.
+    """
+    return bool(ORG_RENAME_COMPLETE and NEW_ORG and NEW_ORG != OLD_ORG)
 
 
 def rewrite_owner(repo_url: str, old_org: str | None = None, new_org: str | None = None) -> str | None:
@@ -123,10 +138,10 @@ def _reconcile_checkout(repo_path: str, expected_url: str) -> str | None:
 def reconcile_app_repo_urls(db: sqlite3.Connection) -> int:
     """Rewrite persisted app repo URLs (and their checkouts' origin) to NEW_ORG.
 
-    Idempotent, and a no-op while NEW_ORG is empty.  Returns the number of app
-    rows changed.  Never raises.
+    Idempotent, and a no-op until ``ORG_RENAME_COMPLETE``.  Returns the number
+    of app rows changed.  Never raises.
     """
-    if not NEW_ORG:
+    if not enabled():
         return 0
 
     changed = 0

--- a/compute_space/src/compute_space/core/org_rename.py
+++ b/compute_space/src/compute_space/core/org_rename.py
@@ -1,0 +1,158 @@
+"""Move persisted GitHub owner references off the old org onto the new one.
+
+An instance stores the URL it installed each app from in ``apps.repo_url``, and
+the app's checkout carries the same URL as its git ``origin``.  Both outlive the
+install, so after the GitHub org is renamed every deployed instance keeps
+fetching through the old owner name.
+
+That works -- GitHub redirects a renamed owner for both git and the API -- but
+only until someone claims the freed-up name.  GitHub releases the old
+organization name for anyone to register, and per GitHub's documentation the new
+holder "can create repositories that override the redirect entries".  An
+instance that still points at the old owner would then fetch an attacker's
+repository and build it, so the redirect is a migration window, not a
+destination.
+
+Hence this reconcile.  It runs on every boot rather than as a one-shot
+versioned migration so that it lands inert (see ``NEW_ORG``) and activates for
+the whole fleet on the release that accompanies the rename.  It is idempotent,
+and it never raises: a boot must not fail because a rewrite did not apply.
+
+Sequencing matters and is the reason ``NEW_ORG`` ships empty.  Rewriting before
+the org is actually renamed would point instances at an owner that does not
+exist yet, which is strictly worse than the redirect dependency it is meant to
+remove.  Set ``NEW_ORG`` only in the release that ships with (or after) the
+rename.
+"""
+
+import sqlite3
+import urllib.parse
+
+import git
+
+from compute_space.core.git_ops import is_github_repo_url
+from compute_space.core.git_ops import is_ssh_url
+from compute_space.core.logging import logger
+
+# The owner every currently-deployed instance has persisted.
+OLD_ORG = "imbue-openhost"
+
+# The owner to move to.  Empty disables the reconcile entirely, which is the
+# correct state until the org has actually been renamed -- see the module
+# docstring.  The name itself is still pending sign-off.
+NEW_ORG = ""
+
+
+def rewrite_owner(repo_url: str, old_org: str | None = None, new_org: str | None = None) -> str | None:
+    """Return ``repo_url`` with its GitHub owner moved ``old_org`` -> ``new_org``.
+
+    ``old_org``/``new_org`` default to the module constants, read at call time
+    rather than bound as default arguments so that flipping ``NEW_ORG`` (and
+    patching it in tests) takes effect.
+
+    Returns None when the URL should be left alone, which covers: the reconcile
+    being disabled (``new_org`` empty), a non-GitHub host, a look-alike host
+    such as ``github.com.evil.example``, an SSH URL, and any owner other than
+    ``old_org``.
+
+    Only the owner segment is touched.  The repository name, any ``@ref``
+    suffix, a ``.git`` suffix, and any query or fragment are preserved --
+    including for a repository whose *name* happens to contain the old owner
+    string.
+    """
+    old_org = OLD_ORG if old_org is None else old_org
+    new_org = NEW_ORG if new_org is None else new_org
+    if not new_org or not old_org or new_org == old_org:
+        return None
+    if not repo_url or is_ssh_url(repo_url):
+        return None
+    if not is_github_repo_url(repo_url):
+        return None
+
+    # Normalise a scheme-less "github.com/owner/repo" so the owner is always
+    # the first path segment, then restore the original shape afterwards.
+    had_scheme = "://" in repo_url
+    parsed = urllib.parse.urlparse(repo_url if had_scheme else "https://" + repo_url)
+    segments = parsed.path.split("/")
+    # path is "/owner/repo..." so segments == ["", owner, repo, ...]
+    if len(segments) < 3 or not segments[1]:
+        return None
+    # GitHub owner names are case-insensitive; compare accordingly but write the
+    # new owner exactly as configured.
+    if segments[1].casefold() != old_org.casefold():
+        return None
+
+    segments[1] = new_org
+    rebuilt = parsed._replace(path="/".join(segments)).geturl()
+    if not had_scheme:
+        rebuilt = rebuilt.removeprefix("https://")
+    return rebuilt if rebuilt != repo_url else None
+
+
+def _reconcile_checkout(repo_path: str, expected_url: str) -> str | None:
+    """Point an app checkout's origin at ``expected_url``.
+
+    Returns a description of what changed, or None if nothing needed doing.
+    Never raises: a missing or broken checkout is not a reason to fail boot,
+    and the DB row is the value that matters for the next clone.
+
+    Uses gitpython directly rather than git_ops.get_remote_url/set_remote_url
+    because those are @async_wrap coroutines and this runs on the sync boot
+    path; bridging an event loop here would buy nothing over four lines of
+    gitpython.
+    """
+    if not repo_path:
+        return None
+    try:
+        repo = git.Repo(repo_path)
+        current = repo.remotes.origin.url
+    except Exception:
+        return None
+    rewritten = rewrite_owner(current)
+    if rewritten is None:
+        return None
+    try:
+        with repo.remotes.origin.config_writer as cw:
+            cw.set("url", rewritten)
+    except Exception as exc:
+        logger.warning("org_rename: could not update origin in %s: %s", repo_path, exc)
+        return None
+    return f"{current} -> {rewritten}"
+
+
+def reconcile_app_repo_urls(db: sqlite3.Connection) -> int:
+    """Rewrite persisted app repo URLs (and their checkouts' origin) to NEW_ORG.
+
+    Idempotent, and a no-op while NEW_ORG is empty.  Returns the number of app
+    rows changed.  Never raises.
+    """
+    if not NEW_ORG:
+        return 0
+
+    changed = 0
+    try:
+        rows = list(db.execute("SELECT app_id, name, repo_url, repo_path FROM apps WHERE repo_url IS NOT NULL"))
+    except Exception as exc:
+        logger.warning("org_rename: could not read apps: %s", exc)
+        return 0
+
+    for row in rows:
+        repo_url = row["repo_url"]
+        rewritten = rewrite_owner(repo_url)
+        if rewritten is None:
+            continue
+        try:
+            db.execute("UPDATE apps SET repo_url = ? WHERE app_id = ?", (rewritten, row["app_id"]))
+            db.commit()
+        except Exception as exc:
+            logger.warning("org_rename: could not update repo_url for %s: %s", row["name"], exc)
+            continue
+        changed += 1
+        logger.info("org_rename: %s repo_url %s -> %s", row["name"], repo_url, rewritten)
+        moved = _reconcile_checkout(row["repo_path"], rewritten)
+        if moved:
+            logger.info("org_rename: %s origin %s", row["name"], moved)
+
+    if changed:
+        logger.info("org_rename: moved %d app(s) from %s to %s", changed, OLD_ORG, NEW_ORG)
+    return changed

--- a/compute_space/src/compute_space/tests/test_add_app_page.py
+++ b/compute_space/src/compute_space/tests/test_add_app_page.py
@@ -92,5 +92,5 @@ def test_callout_offers_install_when_catalog_missing(cfg: Any) -> None:
     assert resp.status_code == 200
     assert "Explore the App Catalog" in resp.text
     assert "Install the catalog" in resp.text
-    assert "https://github.com/imbue-openhost/bottle-catalog" in resp.text
+    assert "https://github.com/imbue-openhost/app-catalog" in resp.text
     assert f"http://catalog.{primary_of(cfg).name}/" not in resp.text

--- a/compute_space/src/compute_space/tests/test_add_app_page.py
+++ b/compute_space/src/compute_space/tests/test_add_app_page.py
@@ -92,5 +92,5 @@ def test_callout_offers_install_when_catalog_missing(cfg: Any) -> None:
     assert resp.status_code == 200
     assert "Explore the App Catalog" in resp.text
     assert "Install the catalog" in resp.text
-    assert "https://github.com/imbue-openhost/openhost-catalog" in resp.text
+    assert "https://github.com/imbue-openhost/bottled-catalog" in resp.text
     assert f"http://catalog.{primary_of(cfg).name}/" not in resp.text

--- a/compute_space/src/compute_space/tests/test_add_app_page.py
+++ b/compute_space/src/compute_space/tests/test_add_app_page.py
@@ -92,5 +92,5 @@ def test_callout_offers_install_when_catalog_missing(cfg: Any) -> None:
     assert resp.status_code == 200
     assert "Explore the App Catalog" in resp.text
     assert "Install the catalog" in resp.text
-    assert "https://github.com/imbue-openhost/bottled-catalog" in resp.text
+    assert "https://github.com/imbue-openhost/bottle-catalog" in resp.text
     assert f"http://catalog.{primary_of(cfg).name}/" not in resp.text

--- a/compute_space/src/compute_space/tests/test_default_apps.py
+++ b/compute_space/src/compute_space/tests/test_default_apps.py
@@ -208,7 +208,7 @@ def test_remote_url_entry_dispatches_to_clone_path(cfg_with_apps, monkeypatch):
     monkeypatch.setattr(da, "clone_and_read_manifest", fake_clone)
 
     # Replace the config's default_apps with a single remote URL entry.
-    cfg = cfg_with_apps.evolve(default_apps=["https://github.com/imbue-openhost/bottle-catalog"])
+    cfg = cfg_with_apps.evolve(default_apps=["https://github.com/imbue-openhost/app-catalog"])
 
     db = sqlite3.connect(cfg.db_path)
     try:
@@ -216,15 +216,15 @@ def test_remote_url_entry_dispatches_to_clone_path(cfg_with_apps, monkeypatch):
     finally:
         db.close()
 
-    assert calls == ["https://github.com/imbue-openhost/bottle-catalog"]
+    assert calls == ["https://github.com/imbue-openhost/app-catalog"]
     assert len(result) == 1
     assert result[0].status == "ok"
-    assert result[0].name == "https://github.com/imbue-openhost/bottle-catalog"
+    assert result[0].name == "https://github.com/imbue-openhost/app-catalog"
 
     # The sentinel keys on the spec string (the URL), not the manifest name.
     with open(cfg.default_apps_sentinel_path) as f:
         sentinel = json.load(f)
-    assert "https://github.com/imbue-openhost/bottle-catalog" in sentinel
+    assert "https://github.com/imbue-openhost/app-catalog" in sentinel
 
 
 def test_remote_url_clone_failure_is_retried(cfg_with_apps, monkeypatch):
@@ -297,7 +297,7 @@ def test_backup_in_default_factory():
 
 
 def test_catalog_in_default_factory():
-    """bottle-catalog must be in the shipped DefaultConfig.default_apps
+    """app-catalog must be in the shipped DefaultConfig.default_apps
     so every new instance auto-installs it at /setup completion.
 
     Regression guard against accidental removal during config refactors.
@@ -307,8 +307,8 @@ def test_catalog_in_default_factory():
         data_root_dir="/tmp/fake",
         start_caddy=False,
     )
-    catalog_entries = [s for s in cfg.default_apps if "bottle-catalog" in s.lower()]
-    assert catalog_entries, f"bottle-catalog not in default_apps: {cfg.default_apps}"
+    catalog_entries = [s for s in cfg.default_apps if "app-catalog" in s.lower()]
+    assert catalog_entries, f"app-catalog not in default_apps: {cfg.default_apps}"
 
 
 def test_filestash_in_default_factory():

--- a/compute_space/src/compute_space/tests/test_default_apps.py
+++ b/compute_space/src/compute_space/tests/test_default_apps.py
@@ -208,7 +208,7 @@ def test_remote_url_entry_dispatches_to_clone_path(cfg_with_apps, monkeypatch):
     monkeypatch.setattr(da, "clone_and_read_manifest", fake_clone)
 
     # Replace the config's default_apps with a single remote URL entry.
-    cfg = cfg_with_apps.evolve(default_apps=["https://github.com/imbue-openhost/bottled-catalog"])
+    cfg = cfg_with_apps.evolve(default_apps=["https://github.com/imbue-openhost/bottle-catalog"])
 
     db = sqlite3.connect(cfg.db_path)
     try:
@@ -216,15 +216,15 @@ def test_remote_url_entry_dispatches_to_clone_path(cfg_with_apps, monkeypatch):
     finally:
         db.close()
 
-    assert calls == ["https://github.com/imbue-openhost/bottled-catalog"]
+    assert calls == ["https://github.com/imbue-openhost/bottle-catalog"]
     assert len(result) == 1
     assert result[0].status == "ok"
-    assert result[0].name == "https://github.com/imbue-openhost/bottled-catalog"
+    assert result[0].name == "https://github.com/imbue-openhost/bottle-catalog"
 
     # The sentinel keys on the spec string (the URL), not the manifest name.
     with open(cfg.default_apps_sentinel_path) as f:
         sentinel = json.load(f)
-    assert "https://github.com/imbue-openhost/bottled-catalog" in sentinel
+    assert "https://github.com/imbue-openhost/bottle-catalog" in sentinel
 
 
 def test_remote_url_clone_failure_is_retried(cfg_with_apps, monkeypatch):
@@ -282,7 +282,7 @@ def test_remote_install_works_from_running_event_loop(cfg_with_apps, monkeypatch
 
 
 def test_backup_in_default_factory():
-    """bottled-backup must be in the shipped DefaultConfig.default_apps
+    """backup must be in the shipped DefaultConfig.default_apps
     so every new instance auto-installs it at /setup completion.
 
     Regression guard against accidental removal during config refactors.
@@ -292,12 +292,12 @@ def test_backup_in_default_factory():
         data_root_dir="/tmp/fake",
         start_caddy=False,
     )
-    backup_entries = [s for s in cfg.default_apps if "bottled-backup" in s.lower()]
-    assert backup_entries, f"bottled-backup not in default_apps: {cfg.default_apps}"
+    backup_entries = [s for s in cfg.default_apps if "backup" in s.lower()]
+    assert backup_entries, f"backup not in default_apps: {cfg.default_apps}"
 
 
 def test_catalog_in_default_factory():
-    """bottled-catalog must be in the shipped DefaultConfig.default_apps
+    """bottle-catalog must be in the shipped DefaultConfig.default_apps
     so every new instance auto-installs it at /setup completion.
 
     Regression guard against accidental removal during config refactors.
@@ -307,8 +307,8 @@ def test_catalog_in_default_factory():
         data_root_dir="/tmp/fake",
         start_caddy=False,
     )
-    catalog_entries = [s for s in cfg.default_apps if "bottled-catalog" in s.lower()]
-    assert catalog_entries, f"bottled-catalog not in default_apps: {cfg.default_apps}"
+    catalog_entries = [s for s in cfg.default_apps if "bottle-catalog" in s.lower()]
+    assert catalog_entries, f"bottle-catalog not in default_apps: {cfg.default_apps}"
 
 
 def test_filestash_in_default_factory():

--- a/compute_space/src/compute_space/tests/test_default_apps.py
+++ b/compute_space/src/compute_space/tests/test_default_apps.py
@@ -282,7 +282,7 @@ def test_remote_install_works_from_running_event_loop(cfg_with_apps, monkeypatch
 
 
 def test_backup_in_default_factory():
-    """openhost-backup must be in the shipped DefaultConfig.default_apps
+    """bottled-backup must be in the shipped DefaultConfig.default_apps
     so every new instance auto-installs it at /setup completion.
 
     Regression guard against accidental removal during config refactors.
@@ -292,12 +292,12 @@ def test_backup_in_default_factory():
         data_root_dir="/tmp/fake",
         start_caddy=False,
     )
-    backup_entries = [s for s in cfg.default_apps if "openhost-backup" in s.lower()]
-    assert backup_entries, f"openhost-backup not in default_apps: {cfg.default_apps}"
+    backup_entries = [s for s in cfg.default_apps if "bottled-backup" in s.lower()]
+    assert backup_entries, f"bottled-backup not in default_apps: {cfg.default_apps}"
 
 
 def test_catalog_in_default_factory():
-    """openhost-catalog must be in the shipped DefaultConfig.default_apps
+    """bottled-catalog must be in the shipped DefaultConfig.default_apps
     so every new instance auto-installs it at /setup completion.
 
     Regression guard against accidental removal during config refactors.
@@ -307,19 +307,19 @@ def test_catalog_in_default_factory():
         data_root_dir="/tmp/fake",
         start_caddy=False,
     )
-    catalog_entries = [s for s in cfg.default_apps if "openhost-catalog" in s.lower()]
-    assert catalog_entries, f"openhost-catalog not in default_apps: {cfg.default_apps}"
+    catalog_entries = [s for s in cfg.default_apps if "bottled-catalog" in s.lower()]
+    assert catalog_entries, f"bottled-catalog not in default_apps: {cfg.default_apps}"
 
 
 def test_filestash_in_default_factory():
-    """openhost-filestash must be in the shipped DefaultConfig.default_apps."""
+    """bottled-filestash must be in the shipped DefaultConfig.default_apps."""
     cfg = DefaultConfig(
         host="127.0.0.1",
         data_root_dir="/tmp/fake",
         start_caddy=False,
     )
-    filestash_entries = [s for s in cfg.default_apps if "openhost-filestash" in s.lower()]
-    assert filestash_entries, f"openhost-filestash not in default_apps: {cfg.default_apps}"
+    filestash_entries = [s for s in cfg.default_apps if "bottled-filestash" in s.lower()]
+    assert filestash_entries, f"bottled-filestash not in default_apps: {cfg.default_apps}"
 
 
 def test_oauth_provider_in_default_factory():

--- a/compute_space/src/compute_space/tests/test_default_apps.py
+++ b/compute_space/src/compute_space/tests/test_default_apps.py
@@ -208,7 +208,7 @@ def test_remote_url_entry_dispatches_to_clone_path(cfg_with_apps, monkeypatch):
     monkeypatch.setattr(da, "clone_and_read_manifest", fake_clone)
 
     # Replace the config's default_apps with a single remote URL entry.
-    cfg = cfg_with_apps.evolve(default_apps=["https://github.com/imbue-openhost/openhost-catalog"])
+    cfg = cfg_with_apps.evolve(default_apps=["https://github.com/imbue-openhost/bottled-catalog"])
 
     db = sqlite3.connect(cfg.db_path)
     try:
@@ -216,15 +216,15 @@ def test_remote_url_entry_dispatches_to_clone_path(cfg_with_apps, monkeypatch):
     finally:
         db.close()
 
-    assert calls == ["https://github.com/imbue-openhost/openhost-catalog"]
+    assert calls == ["https://github.com/imbue-openhost/bottled-catalog"]
     assert len(result) == 1
     assert result[0].status == "ok"
-    assert result[0].name == "https://github.com/imbue-openhost/openhost-catalog"
+    assert result[0].name == "https://github.com/imbue-openhost/bottled-catalog"
 
     # The sentinel keys on the spec string (the URL), not the manifest name.
     with open(cfg.default_apps_sentinel_path) as f:
         sentinel = json.load(f)
-    assert "https://github.com/imbue-openhost/openhost-catalog" in sentinel
+    assert "https://github.com/imbue-openhost/bottled-catalog" in sentinel
 
 
 def test_remote_url_clone_failure_is_retried(cfg_with_apps, monkeypatch):

--- a/compute_space/src/compute_space/tests/test_installer.py
+++ b/compute_space/src/compute_space/tests/test_installer.py
@@ -29,7 +29,7 @@ class TestCheckInstallAllowed:
                 GRANT_KEY_REPO_URL_PREFIX: "https://github.com/imbue-openhost/",
             },
         ]
-        assert check_install_allowed("https://github.com/imbue-openhost/openhost-catalog", grants) is None
+        assert check_install_allowed("https://github.com/imbue-openhost/bottled-catalog", grants) is None
 
     def test_non_matching_prefix_denied(self) -> None:
         grants = [
@@ -71,7 +71,7 @@ class TestCheckInstallAllowed:
                 GRANT_KEY_REPO_URL_PREFIX: "https://github.com/imbue-openhost/",
             },
         ]
-        assert check_install_allowed("https://github.com/imbue-openhost/openhost-catalog", grants) is None
+        assert check_install_allowed("https://github.com/imbue-openhost/bottled-catalog", grants) is None
         assert check_install_allowed("https://github.com/other/", grants) is not None
 
     def test_service_url_constant_is_stable(self) -> None:

--- a/compute_space/src/compute_space/tests/test_installer.py
+++ b/compute_space/src/compute_space/tests/test_installer.py
@@ -29,7 +29,7 @@ class TestCheckInstallAllowed:
                 GRANT_KEY_REPO_URL_PREFIX: "https://github.com/imbue-openhost/",
             },
         ]
-        assert check_install_allowed("https://github.com/imbue-openhost/bottled-catalog", grants) is None
+        assert check_install_allowed("https://github.com/imbue-openhost/bottle-catalog", grants) is None
 
     def test_non_matching_prefix_denied(self) -> None:
         grants = [
@@ -71,7 +71,7 @@ class TestCheckInstallAllowed:
                 GRANT_KEY_REPO_URL_PREFIX: "https://github.com/imbue-openhost/",
             },
         ]
-        assert check_install_allowed("https://github.com/imbue-openhost/bottled-catalog", grants) is None
+        assert check_install_allowed("https://github.com/imbue-openhost/bottle-catalog", grants) is None
         assert check_install_allowed("https://github.com/other/", grants) is not None
 
     def test_service_url_constant_is_stable(self) -> None:

--- a/compute_space/src/compute_space/tests/test_installer.py
+++ b/compute_space/src/compute_space/tests/test_installer.py
@@ -29,7 +29,7 @@ class TestCheckInstallAllowed:
                 GRANT_KEY_REPO_URL_PREFIX: "https://github.com/imbue-openhost/",
             },
         ]
-        assert check_install_allowed("https://github.com/imbue-openhost/bottle-catalog", grants) is None
+        assert check_install_allowed("https://github.com/imbue-openhost/app-catalog", grants) is None
 
     def test_non_matching_prefix_denied(self) -> None:
         grants = [
@@ -71,7 +71,7 @@ class TestCheckInstallAllowed:
                 GRANT_KEY_REPO_URL_PREFIX: "https://github.com/imbue-openhost/",
             },
         ]
-        assert check_install_allowed("https://github.com/imbue-openhost/bottle-catalog", grants) is None
+        assert check_install_allowed("https://github.com/imbue-openhost/app-catalog", grants) is None
         assert check_install_allowed("https://github.com/other/", grants) is not None
 
     def test_service_url_constant_is_stable(self) -> None:

--- a/compute_space/src/compute_space/tests/test_installer_route.py
+++ b/compute_space/src/compute_space/tests/test_installer_route.py
@@ -146,7 +146,7 @@ def test_install_without_grant_returns_permission_required(client: TestClient[Li
     resp = client.post(
         _url("install"),
         headers=_headers(),
-        content=json.dumps({"repo_url": "https://github.com/imbue-openhost/bottled-catalog"}),
+        content=json.dumps({"repo_url": "https://github.com/imbue-openhost/bottle-catalog"}),
     )
     assert resp.status_code == 403
     body = resp.json()

--- a/compute_space/src/compute_space/tests/test_installer_route.py
+++ b/compute_space/src/compute_space/tests/test_installer_route.py
@@ -146,7 +146,7 @@ def test_install_without_grant_returns_permission_required(client: TestClient[Li
     resp = client.post(
         _url("install"),
         headers=_headers(),
-        content=json.dumps({"repo_url": "https://github.com/imbue-openhost/bottle-catalog"}),
+        content=json.dumps({"repo_url": "https://github.com/imbue-openhost/app-catalog"}),
     )
     assert resp.status_code == 403
     body = resp.json()

--- a/compute_space/src/compute_space/tests/test_installer_route.py
+++ b/compute_space/src/compute_space/tests/test_installer_route.py
@@ -146,7 +146,7 @@ def test_install_without_grant_returns_permission_required(client: TestClient[Li
     resp = client.post(
         _url("install"),
         headers=_headers(),
-        content=json.dumps({"repo_url": "https://github.com/imbue-openhost/openhost-catalog"}),
+        content=json.dumps({"repo_url": "https://github.com/imbue-openhost/bottled-catalog"}),
     )
     assert resp.status_code == 403
     body = resp.json()
@@ -207,7 +207,7 @@ def test_proposed_grant_uses_manifest_declared_prefix(cfg: Any) -> None:
         resp = client.post(
             _url("install"),
             headers={"Authorization": f"Bearer {NARROW_CALLER_TOKEN}", "Content-Type": "application/json"},
-            content=json.dumps({"repo_url": "https://github.com/imbue-openhost/openhost-gemini"}),
+            content=json.dumps({"repo_url": "https://github.com/imbue-openhost/bottled-gemini"}),
         )
     assert resp.status_code == 403
     body = resp.json()

--- a/compute_space/src/compute_space/tests/test_org_rename.py
+++ b/compute_space/src/compute_space/tests/test_org_rename.py
@@ -15,6 +15,7 @@ import pytest
 
 from compute_space.core import org_rename
 from compute_space.core.org_rename import OLD_ORG
+from compute_space.core.org_rename import enabled
 from compute_space.core.org_rename import reconcile_app_repo_urls
 from compute_space.core.org_rename import rewrite_owner
 
@@ -28,13 +29,27 @@ def _rw(url: str, new_org: str = NEW) -> str | None:
 # --- the sequencing guard ------------------------------------------------
 
 
-def test_disabled_until_new_org_is_set() -> None:
-    """Shipping with NEW_ORG empty must be a total no-op.
+def test_ships_inert_until_the_rename_is_done() -> None:
+    """The owner name is settled data; acting on it is a separate switch.
 
     Rewriting before the org is actually renamed would point instances at an
-    owner that does not exist, which is worse than the redirect dependency.
+    owner that does not resolve, which is worse than the redirect dependency
+    this removes. So ORG_RENAME_COMPLETE must ship False.
     """
-    assert org_rename.NEW_ORG == "", "NEW_ORG must ship empty; set it only with the rename"
+    assert org_rename.ORG_RENAME_COMPLETE is False, "flip this only in the release that ships with the rename"
+    assert enabled() is False
+
+
+def test_reconcile_is_inert_with_the_real_shipped_constants(db: sqlite3.Connection) -> None:
+    """The regression that matters: NEW_ORG is now a real name, so nothing but
+    the switch stands between a released build and a fleet-wide rewrite."""
+    url = f"https://github.com/{OLD_ORG}/bottled-navidrome@master"
+    _insert(db, "a1", "navidrome", url)
+    assert reconcile_app_repo_urls(db) == 0
+    assert _urls(db)["navidrome"] == url
+
+
+def test_rewrite_is_a_no_op_without_a_target() -> None:
     assert _rw(f"https://github.com/{OLD_ORG}/bottled-navidrome", new_org="") is None
 
 
@@ -131,7 +146,7 @@ def _urls(conn: sqlite3.Connection) -> dict[str, str | None]:
     return {r["name"]: r["repo_url"] for r in conn.execute("SELECT name, repo_url FROM apps")}
 
 
-def test_reconcile_is_a_no_op_while_disabled(db: sqlite3.Connection) -> None:
+def test_reconcile_is_a_no_op_while_the_switch_is_off(db: sqlite3.Connection) -> None:
     _insert(db, "a1", "navidrome", f"https://github.com/{OLD_ORG}/bottled-navidrome@master")
     assert reconcile_app_repo_urls(db) == 0
     assert _urls(db)["navidrome"] == f"https://github.com/{OLD_ORG}/bottled-navidrome@master"
@@ -143,7 +158,7 @@ def test_reconcile_rewrites_only_matching_rows(db: sqlite3.Connection) -> None:
     _insert(db, "a3", "oauth-provider", "file:///home/host/openhost/apps/oauth_provider")
     _insert(db, "a4", "nourl", None)
 
-    with mock.patch.object(org_rename, "NEW_ORG", NEW):
+    with mock.patch.object(org_rename, "ORG_RENAME_COMPLETE", True):
         assert reconcile_app_repo_urls(db) == 1
 
     urls = _urls(db)
@@ -155,7 +170,7 @@ def test_reconcile_rewrites_only_matching_rows(db: sqlite3.Connection) -> None:
 
 def test_reconcile_is_idempotent(db: sqlite3.Connection) -> None:
     _insert(db, "a1", "navidrome", f"https://github.com/{OLD_ORG}/bottled-navidrome")
-    with mock.patch.object(org_rename, "NEW_ORG", NEW):
+    with mock.patch.object(org_rename, "ORG_RENAME_COMPLETE", True):
         assert reconcile_app_repo_urls(db) == 1
         assert reconcile_app_repo_urls(db) == 0
     assert _urls(db)["navidrome"] == f"https://github.com/{NEW}/bottled-navidrome"
@@ -170,7 +185,7 @@ def test_reconcile_updates_the_checkout_origin(db: sqlite3.Connection, tmp_path:
     repo.create_remote("origin", f"https://github.com/{OLD_ORG}/bottled-navidrome")
 
     _insert(db, "a1", "navidrome", f"https://github.com/{OLD_ORG}/bottled-navidrome", str(checkout))
-    with mock.patch.object(org_rename, "NEW_ORG", NEW):
+    with mock.patch.object(org_rename, "ORG_RENAME_COMPLETE", True):
         assert reconcile_app_repo_urls(db) == 1
 
     assert repo.remotes.origin.url == f"https://github.com/{NEW}/bottled-navidrome"
@@ -180,7 +195,7 @@ def test_reconcile_survives_a_missing_checkout(db: sqlite3.Connection, tmp_path:
     """A broken checkout must not stop the DB rewrite, and must not raise: this
     runs during boot."""
     _insert(db, "a1", "navidrome", f"https://github.com/{OLD_ORG}/bottled-navidrome", str(tmp_path / "gone"))
-    with mock.patch.object(org_rename, "NEW_ORG", NEW):
+    with mock.patch.object(org_rename, "ORG_RENAME_COMPLETE", True):
         assert reconcile_app_repo_urls(db) == 1
     assert _urls(db)["navidrome"] == f"https://github.com/{NEW}/bottled-navidrome"
 
@@ -188,5 +203,5 @@ def test_reconcile_survives_a_missing_checkout(db: sqlite3.Connection, tmp_path:
 def test_reconcile_never_raises_on_a_broken_db() -> None:
     conn = sqlite3.connect(":memory:")
     conn.row_factory = sqlite3.Row  # no apps table at all
-    with mock.patch.object(org_rename, "NEW_ORG", NEW):
+    with mock.patch.object(org_rename, "ORG_RENAME_COMPLETE", True):
         assert reconcile_app_repo_urls(conn) == 0

--- a/compute_space/src/compute_space/tests/test_org_rename.py
+++ b/compute_space/src/compute_space/tests/test_org_rename.py
@@ -1,0 +1,192 @@
+"""Tests for moving persisted app repo URLs off a renamed GitHub org.
+
+The rewrite runs against URLs that instances have already stored, so the
+dangerous failure is over-matching: rewriting a URL that points somewhere else
+would silently redirect an app's source to a repository we do not control.
+Most of these cases are therefore about what must *not* change.
+"""
+
+import sqlite3
+from pathlib import Path
+from unittest import mock
+
+import git
+import pytest
+
+from compute_space.core import org_rename
+from compute_space.core.org_rename import OLD_ORG
+from compute_space.core.org_rename import reconcile_app_repo_urls
+from compute_space.core.org_rename import rewrite_owner
+
+NEW = "cloud-in-a-bottle"
+
+
+def _rw(url: str, new_org: str = NEW) -> str | None:
+    return rewrite_owner(url, old_org=OLD_ORG, new_org=new_org)
+
+
+# --- the sequencing guard ------------------------------------------------
+
+
+def test_disabled_until_new_org_is_set() -> None:
+    """Shipping with NEW_ORG empty must be a total no-op.
+
+    Rewriting before the org is actually renamed would point instances at an
+    owner that does not exist, which is worse than the redirect dependency.
+    """
+    assert org_rename.NEW_ORG == "", "NEW_ORG must ship empty; set it only with the rename"
+    assert _rw(f"https://github.com/{OLD_ORG}/bottled-navidrome", new_org="") is None
+
+
+def test_no_op_when_new_equals_old() -> None:
+    assert _rw(f"https://github.com/{OLD_ORG}/x", new_org=OLD_ORG) is None
+
+
+# --- what must be rewritten ---------------------------------------------
+
+
+def test_rewrites_the_owner_segment() -> None:
+    assert _rw(f"https://github.com/{OLD_ORG}/bottled-navidrome") == f"https://github.com/{NEW}/bottled-navidrome"
+
+
+def test_preserves_ref_suffix() -> None:
+    """apps.repo_url stores a pip-style @ref; losing it would change the
+    installed revision."""
+    assert (
+        _rw(f"https://github.com/{OLD_ORG}/bottled-navidrome@master")
+        == f"https://github.com/{NEW}/bottled-navidrome@master"
+    )
+
+
+def test_preserves_git_suffix_and_subpaths() -> None:
+    assert _rw(f"https://github.com/{OLD_ORG}/openhost.git") == f"https://github.com/{NEW}/openhost.git"
+    assert _rw(f"https://github.com/{OLD_ORG}/openhost/tree/main") == f"https://github.com/{NEW}/openhost/tree/main"
+
+
+def test_owner_match_is_case_insensitive() -> None:
+    """GitHub owner names are case-insensitive, so a stored Imbue-OpenHost must
+    still be migrated."""
+    assert _rw("https://github.com/Imbue-OpenHost/bottled-lila") == f"https://github.com/{NEW}/bottled-lila"
+
+
+def test_scheme_less_url_keeps_its_shape() -> None:
+    assert _rw(f"github.com/{OLD_ORG}/bottled-lila") == f"github.com/{NEW}/bottled-lila"
+
+
+# --- what must NOT be rewritten -----------------------------------------
+
+
+def test_leaves_other_owners_alone() -> None:
+    assert _rw("https://github.com/imbue-ai/sculptor") is None
+    assert _rw("https://github.com/CarlKho-Minerva/openhost-cap") is None
+
+
+def test_leaves_look_alike_hosts_alone() -> None:
+    """github.com.evil.example is not GitHub; rewriting it would hand an
+    attacker-controlled host our new owner name."""
+    assert _rw(f"https://github.com.evil.example/{OLD_ORG}/x") is None
+    assert _rw(f"https://notgithub.com/{OLD_ORG}/x") is None
+
+
+def test_leaves_other_forges_alone() -> None:
+    assert _rw(f"https://gitlab.com/{OLD_ORG}/x") is None
+
+
+def test_leaves_ssh_urls_alone() -> None:
+    assert _rw(f"git@github.com:{OLD_ORG}/x.git") is None
+    assert _rw(f"ssh://git@github.com/{OLD_ORG}/x.git") is None
+
+
+def test_does_not_touch_a_repo_named_after_the_owner() -> None:
+    """Only the owner segment moves. A repo whose *name* contains the old org
+    keeps its name."""
+    assert _rw(f"https://github.com/{OLD_ORG}/{OLD_ORG}-tools") == f"https://github.com/{NEW}/{OLD_ORG}-tools"
+    assert _rw(f"https://github.com/someone/{OLD_ORG}") is None
+
+
+def test_leaves_local_and_file_urls_alone() -> None:
+    assert _rw("file:///home/host/openhost/apps/oauth_provider") is None
+    assert _rw("") is None
+
+
+# --- the DB reconcile ----------------------------------------------------
+
+
+@pytest.fixture
+def db() -> sqlite3.Connection:
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    conn.execute(
+        "CREATE TABLE apps (app_id TEXT PRIMARY KEY, name TEXT, repo_url TEXT, repo_path TEXT NOT NULL DEFAULT '')"
+    )
+    return conn
+
+
+def _insert(conn: sqlite3.Connection, app_id: str, name: str, url: str | None, path: str = "") -> None:
+    conn.execute("INSERT INTO apps (app_id, name, repo_url, repo_path) VALUES (?, ?, ?, ?)", (app_id, name, url, path))
+    conn.commit()
+
+
+def _urls(conn: sqlite3.Connection) -> dict[str, str | None]:
+    return {r["name"]: r["repo_url"] for r in conn.execute("SELECT name, repo_url FROM apps")}
+
+
+def test_reconcile_is_a_no_op_while_disabled(db: sqlite3.Connection) -> None:
+    _insert(db, "a1", "navidrome", f"https://github.com/{OLD_ORG}/bottled-navidrome@master")
+    assert reconcile_app_repo_urls(db) == 0
+    assert _urls(db)["navidrome"] == f"https://github.com/{OLD_ORG}/bottled-navidrome@master"
+
+
+def test_reconcile_rewrites_only_matching_rows(db: sqlite3.Connection) -> None:
+    _insert(db, "a1", "navidrome", f"https://github.com/{OLD_ORG}/bottled-navidrome@master")
+    _insert(db, "a2", "sculptor", "https://github.com/imbue-ai/sculptor")
+    _insert(db, "a3", "oauth-provider", "file:///home/host/openhost/apps/oauth_provider")
+    _insert(db, "a4", "nourl", None)
+
+    with mock.patch.object(org_rename, "NEW_ORG", NEW):
+        assert reconcile_app_repo_urls(db) == 1
+
+    urls = _urls(db)
+    assert urls["navidrome"] == f"https://github.com/{NEW}/bottled-navidrome@master"
+    assert urls["sculptor"] == "https://github.com/imbue-ai/sculptor"
+    assert urls["oauth-provider"] == "file:///home/host/openhost/apps/oauth_provider"
+    assert urls["nourl"] is None
+
+
+def test_reconcile_is_idempotent(db: sqlite3.Connection) -> None:
+    _insert(db, "a1", "navidrome", f"https://github.com/{OLD_ORG}/bottled-navidrome")
+    with mock.patch.object(org_rename, "NEW_ORG", NEW):
+        assert reconcile_app_repo_urls(db) == 1
+        assert reconcile_app_repo_urls(db) == 0
+    assert _urls(db)["navidrome"] == f"https://github.com/{NEW}/bottled-navidrome"
+
+
+def test_reconcile_updates_the_checkout_origin(db: sqlite3.Connection, tmp_path: Path) -> None:
+    """The checkout's origin is what an update actually fetches from, so it has
+    to move with the DB row."""
+    checkout = tmp_path / "repo"
+    checkout.mkdir()
+    repo = git.Repo.init(checkout)
+    repo.create_remote("origin", f"https://github.com/{OLD_ORG}/bottled-navidrome")
+
+    _insert(db, "a1", "navidrome", f"https://github.com/{OLD_ORG}/bottled-navidrome", str(checkout))
+    with mock.patch.object(org_rename, "NEW_ORG", NEW):
+        assert reconcile_app_repo_urls(db) == 1
+
+    assert repo.remotes.origin.url == f"https://github.com/{NEW}/bottled-navidrome"
+
+
+def test_reconcile_survives_a_missing_checkout(db: sqlite3.Connection, tmp_path: Path) -> None:
+    """A broken checkout must not stop the DB rewrite, and must not raise: this
+    runs during boot."""
+    _insert(db, "a1", "navidrome", f"https://github.com/{OLD_ORG}/bottled-navidrome", str(tmp_path / "gone"))
+    with mock.patch.object(org_rename, "NEW_ORG", NEW):
+        assert reconcile_app_repo_urls(db) == 1
+    assert _urls(db)["navidrome"] == f"https://github.com/{NEW}/bottled-navidrome"
+
+
+def test_reconcile_never_raises_on_a_broken_db() -> None:
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row  # no apps table at all
+    with mock.patch.object(org_rename, "NEW_ORG", NEW):
+        assert reconcile_app_repo_urls(conn) == 0

--- a/compute_space/src/compute_space/web/app.py
+++ b/compute_space/src/compute_space/web/app.py
@@ -32,6 +32,7 @@ from compute_space.core.first_boot import seed_first_boot
 from compute_space.core.git_ops import SOURCE_URL
 from compute_space.core.image_pruner import start_image_pruner
 from compute_space.core.logging import logger
+from compute_space.core.org_rename import reconcile_app_repo_urls
 from compute_space.core.startup import check_app_status
 from compute_space.core.startup import retry_pending_default_apps
 from compute_space.core.storage import start_storage_guard
@@ -138,6 +139,10 @@ def _full_app_bootstrap(config: Config) -> None:
     db = get_db()  # row_factory=Row; the archive derives its per-zone volume from the domains store
     try:
         archive_backend.attach_on_startup(config, db)
+        # Move any app repo URLs still pointing at the pre-rename GitHub owner.
+        # Idempotent, and inert until org_rename.NEW_ORG is set; see that module
+        # for why this is a per-boot reconcile rather than a versioned migration.
+        reconcile_app_repo_urls(db)
     finally:
         db.close()
     check_app_status(config)

--- a/compute_space/src/compute_space/web/app.py
+++ b/compute_space/src/compute_space/web/app.py
@@ -32,7 +32,6 @@ from compute_space.core.first_boot import seed_first_boot
 from compute_space.core.git_ops import SOURCE_URL
 from compute_space.core.image_pruner import start_image_pruner
 from compute_space.core.logging import logger
-from compute_space.core.org_rename import reconcile_app_repo_urls
 from compute_space.core.startup import check_app_status
 from compute_space.core.startup import retry_pending_default_apps
 from compute_space.core.storage import start_storage_guard
@@ -139,10 +138,6 @@ def _full_app_bootstrap(config: Config) -> None:
     db = get_db()  # row_factory=Row; the archive derives its per-zone volume from the domains store
     try:
         archive_backend.attach_on_startup(config, db)
-        # Move any app repo URLs still pointing at the pre-rename GitHub owner.
-        # Idempotent, and inert until org_rename.NEW_ORG is set; see that module
-        # for why this is a per-boot reconcile rather than a versioned migration.
-        reconcile_app_repo_urls(db)
     finally:
         db.close()
     check_app_status(config)

--- a/compute_space/src/compute_space/web/routes/docs.py
+++ b/compute_space/src/compute_space/web/routes/docs.py
@@ -423,7 +423,7 @@ _TEMPLATE = """<!DOCTYPE html>
   <meta charset="utf-8">
   <meta name="robots" content="noindex">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>{{ page_title }} - OpenHost Manual</title>
+  <title>{{ page_title }} - Cloud in a Bottle Manual</title>
   <style>
     /* The docs page deliberately reuses layout.html's exact palette and
        typography (hardcoded light colours, #222 text on #fff, #ddd
@@ -634,7 +634,7 @@ _TEMPLATE = """<!DOCTYPE html>
 </head>
 <body>
   <header class="space-header">
-    <h1 class="space-title">{% if display_name %}{{ display_name }}'s personal compute space{% else %}OpenHost{% endif %}</h1>
+    <h1 class="space-title">{% if display_name %}{{ display_name }}'s personal compute space{% else %}Cloud in a Bottle{% endif %}</h1>
     {% include "_nav_header.html" %}
   </header>
   <svg width="0" height="0" style="position: absolute" aria-hidden="true" focusable="false">

--- a/compute_space/src/compute_space/web/routes/pages/apps.py
+++ b/compute_space/src/compute_space/web/routes/pages/apps.py
@@ -36,7 +36,7 @@ EDIT_APP_VERSION_SPEC = "<1.0"
 # The app catalog ships as a default app (see Config.default_apps); the Deploy
 # page links to it when installed and offers to install it otherwise.
 CATALOG_APP_NAME = "catalog"
-CATALOG_REPO_URL = "https://github.com/imbue-openhost/bottled-catalog"
+CATALOG_REPO_URL = "https://github.com/imbue-openhost/bottle-catalog"
 
 
 @get(["/", "/dashboard"], guards=[require_owner_auth])

--- a/compute_space/src/compute_space/web/routes/pages/apps.py
+++ b/compute_space/src/compute_space/web/routes/pages/apps.py
@@ -36,7 +36,7 @@ EDIT_APP_VERSION_SPEC = "<1.0"
 # The app catalog ships as a default app (see Config.default_apps); the Deploy
 # page links to it when installed and offers to install it otherwise.
 CATALOG_APP_NAME = "catalog"
-CATALOG_REPO_URL = "https://github.com/imbue-openhost/bottle-catalog"
+CATALOG_REPO_URL = "https://github.com/imbue-openhost/app-catalog"
 
 
 @get(["/", "/dashboard"], guards=[require_owner_auth])

--- a/compute_space/src/compute_space/web/routes/pages/apps.py
+++ b/compute_space/src/compute_space/web/routes/pages/apps.py
@@ -36,7 +36,7 @@ EDIT_APP_VERSION_SPEC = "<1.0"
 # The app catalog ships as a default app (see Config.default_apps); the Deploy
 # page links to it when installed and offers to install it otherwise.
 CATALOG_APP_NAME = "catalog"
-CATALOG_REPO_URL = "https://github.com/imbue-openhost/openhost-catalog"
+CATALOG_REPO_URL = "https://github.com/imbue-openhost/bottled-catalog"
 
 
 @get(["/", "/dashboard"], guards=[require_owner_auth])

--- a/compute_space/src/compute_space/web/setup_app.py
+++ b/compute_space/src/compute_space/web/setup_app.py
@@ -148,7 +148,7 @@ async def setup_post(request: Request[Any, Any, Any], config: NamedDependency[Co
     body = (
         "<!doctype html><html><head><meta http-equiv=refresh content='2; url=/'>"
         "<meta name=robots content=noindex>"
-        "<title>OpenHost — restarting</title></head>"
+        "<title>Cloud in a Bottle — restarting</title></head>"
         "<body style='font-family:system-ui;text-align:center;margin-top:4em;'>"
         "<p>Setup complete. Restarting…</p></body></html>"
     )

--- a/compute_space/src/compute_space/web/templates/_nav_header.html
+++ b/compute_space/src/compute_space/web/templates/_nav_header.html
@@ -12,7 +12,7 @@
   <a href="/system/" class="nav-tab">System Info</a>
   <a href="/diagnostics/" class="nav-tab">Diagnostics</a>
   <a href="/settings" class="nav-tab">Settings</a>
-  {#- Provenance link: the exact branch/fork of OpenHost this instance is running,
+  {#- Provenance link: the exact branch/fork of Cloud in a Bottle this instance is running,
       surfaced as GitHub's official (unmodified) Invertocat mark. Right-aligned so
       it stays out of the tab flow, and hidden entirely on tarball deploys where
       ``source_url`` is None. Also supports the AGPL source-offer to network users. -#}

--- a/compute_space/src/compute_space/web/templates/diagnostics.html
+++ b/compute_space/src/compute_space/web/templates/diagnostics.html
@@ -2,7 +2,7 @@
 {% block title_suffix %} - Diagnostics{% endblock %}
 {% block content %}
 <h2>Diagnostics</h2>
-<p class="hint">A snapshot of this instance for debugging: OpenHost version, host system
+<p class="hint">A snapshot of this instance for debugging: Cloud in a Bottle version, host system
 info, installed dependency versions, container runtime, disk usage, and every
 installed app. Copy or download it and include it in a bug report.</p>
 

--- a/compute_space/src/compute_space/web/templates/identity_approve.html
+++ b/compute_space/src/compute_space/web/templates/identity_approve.html
@@ -2,7 +2,7 @@
 <html>
 <head>
   <meta name="robots" content="noindex">
-  <title>OpenHost - Identity Request</title>
+  <title>Cloud in a Bottle - Identity Request</title>
   <style>
     body { font-family: -apple-system, system-ui, sans-serif; max-width: 500px; margin: 4em auto; padding: 0 1em; }
     .info { background: #f0f4ff; border: 1px solid #c0d0f0; border-radius: 6px; padding: 1em; margin: 1em 0; }
@@ -18,7 +18,7 @@
 </head>
 <body>
   <h2>Identity Login Request</h2>
-  <p>An app is asking you to prove your OpenHost identity.</p>
+  <p>An app is asking you to prove your Cloud in a Bottle identity.</p>
 
   <div class="info">
     <dl>

--- a/compute_space/src/compute_space/web/templates/layout.html
+++ b/compute_space/src/compute_space/web/templates/layout.html
@@ -5,7 +5,7 @@
 <html>
 <head>
   <meta name="robots" content="noindex">
-  <title>{% if display_name %}{{ display_name }}'s personal compute space{% else %}OpenHost{% endif %}{% block title_suffix %}{% endblock %}</title>
+  <title>{% if display_name %}{{ display_name }}'s personal compute space{% else %}Cloud in a Bottle{% endif %}{% block title_suffix %}{% endblock %}</title>
   <style>
     /* Always reserve the vertical scrollbar gutter so the centred body doesn't
        shift sideways when navigating between pages that scroll and pages that
@@ -57,7 +57,7 @@
   </style>
 </head>
 <body>
-  <h1>{% if display_name %}{{ display_name }}'s personal compute space{% else %}OpenHost{% endif %}</h1>
+  <h1>{% if display_name %}{{ display_name }}'s personal compute space{% else %}Cloud in a Bottle{% endif %}</h1>
   {% include "_nav_header.html" %}
   {% block content %}{% endblock %}
 </body>

--- a/compute_space/src/compute_space/web/templates/login.html
+++ b/compute_space/src/compute_space/web/templates/login.html
@@ -2,7 +2,7 @@
 <html>
 <head>
   <meta name="robots" content="noindex">
-  <title>OpenHost - Login</title>
+  <title>Cloud in a Bottle - Login</title>
   <style>
     body { font-family: -apple-system, system-ui, sans-serif; max-width: 400px; margin: 4em auto; padding: 0 1em; }
     input { display: block; margin: 0.5em 0; padding: 0.4em; width: 100%; box-sizing: border-box; }
@@ -10,7 +10,7 @@
   </style>
 </head>
 <body>
-  <h2>OpenHost Login</h2>
+  <h2>Cloud in a Bottle Login</h2>
   {% if error %}<p class="error">{{ error }}</p>{% endif %}
   <form method="post">
     <input type="hidden" name="next" value="{{ next }}">

--- a/compute_space/src/compute_space/web/templates/setup.html
+++ b/compute_space/src/compute_space/web/templates/setup.html
@@ -2,7 +2,7 @@
 <html>
 <head>
   <meta name="robots" content="noindex">
-  <title>OpenHost - Setup</title>
+  <title>Cloud in a Bottle - Setup</title>
   <style>
     body { font-family: -apple-system, system-ui, sans-serif; max-width: 400px; margin: 4em auto; padding: 0 1em; }
     input { display: block; margin: 0.5em 0; padding: 0.4em; width: 100%; box-sizing: border-box; }
@@ -13,8 +13,8 @@
   </style>
 </head>
 <body>
-  <h2>OpenHost Setup</h2>
-  <p>Set a password for this OpenHost instance.</p>
+  <h2>Cloud in a Bottle Setup</h2>
+  <p>Set a password for this Cloud in a Bottle instance.</p>
   {% if error %}<p class="error">{{ error }}</p>{% endif %}
   <form method="post" id="setup-form">
     {% if claim %}<input type="hidden" name="claim" value="{{ claim }}">{% endif %}

--- a/compute_space_cli/README.md
+++ b/compute_space_cli/README.md
@@ -1,6 +1,6 @@
-# oh — OpenHost CLI
+# oh — Cloud in a Bottle CLI
 
-Command-line tool for managing apps on your OpenHost compute space.
+Command-line tool for managing apps on your Cloud in a Bottle compute space.
 
 ## Install
 

--- a/compute_space_cli/pyproject.toml
+++ b/compute_space_cli/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "oh"
 version = "0.1.0"
-description = "OpenHost CLI — manage apps on your compute space"
+description = "Cloud in a Bottle CLI — manage apps on your compute space"
 requires-python = ">=3.12"
 dependencies = [
     "attrs",

--- a/compute_space_cli/src/compute_space_cli/config.py
+++ b/compute_space_cli/src/compute_space_cli/config.py
@@ -36,7 +36,7 @@ def hostname_from_url(url: str) -> str:
 
 @attr.s(auto_attribs=True, frozen=True)
 class Instance:
-    """A single OpenHost compute-space instance."""
+    """A single Cloud in a Bottle compute-space instance."""
 
     hostname: str = attr.ib()
     token: str = attr.ib()

--- a/compute_space_cli/src/compute_space_cli/main.py
+++ b/compute_space_cli/src/compute_space_cli/main.py
@@ -612,7 +612,7 @@ class Diagnostics:
         print(json.dumps(result.json(), indent=2))
 
 
-@cappa.command(name="curl", help="curl with your OpenHost bearer token injected.")
+@cappa.command(name="curl", help="curl with your Cloud in a Bottle bearer token injected.")
 @attrs.define
 class Curl:
     args: Annotated[
@@ -629,7 +629,7 @@ class Curl:
         raise SystemExit(subprocess.call(cmd))
 
 
-@cappa.command(name="oh", help="OpenHost compute space CLI — manage things in your compute space.")
+@cappa.command(name="oh", help="Cloud in a Bottle compute space CLI — manage things in your compute space.")
 @attrs.define
 class Oh:
     subcommand: cappa.Subcommands[Status | AppCmd | TokensCmd | LogsCmd | InstanceCmd | Curl | Version | Diagnostics]

--- a/docs/book.toml
+++ b/docs/book.toml
@@ -1,7 +1,7 @@
 [book]
-title = "OpenHost Manual"
+title = "Cloud in a Bottle Manual"
 authors = ["Imbue"]
-description = "Documentation for the OpenHost platform, for operators and app authors."
+description = "Documentation for the Cloud in a Bottle platform, for operators and app authors."
 src = "src"
 language = "en"
 

--- a/docs/src/creating_an_app.md
+++ b/docs/src/creating_an_app.md
@@ -1,6 +1,6 @@
-# Creating an App for OpenHost
+# Creating an App for Cloud in a Bottle
 
-This guide walks through building an app that runs on OpenHost.
+This guide walks through building an app that runs on Cloud in a Bottle.
 
 ## Deploying your app
 
@@ -9,19 +9,19 @@ From the dashboard, click "Deploy New App" and provide a git repo URL (public or
 The router reads `openhost.toml`, builds the container image from your `Dockerfile` using rootless podman, and starts routing requests to it. Apps are accessible at `https://{app_name}.{zone_domain}/` (e.g., `https://my-app.user.host.imbue.com/`).
 
 
-## Writing an app to run on OpenHost
+## Writing an app to run on Cloud in a Bottle
 
-Apps can be anything that can run in an OCI container, and accessed via HTTP(s). OpenHost runs every app under rootless podman, so container-root maps to an unprivileged subuid on the host rather than real root.
+Apps can be anything that can run in an OCI container, and accessed via HTTP(s). Cloud in a Bottle runs every app under rootless podman, so container-root maps to an unprivileged subuid on the host rather than real root.
 
-An `openhost.toml` manifest must be placed at the root of your repo, to indicate to OpenHost how to run your app. See the [manifest spec](manifest_spec.md) for the full field reference.
+An `openhost.toml` manifest must be placed at the root of your repo, to indicate to Cloud in a Bottle how to run your app. See the [manifest spec](manifest_spec.md) for the full field reference.
 
 ## App template
 
-OpenHost has a standard app template available as a starting point: [https://github.com/imbue-openhost/app-template](https://github.com/imbue-openhost/app-template)
+Cloud in a Bottle has a standard app template available as a starting point: [https://github.com/imbue-openhost/app-template](https://github.com/imbue-openhost/app-template)
 
-This repo contains a Python 3.12 server using Litestar and Hypercorn, managed with uv. It includes pre-commit hooks (ruff formatting, mypy strict type checking), and an integration test suite using pytest, httpx, and Playwright. Tests run both locally and as a full containerized app, building the Dockerfile and fronting it with the real OpenHost router. 
+This repo contains a Python 3.12 server using Litestar and Hypercorn, managed with uv. It includes pre-commit hooks (ruff formatting, mypy strict type checking), and an integration test suite using pytest, httpx, and Playwright. Tests run both locally and as a full containerized app, building the Dockerfile and fronting it with the real Cloud in a Bottle router. 
 
-The template is recommended when starting a new app from scratch. Existing projects can also be deployed to OpenHost directly via their own Dockerfile without using this template.
+The template is recommended when starting a new app from scratch. Existing projects can also be deployed to Cloud in a Bottle directly via their own Dockerfile without using this template.
 
 
 ### Rootless constraints
@@ -115,7 +115,7 @@ The router injects these environment variables into your app:
 
 | Variable | Example | Description                                                                                                     |
 |----------|---------|-----------------------------------------------------------------------------------------------------------------|
-| `OPENHOST_APP_NAME` | `my-app` | Your app's name, as registered with OpenHost. This will be the subdomain the app is routeable at.               |
+| `OPENHOST_APP_NAME` | `my-app` | Your app's name, as registered with Cloud in a Bottle. This will be the subdomain the app is routeable at.               |
 | `OPENHOST_APP_ID` | `4Hm9pX2Qk7Lt` (12-char base58) | Opaque, immutable per-app identity. Stable across renames; safe to key persistent state on. |
 | `OPENHOST_APP_TOKEN` | `kF3xP_2qA-bN4...` (43-char url-safe token) | Random per-app token used to authenticate cross-app service calls                                               |
 | `OPENHOST_ROUTER_URL` | `http://host.containers.internal:8080` | internal URL of the router, used for constructing service requests. |
@@ -141,7 +141,7 @@ Apps receive a persistent data directory by default. You can opt out or request 
 - **`access_all_data = true`** — convenience shorthand for `access_all_app_data = true` + `access_all_archive = true`.
 
 
-The storage guard requires a minimum amount of free persistent storage, stopping running apps when free space drops below `storage_min_free_mb` until space is freed. It is enabled by default; the host operator can change the threshold (or disable it with `0`) in the OpenHost config and reboot. The guard can be temporarily paused from the System page to allow starting a file-browser app for cleanup.
+The storage guard requires a minimum amount of free persistent storage, stopping running apps when free space drops below `storage_min_free_mb` until space is freed. It is enabled by default; the host operator can change the threshold (or disable it with `0`) in the Cloud in a Bottle config and reboot. The guard can be temporarily paused from the System page to allow starting a file-browser app for cleanup.
 
 See the [manifest spec](manifest_spec.md) for the full reference.
 
@@ -153,7 +153,7 @@ See [OAuth in Apps](./oauth.md) for an example - getting oauth tokens to externa
 
 ### Identity
 
-For apps that should be available to multiple users and require more than trivial publicly routes or token-protected public routes, see [User Identity](./user_identity.md) for how to implement this with the OpenHost user identity provider.
+For apps that should be available to multiple users and require more than trivial publicly routes or token-protected public routes, see [User Identity](./user_identity.md) for how to implement this with the Cloud in a Bottle user identity provider.
 
 
 ## Development / Debugging workflow
@@ -166,7 +166,7 @@ In general, the debugging flow is something like:
 5. "Update and reload" from the app details page (pulls new code and rebuilds)
 6. Retest and repeat
 
-We find AI tools work best when they can directly reference openhost code+docs. So we'd suggest:
+We find AI tools work best when they can directly reference Cloud in a Bottle code+docs. So we'd suggest:
 ```cd some_dir && git clone https://github.com/imbue-openhost/openhost.git```
 then point them at that checkout and tell them to read this doc.
 

--- a/docs/src/cross_app_services.md
+++ b/docs/src/cross_app_services.md
@@ -69,7 +69,7 @@ If permission is needed to access the service, a 403 is returned - see the Permi
 
 ### Provider selection
 
-Each service URL has a configured default provider - by default it's first app installed providing that service, but can be configured in openhost's settings.
+Each service URL has a configured default provider - by default it's first app installed providing that service, but can be configured in Cloud in a Bottle's settings.
 
 If the resolved default's version doesn't satisfy the consumer's version specifier, the router returns 503 `service_not_available`.
 
@@ -123,7 +123,7 @@ For `scope: "global"`, the router rewrites the response to add a `grant_url` poi
 
 The consumer redirects the owner to `grant_url`; after approval, the call can be retried.
 
-**Granting at deploy time.** Global-scoped permissions specified in the consumer app manifest (`grants`) can be granted as part of the app install, either in the openhost web UI or via the compute_space CLI's `--grant-permissions-v2` flag.
+**Granting at deploy time.** Global-scoped permissions specified in the consumer app manifest (`grants`) can be granted as part of the app install, either in the Cloud in a Bottle web UI or via the compute_space CLI's `--grant-permissions-v2` flag.
 
 #### Provider-app-scoped permissions
 

--- a/docs/src/deploying.md
+++ b/docs/src/deploying.md
@@ -1,4 +1,4 @@
-# Running OpenHost in a local QEMU VM
+# Running Cloud in a Bottle in a local QEMU VM
 
 > The authoritative deployment reference is
 > **[`ansible/readme.md`](https://github.com/imbue-openhost/openhost/blob/main/ansible/readme.md)**
@@ -8,13 +8,13 @@
 > [QEMU](https://www.qemu.org/download/) ·
 > [Ubuntu Server](https://ubuntu.com/download/server)
 
-This gets OpenHost running on an **Ubuntu 24.04 VM under QEMU** on your
+This gets Cloud in a Bottle running on an **Ubuntu 24.04 VM under QEMU** on your
 desktop — good for trying it out before you buy a dedicated domain or machine.
 Two parts:
 
 1. **[Build the VM](#part-1--build-an-ubuntu-vm-in-qemu)** — install QEMU and
    stand up an Ubuntu VM.
-2. **[Deploy OpenHost](#part-2--deploy-openhost-onto-the-vm)** — run the Ansible
+2. **[Deploy Cloud in a Bottle](#part-2--deploy-openhost-onto-the-vm)** — run the Ansible
    playbook against that VM (HTTP-only mode; no domain needed).
 
 For a dedicated instance instead, see
@@ -176,7 +176,7 @@ On arm64 Linux, keep `-machine virt` but use
 
 ---
 
-## Part 2 — Deploy OpenHost onto the VM
+## Part 2 — Deploy Cloud in a Bottle onto the VM
 
 Run these from your **desktop** (not inside the VM), with the VM from Part 1
 still running.
@@ -218,10 +218,10 @@ ansible-playbook ansible/setup.yml \
   --ask-become-pass          # the VM user's sudo password (set in the cloud-init seed)
 ```
 
-This installs rootless Podman, pixi, the systemd units, and deploys OpenHost's
+This installs rootless Podman, pixi, the systemd units, and deploys Cloud in a Bottle's
 default apps. It takes several minutes the first time.
 
-> **Why `DOMAIN=lvh.me:8080`?** OpenHost routes apps by subdomain
+> **Why `DOMAIN=lvh.me:8080`?** Cloud in a Bottle routes apps by subdomain
 > (`<app>.<domain>`), and `localhost` can't have working wildcard subdomains.
 > `lvh.me` and `*.lvh.me` resolve to `127.0.0.1` in public DNS with no setup, so
 > `http://myapp.lvh.me:8080` just works. Include the **`:8080`** so the router's

--- a/docs/src/introduction.md
+++ b/docs/src/introduction.md
@@ -1,9 +1,9 @@
 # Introduction
 
-This is the OpenHost Manual.  It documents the platform from the
-perspective of an *operator* (someone running a personal OpenHost
+This is the Cloud in a Bottle Manual.  It documents the platform from the
+perspective of an *operator* (someone running a personal Cloud in a Bottle
 zone) and from the perspective of an *app author* (someone packaging
-an application to run on OpenHost).
+an application to run on Cloud in a Bottle).
 
 Both audiences need different things, so the manual is split into
 two halves.
@@ -19,10 +19,10 @@ Most of this is in the dashboard at
 
 ## For app authors
 
-Sections about how OpenHost expects an app to be packaged — the
+Sections about how Cloud in a Bottle expects an app to be packaged — the
 manifest format, the runtime contract, what your container can
 expect from the environment, and how to integrate with the
-OpenHost identity / permissions / inter-app services machinery.
+Cloud in a Bottle identity / permissions / inter-app services machinery.
 
 If you're building an app from scratch, start at [Creating an
 App](./creating_an_app.md).  If you have an existing app and want
@@ -38,7 +38,7 @@ repository.  The pages are rendered server-side on every request
 to ship doc changes — no build step required.  When you're reading
 the manual on your own zone at
 `https://your-zone.example.com/docs/`, you're reading the docs
-that match the OpenHost version you have running — never out of
+that match the Cloud in a Bottle version you have running — never out of
 sync.
 
 ## Feeding the manual to an AI agent
@@ -53,7 +53,7 @@ curl https://your-zone.example.com/docs/all.md
 ```
 
 The copy icons put the same text on your clipboard: the one beside
-each page's heading copies that page, and the one beside **OpenHost
+each page's heading copies that page, and the one beside **Cloud in a Bottle
 Manual** in the sidebar copies the whole thing.
 
 ## Improving the docs

--- a/docs/src/logs.md
+++ b/docs/src/logs.md
@@ -1,6 +1,6 @@
 ## Logs
 
-OpenHost produces several distinct log streams, stored in different places depending on the process.
+Cloud in a Bottle produces several distinct log streams, stored in different places depending on the process.
 
 ---
 
@@ -20,7 +20,7 @@ The router writes to two sinks simultaneously via loguru:
 - Written at DEBUG level and above.
 - Captured by systemd from the router process's stderr and stored in journald's binary database at `/var/log/journal/`.
 - Also contains output from Caddy and CoreDNS, because both are child processes of the router — their stdout is read line-by-line and re-emitted through the router's logger.
-- Persists across restarts and accumulates until journald's on-disk size cap is hit. OpenHost caps the total journal at 500 MB via a drop-in at `/etc/systemd/journald.conf.d/10-openhost.conf` (`SystemMaxUse=500M`) so the journal alone can't fill the host disk; older entries are discarded once the cap is reached.
+- Persists across restarts and accumulates until journald's on-disk size cap is hit. Cloud in a Bottle caps the total journal at 500 MB via a drop-in at `/etc/systemd/journald.conf.d/10-openhost.conf` (`SystemMaxUse=500M`) so the journal alone can't fill the host disk; older entries are discarded once the cap is reached.
 - Access via `journalctl -u openhost` or `journalctl -u openhost -f` to follow.
 
 ---
@@ -39,7 +39,7 @@ Container stdout and stderr are written to a per-app file via podman's `k8s-file
 - Up to 5 archived build logs are kept per app; older ones are deleted when the limit is exceeded.
 - Deleted entirely when the app is removed.
 - Access via `oh app logs <name>` (the current runtime log is appended to the build log).
-- Runtime logs do not appear in journald, which is used for openhost status logs
+- Runtime logs do not appear in journald, which is used for Cloud in a Bottle status logs
 
 ---
 
@@ -65,4 +65,4 @@ journalctl -u openhost-juicefs
 - App container stdout/stderr (now written to `container.log` via k8s-file)
 - The contents of `compute_space.log` (the file sink is separate from journald)
 
-Journald stores logs in a binary indexed format across multiple files. Queries are indexed by unit, priority, and time — they are not a linear scan — but total journal size still affects seek time. OpenHost caps the total on-disk journal at 500 MB via `SystemMaxUse` in a drop-in at `/etc/systemd/journald.conf.d/10-openhost.conf`. Operators who need a different limit can add `SystemMaxFiles` or `MaxRetentionSec`, or override `SystemMaxUse`, in a higher-numbered drop-in (e.g. `/etc/systemd/journald.conf.d/20-local.conf`).
+Journald stores logs in a binary indexed format across multiple files. Queries are indexed by unit, priority, and time — they are not a linear scan — but total journal size still affects seek time. Cloud in a Bottle caps the total on-disk journal at 500 MB via `SystemMaxUse` in a drop-in at `/etc/systemd/journald.conf.d/10-openhost.conf`. Operators who need a different limit can add `SystemMaxFiles` or `MaxRetentionSec`, or override `SystemMaxUse`, in a higher-numbered drop-in (e.g. `/etc/systemd/journald.conf.d/20-local.conf`).

--- a/docs/src/manifest_spec.md
+++ b/docs/src/manifest_spec.md
@@ -1,6 +1,6 @@
-# OpenHost Manifest Spec (v0.1)
+# Cloud in a Bottle Manifest Spec (v0.1)
 
-Apps declare how they should be deployed on OpenHost by placing an `openhost.toml` file at the root of their repository. For a walkthrough of building an app from scratch, see [Creating an App](creating_an_app.md).
+Apps declare how they should be deployed on Cloud in a Bottle by placing an `openhost.toml` file at the root of their repository. For a walkthrough of building an app from scratch, see [Creating an App](creating_an_app.md).
 
 ## Field Reference
 
@@ -45,7 +45,7 @@ Rootless podman can bind ports >= 25 only; `host_port` values below 25 are rejec
 
 ### `[[links]]` — optional, repeatable
 
-User-facing links the app advertises for paths on its own URL that aren't the bare root — for example an admin console at `/_openhost/admin`. The dashboard displays these on the app's detail page. The `path` is taken at face value: OpenHost does not check that it exists, is reachable, or is (or isn't) behind auth — it just shows it to the user.
+User-facing links the app advertises for paths on its own URL that aren't the bare root — for example an admin console at `/_openhost/admin`. The dashboard displays these on the app's detail page. The `path` is taken at face value: Cloud in a Bottle does not check that it exists, is reachable, or is (or isn't) behind auth — it just shows it to the user.
 
 | Field | Type | Required | Default | Description |
 |-------|------|----------|---------|-------------|
@@ -86,7 +86,7 @@ Apps have three storage areas, each with different durability + size + latency t
 
 The archive tier defaults to local-disk backing and is always available. The operator can upgrade a zone to S3 one-shot from the dashboard, supplying S3 credentials and a per-zone prefix; archive bytes then route through a JuiceFS mount of the operator-supplied bucket (and any existing local archive data is migrated into it). Apps see `/data/app_archive/<app>/` as a normal POSIX directory and don't need to know which backing is in use.
 
-The storage guard requires a minimum amount of free disk space, stopping running apps when free space drops below `storage_min_free_mb` until space is freed. It is enabled by default; the host operator can change the threshold (or disable it with `0`) in the OpenHost config and reboot.
+The storage guard requires a minimum amount of free disk space, stopping running apps when free space drops below `storage_min_free_mb` until space is freed. It is enabled by default; the host operator can change the threshold (or disable it with `0`) in the Cloud in a Bottle config and reboot.
 
 All data dirs live under `/data/` in the container. All apps see the same path structure regardless of permissions — only the dirs they have access to are mounted. With `access_all_app_data`, the parent dirs `/data/app_data/` and `/data/app_temp_data/` are mounted so the app can see all apps' data. With `access_all_archive`, the `/data/app_archive/` parent is mounted.
 

--- a/docs/src/roadmap.md
+++ b/docs/src/roadmap.md
@@ -1,4 +1,4 @@
-Roadmap for the Openhost team - what is done and what we are planning to work on in the future.
+Roadmap for the Cloud in a Bottle team - what is done and what we are planning to work on in the future.
 
 
 last updated 8/10/26
@@ -18,7 +18,7 @@ things being worked on / polished up now:
 - great self-hosted onboarding
 
 roadmap (likely to happen):
-- add openhost platform support for notifications
+- add Cloud in a Bottle platform support for notifications
 - get notifications working in community chat app
 - email auto-setup in new spaces
 - share apps with others via email address (with email magic link auth)

--- a/docs/src/user_identity.md
+++ b/docs/src/user_identity.md
@@ -4,23 +4,23 @@
 - eventually this will become a new DID method, so let's keep close to that setup
 - i want a new hybrid method - public key / DID is the source of truth, but the domain is the human-readable advisory ID. anytime you really need to ensure the domain shortname is valid, you’ll hit the domain and verify it still controls its private key. and the user can refer to themselves by their domain - eg to create a login - with the assumption that if the user thinks they control their domain, it’s probably safe to assume that is true for the next ~5 mins or whatever. so you can hit their domain and fetch their public key.
 - openhost-specific context
-  - each user has an openhost space, accessable at a specific domain (user.host.imbue.com or whatever).
+  - each user has a Cloud in a Bottle space, accessable at a specific domain (user.host.imbue.com or whatever).
   - their userspaces all run a copy of an identity provider service that handles to the challenges+flows discussed in this doc.
-  - an openhost app (owned/hosted by user A) can give access to other openhost users (user B) by the following flow
-    - user A adds/invites user B by their openhost URL (userb.host.imbue.com)
+  - a Cloud in a Bottle app (owned/hosted by user A) can give access to other Cloud in a Bottle users (user B) by the following flow
+    - user A adds/invites user B by their Cloud in a Bottle URL (userb.host.imbue.com)
     - the app immediately contacts user B's server to get their full public key / public identity
-    - later, user B visits the app hosted in user A's space. the app says something like "please login with your openhost identity". user B clicks this button, and it routes them to a path in their own space (via the my.host.imbue.com route, which for user B redirects to userb.host.imbue.com). this may be something like `/identity-challenge/?source=app.usera.host.imbue.com`. probably with some type of token thing?
-    - the identity provider server in user B's space receives this request and shows the user a page like "you're getting a login request from app.usera.host.imbue.com, would you like to use your openhost identity to login?". of course this only works if user B is logged into their own space.
+    - later, user B visits the app hosted in user A's space. the app says something like "please login with your Cloud in a Bottle identity". user B clicks this button, and it routes them to a path in their own space (via the my.host.imbue.com route, which for user B redirects to userb.host.imbue.com). this may be something like `/identity-challenge/?source=app.usera.host.imbue.com`. probably with some type of token thing?
+    - the identity provider server in user B's space receives this request and shows the user a page like "you're getting a login request from app.usera.host.imbue.com, would you like to use your Cloud in a Bottle identity to login?". of course this only works if user B is logged into their own space.
     - user B clicks yes, and this redirects back to `app.usera.host.imbue.com/identity-response` with some sort of cryptographic token proving that they do indeed control their private key (which is stored in their space).
 
 
 
 ## General context (copied from another doc)
 
-- i want a way to do things like give permissions to an app to specific other openhost users. so they are authed if they’re logged into their instance, i guess?
+- i want a way to do things like give permissions to an app to specific other Cloud in a Bottle users. so they are authed if they’re logged into their instance, i guess?
 - eg for the project management system - i need a way to invite other users, and i don’t want them to have to make accounts specifically for this. they should be able to use their VM as a SSO provider, maybe?
     - i guess how this would work:
-        - you have some way of uniquely+securely identifying another openhost user, probably via a PGP public key or similar.
+        - you have some way of uniquely+securely identifying another Cloud in a Bottle user, probably via a PGP public key or similar.
             - this could come from a “contacts”/”friends” app/service in your VM, so you can add known people once and then reference them easily later.
         - then you say “i will share this with user xyz”
         - when user xyz accesses your space/app, the app is like “tell me who you are”.

--- a/openhost_system_agent/src/openhost_system_agent/migrations/versions/v0002_baseline.py
+++ b/openhost_system_agent/src/openhost_system_agent/migrations/versions/v0002_baseline.py
@@ -58,7 +58,7 @@ def build_openhost_service_unit(host_uid: int) -> str:
     stay consistent with the baseline (and with ansible's template)."""
     return (
         "[Unit]\n"
-        "Description=OpenHost Compute Space\n"
+        "Description=Cloud in a Bottle Compute Space\n"
         f"After=network-online.target user@{host_uid}.service\n"
         f"Wants=network-online.target user@{host_uid}.service\n"
         # Crash limiter for Restart=on-failure (see below): after StartLimitBurst

--- a/routerd_cli/src/self_host_cli/down.py
+++ b/routerd_cli/src/self_host_cli/down.py
@@ -1,4 +1,4 @@
-"""``openhost down`` -- stop the OpenHost router cleanly."""
+"""``openhost down`` -- stop the Cloud in a Bottle router cleanly."""
 
 import argparse
 import os
@@ -72,7 +72,7 @@ def _cleanup_pidfile(path: str) -> None:
 
 
 def run_down(_args: argparse.Namespace) -> None:
-    print("Stopping OpenHost...")
+    print("Stopping Cloud in a Bottle...")
     _stop_process("Router", _ROUTER_PID)
     print()
-    print("OpenHost stopped.")
+    print("Cloud in a Bottle stopped.")

--- a/routerd_cli/src/self_host_cli/main.py
+++ b/routerd_cli/src/self_host_cli/main.py
@@ -20,7 +20,7 @@ from self_host_cli.update import run_update
 def _build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="openhost",
-        description="OpenHost -- run open-source apps on your own compute.",
+        description="Cloud in a Bottle -- run open-source apps on your own compute.",
     )
     sub = parser.add_subparsers(dest="command")
 
@@ -28,7 +28,7 @@ def _build_parser() -> argparse.ArgumentParser:
     up_parser = sub.add_parser(
         "up",
         help="Start OpenHost.",
-        description="Launches the OpenHost router directly on this machine.",
+        description="Launches the Cloud in a Bottle router directly on this machine.",
     )
     up_parser.add_argument(
         "--domain",

--- a/routerd_cli/src/self_host_cli/up.py
+++ b/routerd_cli/src/self_host_cli/up.py
@@ -1,4 +1,4 @@
-"""``openhost up`` -- start the OpenHost router.
+"""``openhost up`` -- start the Cloud in a Bottle router.
 
 --domain: enables TLS via ACME.
 --zone-domain: enables host-based app subdomain routing without TLS.
@@ -161,7 +161,7 @@ def _resolve_zone_domain(args: argparse.Namespace) -> str:
 
 def run_up(args: argparse.Namespace) -> None:
     """Run the router directly on the host."""
-    print("Starting OpenHost...")
+    print("Starting Cloud in a Bottle...")
     print()
 
     zone_domain = _resolve_zone_domain(args)

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -721,7 +721,7 @@ class TestSelfHost:
         """Deploy MinIO from its public GitHub repo."""
         r = session.post(
             f"{router_url}/api/add_app",
-            json={"repo_url": "https://github.com/imbue-openhost/openhost-minio"},
+            json={"repo_url": "https://github.com/imbue-openhost/bottled-minio"},
             timeout=120,
         )
         assert r.status_code == 200, f"add_app minio failed: {r.status_code}: {r.text[:500]}"


### PR DESCRIPTION
Umbrella PR for the OpenHost to Cloud in a Bottle migration in the platform repo. This changes necessary parts of the code as well as visible messaging on the platform. 