### PR TITLE
Call the org-rename reconcile at boot

### DIFF
--- a/compute_space/src/compute_space/web/app.py
+++ b/compute_space/src/compute_space/web/app.py
@@ -32,6 +32,7 @@ from compute_space.core.first_boot import seed_first_boot
 from compute_space.core.git_ops import SOURCE_URL
 from compute_space.core.image_pruner import start_image_pruner
 from compute_space.core.logging import logger
+from compute_space.core.org_rename import reconcile_app_repo_urls
 from compute_space.core.startup import check_app_status
 from compute_space.core.startup import retry_pending_default_apps
 from compute_space.core.storage import start_storage_guard
@@ -138,6 +139,11 @@ def _full_app_bootstrap(config: Config) -> None:
     db = get_db()  # row_factory=Row; the archive derives its per-zone volume from the domains store
     try:
         archive_backend.attach_on_startup(config, db)
+        # Move any app repo URLs still pointing at the pre-rename GitHub owner.
+        # Idempotent, and inert until org_rename.ORG_RENAME_COMPLETE is flipped;
+        # see that module for why this is a per-boot reconcile rather than a
+        # versioned migration.
+        reconcile_app_repo_urls(db)
     finally:
         db.close()
     check_app_status(config)


### PR DESCRIPTION
Stacked on #286, which adds core/org_rename. Split out because web/app.py is the only CODEOWNERS-gated file in that work, so this six-line diff is the entire review surface -- it was otherwise holding back 38 unrelated files. GitHub will retarget this to main when #286 merges.

What it does: calls reconcile_app_repo_urls in _full_app_bootstrap, alongside the archive attach that already runs on the same db handle. That reconcile moves apps.repo_url (and the checkout's git origin) off the pre-rename GitHub owner.

Why it is safe to merge now: the reconcile returns immediately unless org_rename.ORG_RENAME_COMPLETE is True, and it ships False, so this changes no behaviour until the release that accompanies the actual org rename. It also never raises -- a failed rewrite must not stop boot.

Why the reconcile exists at all: after the org is renamed, persisted URLs keep resolving through GitHub's owner redirect, but GitHub releases the old org name for anyone to claim and per GitHub's docs the new holder can create repositories that override the redirect entries. An instance still pointing at the old owner would then fetch and build an attacker's repo. The redirect is a migration window, not a destination.