### PR TITLE
Stream app logs over a WebSocket (shared process-follow primitive)

### DIFF
--- a/compute_space/src/compute_space/core/containers.py
+++ b/compute_space/src/compute_space/core/containers.py
@@ -340,7 +340,7 @@ def run_container(
 
     # max-file is not supported by podman's k8s-file driver; archiving is
     # handled by the reload route before run_container is called.
-    # max-size=10mb is kept as a safety net against unbounded growth between reloads.
+    # max-size=1mb is kept as a safety net against unbounded growth between reloads.
     container_log_file = os.path.join(app_temp_dir, "container.log")
     os.makedirs(app_temp_dir, exist_ok=True)
 
@@ -353,7 +353,7 @@ def run_container(
             "--security-opt=no-new-privileges=true",
             "--log-driver=k8s-file",
             f"--log-opt=path={container_log_file}",
-            "--log-opt=max-size=10mb",
+            "--log-opt=max-size=1mb",
         ]
     )
     if manifest.shm_mb > 0:

--- a/compute_space/src/compute_space/core/log_stream.py
+++ b/compute_space/src/compute_space/core/log_stream.py
@@ -129,12 +129,17 @@ async def stream_app_logs(app_id: str, build_log_path: str) -> AsyncIterator[str
     The app's ``(status, container_id)`` is re-queried while a build is in flight so we
     can hand off from tailing ``docker.log`` to following the container as it comes up.
     """
+    emitted = False
     if _still_building(app_id):
         # Build in flight: follow docker.log live until the container comes up.
         async for line in _follow_build_until_container(app_id, build_log_path):
+            emitted = True
             yield line
-    elif os.path.exists(build_log_path):
-        # Already built: replay the build log's tail once, then show container logs.
+
+    # Replay the build log's tail once if the live follow produced nothing — either the
+    # app was already built, or the build ended before docker.log appeared and it only
+    # landed just now. Guarded on ``emitted`` so a followed build isn't replayed twice.
+    if not emitted and os.path.exists(build_log_path):
         async for raw in stream_process_lines(
             _tail_argv(build_log_path, follow=False), merge_stderr=True, raise_on_error=True
         ):

--- a/compute_space/src/compute_space/core/log_stream.py
+++ b/compute_space/src/compute_space/core/log_stream.py
@@ -5,26 +5,20 @@ chunks (each with no trailing newline) that a transport layer — currently the
 WebSocket route in ``web/routes/api/apps.py`` — forwards to the browser, which
 appends each chunk as one line.
 
-Two sources, matching the two phases of an app's life:
-
-* The **build log** (``docker.log``) is a file our own build process appends to
-  (only ever rotated on an explicit reload, which reloads the whole page), so we
-  read it directly by byte offset. A missing file is the *expected* "build hasn't
-  written yet" state and reads empty; any other read error (e.g. permission
-  denied) propagates rather than being turned into a silent empty log.
-* The **container log** comes from ``podman logs --follow`` via the shared
-  :func:`compute_space.core.process_stream.stream_process_lines` primitive (the
-  same one the memory guard uses for its ``journalctl`` / ``podman events``
-  streams). podman — not us — owns incrementalism and log rotation, so we never
-  compute an offset into a file that can move underneath us. We just strip its
-  ``--timestamps`` prefix and ANSI codes, reproducing what the old one-shot
-  ``podman logs`` call showed.
+Both sources are followed through the same shared primitive,
+:func:`compute_space.core.process_stream.stream_process_lines` (also used by the
+memory guard): the container log via ``podman logs --follow``, and the build log
+(``docker.log``) via ``tail``. The build tail waits for the file to appear first —
+during a build ``docker.log`` may not exist yet, which is expected — and then runs
+``tail``; an unreadable file makes ``tail`` exit non-zero, which surfaces loudly via
+``raise_on_error`` rather than as a silent empty log. Container-log lines carry a
+``--timestamps`` prefix and ANSI codes, which we strip.
 """
 
 from __future__ import annotations
 
 import asyncio
-import os
+import contextlib
 from collections.abc import AsyncIterator
 from collections.abc import Callable
 
@@ -34,76 +28,81 @@ from compute_space.core.process_stream import stream_process_lines
 # Initial history replayed on connect; the live follow supplies everything after.
 _CONTAINER_TAIL_LINES = 2000
 _BUILD_TAIL_BYTES = 256 * 1024
-# While a build is in flight there is no container yet, so we poll docker.log for
-# appended bytes at this cadence until a container appears (or the build ends).
+# How often, while a build is in flight, we re-check the app's state to notice the
+# container coming up (and hand off from the build log to the container log).
 _BUILD_POLL_SECONDS = 0.5
 _BUILDING_STATES = frozenset({"building", "starting"})
 
+# Distinguishes "the build tail ended" from a real line in the follow loop below.
+_EOF = object()
 
-def _read_build_tail(path: str, max_bytes: int) -> tuple[str, int]:
-    """Return ``(text, eof_offset)`` for the last ``max_bytes`` of ``path``.
 
-    Drops a partial leading line when the file is longer than ``max_bytes`` so we
-    never start mid-line. ``eof_offset`` is the file size, i.e. where a follow
-    should resume from. A missing file (build hasn't written yet) is expected and
-    returns ``("", 0)``; any other error propagates — we don't hide, say, a
-    permission problem behind an empty log.
+def _build_tail_argv(build_log_path: str, *, follow: bool) -> list[str]:
+    """Shell command streaming the build log's last ``_BUILD_TAIL_BYTES`` bytes.
+
+    ``follow`` waits for the file to appear (expected during early build) and then
+    ``tail -f``s it live; without it the file is dumped once (an already-built app's
+    history) and a missing file is simply empty. Either way an existing-but-unreadable
+    file lets ``tail`` exit non-zero, surfaced loudly by the caller's ``raise_on_error``.
     """
-    try:
-        with open(path, "rb") as f:
-            f.seek(0, os.SEEK_END)
-            size = f.tell()
-            start = max(0, size - max_bytes)
-            f.seek(start)
-            data = f.read()
-    except FileNotFoundError:
-        return "", 0
-    if start > 0:
-        nl = data.find(b"\n")
-        data = data[nl + 1 :] if nl != -1 else b""
-    return data.decode("utf-8", "replace"), size
-
-
-def _read_from(path: str, offset: int) -> tuple[str, int]:
-    """Return ``(new_text_since_offset, new_offset)`` for an append-only file.
-
-    If the file shrank (rotated/truncated under us) we resync from the start and
-    skip the gap rather than reading misaligned bytes. A missing file is expected
-    (returns no new text); other read errors propagate.
-    """
-    try:
-        with open(path, "rb") as f:
-            f.seek(0, os.SEEK_END)
-            size = f.tell()
-            if size < offset:  # rotated/truncated — resync instead of misreading
-                offset = 0
-            if size <= offset:
-                return "", offset
-            f.seek(offset)
-            data = f.read()
-    except FileNotFoundError:
-        return "", offset
-    return data.decode("utf-8", "replace"), size
+    tail = f'exec tail -c {_BUILD_TAIL_BYTES} {"-f " if follow else ""}"$1"'
+    if follow:
+        # Wait for docker.log to appear (expected during early build), then follow it.
+        script = f'while [ ! -e "$1" ]; do sleep {_BUILD_POLL_SECONDS}; done; {tail}'
+    else:
+        # Dump once if it exists; a missing log is just empty (a clean exit-0 end).
+        script = f'if [ -e "$1" ]; then {tail}; fi'
+    return ["sh", "-c", script, "sh", build_log_path]
 
 
 async def _podman_follow(container_id: str, tail_lines: int) -> AsyncIterator[str]:
-    """Yield container log lines (no trailing newline), starting with the last
-    ``tail_lines`` and then following live until the container stops or the
-    consumer disconnects.
+    """Yield container log lines (no trailing newline), the last ``tail_lines`` then live.
 
-    Uses ``podman logs --follow`` (via the shared process-stream helper) so podman
-    handles the initial tail, live updates, and rotation. ``--timestamps`` lets
-    nothing here depend on file offsets; we strip that prefix (and ANSI codes)
-    before yielding. ``merge_stderr`` folds the container's stderr into the feed,
-    matching the old one-shot ``podman logs`` behaviour.
+    ``podman logs --follow`` (via the shared helper) owns the initial tail, live
+    updates, and rotation. ``--timestamps`` lets nothing depend on file offsets; we
+    strip that prefix (and ANSI codes) before yielding, and ``merge_stderr`` folds the
+    container's stderr into the feed like the old one-shot ``podman logs``.
     """
     argv = ["podman", "logs", "--follow", "--tail", str(tail_lines), "--timestamps", container_id]
     async for raw in stream_process_lines(argv, merge_stderr=True):
         line = raw.decode("utf-8", "replace").rstrip("\r")
         # Drop the RFC3339 timestamp that --timestamps prepends ("<ts> <log>").
         sp = line.find(" ")
-        content = line[sp + 1 :] if sp != -1 else ""
-        yield _ANSI_RE.sub("", content)
+        yield _ANSI_RE.sub("", line[sp + 1 :] if sp != -1 else "")
+
+
+async def _follow_build_until_container(
+    build_log_path: str, get_state: Callable[[], tuple[str, str | None]]
+) -> AsyncIterator[str]:
+    """Follow the build log live, stopping once the container appears or the build ends.
+
+    ``asyncio.wait`` with a timeout polls ``get_state`` between lines *without*
+    cancelling the in-flight read — cancelling it would tear down the ``tail`` process
+    — so the pending read simply carries over to the next poll.
+    """
+    gen = stream_process_lines(_build_tail_argv(build_log_path, follow=True), merge_stderr=True, raise_on_error=True)
+    pending: asyncio.Task[object] | None = None
+    try:
+        while True:
+            if pending is None:
+                pending = asyncio.ensure_future(anext(gen, _EOF))
+            done, _ = await asyncio.wait({pending}, timeout=_BUILD_POLL_SECONDS)
+            if pending in done:
+                line = pending.result()
+                pending = None
+                if line is _EOF:
+                    return
+                assert isinstance(line, bytes)
+                yield line.decode("utf-8", "replace").rstrip("\r")
+            status, container_id = get_state()
+            if container_id is not None or status not in _BUILDING_STATES:
+                return
+    finally:
+        if pending is not None:
+            pending.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await pending
+        await gen.aclose()
 
 
 async def stream_app_logs(
@@ -113,28 +112,23 @@ async def stream_app_logs(
 ) -> AsyncIterator[str]:
     """Yield an app's logs as text chunks: build-log tail, then live container logs.
 
-    ``get_state`` returns ``(status, container_id)`` and is re-queried while a
-    build is in flight so we can switch from tailing ``docker.log`` to following
-    the container as soon as it comes up.
+    ``get_state`` returns ``(status, container_id)`` and is re-queried while a build is
+    in flight so we can hand off from tailing ``docker.log`` to following the container
+    as soon as it comes up.
     """
     status, container_id = get_state()
 
-    tail, build_offset = _read_build_tail(build_log_path, _BUILD_TAIL_BYTES)
-    if tail.strip():
-        yield tail.rstrip("\n")
-
-    # Build phase: no container yet, so follow docker.log until one appears.
-    while container_id is None and status in _BUILDING_STATES:
-        await asyncio.sleep(_BUILD_POLL_SECONDS)
-        chunk, build_offset = _read_from(build_log_path, build_offset)
-        if chunk:
-            yield chunk.rstrip("\n")
-        status, container_id = get_state()
-
-    # Flush any build output written between the last poll and the switch-over.
-    chunk, _ = _read_from(build_log_path, build_offset)
-    if chunk:
-        yield chunk.rstrip("\n")
+    if container_id is None and status in _BUILDING_STATES:
+        # Build in flight: follow docker.log live until the container comes up.
+        async for line in _follow_build_until_container(build_log_path, get_state):
+            yield line
+        _, container_id = get_state()
+    else:
+        # Already built: replay the build log's tail once, then show container logs.
+        async for raw in stream_process_lines(
+            _build_tail_argv(build_log_path, follow=False), merge_stderr=True, raise_on_error=True
+        ):
+            yield raw.decode("utf-8", "replace").rstrip("\r")
 
     if container_id:
         yield "=== Container logs ==="

--- a/compute_space/src/compute_space/core/log_stream.py
+++ b/compute_space/src/compute_space/core/log_stream.py
@@ -59,44 +59,45 @@ async def _podman_follow(container_id: str, tail_lines: int) -> AsyncIterator[st
         yield _ANSI_RE.sub("", raw.decode("utf-8", "replace").rstrip("\r"))
 
 
+def _still_building(get_state: Callable[[], tuple[str, str | None]]) -> bool:
+    """True while a build is in flight and no container has appeared yet."""
+    status, container_id = get_state()
+    return container_id is None and status in _BUILDING_STATES
+
+
 async def _follow_build_until_container(
     build_log_path: str, get_state: Callable[[], tuple[str, str | None]]
 ) -> AsyncIterator[str]:
     """Follow the build log live, stopping once the container appears or the build ends.
 
-    First waits for docker.log to appear (briefly absent at build start / across a
-    reload's log rotation), giving up if the build ends first. Then ``asyncio.wait``'s
-    timeout polls ``get_state`` between lines *without* cancelling the in-flight read —
-    cancelling it would tear down the ``tail`` process — so the pending read carries over.
+    docker.log is briefly absent at build start and across a reload's log rotation, so
+    we first wait for it to appear (giving up if the build ends first). Then we stream
+    its lines, re-checking the app state between them: ``wait_for`` bounds how long we
+    block waiting for the next line, and ``shield`` keeps that in-flight read alive
+    across a timeout (cancelling it would kill ``tail``) so it resumes next iteration.
     """
     while not os.path.exists(build_log_path):
-        status, container_id = get_state()
-        if container_id is not None or status not in _BUILDING_STATES:
+        if not _still_building(get_state):
             return
         await asyncio.sleep(_BUILD_POLL_SECONDS)
 
     gen = stream_process_lines(_tail_argv(build_log_path, follow=True), merge_stderr=True, raise_on_error=True)
-    pending: asyncio.Task[object] | None = None
+    pending = asyncio.ensure_future(anext(gen, _EOF))
     try:
-        while True:
-            if pending is None:
-                pending = asyncio.ensure_future(anext(gen, _EOF))
-            done, _ = await asyncio.wait({pending}, timeout=_BUILD_POLL_SECONDS)
-            if pending in done:
-                line = pending.result()
-                pending = None
-                if line is _EOF:
-                    return
-                assert isinstance(line, bytes)
-                yield line.decode("utf-8", "replace").rstrip("\r")
-            status, container_id = get_state()
-            if container_id is not None or status not in _BUILDING_STATES:
+        while _still_building(get_state):
+            try:
+                line = await asyncio.wait_for(asyncio.shield(pending), _BUILD_POLL_SECONDS)
+            except TimeoutError:
+                continue  # no line this interval; re-check state and keep the read going
+            if line is _EOF:
                 return
+            assert isinstance(line, bytes)
+            yield line.decode("utf-8", "replace").rstrip("\r")
+            pending = asyncio.ensure_future(anext(gen, _EOF))
     finally:
-        if pending is not None:
-            pending.cancel()
-            with contextlib.suppress(asyncio.CancelledError):
-                await pending
+        pending.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await pending
         await gen.aclose()
 
 
@@ -111,13 +112,10 @@ async def stream_app_logs(
     in flight so we can hand off from tailing ``docker.log`` to following the container
     as soon as it comes up.
     """
-    status, container_id = get_state()
-
-    if container_id is None and status in _BUILDING_STATES:
+    if _still_building(get_state):
         # Build in flight: follow docker.log live until the container comes up.
         async for line in _follow_build_until_container(build_log_path, get_state):
             yield line
-        _, container_id = get_state()
     elif os.path.exists(build_log_path):
         # Already built: replay the build log's tail once, then show container logs.
         async for raw in stream_process_lines(
@@ -125,6 +123,7 @@ async def stream_app_logs(
         ):
             yield raw.decode("utf-8", "replace").rstrip("\r")
 
+    _, container_id = get_state()
     if container_id:
         yield "=== Container logs ==="
         async for line in _podman_follow(container_id, _CONTAINER_TAIL_LINES):

--- a/compute_space/src/compute_space/core/log_stream.py
+++ b/compute_space/src/compute_space/core/log_stream.py
@@ -1,0 +1,142 @@
+"""Stream an app's logs (build log followed by live container logs) as text.
+
+Framework-neutral: :func:`stream_app_logs` is an async generator of plain ``str``
+chunks (each with no trailing newline) that a transport layer — currently the
+WebSocket route in ``web/routes/api/apps.py`` — forwards to the browser, which
+appends each chunk as one line.
+
+Two sources, matching the two phases of an app's life:
+
+* The **build log** (``docker.log``) is a file our own build process appends to
+  (only ever rotated on an explicit reload, which reloads the whole page), so we
+  read it directly by byte offset. A missing file is the *expected* "build hasn't
+  written yet" state and reads empty; any other read error (e.g. permission
+  denied) propagates rather than being turned into a silent empty log.
+* The **container log** comes from ``podman logs --follow`` via the shared
+  :func:`compute_space.core.process_stream.stream_process_lines` primitive (the
+  same one the memory guard uses for its ``journalctl`` / ``podman events``
+  streams). podman — not us — owns incrementalism and log rotation, so we never
+  compute an offset into a file that can move underneath us. We just strip its
+  ``--timestamps`` prefix and ANSI codes, reproducing what the old one-shot
+  ``podman logs`` call showed.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from collections.abc import AsyncIterator
+from collections.abc import Callable
+
+from compute_space.core.containers import _ANSI_RE
+from compute_space.core.process_stream import stream_process_lines
+
+# Initial history replayed on connect; the live follow supplies everything after.
+_CONTAINER_TAIL_LINES = 2000
+_BUILD_TAIL_BYTES = 256 * 1024
+# While a build is in flight there is no container yet, so we poll docker.log for
+# appended bytes at this cadence until a container appears (or the build ends).
+_BUILD_POLL_SECONDS = 0.5
+_BUILDING_STATES = frozenset({"building", "starting"})
+
+
+def _read_build_tail(path: str, max_bytes: int) -> tuple[str, int]:
+    """Return ``(text, eof_offset)`` for the last ``max_bytes`` of ``path``.
+
+    Drops a partial leading line when the file is longer than ``max_bytes`` so we
+    never start mid-line. ``eof_offset`` is the file size, i.e. where a follow
+    should resume from. A missing file (build hasn't written yet) is expected and
+    returns ``("", 0)``; any other error propagates — we don't hide, say, a
+    permission problem behind an empty log.
+    """
+    try:
+        with open(path, "rb") as f:
+            f.seek(0, os.SEEK_END)
+            size = f.tell()
+            start = max(0, size - max_bytes)
+            f.seek(start)
+            data = f.read()
+    except FileNotFoundError:
+        return "", 0
+    if start > 0:
+        nl = data.find(b"\n")
+        data = data[nl + 1 :] if nl != -1 else b""
+    return data.decode("utf-8", "replace"), size
+
+
+def _read_from(path: str, offset: int) -> tuple[str, int]:
+    """Return ``(new_text_since_offset, new_offset)`` for an append-only file.
+
+    If the file shrank (rotated/truncated under us) we resync from the start and
+    skip the gap rather than reading misaligned bytes. A missing file is expected
+    (returns no new text); other read errors propagate.
+    """
+    try:
+        with open(path, "rb") as f:
+            f.seek(0, os.SEEK_END)
+            size = f.tell()
+            if size < offset:  # rotated/truncated — resync instead of misreading
+                offset = 0
+            if size <= offset:
+                return "", offset
+            f.seek(offset)
+            data = f.read()
+    except FileNotFoundError:
+        return "", offset
+    return data.decode("utf-8", "replace"), size
+
+
+async def _podman_follow(container_id: str, tail_lines: int) -> AsyncIterator[str]:
+    """Yield container log lines (no trailing newline), starting with the last
+    ``tail_lines`` and then following live until the container stops or the
+    consumer disconnects.
+
+    Uses ``podman logs --follow`` (via the shared process-stream helper) so podman
+    handles the initial tail, live updates, and rotation. ``--timestamps`` lets
+    nothing here depend on file offsets; we strip that prefix (and ANSI codes)
+    before yielding. ``merge_stderr`` folds the container's stderr into the feed,
+    matching the old one-shot ``podman logs`` behaviour.
+    """
+    argv = ["podman", "logs", "--follow", "--tail", str(tail_lines), "--timestamps", container_id]
+    async for raw in stream_process_lines(argv, merge_stderr=True):
+        line = raw.decode("utf-8", "replace").rstrip("\r")
+        # Drop the RFC3339 timestamp that --timestamps prepends ("<ts> <log>").
+        sp = line.find(" ")
+        content = line[sp + 1 :] if sp != -1 else ""
+        yield _ANSI_RE.sub("", content)
+
+
+async def stream_app_logs(
+    app_name: str,
+    build_log_path: str,
+    get_state: Callable[[], tuple[str, str | None]],
+) -> AsyncIterator[str]:
+    """Yield an app's logs as text chunks: build-log tail, then live container logs.
+
+    ``get_state`` returns ``(status, container_id)`` and is re-queried while a
+    build is in flight so we can switch from tailing ``docker.log`` to following
+    the container as soon as it comes up.
+    """
+    status, container_id = get_state()
+
+    tail, build_offset = _read_build_tail(build_log_path, _BUILD_TAIL_BYTES)
+    if tail.strip():
+        yield tail.rstrip("\n")
+
+    # Build phase: no container yet, so follow docker.log until one appears.
+    while container_id is None and status in _BUILDING_STATES:
+        await asyncio.sleep(_BUILD_POLL_SECONDS)
+        chunk, build_offset = _read_from(build_log_path, build_offset)
+        if chunk:
+            yield chunk.rstrip("\n")
+        status, container_id = get_state()
+
+    # Flush any build output written between the last poll and the switch-over.
+    chunk, _ = _read_from(build_log_path, build_offset)
+    if chunk:
+        yield chunk.rstrip("\n")
+
+    if container_id:
+        yield "=== Container logs ==="
+        async for line in _podman_follow(container_id, _CONTAINER_TAIL_LINES):
+            yield line

--- a/compute_space/src/compute_space/core/log_stream.py
+++ b/compute_space/src/compute_space/core/log_stream.py
@@ -21,10 +21,10 @@ import asyncio
 import contextlib
 import os
 from collections.abc import AsyncIterator
-from collections.abc import Callable
 
 from compute_space.core.containers import _ANSI_RE
 from compute_space.core.process_stream import stream_process_lines
+from compute_space.db.connection import get_db
 
 # Initial history replayed on connect; the live follow supplies everything after.
 _CONTAINER_TAIL_LINES = 2000
@@ -59,38 +59,60 @@ async def _podman_follow(container_id: str, tail_lines: int) -> AsyncIterator[st
         yield _ANSI_RE.sub("", raw.decode("utf-8", "replace").rstrip("\r"))
 
 
-def _still_building(get_state: Callable[[], tuple[str, str | None]]) -> bool:
+def _get_state(app_id: str) -> tuple[str, str | None]:
+    """Return ``(status, container_id)`` for an app, or ``("removed", None)`` if it's gone.
+
+    The stream outlives the request that started it, so we open (and close) a fresh
+    short-lived connection each call rather than holding one for the connection's life.
+    """
+    with contextlib.closing(get_db()) as conn:
+        row = conn.execute("SELECT status, container_id FROM apps WHERE app_id = ?", (app_id,)).fetchone()
+    if row is None:
+        return "removed", None
+    return row["status"], row["container_id"]
+
+
+def _still_building(app_id: str) -> bool:
     """True while a build is in flight and no container has appeared yet."""
-    status, container_id = get_state()
+    status, container_id = _get_state(app_id)
     return container_id is None and status in _BUILDING_STATES
 
 
-async def _follow_build_until_container(
-    build_log_path: str, get_state: Callable[[], tuple[str, str | None]]
-) -> AsyncIterator[str]:
+async def _next_build_line(pending: asyncio.Future[object], app_id: str) -> object:
+    """Await the next build-log line, or ``_EOF`` once the follow should hand off.
+
+    Each wait is bounded to ``_BUILD_POLL_SECONDS`` so a quiet interval lets us re-query
+    the app state; ``shield`` keeps the in-flight read alive across that timeout
+    (cancelling it would kill ``tail``) so it resumes on the next call. The tail ending
+    surfaces as ``_EOF`` from ``pending`` itself; the container coming up we detect here
+    and report as ``_EOF`` too, since either way the caller stops tailing docker.log. The
+    caller owns ``pending``'s lifecycle and reaps the shielded read in its ``finally``.
+    """
+    while True:
+        try:
+            return await asyncio.wait_for(asyncio.shield(pending), _BUILD_POLL_SECONDS)
+        except TimeoutError:
+            if not _still_building(app_id):
+                return _EOF
+
+
+async def _follow_build_until_container(app_id: str, build_log_path: str) -> AsyncIterator[str]:
     """Follow the build log live, stopping once the container appears or the build ends.
 
-    docker.log is briefly absent at build start and across a reload's log rotation, so
-    we first wait for it to appear (giving up if the build ends first). Then we stream
-    its lines, re-checking the app state between them: ``wait_for`` bounds how long we
-    block waiting for the next line, and ``shield`` keeps that in-flight read alive
-    across a timeout (cancelling it would kill ``tail``) so it resumes next iteration.
+    docker.log is briefly absent at build start and across a reload's log rotation, so we
+    first wait for it to appear (giving up if the build ends first). Then we forward its
+    lines until :func:`_next_build_line` reports ``_EOF`` — the tail ending, or a quiet
+    interval in which the container has come up so we hand off to following it.
     """
     while not os.path.exists(build_log_path):
-        if not _still_building(get_state):
+        if not _still_building(app_id):
             return
         await asyncio.sleep(_BUILD_POLL_SECONDS)
 
     gen = stream_process_lines(_tail_argv(build_log_path, follow=True), merge_stderr=True, raise_on_error=True)
     pending = asyncio.ensure_future(anext(gen, _EOF))
     try:
-        while _still_building(get_state):
-            try:
-                line = await asyncio.wait_for(asyncio.shield(pending), _BUILD_POLL_SECONDS)
-            except TimeoutError:
-                continue  # no line this interval; re-check state and keep the read going
-            if line is _EOF:
-                return
+        while (line := await _next_build_line(pending, app_id)) is not _EOF:
             assert isinstance(line, bytes)
             yield line.decode("utf-8", "replace").rstrip("\r")
             pending = asyncio.ensure_future(anext(gen, _EOF))
@@ -101,20 +123,15 @@ async def _follow_build_until_container(
         await gen.aclose()
 
 
-async def stream_app_logs(
-    app_name: str,
-    build_log_path: str,
-    get_state: Callable[[], tuple[str, str | None]],
-) -> AsyncIterator[str]:
+async def stream_app_logs(app_id: str, build_log_path: str) -> AsyncIterator[str]:
     """Yield an app's logs as text chunks: build-log tail, then live container logs.
 
-    ``get_state`` returns ``(status, container_id)`` and is re-queried while a build is
-    in flight so we can hand off from tailing ``docker.log`` to following the container
-    as soon as it comes up.
+    The app's ``(status, container_id)`` is re-queried while a build is in flight so we
+    can hand off from tailing ``docker.log`` to following the container as it comes up.
     """
-    if _still_building(get_state):
+    if _still_building(app_id):
         # Build in flight: follow docker.log live until the container comes up.
-        async for line in _follow_build_until_container(build_log_path, get_state):
+        async for line in _follow_build_until_container(app_id, build_log_path):
             yield line
     elif os.path.exists(build_log_path):
         # Already built: replay the build log's tail once, then show container logs.
@@ -123,7 +140,7 @@ async def stream_app_logs(
         ):
             yield raw.decode("utf-8", "replace").rstrip("\r")
 
-    _, container_id = get_state()
+    _, container_id = _get_state(app_id)
     if container_id:
         yield "=== Container logs ==="
         async for line in _podman_follow(container_id, _CONTAINER_TAIL_LINES):

--- a/compute_space/src/compute_space/core/log_stream.py
+++ b/compute_space/src/compute_space/core/log_stream.py
@@ -8,17 +8,18 @@ appends each chunk as one line.
 Both sources are followed through the same shared primitive,
 :func:`compute_space.core.process_stream.stream_process_lines` (also used by the
 memory guard): the container log via ``podman logs --follow``, and the build log
-(``docker.log``) via ``tail``. The build tail waits for the file to appear first —
-during a build ``docker.log`` may not exist yet, which is expected — and then runs
-``tail``; an unreadable file makes ``tail`` exit non-zero, which surfaces loudly via
-``raise_on_error`` rather than as a silent empty log. Container-log lines carry a
-``--timestamps`` prefix and ANSI codes, which we strip.
+(``docker.log``) via ``tail``. We check for docker.log's existence in Python — it's
+briefly absent at build start and across a reload's log rotation, which is expected —
+so ``tail`` only ever runs against a file that exists; if that file is unreadable
+(permission denied) ``tail`` exits non-zero and ``raise_on_error`` surfaces it loudly
+rather than as a silent empty log.
 """
 
 from __future__ import annotations
 
 import asyncio
 import contextlib
+import os
 from collections.abc import AsyncIterator
 from collections.abc import Callable
 
@@ -28,8 +29,8 @@ from compute_space.core.process_stream import stream_process_lines
 # Initial history replayed on connect; the live follow supplies everything after.
 _CONTAINER_TAIL_LINES = 2000
 _BUILD_TAIL_BYTES = 256 * 1024
-# How often, while a build is in flight, we re-check the app's state to notice the
-# container coming up (and hand off from the build log to the container log).
+# How often, while a build is in flight, we re-check the app's state (to notice the
+# container coming up) and docker.log's existence (to notice the build starting).
 _BUILD_POLL_SECONDS = 0.5
 _BUILDING_STATES = frozenset({"building", "starting"})
 
@@ -37,38 +38,25 @@ _BUILDING_STATES = frozenset({"building", "starting"})
 _EOF = object()
 
 
-def _build_tail_argv(build_log_path: str, *, follow: bool) -> list[str]:
-    """Shell command streaming the build log's last ``_BUILD_TAIL_BYTES`` bytes.
+def _tail_argv(build_log_path: str, *, follow: bool) -> list[str]:
+    """``tail`` argv for the build log's last ``_BUILD_TAIL_BYTES`` bytes (``-f`` to follow).
 
-    ``follow`` waits for the file to appear (expected during early build) and then
-    ``tail -f``s it live; without it the file is dumped once (an already-built app's
-    history) and a missing file is simply empty. Either way an existing-but-unreadable
-    file lets ``tail`` exit non-zero, surfaced loudly by the caller's ``raise_on_error``.
+    Callers guard existence themselves (a missing docker.log is expected mid-build); an
+    existing-but-unreadable file lets ``tail`` exit non-zero, surfaced by ``raise_on_error``.
     """
-    tail = f'exec tail -c {_BUILD_TAIL_BYTES} {"-f " if follow else ""}"$1"'
-    if follow:
-        # Wait for docker.log to appear (expected during early build), then follow it.
-        script = f'while [ ! -e "$1" ]; do sleep {_BUILD_POLL_SECONDS}; done; {tail}'
-    else:
-        # Dump once if it exists; a missing log is just empty (a clean exit-0 end).
-        script = f'if [ -e "$1" ]; then {tail}; fi'
-    return ["sh", "-c", script, "sh", build_log_path]
+    return ["tail", "-c", str(_BUILD_TAIL_BYTES), *(["-f"] if follow else []), build_log_path]
 
 
 async def _podman_follow(container_id: str, tail_lines: int) -> AsyncIterator[str]:
     """Yield container log lines (no trailing newline), the last ``tail_lines`` then live.
 
-    ``podman logs --follow`` (via the shared helper) owns the initial tail, live
-    updates, and rotation. ``--timestamps`` lets nothing depend on file offsets; we
-    strip that prefix (and ANSI codes) before yielding, and ``merge_stderr`` folds the
-    container's stderr into the feed like the old one-shot ``podman logs``.
+    ``podman logs --follow`` (via the shared helper) owns the initial tail, live updates,
+    and rotation; ``merge_stderr`` folds the container's stderr into the feed like the old
+    one-shot ``podman logs``. Each line is ANSI-stripped to match that call.
     """
-    argv = ["podman", "logs", "--follow", "--tail", str(tail_lines), "--timestamps", container_id]
+    argv = ["podman", "logs", "--follow", "--tail", str(tail_lines), container_id]
     async for raw in stream_process_lines(argv, merge_stderr=True):
-        line = raw.decode("utf-8", "replace").rstrip("\r")
-        # Drop the RFC3339 timestamp that --timestamps prepends ("<ts> <log>").
-        sp = line.find(" ")
-        yield _ANSI_RE.sub("", line[sp + 1 :] if sp != -1 else "")
+        yield _ANSI_RE.sub("", raw.decode("utf-8", "replace").rstrip("\r"))
 
 
 async def _follow_build_until_container(
@@ -76,11 +64,18 @@ async def _follow_build_until_container(
 ) -> AsyncIterator[str]:
     """Follow the build log live, stopping once the container appears or the build ends.
 
-    ``asyncio.wait`` with a timeout polls ``get_state`` between lines *without*
-    cancelling the in-flight read — cancelling it would tear down the ``tail`` process
-    — so the pending read simply carries over to the next poll.
+    First waits for docker.log to appear (briefly absent at build start / across a
+    reload's log rotation), giving up if the build ends first. Then ``asyncio.wait``'s
+    timeout polls ``get_state`` between lines *without* cancelling the in-flight read —
+    cancelling it would tear down the ``tail`` process — so the pending read carries over.
     """
-    gen = stream_process_lines(_build_tail_argv(build_log_path, follow=True), merge_stderr=True, raise_on_error=True)
+    while not os.path.exists(build_log_path):
+        status, container_id = get_state()
+        if container_id is not None or status not in _BUILDING_STATES:
+            return
+        await asyncio.sleep(_BUILD_POLL_SECONDS)
+
+    gen = stream_process_lines(_tail_argv(build_log_path, follow=True), merge_stderr=True, raise_on_error=True)
     pending: asyncio.Task[object] | None = None
     try:
         while True:
@@ -123,10 +118,10 @@ async def stream_app_logs(
         async for line in _follow_build_until_container(build_log_path, get_state):
             yield line
         _, container_id = get_state()
-    else:
+    elif os.path.exists(build_log_path):
         # Already built: replay the build log's tail once, then show container logs.
         async for raw in stream_process_lines(
-            _build_tail_argv(build_log_path, follow=False), merge_stderr=True, raise_on_error=True
+            _tail_argv(build_log_path, follow=False), merge_stderr=True, raise_on_error=True
         ):
             yield raw.decode("utf-8", "replace").rstrip("\r")
 

--- a/compute_space/src/compute_space/core/memory_guard.py
+++ b/compute_space/src/compute_space/core/memory_guard.py
@@ -32,6 +32,7 @@ import re
 import sqlite3
 import threading
 import time
+from collections import deque
 from collections.abc import AsyncIterator
 
 import attr
@@ -50,6 +51,9 @@ _MEMORY_CLEAR_PERCENT = 80.0
 # After a follow stream ends (or its binary is missing) wait this long before
 # (re)connecting, so a persistent failure retries steadily instead of spinning.
 _STREAM_RECONNECT_SECONDS = 5
+
+# How many trailing stderr lines to keep from a follow, to name the reason it ended.
+_STDERR_TAIL_LINES = 5
 
 # The two OOM detectors each follow a subprocess that emits newline-delimited JSON.
 # journalctl reads the kernel log from the system journal (needs the systemd-journal
@@ -96,8 +100,12 @@ async def _follow_lines(argv: list[str], detector: str) -> AsyncIterator[bytes]:
     """
     warned_missing = False
     while True:
+        # Divert stderr (not into the parsed JSON) so an abnormal end — e.g. the
+        # journal grant not taking effect, so journalctl exits "permission denied" —
+        # surfaces its real reason below instead of a bare "stream ended".
+        recent_stderr: deque[bytes] = deque(maxlen=_STDERR_TAIL_LINES)
         try:
-            async for line in stream_process_lines(argv, merge_stderr=False):
+            async for line in stream_process_lines(argv, merge_stderr=False, stderr_sink=recent_stderr.append):
                 if line.strip():
                     yield line
         except FileNotFoundError:
@@ -107,9 +115,13 @@ async def _follow_lines(argv: list[str], detector: str) -> AsyncIterator[bytes]:
             await asyncio.sleep(_STREAM_RECONNECT_SECONDS)
             continue
         # Clean EOF: the stream ended. It had connected, so re-arm the missing
-        # warning and reconnect after a pause.
+        # warning and reconnect after a pause, naming any stderr it left behind.
         warned_missing = False
-        logger.warning("`%s` stream ended; reconnecting for %s", argv[0], detector)
+        reason = b" / ".join(recent_stderr).decode("utf-8", "replace").strip()
+        if reason:
+            logger.warning("`%s` stream ended for %s (%s); reconnecting", argv[0], detector, reason)
+        else:
+            logger.warning("`%s` stream ended; reconnecting for %s", argv[0], detector)
         await asyncio.sleep(_STREAM_RECONNECT_SECONDS)
 
 

--- a/compute_space/src/compute_space/core/memory_guard.py
+++ b/compute_space/src/compute_space/core/memory_guard.py
@@ -209,11 +209,16 @@ class _MemoryGuard:
     async def _run_podman_oom(self, config: Config) -> None:
         """Report each per-app OOM kill, naming the owning app when we can map it.
 
-        ``_parse_podman_event`` raises on an unrecognized shape rather than silently
-        dropping the kill; that surfaces at ``run``'s caller (the loop's handler).
+        A malformed event line is logged and skipped, not propagated: letting the
+        ``ValueError`` escape would fail ``run``'s gather and tear down the sibling
+        host-OOM and pressure detectors, losing far more than the one dropped kill.
         """
         async for line in _follow_lines(_PODMAN_OOM_EVENTS, "Per-app OOM detection"):
-            kill = _parse_podman_event(line)
+            try:
+                kill = _parse_podman_event(line)
+            except ValueError:
+                logger.exception("Skipping unparseable podman OOM event")
+                continue
             rows = _query_container_rows(config)
             self._report_container_ooms([kill], rows)
 

--- a/compute_space/src/compute_space/core/memory_guard.py
+++ b/compute_space/src/compute_space/core/memory_guard.py
@@ -1,9 +1,23 @@
 """Memory guard: warn the owner about memory pressure and OOM kills.
 
-A daemon thread (mirroring the storage guard) that each tick warns when an app
-nears its memory limit, when an app's container is OOM-killed (per-app, from
-``podman events``), or when the host runs out of memory and the kernel OOM killer
-reaps any process (from the system journal via ``journalctl``).
+A daemon thread (mirroring the storage guard) that warns when an app nears its
+memory limit, when an app's container is OOM-killed (per-app, from ``podman
+events``), or when the host runs out of memory and the kernel OOM killer reaps any
+process (from the system journal via ``journalctl``).
+
+The two OOM detectors each *follow a subprocess for log lines*, which is the same
+job the app-log stream does with ``podman logs --follow``; they share the
+:func:`compute_space.core.process_stream.stream_process_lines` primitive. Here we
+wrap it in :func:`_follow_lines`, which reconnects when a stream ends and treats a
+missing binary (no podman/journalctl on a dev host) as an expected "detector off"
+state rather than an error.
+
+The guard runs its own asyncio event loop on its own daemon thread — deliberately
+*not* the loop hypercorn serves requests on. It does its blocking work (``podman
+stats`` via ``collect_app_resources``, sqlite) inline on that loop: on a loop that
+serves nothing else this is fine — a slow pressure check just pushes out its own next
+tick and briefly holds off the OOM followers (whose output buffers in the pipe
+meanwhile). It only mustn't share hypercorn's loop, where it would stall requests.
 
 The "notification" is only a log line today; the ``TODO:`` markers are where the
 real notification system will hook in once it exists.
@@ -11,19 +25,21 @@ real notification system will hook in once it exists.
 
 from __future__ import annotations
 
+import asyncio
+import contextlib
 import json
-import os
 import re
 import sqlite3
-import subprocess
 import threading
 import time
+from collections.abc import AsyncIterator
 
 import attr
 
 from compute_space.config import Config
 from compute_space.core.diagnostics import collect_app_resources
 from compute_space.core.logging import logger
+from compute_space.core.process_stream import stream_process_lines
 from compute_space.core.storage import format_bytes
 
 _MEMORY_GUARD_INTERVAL_SECONDS = 60
@@ -31,9 +47,11 @@ _MEMORY_GUARD_INTERVAL_SECONDS = 60
 _MEMORY_WARN_PERCENT = 90.0
 _MEMORY_CLEAR_PERCENT = 80.0
 
-_STREAM_READ_BYTES = 65536
+# After a follow stream ends (or its binary is missing) wait this long before
+# (re)connecting, so a persistent failure retries steadily instead of spinning.
+_STREAM_RECONNECT_SECONDS = 5
 
-# The two OOM detectors each stream a subprocess that emits newline-delimited JSON.
+# The two OOM detectors each follow a subprocess that emits newline-delimited JSON.
 # journalctl reads the kernel log from the system journal (needs the systemd-journal
 # group, granted via the unit's SupplementaryGroups=, not CAP_SYSLOG); --lines=0 so
 # --follow reports only kills that happen while we run, not stale ones from the boot.
@@ -66,88 +84,33 @@ class _ContainerOomKill:
     container_name: str
 
 
-def _read_stream_chunk(fd: int) -> bytes | None:
-    """Return the next chunk of a streaming subprocess's stdout, or None if it would block.
+async def _follow_lines(argv: list[str], detector: str) -> AsyncIterator[bytes]:
+    """Follow a long-lived streaming command forever, yielding its non-blank lines.
 
-    The stdout is a raw byte stream, so a chunk may hold part of a line, several
-    lines, or a line split across reads — the caller reassembles on newlines. Empty
-    bytes means EOF (the process exited); None means nothing is available right now.
+    Reconnects when the stream ends (the daemon restarted, the journal rotated).
+    A **missing binary** — no podman/journalctl, e.g. a macOS dev host — is an
+    *expected* state: it's caught, warned once, and retried, so the detector just
+    stays off rather than crashing the guard. Anything else (a read/permission
+    error) propagates to the guard's top-level handler; we don't paper it over as
+    a silent no-op.
     """
-    try:
-        return os.read(fd, _STREAM_READ_BYTES)  # b"" at EOF
-    except BlockingIOError:
-        return None
-
-
-class _JsonEventStream:
-    """A long-lived command whose stdout is drained as complete lines each tick.
-
-    Both OOM detectors read newline-delimited JSON from a streaming subprocess —
-    ``journalctl`` for the host, ``podman events`` per app — so this owns the shared
-    plumbing: a non-blocking read, partial-line buffering across ticks, and
-    reconnect-on-EOF. Owned by the one guard-loop thread, so it needs no locking. If
-    the command can't start (binary missing) it stays off and ``drain_lines`` retries
-    the start on a later tick; if the stream ends it reconnects on the next drain
-    (lines during that brief gap are missed — acceptable for a rare outage).
-    """
-
-    def __init__(self, argv: list[str], detector: str) -> None:
-        self._argv = argv
-        self._detector = detector  # human label for log lines, e.g. "Host OOM detection"
-        self._proc: subprocess.Popen[bytes] | None = None
-        self._buf = b""
-        # Suppress repeated "cannot start" warnings while the binary stays absent.
-        self._start_warned = False
-        self._start()
-
-    def _start(self) -> None:
-        """(Re)start the stream; leaves ``_proc`` None on failure."""
+    warned_missing = False
+    while True:
         try:
-            proc = subprocess.Popen(self._argv, stdout=subprocess.PIPE, stderr=subprocess.DEVNULL)
-        except OSError as e:
-            if not self._start_warned:
-                logger.warning("Cannot start `%s` for %s: %s", self._argv[0], self._detector, e)
-                self._start_warned = True
-            self._proc = None
-            return
-        assert proc.stdout is not None
-        # Non-blocking so ``drain_lines`` reads whatever is available and returns
-        # rather than blocking the guard loop until the next line arrives.
-        os.set_blocking(proc.stdout.fileno(), False)
-        self._proc = proc
-        self._buf = b""
-        self._start_warned = False
-        logger.info("%s active (streaming `%s`)", self._detector, " ".join(self._argv[:2]))
-
-    def _reconnect(self) -> None:
-        """Reap the ended stream and start a fresh one."""
-        if self._proc is not None:
-            if self._proc.stdout is not None:
-                self._proc.stdout.close()
-            self._proc.wait()  # Already exited (we hit EOF); reap the zombie.
-            self._proc = None
-        logger.warning("`%s` stream ended; reconnecting for %s", self._argv[0], self._detector)
-        self._start()
-
-    def drain_lines(self) -> list[bytes]:
-        """Return the complete lines seen since the last drain; reconnect if the stream ended."""
-        if self._proc is None:
-            self._start()
-            if self._proc is None:
-                return []
-        assert self._proc.stdout is not None
-        fd = self._proc.stdout.fileno()
-
-        while chunk := _read_stream_chunk(fd):
-            self._buf += chunk
-
-        # Last line may be partial. Leave it in the buffer until we see a trailing newline.
-        *complete_lines, self._buf = self._buf.split(b"\n")
-
-        # On a falsy read, b"" is EOF so we have to reconnect; None is just "nothing right now".
-        if chunk == b"":
-            self._reconnect()
-        return [line for line in complete_lines if line.strip()]
+            async for line in stream_process_lines(argv, merge_stderr=False):
+                if line.strip():
+                    yield line
+        except FileNotFoundError:
+            if not warned_missing:
+                logger.warning("Cannot start `%s` for %s: not installed; detection disabled", argv[0], detector)
+                warned_missing = True
+            await asyncio.sleep(_STREAM_RECONNECT_SECONDS)
+            continue
+        # Clean EOF: the stream ended. It had connected, so re-arm the missing
+        # warning and reconnect after a pause.
+        warned_missing = False
+        logger.warning("`%s` stream ended; reconnecting for %s", argv[0], detector)
+        await asyncio.sleep(_STREAM_RECONNECT_SECONDS)
 
 
 def _parse_journal_oom(line: bytes) -> _HostOomKill | None:
@@ -172,31 +135,6 @@ def _parse_journal_oom(line: bytes) -> _HostOomKill | None:
     return _HostOomKill(pid=int(match.group(1)), comm=match.group(2))
 
 
-class _HostOomReader:
-    """Reports host-level (global) OOM kills from the kernel log, via ``journalctl``.
-
-    Reads kernel messages from the system journal rather than /dev/kmsg, so the unit
-    needs only membership in the ``systemd-journal`` group (``SupplementaryGroups=``),
-    not CAP_SYSLOG. Most kernel lines aren't OOM kills, so it filters for the ones
-    that are.
-    """
-
-    def __init__(self) -> None:
-        self._stream = _JsonEventStream(_JOURNALCTL_KERNEL_FOLLOW, "Host OOM detection")
-
-    def check(self) -> None:
-        """Report any host OOM kills seen since the last check."""
-        for line in self._stream.drain_lines():
-            kill = _parse_journal_oom(line)
-            if kill is not None:
-                logger.warning(
-                    "TODO: make this a notification — the host OOM killer killed process %d (%s); "
-                    "the machine is out of memory",
-                    kill.pid,
-                    kill.comm,
-                )
-
-
 def _parse_podman_event(line: bytes) -> _ContainerOomKill:
     """Parse one ``podman events --format json`` line into a container OOM kill.
 
@@ -215,56 +153,71 @@ def _parse_podman_event(line: bytes) -> _ContainerOomKill:
         raise ValueError(f"unrecognized `podman events` line {line[:300]!r}") from e
 
 
-class _PodmanOomReader:
-    """Streams per-app (cgroup-limit) OOM kills from a long-lived ``podman events``.
-
-    We stream events rather than poll ``podman inspect`` because ``--restart`` resets
-    ``OOMKilled`` to false on the restarted run, so a poll races the restart and can
-    miss the kill; the event is emitted the instant the kill happens and delivered
-    exactly once.
-    """
-
-    def __init__(self) -> None:
-        self._stream = _JsonEventStream(_PODMAN_OOM_EVENTS, "Per-app OOM detection")
-
-    def drain(self) -> list[_ContainerOomKill]:
-        """Return per-app OOM kills seen since the last drain.
-
-        Every line is (by our ``--filter``) an OOM event, and ``_parse_podman_event``
-        raises on an unrecognized shape rather than silently dropping the kill.
-        """
-        return [_parse_podman_event(line) for line in self._stream.drain_lines()]
+def _query_container_rows(config: Config) -> list[sqlite3.Row]:
+    """Rows for every app that currently has a container (the guard's unit of work)."""
+    with contextlib.closing(sqlite3.connect(config.db_path)) as db:
+        db.row_factory = sqlite3.Row
+        return db.execute(
+            "SELECT app_id, name, container_id, cpu_cores, memory_mb FROM apps WHERE container_id IS NOT NULL"
+        ).fetchall()
 
 
 class _MemoryGuard:
-    """One guard loop's state and checks: OOM readers plus per-app pressure debounce.
+    """The guard's detectors and per-app pressure debounce state.
 
-    Everything here is owned by the one loop thread, so none of it needs locking.
-    ``_pressure_notified`` is the debounce state (see ``_check_memory_pressure``);
-    OOM kills need no such state, as each ``podman events`` event arrives once.
+    ``run`` drives three concurrent detectors on the guard's own loop, each doing its
+    blocking work (podman stats, sqlite) inline since the loop serves nothing else.
+    ``_pressure_notified`` (the debounce state) is touched only by the pressure loop,
+    so it needs no locking.
     """
 
     def __init__(self) -> None:
-        self._host_oom = _HostOomReader()
-        self._podman_oom = _PodmanOomReader()
         self._pressure_notified: set[str] = set()
 
-    def check_once(self, config: Config) -> None:
-        """Run one pass: host OOM + per-app OOM (events) + per-app memory pressure."""
-        self._host_oom.check()
-        container_ooms = self._podman_oom.drain()
+    async def run(self, config: Config) -> None:
+        """Run host-OOM, per-app-OOM, and memory-pressure detectors until cancelled."""
+        await asyncio.gather(
+            self._run_host_oom(),
+            self._run_podman_oom(config),
+            self._run_pressure_loop(config),
+        )
 
-        db = sqlite3.connect(config.db_path)
-        db.row_factory = sqlite3.Row
-        try:
-            rows = db.execute(
-                "SELECT app_id, name, container_id, cpu_cores, memory_mb FROM apps WHERE container_id IS NOT NULL"
-            ).fetchall()
-        finally:
-            db.close()
+    async def _run_host_oom(self) -> None:
+        """Warn on each host-level (global) OOM kill seen on the kernel journal."""
+        async for line in _follow_lines(_JOURNALCTL_KERNEL_FOLLOW, "Host OOM detection"):
+            kill = _parse_journal_oom(line)
+            if kill is not None:
+                logger.warning(
+                    "TODO: make this a notification — the host OOM killer killed process %d (%s); "
+                    "the machine is out of memory",
+                    kill.pid,
+                    kill.comm,
+                )
 
-        self._report_container_ooms(container_ooms, rows)
-        for row in rows:
+    async def _run_podman_oom(self, config: Config) -> None:
+        """Report each per-app OOM kill, naming the owning app when we can map it.
+
+        ``_parse_podman_event`` raises on an unrecognized shape rather than silently
+        dropping the kill; that surfaces at ``run``'s caller (the loop's handler).
+        """
+        async for line in _follow_lines(_PODMAN_OOM_EVENTS, "Per-app OOM detection"):
+            kill = _parse_podman_event(line)
+            rows = _query_container_rows(config)
+            self._report_container_ooms([kill], rows)
+
+    async def _run_pressure_loop(self, config: Config) -> None:
+        """Every ``_MEMORY_GUARD_INTERVAL_SECONDS``, check each app's memory pressure.
+
+        The check runs inline, so ``podman stats`` blocks the loop for the seconds it
+        takes; that just pushes out the next tick (the interval is a floor, not a
+        guarantee) and briefly delays the OOM followers, which is fine here.
+        """
+        while True:
+            self._check_pressure_once(config)
+            await asyncio.sleep(_MEMORY_GUARD_INTERVAL_SECONDS)
+
+    def _check_pressure_once(self, config: Config) -> None:
+        for row in _query_container_rows(config):
             self._check_memory_pressure(row)
 
     def _report_container_ooms(self, kills: list[_ContainerOomKill], rows: list[sqlite3.Row]) -> None:
@@ -321,16 +274,18 @@ class _MemoryGuard:
 
 
 def _memory_guard_loop(config: Config) -> None:
-    guard = _MemoryGuard()
+    """Run the guard's asyncio loop on this dedicated daemon thread.
+
+    A *separate* event loop from the one hypercorn serves requests on (see the module
+    docstring). ``_MemoryGuard.run`` only returns by raising — a detector hit an
+    unexpected error — so we log it and restart, mirroring the old per-tick handler.
+    """
     while True:
         try:
-            guard.check_once(config)
+            asyncio.run(_MemoryGuard().run(config))
         except Exception:
-            logger.exception(
-                "Memory guard tick failed; skipping this cycle and retrying in %ds",
-                _MEMORY_GUARD_INTERVAL_SECONDS,
-            )
-        time.sleep(_MEMORY_GUARD_INTERVAL_SECONDS)
+            logger.exception("Memory guard crashed; restarting in %ds", _STREAM_RECONNECT_SECONDS)
+            time.sleep(_STREAM_RECONNECT_SECONDS)
 
 
 def ensure_memory_guard(config: Config) -> None:

--- a/compute_space/src/compute_space/core/process_stream.py
+++ b/compute_space/src/compute_space/core/process_stream.py
@@ -44,15 +44,23 @@ def _terminate(proc: asyncio.subprocess.Process) -> None:
             proc.terminate()
 
 
-async def stream_process_lines(argv: list[str], *, merge_stderr: bool) -> AsyncGenerator[bytes, None]:
+async def stream_process_lines(
+    argv: list[str], *, merge_stderr: bool, raise_on_error: bool = False
+) -> AsyncGenerator[bytes, None]:
     """Spawn ``argv`` and yield its stdout line by line (newline stripped) until EOF.
 
     ``merge_stderr`` folds the child's stderr into the yielded stream (True — right
     for ``podman logs``, where container stderr is part of the log) or discards it
     (False — right for the OOM streams, where stderr is diagnostic noise).
 
-    Only EOF ends the generator cleanly. A spawn or read failure propagates; see the
-    module docstring. The child is terminated and reaped in all exit paths.
+    ``raise_on_error`` turns a non-zero *self*-exit into a raised ``RuntimeError``
+    instead of a silent EOF — for callers (like the build-log tail) where the child
+    exiting non-zero means a real failure, not a normal end. It only fires when the
+    child closes stdout on its own; a consumer that stops early (cancels) still tears
+    the child down quietly, since we terminated it, not it failing.
+
+    Only EOF ends the generator cleanly otherwise. A spawn or read failure propagates;
+    see the module docstring. The child is terminated and reaped in all exit paths.
     """
     proc = await asyncio.create_subprocess_exec(
         *argv,
@@ -63,11 +71,14 @@ async def stream_process_lines(argv: list[str], *, merge_stderr: bool) -> AsyncG
     _active.add(proc)
     try:
         assert proc.stdout is not None
-        while True:
-            line = await proc.stdout.readline()
-            if not line:
-                break  # stdout closed — the process has ended (or is ending).
+        # readline() returns b"" only at EOF; a blank line still carries its newline,
+        # so the walrus loop stops on stream close, not on empty output.
+        while line := await proc.stdout.readline():
             yield line.rstrip(b"\n")
+        if raise_on_error:
+            await proc.wait()
+            if proc.returncode:
+                raise RuntimeError(f"`{argv[0]}` exited with status {proc.returncode}")
     finally:
         _active.discard(proc)
         _terminate(proc)

--- a/compute_space/src/compute_space/core/process_stream.py
+++ b/compute_space/src/compute_space/core/process_stream.py
@@ -1,0 +1,82 @@
+"""Watch a subprocess and consume its stdout as a stream of lines.
+
+:func:`stream_process_lines` spawns a command and yields its stdout one line at a
+time (trailing newline stripped) until the process closes stdout. It is the shared
+primitive behind anything that "follows" a long-lived command — ``podman logs
+--follow`` for an app's container log (see ``core.log_stream``) and the
+``journalctl`` / ``podman events`` OOM streams (see ``core.memory_guard``).
+
+Error philosophy — we do **not** paper over failures:
+
+* **EOF is the one normal terminator.** stdout closing just ends the iteration;
+  the caller decides whether that means "done" (a stopped container) or "reconnect"
+  (a restarted daemon).
+* **Everything else propagates.** A missing binary, an exec failure, a read error
+  (e.g. permission denied) raises out of the generator rather than being swallowed
+  into a silent empty stream. Whether such a state is *expected* is the caller's
+  call: the memory guard treats "binary not installed" as expected on a dev host
+  and catches it to disable a detector; the log-stream route lets it error the
+  request. Neither one gets a quiet "no data" that hides a real problem.
+
+The subprocess is always terminated and reaped, even when the consumer stops early
+(its ``async for`` breaks or the surrounding task is cancelled).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+from collections.abc import AsyncGenerator
+
+# Generous per-line cap so a long (but legitimate) log line doesn't trip asyncio's
+# default 64 KiB StreamReader limit and raise mid-stream. A line beyond this is
+# pathological and still fails loudly rather than being silently truncated.
+_LINE_LIMIT_BYTES = 1024 * 1024
+
+# Live follow subprocesses, so a process-wide shutdown can reap any that outlive
+# their consumer (mirrors ``core.terminal._active_sessions``).
+_active: set[asyncio.subprocess.Process] = set()
+
+
+def _terminate(proc: asyncio.subprocess.Process) -> None:
+    if proc.returncode is None:
+        with contextlib.suppress(ProcessLookupError):
+            proc.terminate()
+
+
+async def stream_process_lines(argv: list[str], *, merge_stderr: bool) -> AsyncGenerator[bytes, None]:
+    """Spawn ``argv`` and yield its stdout line by line (newline stripped) until EOF.
+
+    ``merge_stderr`` folds the child's stderr into the yielded stream (True — right
+    for ``podman logs``, where container stderr is part of the log) or discards it
+    (False — right for the OOM streams, where stderr is diagnostic noise).
+
+    Only EOF ends the generator cleanly. A spawn or read failure propagates; see the
+    module docstring. The child is terminated and reaped in all exit paths.
+    """
+    proc = await asyncio.create_subprocess_exec(
+        *argv,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.STDOUT if merge_stderr else asyncio.subprocess.DEVNULL,
+        limit=_LINE_LIMIT_BYTES,
+    )
+    _active.add(proc)
+    try:
+        assert proc.stdout is not None
+        while True:
+            line = await proc.stdout.readline()
+            if not line:
+                break  # stdout closed — the process has ended (or is ending).
+            yield line.rstrip(b"\n")
+    finally:
+        _active.discard(proc)
+        _terminate(proc)
+        with contextlib.suppress(Exception):
+            await proc.wait()
+
+
+def cleanup_all() -> None:
+    """Terminate any live follow subprocesses. Called at process shutdown."""
+    for proc in list(_active):
+        _terminate(proc)
+    _active.clear()

--- a/compute_space/src/compute_space/core/process_stream.py
+++ b/compute_space/src/compute_space/core/process_stream.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 import asyncio
 import contextlib
 from collections.abc import AsyncGenerator
+from collections.abc import Callable
 
 # Generous per-line cap so a long (but legitimate) log line doesn't trip asyncio's
 # default 64 KiB StreamReader limit and raise mid-stream. A line beyond this is
@@ -44,14 +45,34 @@ def _terminate(proc: asyncio.subprocess.Process) -> None:
             proc.terminate()
 
 
+async def _drain_stderr(reader: asyncio.StreamReader, sink: Callable[[bytes], None]) -> None:
+    """Forward the child's stderr to ``sink`` line by line (newline stripped) until it closes.
+
+    Drained concurrently with stdout so a child that chatters on stderr can't fill its
+    stderr pipe buffer and block — which would then stall the stdout we actually read.
+    """
+    while line := await reader.readline():
+        sink(line.rstrip(b"\n"))
+
+
 async def stream_process_lines(
-    argv: list[str], *, merge_stderr: bool, raise_on_error: bool = False
+    argv: list[str],
+    *,
+    merge_stderr: bool,
+    raise_on_error: bool = False,
+    stderr_sink: Callable[[bytes], None] | None = None,
 ) -> AsyncGenerator[bytes, None]:
     """Spawn ``argv`` and yield its stdout line by line (newline stripped) until EOF.
 
     ``merge_stderr`` folds the child's stderr into the yielded stream (True — right
     for ``podman logs``, where container stderr is part of the log) or discards it
     (False — right for the OOM streams, where stderr is diagnostic noise).
+
+    ``stderr_sink`` (only valid with ``merge_stderr=False``) instead diverts each
+    stderr line to the callback — for callers that want to keep stderr *out* of the
+    parsed stdout stream (e.g. the OOM followers' JSON) yet still surface it, say to
+    log the real reason a follow ended instead of a bare EOF. It's drained on its own
+    task so it can't stall stdout.
 
     ``raise_on_error`` turns a non-zero *self*-exit into a raised ``RuntimeError``
     instead of a silent EOF — for callers (like the build-log tail) where the child
@@ -62,13 +83,23 @@ async def stream_process_lines(
     Only EOF ends the generator cleanly otherwise. A spawn or read failure propagates;
     see the module docstring. The child is terminated and reaped in all exit paths.
     """
+    assert not (merge_stderr and stderr_sink is not None), "stderr_sink can't observe stderr that's merged into stdout"
+    if merge_stderr:
+        stderr = asyncio.subprocess.STDOUT
+    elif stderr_sink is not None:
+        stderr = asyncio.subprocess.PIPE
+    else:
+        stderr = asyncio.subprocess.DEVNULL
     proc = await asyncio.create_subprocess_exec(
         *argv,
         stdout=asyncio.subprocess.PIPE,
-        stderr=asyncio.subprocess.STDOUT if merge_stderr else asyncio.subprocess.DEVNULL,
+        stderr=stderr,
         limit=_LINE_LIMIT_BYTES,
     )
     _active.add(proc)
+    drain: asyncio.Task[None] | None = None
+    if stderr_sink is not None and proc.stderr is not None:
+        drain = asyncio.ensure_future(_drain_stderr(proc.stderr, stderr_sink))
     try:
         assert proc.stdout is not None
         # readline() returns b"" only at EOF; a blank line still carries its newline,
@@ -84,6 +115,13 @@ async def stream_process_lines(
         _terminate(proc)
         with contextlib.suppress(Exception):
             await proc.wait()
+        if drain is not None:
+            # The child is reaped above, so its stderr is now closed; the drain task
+            # reads the last buffered lines, sees EOF, and ends on its own. Await it
+            # (rather than cancel) so a normally-exiting child's buffered stderr is
+            # fully delivered to the sink instead of being cut off mid-drain.
+            with contextlib.suppress(Exception):
+                await drain
 
 
 def cleanup_all() -> None:

--- a/compute_space/src/compute_space/core/process_stream.py
+++ b/compute_space/src/compute_space/core/process_stream.py
@@ -113,15 +113,20 @@ async def stream_process_lines(
     finally:
         _active.discard(proc)
         _terminate(proc)
+        # Shield the reap: _terminate only signals, so wait() must run to actually reap
+        # the child. A cancellation arriving here is a BaseException that suppress(Exception)
+        # wouldn't catch, so a bare ``await proc.wait()`` would leave the signalled child
+        # unreaped. Shielding lets wait() finish reaping in the background while the
+        # CancelledError still propagates, keeping both the reap guarantee and cancellation.
         with contextlib.suppress(Exception):
-            await proc.wait()
+            await asyncio.shield(proc.wait())
         if drain is not None:
             # The child is reaped above, so its stderr is now closed; the drain task
             # reads the last buffered lines, sees EOF, and ends on its own. Await it
             # (rather than cancel) so a normally-exiting child's buffered stderr is
             # fully delivered to the sink instead of being cut off mid-drain.
             with contextlib.suppress(Exception):
-                await drain
+                await asyncio.shield(drain)
 
 
 def cleanup_all() -> None:

--- a/compute_space/src/compute_space/tests/test_app_logs_stream.py
+++ b/compute_space/src/compute_space/tests/test_app_logs_stream.py
@@ -68,7 +68,7 @@ def _seed_running_app(cfg: Any, name: str, container_id: str | None, port: int) 
 
 
 def _fake_stream_app_logs(chunks: list[str], monkeypatch: pytest.MonkeyPatch) -> None:
-    async def fake(app_name: str, build_log_path: str, get_state: Any) -> AsyncIterator[str]:
+    async def fake(app_id: str, build_log_path: str) -> AsyncIterator[str]:
         for chunk in chunks:
             yield chunk
 

--- a/compute_space/src/compute_space/tests/test_app_logs_stream.py
+++ b/compute_space/src/compute_space/tests/test_app_logs_stream.py
@@ -1,0 +1,130 @@
+"""Route-level tests for the ``/app_logs_stream/<app_id>`` WebSocket endpoint.
+
+Drives the real WebSocket layer (inline auth check, route wiring, the
+build-log-then-container-follow handoff) via TestClient; podman is faked so no
+daemon is required.
+"""
+
+from __future__ import annotations
+
+import os
+import sqlite3
+from collections.abc import AsyncIterator
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Any
+
+import pytest
+from litestar import Litestar
+from litestar.exceptions import WebSocketDisconnect
+from litestar.testing import TestClient
+
+from compute_space.core import log_stream
+from compute_space.core.app_id import new_app_id
+from compute_space.db.connection import init_db
+from compute_space.tests._litestar_helpers import auth_cookie
+from compute_space.tests._litestar_helpers import make_test_app
+from compute_space.tests.conftest import _make_test_config
+from compute_space.web.routes.api.apps import api_apps_routes
+
+
+@pytest.fixture
+def cfg(tmp_path: Path) -> Any:
+    cfg = _make_test_config(tmp_path, port=20200)
+    init_db(cfg.db_path)
+    return cfg
+
+
+@pytest.fixture
+def client(cfg: Any) -> Iterator[TestClient[Litestar]]:
+    with TestClient(app=make_test_app(api_apps_routes)) as c:
+        yield c
+
+
+@pytest.fixture
+def cookies(cfg: Any) -> dict[str, str]:
+    return auth_cookie(cfg)
+
+
+def _cookie_header(cookies: dict[str, str]) -> dict[str, str]:
+    # The WebSocket handshake is a plain HTTP GET, so the session cookie rides in
+    # a Cookie header just like a normal request.
+    return {"cookie": "; ".join(f"{k}={v}" for k, v in cookies.items())}
+
+
+def _seed_running_app(cfg: Any, name: str, container_id: str | None, port: int) -> str:
+    app_id = new_app_id()
+    db = sqlite3.connect(cfg.db_path)
+    try:
+        db.execute(
+            """INSERT INTO apps (app_id, name, version, repo_path, local_port, status, container_id)
+               VALUES (?, ?, '1.0', ?, ?, 'running', ?)""",
+            (app_id, name, f"/repo/{name}", port, container_id),
+        )
+        db.commit()
+    finally:
+        db.close()
+    return app_id
+
+
+def _write_build_log(cfg: Any, name: str, text: str) -> None:
+    path = os.path.join(cfg.temporary_data_dir, "app_temp_data", name, "docker.log")
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "w") as f:
+        f.write(text)
+
+
+def _fake_follow(lines: list[str], monkeypatch: pytest.MonkeyPatch) -> None:
+    async def fake(container_id: str, tail_lines: int) -> AsyncIterator[str]:
+        for line in lines:
+            yield line
+
+    monkeypatch.setattr(log_stream, "_podman_follow", fake)
+
+
+def test_stream_requires_auth(cfg: Any, client: TestClient[Litestar]) -> None:
+    app_id = _seed_running_app(cfg, "notes", "cid1", 20210)
+    with pytest.raises(WebSocketDisconnect) as exc:
+        with client.websocket_connect(f"/app_logs_stream/{app_id}") as ws:  # no cookie
+            ws.receive_text()
+    assert exc.value.code == 4401
+
+
+def test_stream_unknown_app_closes(cfg: Any, client: TestClient[Litestar], cookies: dict[str, str]) -> None:
+    with pytest.raises(WebSocketDisconnect) as exc:
+        with client.websocket_connect(f"/app_logs_stream/{new_app_id()}", headers=_cookie_header(cookies)) as ws:
+            ws.receive_text()
+    assert exc.value.code == 4404
+
+
+def test_stream_emits_build_log_then_container_lines(
+    cfg: Any, client: TestClient[Litestar], cookies: dict[str, str], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _write_build_log(cfg, "notes", "build line 1\nbuild line 2\n")
+    _fake_follow(["container line a", "container line b"], monkeypatch)
+    app_id = _seed_running_app(cfg, "notes", "cid1", 20211)
+
+    msgs = []
+    with client.websocket_connect(f"/app_logs_stream/{app_id}", headers=_cookie_header(cookies)) as ws:
+        for _ in range(4):
+            msgs.append(ws.receive_text())
+
+    assert msgs == [
+        "build line 1\nbuild line 2",
+        "=== Container logs ===",
+        "container line a",
+        "container line b",
+    ]
+
+
+def test_stream_no_container_emits_build_only(
+    cfg: Any, client: TestClient[Litestar], cookies: dict[str, str], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _write_build_log(cfg, "notes", "only a build log\n")
+    _fake_follow(["should not appear"], monkeypatch)
+    app_id = _seed_running_app(cfg, "notes", None, 20212)  # no container
+
+    with client.websocket_connect(f"/app_logs_stream/{app_id}", headers=_cookie_header(cookies)) as ws:
+        first = ws.receive_text()
+
+    assert first == "only a build log"

--- a/compute_space/src/compute_space/tests/test_app_logs_stream.py
+++ b/compute_space/src/compute_space/tests/test_app_logs_stream.py
@@ -1,13 +1,13 @@
 """Route-level tests for the ``/app_logs_stream/<app_id>`` WebSocket endpoint.
 
-Drives the real WebSocket layer (inline auth check, route wiring, the
-build-log-then-container-follow handoff) via TestClient; podman is faked so no
-daemon is required.
+Drives the real WebSocket layer (inline auth check, route wiring, socket pump) via
+TestClient. ``stream_app_logs`` is faked: the TestClient runs the ASGI app in a
+worker thread whose event loop can't spawn subprocesses (asyncio's child watcher is
+main-thread only), and the log *content* generation is covered by test_log_stream.
 """
 
 from __future__ import annotations
 
-import os
 import sqlite3
 from collections.abc import AsyncIterator
 from collections.abc import Iterator
@@ -19,12 +19,12 @@ from litestar import Litestar
 from litestar.exceptions import WebSocketDisconnect
 from litestar.testing import TestClient
 
-from compute_space.core import log_stream
 from compute_space.core.app_id import new_app_id
 from compute_space.db.connection import init_db
 from compute_space.tests._litestar_helpers import auth_cookie
 from compute_space.tests._litestar_helpers import make_test_app
 from compute_space.tests.conftest import _make_test_config
+from compute_space.web.routes.api import apps
 from compute_space.web.routes.api.apps import api_apps_routes
 
 
@@ -67,19 +67,12 @@ def _seed_running_app(cfg: Any, name: str, container_id: str | None, port: int) 
     return app_id
 
 
-def _write_build_log(cfg: Any, name: str, text: str) -> None:
-    path = os.path.join(cfg.temporary_data_dir, "app_temp_data", name, "docker.log")
-    os.makedirs(os.path.dirname(path), exist_ok=True)
-    with open(path, "w") as f:
-        f.write(text)
+def _fake_stream_app_logs(chunks: list[str], monkeypatch: pytest.MonkeyPatch) -> None:
+    async def fake(app_name: str, build_log_path: str, get_state: Any) -> AsyncIterator[str]:
+        for chunk in chunks:
+            yield chunk
 
-
-def _fake_follow(lines: list[str], monkeypatch: pytest.MonkeyPatch) -> None:
-    async def fake(container_id: str, tail_lines: int) -> AsyncIterator[str]:
-        for line in lines:
-            yield line
-
-    monkeypatch.setattr(log_stream, "_podman_follow", fake)
+    monkeypatch.setattr(apps, "stream_app_logs", fake)
 
 
 def test_stream_requires_auth(cfg: Any, client: TestClient[Litestar]) -> None:
@@ -97,34 +90,28 @@ def test_stream_unknown_app_closes(cfg: Any, client: TestClient[Litestar], cooki
     assert exc.value.code == 4404
 
 
-def test_stream_emits_build_log_then_container_lines(
+def test_stream_forwards_chunks_over_the_socket(
     cfg: Any, client: TestClient[Litestar], cookies: dict[str, str], monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    _write_build_log(cfg, "notes", "build line 1\nbuild line 2\n")
-    _fake_follow(["container line a", "container line b"], monkeypatch)
+    chunks = ["build line 1\nbuild line 2", "=== Container logs ===", "container a", "container b"]
+    _fake_stream_app_logs(chunks, monkeypatch)
     app_id = _seed_running_app(cfg, "notes", "cid1", 20211)
 
     msgs = []
     with client.websocket_connect(f"/app_logs_stream/{app_id}", headers=_cookie_header(cookies)) as ws:
-        for _ in range(4):
+        for _ in range(len(chunks)):
             msgs.append(ws.receive_text())
 
-    assert msgs == [
-        "build line 1\nbuild line 2",
-        "=== Container logs ===",
-        "container line a",
-        "container line b",
-    ]
+    assert msgs == chunks
 
 
-def test_stream_no_container_emits_build_only(
+def test_stream_holds_socket_open_after_the_log_ends(
     cfg: Any, client: TestClient[Litestar], cookies: dict[str, str], monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    _write_build_log(cfg, "notes", "only a build log\n")
-    _fake_follow(["should not appear"], monkeypatch)
+    # A short (stopped-app) log still delivers, and the socket stays open at the
+    # final state rather than closing and prompting a client reconnect.
+    _fake_stream_app_logs(["only a build log"], monkeypatch)
     app_id = _seed_running_app(cfg, "notes", None, 20212)  # no container
 
     with client.websocket_connect(f"/app_logs_stream/{app_id}", headers=_cookie_header(cookies)) as ws:
-        first = ws.receive_text()
-
-    assert first == "only a build log"
+        assert ws.receive_text() == "only a build log"

--- a/compute_space/src/compute_space/tests/test_log_stream.py
+++ b/compute_space/src/compute_space/tests/test_log_stream.py
@@ -1,8 +1,9 @@
 """Unit tests for compute_space.core.log_stream.
 
-The container-log path shells out to ``podman logs --follow`` (via the shared
-process-stream helper); here that is faked so the tests run without a live podman.
-The file-tailing helpers and the build→container flow are exercised directly.
+The build-log tail command (``sh``/``tail``) is exercised for real against temp
+files — including the fail-loud unreadable case — while the container follow
+(``podman logs``) and the async build→container orchestration are faked so the
+tests run without a live podman and deterministically.
 """
 
 from __future__ import annotations
@@ -16,167 +17,52 @@ from typing import Any
 import pytest
 
 from compute_space.core import log_stream
-from compute_space.core.log_stream import _read_build_tail
-from compute_space.core.log_stream import _read_from
 from compute_space.core.log_stream import stream_app_logs
+from compute_space.core.process_stream import stream_process_lines
 
 
 async def _collect(gen: AsyncIterator[str]) -> list[str]:
     return [chunk async for chunk in gen]
 
 
-def test_read_build_tail_returns_whole_small_file(tmp_path: Path) -> None:
+async def _collect_bytes(gen: AsyncIterator[bytes]) -> list[bytes]:
+    return [chunk async for chunk in gen]
+
+
+# ─── the build-log tail shell command (real sh/tail) ──────────────────────────
+
+
+def test_build_tail_oneshot_reads_existing_file(tmp_path: Path) -> None:
     p = tmp_path / "docker.log"
-    p.write_text("line1\nline2\n")
-    text, offset = _read_build_tail(str(p), max_bytes=1024)
-    assert text == "line1\nline2\n"
-    assert offset == p.stat().st_size
+    p.write_text("build 1\nbuild 2\n")
+    argv = log_stream._build_tail_argv(str(p), follow=False)
+    lines = asyncio.run(_collect_bytes(stream_process_lines(argv, merge_stderr=True, raise_on_error=True)))
+    assert lines == [b"build 1", b"build 2"]
 
 
-def test_read_build_tail_drops_partial_leading_line_when_truncated(tmp_path: Path) -> None:
-    p = tmp_path / "docker.log"
-    p.write_text("aaaa\nbbbb\ncccc\n")
-    # max_bytes lands mid-first-line, so the partial "aaaa" line is dropped.
-    text, offset = _read_build_tail(str(p), max_bytes=11)
-    assert text == "bbbb\ncccc\n"
-    assert offset == p.stat().st_size
-
-
-def test_read_build_tail_missing_file_is_quiet() -> None:
-    # Build hasn't written yet: expected, so empty rather than an error.
-    text, offset = _read_build_tail("/no/such/file.log", max_bytes=1024)
-    assert text == ""
-    assert offset == 0
+def test_build_tail_oneshot_missing_file_is_quiet() -> None:
+    # docker.log not written yet: expected, so empty and a clean (exit-0) end.
+    argv = log_stream._build_tail_argv("/no/such/file.log", follow=False)
+    lines = asyncio.run(_collect_bytes(stream_process_lines(argv, merge_stderr=True, raise_on_error=True)))
+    assert lines == []
 
 
 @pytest.mark.skipif(os.geteuid() == 0, reason="root bypasses file permission checks")
-def test_read_build_tail_permission_denied_fails_loud(tmp_path: Path) -> None:
-    # A weird error (not "hasn't started yet") must not be papered over as empty.
+def test_build_tail_unreadable_fails_loud(tmp_path: Path) -> None:
+    # Exists but unreadable (EACCES): tail exits non-zero, which raise_on_error
+    # surfaces rather than papering over as an empty log.
     p = tmp_path / "docker.log"
     p.write_text("secret\n")
     p.chmod(0o000)
+    argv = log_stream._build_tail_argv(str(p), follow=False)
     try:
-        with pytest.raises(PermissionError):
-            _read_build_tail(str(p), max_bytes=1024)
+        with pytest.raises(RuntimeError):
+            asyncio.run(_collect_bytes(stream_process_lines(argv, merge_stderr=False, raise_on_error=True)))
     finally:
         p.chmod(0o644)
 
 
-def test_read_from_returns_only_appended_bytes(tmp_path: Path) -> None:
-    p = tmp_path / "docker.log"
-    p.write_text("hello\n")
-    text, offset = _read_from(str(p), 0)
-    assert text == "hello\n"
-    assert offset == 6
-    # nothing new since last offset
-    text2, offset2 = _read_from(str(p), offset)
-    assert text2 == ""
-    assert offset2 == 6
-    # append and read only the delta
-    with open(p, "a") as f:
-        f.write("world\n")
-    text3, offset3 = _read_from(str(p), offset2)
-    assert text3 == "world\n"
-    assert offset3 == 12
-
-
-def test_read_from_resyncs_when_file_shrinks(tmp_path: Path) -> None:
-    """A rotated/truncated file (size < offset) resyncs from the start rather
-    than seeking past EOF and reading misaligned bytes."""
-    p = tmp_path / "docker.log"
-    p.write_text("aaaaaaaaaa\n")
-    # Pretend we had already consumed more than the file now holds.
-    p.write_text("new\n")
-    text, offset = _read_from(str(p), 50)
-    assert text == "new\n"
-    assert offset == p.stat().st_size
-
-
-def test_read_from_missing_file_is_quiet() -> None:
-    text, offset = _read_from("/no/such/file.log", 10)
-    assert text == ""
-    assert offset == 10
-
-
-@pytest.fixture
-def fake_podman(monkeypatch: pytest.MonkeyPatch) -> Any:
-    """Replace _podman_follow with a generator yielding canned container lines."""
-
-    def _install(lines: list[str]) -> dict[str, object]:
-        seen: dict[str, object] = {}
-
-        async def fake_follow(container_id: str, tail_lines: int) -> AsyncIterator[str]:
-            seen["container_id"] = container_id
-            seen["tail_lines"] = tail_lines
-            for line in lines:
-                yield line
-
-        monkeypatch.setattr(log_stream, "_podman_follow", fake_follow)
-        return seen
-
-    return _install
-
-
-def test_stream_running_app_emits_build_then_container(tmp_path: Path, fake_podman: Any) -> None:
-    build = tmp_path / "docker.log"
-    build.write_text("build step 1\nbuild step 2\n")
-    seen = fake_podman(["container line a", "container line b"])
-
-    def get_state() -> tuple[str, str | None]:
-        return "running", "cid123"
-
-    chunks = asyncio.run(_collect(stream_app_logs("myapp", str(build), get_state)))
-
-    assert chunks == [
-        "build step 1\nbuild step 2",
-        "=== Container logs ===",
-        "container line a",
-        "container line b",
-    ]
-    assert seen["container_id"] == "cid123"
-
-
-def test_stream_no_container_emits_build_only(tmp_path: Path, fake_podman: Any) -> None:
-    build = tmp_path / "docker.log"
-    build.write_text("just a build log\n")
-    fake_podman(["should not appear"])
-
-    def get_state() -> tuple[str, str | None]:
-        return "stopped", None
-
-    chunks = asyncio.run(_collect(stream_app_logs("myapp", str(build), get_state)))
-    assert chunks == ["just a build log"]
-
-
-def test_stream_building_then_container_appears(
-    tmp_path: Path, fake_podman: Any, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """While building we follow docker.log; once a container id appears we flush
-    the remaining build output and switch to the container feed."""
-    monkeypatch.setattr(log_stream, "_BUILD_POLL_SECONDS", 0)
-    build = tmp_path / "docker.log"
-    build.write_text("building...\n")
-    fake_podman(["container up"])
-
-    states = [("building", None), ("building", None), ("running", "cid9")]
-
-    def get_state() -> tuple[str, str | None]:
-        # Simulate more build output arriving between polls.
-        with open(build, "a") as f:
-            f.write("more build output\n")
-        return states.pop(0)
-
-    chunks = asyncio.run(_collect(stream_app_logs("myapp", str(build), get_state)))
-
-    assert "=== Container logs ===" in chunks
-    assert chunks[-1] == "container up"
-    # all build output is delivered before the container separator
-    sep = chunks.index("=== Container logs ===")
-    joined_build = "\n".join(chunks[:sep])
-    assert "building..." in joined_build
-    assert "more build output" in joined_build
-    # and the container feed contains nothing but the separator + follow lines
-    assert chunks[sep:] == ["=== Container logs ===", "container up"]
+# ─── container follow: timestamp + ANSI stripping ─────────────────────────────
 
 
 def test_podman_follow_strips_timestamp_and_ansi(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -190,7 +76,9 @@ def test_podman_follow_strips_timestamp_and_ansi(monkeypatch: pytest.MonkeyPatch
         b"2026-07-30T15:27:36.000000000+00:00 ",  # empty content
     ]
 
-    async def fake_stream(argv: list[str], *, merge_stderr: bool) -> AsyncIterator[bytes]:
+    async def fake_stream(
+        argv: list[str], *, merge_stderr: bool, raise_on_error: bool = False
+    ) -> AsyncIterator[bytes]:
         assert "--follow" in argv and "--timestamps" in argv
         assert merge_stderr is True
         for line in raw:
@@ -201,5 +89,81 @@ def test_podman_follow_strips_timestamp_and_ansi(monkeypatch: pytest.MonkeyPatch
     async def run() -> list[str]:
         return [line async for line in log_stream._podman_follow("cid", 2000)]
 
-    lines = asyncio.run(run())
-    assert lines == ["plain line", "red text", ""]
+    assert asyncio.run(run()) == ["plain line", "red text", ""]
+
+
+# ─── build→container orchestration ────────────────────────────────────────────
+
+
+def _fake_build_stream(monkeypatch: pytest.MonkeyPatch, lines: list[bytes]) -> None:
+    async def fake_stream(
+        argv: list[str], *, merge_stderr: bool, raise_on_error: bool = False
+    ) -> AsyncIterator[bytes]:
+        for line in lines:
+            yield line
+
+    monkeypatch.setattr(log_stream, "stream_process_lines", fake_stream)
+
+
+def _fake_podman(monkeypatch: pytest.MonkeyPatch, lines: list[str]) -> None:
+    async def fake_follow(container_id: str, tail_lines: int) -> AsyncIterator[str]:
+        for line in lines:
+            yield line
+
+    monkeypatch.setattr(log_stream, "_podman_follow", fake_follow)
+
+
+def test_stream_app_logs_running_emits_build_then_container(monkeypatch: pytest.MonkeyPatch) -> None:
+    _fake_build_stream(monkeypatch, [b"build 1", b"build 2"])
+    _fake_podman(monkeypatch, ["container a", "container b"])
+
+    def get_state() -> tuple[str, str | None]:
+        return "running", "cid123"
+
+    chunks = asyncio.run(_collect(stream_app_logs("app", "/p/docker.log", get_state)))
+    assert chunks == ["build 1", "build 2", "=== Container logs ===", "container a", "container b"]
+
+
+def test_stream_app_logs_no_container_emits_build_only(monkeypatch: pytest.MonkeyPatch) -> None:
+    _fake_build_stream(monkeypatch, [b"only a build log"])
+    _fake_podman(monkeypatch, ["should not appear"])
+
+    def get_state() -> tuple[str, str | None]:
+        return "stopped", None
+
+    chunks = asyncio.run(_collect(stream_app_logs("app", "/p/docker.log", get_state)))
+    assert chunks == ["only a build log"]
+
+
+def test_stream_app_logs_building_then_container_appears(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def fake_follow_build(build_log_path: str, get_state: Any) -> AsyncIterator[str]:
+        for line in ("building...", "more build output"):
+            yield line
+
+    monkeypatch.setattr(log_stream, "_follow_build_until_container", fake_follow_build)
+    _fake_podman(monkeypatch, ["container up"])
+
+    # building at connect; a container has appeared by the time the build follow returns.
+    states = iter([("building", None), ("running", "cid9")])
+
+    def get_state() -> tuple[str, str | None]:
+        return next(states)
+
+    chunks = asyncio.run(_collect(stream_app_logs("app", "/p/docker.log", get_state)))
+    assert chunks == ["building...", "more build output", "=== Container logs ===", "container up"]
+
+
+def test_follow_build_stops_when_container_appears(monkeypatch: pytest.MonkeyPatch) -> None:
+    # The follow yields build lines and returns as soon as get_state reports a
+    # container, without draining the rest of the (still-live) build stream.
+    _fake_build_stream(monkeypatch, [b"a", b"b", b"c"])
+    states = iter([("building", None), ("running", "cid")])
+
+    def get_state() -> tuple[str, str | None]:
+        try:
+            return next(states)
+        except StopIteration:
+            return "running", "cid"
+
+    lines = asyncio.run(_collect(log_stream._follow_build_until_container("/p/docker.log", get_state)))
+    assert lines == ["a", "b"]

--- a/compute_space/src/compute_space/tests/test_log_stream.py
+++ b/compute_space/src/compute_space/tests/test_log_stream.py
@@ -145,6 +145,30 @@ def test_stream_app_logs_building_then_container_appears(monkeypatch: pytest.Mon
     assert chunks == ["building...", "more build output", "=== Container logs ===", "container up"]
 
 
+def test_stream_app_logs_replays_build_log_that_lands_as_build_ends(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # The build ended before docker.log ever appeared, so the live follow yields
+    # nothing; the file lands a moment later. The tail must still be replayed (the
+    # replay is a standalone `if not emitted`, not an `elif`), else the viewer is
+    # left with an empty pane.
+    build = tmp_path / "docker.log"
+    build.write_text("late build output")
+
+    async def empty_follow(app_id: str, build_log_path: str) -> AsyncIterator[str]:
+        for line in []:  # an async generator that yields nothing
+            yield line
+
+    monkeypatch.setattr(log_stream, "_follow_build_until_container", empty_follow)
+    _fake_build_stream(monkeypatch, [b"late build output"])
+    # building at connect (so we enter the follow), and no container ever came up.
+    states = iter([("building", None), ("error", None)])
+    _fake_state(monkeypatch, lambda: next(states))
+
+    chunks = asyncio.run(_collect(stream_app_logs("app-1", str(build))))
+    assert chunks == ["late build output"]
+
+
 def test_follow_build_streams_until_eof(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     # While the build keeps going, every build line is yielded until the stream ends.
     build = tmp_path / "docker.log"

--- a/compute_space/src/compute_space/tests/test_log_stream.py
+++ b/compute_space/src/compute_space/tests/test_log_stream.py
@@ -1,0 +1,205 @@
+"""Unit tests for compute_space.core.log_stream.
+
+The container-log path shells out to ``podman logs --follow`` (via the shared
+process-stream helper); here that is faked so the tests run without a live podman.
+The file-tailing helpers and the build→container flow are exercised directly.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from collections.abc import AsyncIterator
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from compute_space.core import log_stream
+from compute_space.core.log_stream import _read_build_tail
+from compute_space.core.log_stream import _read_from
+from compute_space.core.log_stream import stream_app_logs
+
+
+async def _collect(gen: AsyncIterator[str]) -> list[str]:
+    return [chunk async for chunk in gen]
+
+
+def test_read_build_tail_returns_whole_small_file(tmp_path: Path) -> None:
+    p = tmp_path / "docker.log"
+    p.write_text("line1\nline2\n")
+    text, offset = _read_build_tail(str(p), max_bytes=1024)
+    assert text == "line1\nline2\n"
+    assert offset == p.stat().st_size
+
+
+def test_read_build_tail_drops_partial_leading_line_when_truncated(tmp_path: Path) -> None:
+    p = tmp_path / "docker.log"
+    p.write_text("aaaa\nbbbb\ncccc\n")
+    # max_bytes lands mid-first-line, so the partial "aaaa" line is dropped.
+    text, offset = _read_build_tail(str(p), max_bytes=11)
+    assert text == "bbbb\ncccc\n"
+    assert offset == p.stat().st_size
+
+
+def test_read_build_tail_missing_file_is_quiet() -> None:
+    # Build hasn't written yet: expected, so empty rather than an error.
+    text, offset = _read_build_tail("/no/such/file.log", max_bytes=1024)
+    assert text == ""
+    assert offset == 0
+
+
+@pytest.mark.skipif(os.geteuid() == 0, reason="root bypasses file permission checks")
+def test_read_build_tail_permission_denied_fails_loud(tmp_path: Path) -> None:
+    # A weird error (not "hasn't started yet") must not be papered over as empty.
+    p = tmp_path / "docker.log"
+    p.write_text("secret\n")
+    p.chmod(0o000)
+    try:
+        with pytest.raises(PermissionError):
+            _read_build_tail(str(p), max_bytes=1024)
+    finally:
+        p.chmod(0o644)
+
+
+def test_read_from_returns_only_appended_bytes(tmp_path: Path) -> None:
+    p = tmp_path / "docker.log"
+    p.write_text("hello\n")
+    text, offset = _read_from(str(p), 0)
+    assert text == "hello\n"
+    assert offset == 6
+    # nothing new since last offset
+    text2, offset2 = _read_from(str(p), offset)
+    assert text2 == ""
+    assert offset2 == 6
+    # append and read only the delta
+    with open(p, "a") as f:
+        f.write("world\n")
+    text3, offset3 = _read_from(str(p), offset2)
+    assert text3 == "world\n"
+    assert offset3 == 12
+
+
+def test_read_from_resyncs_when_file_shrinks(tmp_path: Path) -> None:
+    """A rotated/truncated file (size < offset) resyncs from the start rather
+    than seeking past EOF and reading misaligned bytes."""
+    p = tmp_path / "docker.log"
+    p.write_text("aaaaaaaaaa\n")
+    # Pretend we had already consumed more than the file now holds.
+    p.write_text("new\n")
+    text, offset = _read_from(str(p), 50)
+    assert text == "new\n"
+    assert offset == p.stat().st_size
+
+
+def test_read_from_missing_file_is_quiet() -> None:
+    text, offset = _read_from("/no/such/file.log", 10)
+    assert text == ""
+    assert offset == 10
+
+
+@pytest.fixture
+def fake_podman(monkeypatch: pytest.MonkeyPatch) -> Any:
+    """Replace _podman_follow with a generator yielding canned container lines."""
+
+    def _install(lines: list[str]) -> dict[str, object]:
+        seen: dict[str, object] = {}
+
+        async def fake_follow(container_id: str, tail_lines: int) -> AsyncIterator[str]:
+            seen["container_id"] = container_id
+            seen["tail_lines"] = tail_lines
+            for line in lines:
+                yield line
+
+        monkeypatch.setattr(log_stream, "_podman_follow", fake_follow)
+        return seen
+
+    return _install
+
+
+def test_stream_running_app_emits_build_then_container(tmp_path: Path, fake_podman: Any) -> None:
+    build = tmp_path / "docker.log"
+    build.write_text("build step 1\nbuild step 2\n")
+    seen = fake_podman(["container line a", "container line b"])
+
+    def get_state() -> tuple[str, str | None]:
+        return "running", "cid123"
+
+    chunks = asyncio.run(_collect(stream_app_logs("myapp", str(build), get_state)))
+
+    assert chunks == [
+        "build step 1\nbuild step 2",
+        "=== Container logs ===",
+        "container line a",
+        "container line b",
+    ]
+    assert seen["container_id"] == "cid123"
+
+
+def test_stream_no_container_emits_build_only(tmp_path: Path, fake_podman: Any) -> None:
+    build = tmp_path / "docker.log"
+    build.write_text("just a build log\n")
+    fake_podman(["should not appear"])
+
+    def get_state() -> tuple[str, str | None]:
+        return "stopped", None
+
+    chunks = asyncio.run(_collect(stream_app_logs("myapp", str(build), get_state)))
+    assert chunks == ["just a build log"]
+
+
+def test_stream_building_then_container_appears(
+    tmp_path: Path, fake_podman: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """While building we follow docker.log; once a container id appears we flush
+    the remaining build output and switch to the container feed."""
+    monkeypatch.setattr(log_stream, "_BUILD_POLL_SECONDS", 0)
+    build = tmp_path / "docker.log"
+    build.write_text("building...\n")
+    fake_podman(["container up"])
+
+    states = [("building", None), ("building", None), ("running", "cid9")]
+
+    def get_state() -> tuple[str, str | None]:
+        # Simulate more build output arriving between polls.
+        with open(build, "a") as f:
+            f.write("more build output\n")
+        return states.pop(0)
+
+    chunks = asyncio.run(_collect(stream_app_logs("myapp", str(build), get_state)))
+
+    assert "=== Container logs ===" in chunks
+    assert chunks[-1] == "container up"
+    # all build output is delivered before the container separator
+    sep = chunks.index("=== Container logs ===")
+    joined_build = "\n".join(chunks[:sep])
+    assert "building..." in joined_build
+    assert "more build output" in joined_build
+    # and the container feed contains nothing but the separator + follow lines
+    assert chunks[sep:] == ["=== Container logs ===", "container up"]
+
+
+def test_podman_follow_strips_timestamp_and_ansi(monkeypatch: pytest.MonkeyPatch) -> None:
+    """--timestamps prepends an RFC3339 stamp to each line; that and ANSI colour
+    codes are stripped so the browser shows the same text the old podman-logs call
+    produced. The spawn/reap is the shared helper's job (tested there); here we fake
+    it to feed raw lines."""
+    raw = [
+        b"2026-07-30T15:27:34.860265157+00:00 plain line",
+        b"2026-07-30T15:27:35.000000000+00:00 \x1b[31mred\x1b[0m text",
+        b"2026-07-30T15:27:36.000000000+00:00 ",  # empty content
+    ]
+
+    async def fake_stream(argv: list[str], *, merge_stderr: bool) -> AsyncIterator[bytes]:
+        assert "--follow" in argv and "--timestamps" in argv
+        assert merge_stderr is True
+        for line in raw:
+            yield line
+
+    monkeypatch.setattr(log_stream, "stream_process_lines", fake_stream)
+
+    async def run() -> list[str]:
+        return [line async for line in log_stream._podman_follow("cid", 2000)]
+
+    lines = asyncio.run(run())
+    assert lines == ["plain line", "red text", ""]

--- a/compute_space/src/compute_space/tests/test_log_stream.py
+++ b/compute_space/src/compute_space/tests/test_log_stream.py
@@ -1,9 +1,9 @@
 """Unit tests for compute_space.core.log_stream.
 
-The build-log tail command (``sh``/``tail``) is exercised for real against temp
-files — including the fail-loud unreadable case — while the container follow
-(``podman logs``) and the async build→container orchestration are faked so the
-tests run without a live podman and deterministically.
+The build-log ``tail`` command is exercised for real against temp files — including
+the fail-loud unreadable case — while the container follow (``podman logs``) and the
+async build→container orchestration are faked so the tests run without a live podman
+and deterministically.
 """
 
 from __future__ import annotations
@@ -29,32 +29,25 @@ async def _collect_bytes(gen: AsyncIterator[bytes]) -> list[bytes]:
     return [chunk async for chunk in gen]
 
 
-# ─── the build-log tail shell command (real sh/tail) ──────────────────────────
+# ─── the build-log tail command (real tail) ───────────────────────────────────
 
 
-def test_build_tail_oneshot_reads_existing_file(tmp_path: Path) -> None:
+def test_tail_reads_existing_file(tmp_path: Path) -> None:
     p = tmp_path / "docker.log"
     p.write_text("build 1\nbuild 2\n")
-    argv = log_stream._build_tail_argv(str(p), follow=False)
+    argv = log_stream._tail_argv(str(p), follow=False)
     lines = asyncio.run(_collect_bytes(stream_process_lines(argv, merge_stderr=True, raise_on_error=True)))
     assert lines == [b"build 1", b"build 2"]
 
 
-def test_build_tail_oneshot_missing_file_is_quiet() -> None:
-    # docker.log not written yet: expected, so empty and a clean (exit-0) end.
-    argv = log_stream._build_tail_argv("/no/such/file.log", follow=False)
-    lines = asyncio.run(_collect_bytes(stream_process_lines(argv, merge_stderr=True, raise_on_error=True)))
-    assert lines == []
-
-
 @pytest.mark.skipif(os.geteuid() == 0, reason="root bypasses file permission checks")
-def test_build_tail_unreadable_fails_loud(tmp_path: Path) -> None:
+def test_tail_unreadable_fails_loud(tmp_path: Path) -> None:
     # Exists but unreadable (EACCES): tail exits non-zero, which raise_on_error
     # surfaces rather than papering over as an empty log.
     p = tmp_path / "docker.log"
     p.write_text("secret\n")
     p.chmod(0o000)
-    argv = log_stream._build_tail_argv(str(p), follow=False)
+    argv = log_stream._tail_argv(str(p), follow=False)
     try:
         with pytest.raises(RuntimeError):
             asyncio.run(_collect_bytes(stream_process_lines(argv, merge_stderr=False, raise_on_error=True)))
@@ -62,24 +55,19 @@ def test_build_tail_unreadable_fails_loud(tmp_path: Path) -> None:
         p.chmod(0o644)
 
 
-# ─── container follow: timestamp + ANSI stripping ─────────────────────────────
+# ─── container follow: ANSI stripping ─────────────────────────────────────────
 
 
-def test_podman_follow_strips_timestamp_and_ansi(monkeypatch: pytest.MonkeyPatch) -> None:
-    """--timestamps prepends an RFC3339 stamp to each line; that and ANSI colour
-    codes are stripped so the browser shows the same text the old podman-logs call
-    produced. The spawn/reap is the shared helper's job (tested there); here we fake
-    it to feed raw lines."""
-    raw = [
-        b"2026-07-30T15:27:34.860265157+00:00 plain line",
-        b"2026-07-30T15:27:35.000000000+00:00 \x1b[31mred\x1b[0m text",
-        b"2026-07-30T15:27:36.000000000+00:00 ",  # empty content
-    ]
+def test_podman_follow_strips_ansi(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Container lines are ANSI-stripped so the browser shows the same text the old
+    one-shot podman-logs call produced. The spawn/reap is the shared helper's job
+    (tested there); here we fake it to feed raw lines."""
+    raw = [b"plain line", b"\x1b[31mred\x1b[0m text", b""]
 
     async def fake_stream(
         argv: list[str], *, merge_stderr: bool, raise_on_error: bool = False
     ) -> AsyncIterator[bytes]:
-        assert "--follow" in argv and "--timestamps" in argv
+        assert "--follow" in argv and "--timestamps" not in argv
         assert merge_stderr is True
         for line in raw:
             yield line
@@ -113,26 +101,29 @@ def _fake_podman(monkeypatch: pytest.MonkeyPatch, lines: list[str]) -> None:
     monkeypatch.setattr(log_stream, "_podman_follow", fake_follow)
 
 
-def test_stream_app_logs_running_emits_build_then_container(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_stream_app_logs_running_emits_build_then_container(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    build = tmp_path / "docker.log"
+    build.write_text("present")  # must exist for the one-shot existence guard
     _fake_build_stream(monkeypatch, [b"build 1", b"build 2"])
     _fake_podman(monkeypatch, ["container a", "container b"])
 
     def get_state() -> tuple[str, str | None]:
         return "running", "cid123"
 
-    chunks = asyncio.run(_collect(stream_app_logs("app", "/p/docker.log", get_state)))
+    chunks = asyncio.run(_collect(stream_app_logs("app", str(build), get_state)))
     assert chunks == ["build 1", "build 2", "=== Container logs ===", "container a", "container b"]
 
 
-def test_stream_app_logs_no_container_emits_build_only(monkeypatch: pytest.MonkeyPatch) -> None:
-    _fake_build_stream(monkeypatch, [b"only a build log"])
-    _fake_podman(monkeypatch, ["should not appear"])
+def test_stream_app_logs_running_missing_build_log_shows_container_only(monkeypatch: pytest.MonkeyPatch) -> None:
+    # No docker.log on disk: the build tail is skipped entirely (no subprocess), and
+    # only the container logs are streamed.
+    _fake_podman(monkeypatch, ["container a"])
 
     def get_state() -> tuple[str, str | None]:
-        return "stopped", None
+        return "running", "cid123"
 
-    chunks = asyncio.run(_collect(stream_app_logs("app", "/p/docker.log", get_state)))
-    assert chunks == ["only a build log"]
+    chunks = asyncio.run(_collect(stream_app_logs("app", "/no/such/docker.log", get_state)))
+    assert chunks == ["=== Container logs ===", "container a"]
 
 
 def test_stream_app_logs_building_then_container_appears(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -153,9 +144,11 @@ def test_stream_app_logs_building_then_container_appears(monkeypatch: pytest.Mon
     assert chunks == ["building...", "more build output", "=== Container logs ===", "container up"]
 
 
-def test_follow_build_stops_when_container_appears(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_follow_build_stops_when_container_appears(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     # The follow yields build lines and returns as soon as get_state reports a
     # container, without draining the rest of the (still-live) build stream.
+    build = tmp_path / "docker.log"
+    build.write_text("present")  # exists, so the follow skips the wait-for-appear
     _fake_build_stream(monkeypatch, [b"a", b"b", b"c"])
     states = iter([("building", None), ("running", "cid")])
 
@@ -165,5 +158,18 @@ def test_follow_build_stops_when_container_appears(monkeypatch: pytest.MonkeyPat
         except StopIteration:
             return "running", "cid"
 
-    lines = asyncio.run(_collect(log_stream._follow_build_until_container("/p/docker.log", get_state)))
+    lines = asyncio.run(_collect(log_stream._follow_build_until_container(str(build), get_state)))
     assert lines == ["a", "b"]
+
+
+def test_follow_build_gives_up_when_build_ends_before_log_appears(monkeypatch: pytest.MonkeyPatch) -> None:
+    # docker.log never appears and the build ends: return cleanly with no lines and
+    # without ever spawning tail.
+    monkeypatch.setattr(log_stream, "_BUILD_POLL_SECONDS", 0)
+    states = iter([("building", None), ("error", None)])
+
+    def get_state() -> tuple[str, str | None]:
+        return next(states)
+
+    lines = asyncio.run(_collect(log_stream._follow_build_until_container("/no/such/docker.log", get_state)))
+    assert lines == []

--- a/compute_space/src/compute_space/tests/test_log_stream.py
+++ b/compute_space/src/compute_space/tests/test_log_stream.py
@@ -144,22 +144,56 @@ def test_stream_app_logs_building_then_container_appears(monkeypatch: pytest.Mon
     assert chunks == ["building...", "more build output", "=== Container logs ===", "container up"]
 
 
-def test_follow_build_stops_when_container_appears(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    # The follow yields build lines and returns as soon as get_state reports a
-    # container, without draining the rest of the (still-live) build stream.
+def test_follow_build_streams_until_eof(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    # While the build keeps going, every build line is yielded until the stream ends.
     build = tmp_path / "docker.log"
     build.write_text("present")  # exists, so the follow skips the wait-for-appear
-    _fake_build_stream(monkeypatch, [b"a", b"b", b"c"])
-    states = iter([("building", None), ("running", "cid")])
+    _fake_build_stream(monkeypatch, [b"a", b"b"])
 
     def get_state() -> tuple[str, str | None]:
-        try:
-            return next(states)
-        except StopIteration:
-            return "running", "cid"
+        return "building", None
 
     lines = asyncio.run(_collect(log_stream._follow_build_until_container(str(build), get_state)))
     assert lines == ["a", "b"]
+
+
+def test_follow_build_stops_when_container_appears(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    # The follow returns as soon as get_state reports a container, without draining
+    # the rest of the (still-live) build stream.
+    build = tmp_path / "docker.log"
+    build.write_text("present")  # exists, so the follow skips the wait-for-appear
+    _fake_build_stream(monkeypatch, [b"a", b"b", b"c"])
+    calls = {"n": 0}
+
+    def get_state() -> tuple[str, str | None]:
+        # building for the first check, a container by the next — so exactly one line.
+        calls["n"] += 1
+        return ("running", "cid") if calls["n"] > 1 else ("building", None)
+
+    lines = asyncio.run(_collect(log_stream._follow_build_until_container(str(build), get_state)))
+    assert lines == ["a"]
+
+
+def test_follow_build_read_survives_a_timeout(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    # A line that takes longer than the poll interval to arrive is still delivered:
+    # the timed-out read is shielded (kept alive), not cancelled/lost.
+    monkeypatch.setattr(log_stream, "_BUILD_POLL_SECONDS", 0.01)
+    build = tmp_path / "docker.log"
+    build.write_text("present")
+
+    async def slow_stream(
+        argv: list[str], *, merge_stderr: bool, raise_on_error: bool = False
+    ) -> AsyncIterator[bytes]:
+        await asyncio.sleep(0.05)  # several poll intervals with no line
+        yield b"late line"
+
+    monkeypatch.setattr(log_stream, "stream_process_lines", slow_stream)
+
+    def get_state() -> tuple[str, str | None]:
+        return "building", None
+
+    lines = asyncio.run(_collect(log_stream._follow_build_until_container(str(build), get_state)))
+    assert lines == ["late line"]
 
 
 def test_follow_build_gives_up_when_build_ends_before_log_appears(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/compute_space/src/compute_space/tests/test_log_stream.py
+++ b/compute_space/src/compute_space/tests/test_log_stream.py
@@ -1,8 +1,8 @@
 """Unit tests for compute_space.core.log_stream.
 
 The build-log ``tail`` command is exercised for real against temp files — including
-the fail-loud unreadable case — while the container follow (``podman logs``) and the
-async build→container orchestration are faked so the tests run without a live podman
+the fail-loud unreadable case. The container follow (``podman logs``) and the app's
+DB state (``_get_state``) are faked so the tests run without a live podman or database
 and deterministically.
 """
 
@@ -11,14 +11,16 @@ from __future__ import annotations
 import asyncio
 import os
 from collections.abc import AsyncIterator
+from collections.abc import Callable
 from pathlib import Path
-from typing import Any
 
 import pytest
 
 from compute_space.core import log_stream
 from compute_space.core.log_stream import stream_app_logs
 from compute_space.core.process_stream import stream_process_lines
+
+_State = tuple[str, str | None]
 
 
 async def _collect(gen: AsyncIterator[str]) -> list[str]:
@@ -27,6 +29,29 @@ async def _collect(gen: AsyncIterator[str]) -> list[str]:
 
 async def _collect_bytes(gen: AsyncIterator[bytes]) -> list[bytes]:
     return [chunk async for chunk in gen]
+
+
+def _fake_state(monkeypatch: pytest.MonkeyPatch, get: Callable[[], _State]) -> None:
+    """Make ``_get_state(app_id)`` return whatever ``get()`` yields (ignoring app_id)."""
+    monkeypatch.setattr(log_stream, "_get_state", lambda _app_id: get())
+
+
+def _fake_build_stream(monkeypatch: pytest.MonkeyPatch, lines: list[bytes]) -> None:
+    async def fake_stream(
+        argv: list[str], *, merge_stderr: bool, raise_on_error: bool = False
+    ) -> AsyncIterator[bytes]:
+        for line in lines:
+            yield line
+
+    monkeypatch.setattr(log_stream, "stream_process_lines", fake_stream)
+
+
+def _fake_podman(monkeypatch: pytest.MonkeyPatch, lines: list[str]) -> None:
+    async def fake_follow(container_id: str, tail_lines: int) -> AsyncIterator[str]:
+        for line in lines:
+            yield line
+
+    monkeypatch.setattr(log_stream, "_podman_follow", fake_follow)
 
 
 # ─── the build-log tail command (real tail) ───────────────────────────────────
@@ -83,34 +108,14 @@ def test_podman_follow_strips_ansi(monkeypatch: pytest.MonkeyPatch) -> None:
 # ─── build→container orchestration ────────────────────────────────────────────
 
 
-def _fake_build_stream(monkeypatch: pytest.MonkeyPatch, lines: list[bytes]) -> None:
-    async def fake_stream(
-        argv: list[str], *, merge_stderr: bool, raise_on_error: bool = False
-    ) -> AsyncIterator[bytes]:
-        for line in lines:
-            yield line
-
-    monkeypatch.setattr(log_stream, "stream_process_lines", fake_stream)
-
-
-def _fake_podman(monkeypatch: pytest.MonkeyPatch, lines: list[str]) -> None:
-    async def fake_follow(container_id: str, tail_lines: int) -> AsyncIterator[str]:
-        for line in lines:
-            yield line
-
-    monkeypatch.setattr(log_stream, "_podman_follow", fake_follow)
-
-
 def test_stream_app_logs_running_emits_build_then_container(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     build = tmp_path / "docker.log"
     build.write_text("present")  # must exist for the one-shot existence guard
     _fake_build_stream(monkeypatch, [b"build 1", b"build 2"])
     _fake_podman(monkeypatch, ["container a", "container b"])
+    _fake_state(monkeypatch, lambda: ("running", "cid123"))
 
-    def get_state() -> tuple[str, str | None]:
-        return "running", "cid123"
-
-    chunks = asyncio.run(_collect(stream_app_logs("app", str(build), get_state)))
+    chunks = asyncio.run(_collect(stream_app_logs("app-1", str(build))))
     assert chunks == ["build 1", "build 2", "=== Container logs ===", "container a", "container b"]
 
 
@@ -118,16 +123,14 @@ def test_stream_app_logs_running_missing_build_log_shows_container_only(monkeypa
     # No docker.log on disk: the build tail is skipped entirely (no subprocess), and
     # only the container logs are streamed.
     _fake_podman(monkeypatch, ["container a"])
+    _fake_state(monkeypatch, lambda: ("running", "cid123"))
 
-    def get_state() -> tuple[str, str | None]:
-        return "running", "cid123"
-
-    chunks = asyncio.run(_collect(stream_app_logs("app", "/no/such/docker.log", get_state)))
+    chunks = asyncio.run(_collect(stream_app_logs("app-1", "/no/such/docker.log")))
     assert chunks == ["=== Container logs ===", "container a"]
 
 
 def test_stream_app_logs_building_then_container_appears(monkeypatch: pytest.MonkeyPatch) -> None:
-    async def fake_follow_build(build_log_path: str, get_state: Any) -> AsyncIterator[str]:
+    async def fake_follow_build(app_id: str, build_log_path: str) -> AsyncIterator[str]:
         for line in ("building...", "more build output"):
             yield line
 
@@ -136,11 +139,9 @@ def test_stream_app_logs_building_then_container_appears(monkeypatch: pytest.Mon
 
     # building at connect; a container has appeared by the time the build follow returns.
     states = iter([("building", None), ("running", "cid9")])
+    _fake_state(monkeypatch, lambda: next(states))
 
-    def get_state() -> tuple[str, str | None]:
-        return next(states)
-
-    chunks = asyncio.run(_collect(stream_app_logs("app", "/p/docker.log", get_state)))
+    chunks = asyncio.run(_collect(stream_app_logs("app-1", "/p/docker.log")))
     assert chunks == ["building...", "more build output", "=== Container logs ===", "container up"]
 
 
@@ -149,28 +150,32 @@ def test_follow_build_streams_until_eof(tmp_path: Path, monkeypatch: pytest.Monk
     build = tmp_path / "docker.log"
     build.write_text("present")  # exists, so the follow skips the wait-for-appear
     _fake_build_stream(monkeypatch, [b"a", b"b"])
+    _fake_state(monkeypatch, lambda: ("building", None))
 
-    def get_state() -> tuple[str, str | None]:
-        return "building", None
-
-    lines = asyncio.run(_collect(log_stream._follow_build_until_container(str(build), get_state)))
+    lines = asyncio.run(_collect(log_stream._follow_build_until_container("app-1", str(build))))
     assert lines == ["a", "b"]
 
 
-def test_follow_build_stops_when_container_appears(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    # The follow returns as soon as get_state reports a container, without draining
-    # the rest of the (still-live) build stream.
+def test_follow_build_hands_off_after_a_quiet_interval(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    # State is re-checked only when a read times out — a promptly-arriving line is
+    # itself evidence the build is live. So a line already waiting is still forwarded
+    # even though the container is up; the follow hands off only once the stream goes
+    # quiet and the next read times out.
+    monkeypatch.setattr(log_stream, "_BUILD_POLL_SECONDS", 0.01)
     build = tmp_path / "docker.log"
     build.write_text("present")  # exists, so the follow skips the wait-for-appear
-    _fake_build_stream(monkeypatch, [b"a", b"b", b"c"])
-    calls = {"n": 0}
 
-    def get_state() -> tuple[str, str | None]:
-        # building for the first check, a container by the next — so exactly one line.
-        calls["n"] += 1
-        return ("running", "cid") if calls["n"] > 1 else ("building", None)
+    async def one_then_quiet(
+        argv: list[str], *, merge_stderr: bool, raise_on_error: bool = False
+    ) -> AsyncIterator[bytes]:
+        yield b"a"
+        await asyncio.sleep(30)  # go quiet so the next read times out (cancelled on aclose)
+        yield b"b"
 
-    lines = asyncio.run(_collect(log_stream._follow_build_until_container(str(build), get_state)))
+    monkeypatch.setattr(log_stream, "stream_process_lines", one_then_quiet)
+    _fake_state(monkeypatch, lambda: ("running", "cid"))  # container already up
+
+    lines = asyncio.run(_collect(log_stream._follow_build_until_container("app-1", str(build))))
     assert lines == ["a"]
 
 
@@ -188,11 +193,9 @@ def test_follow_build_read_survives_a_timeout(tmp_path: Path, monkeypatch: pytes
         yield b"late line"
 
     monkeypatch.setattr(log_stream, "stream_process_lines", slow_stream)
+    _fake_state(monkeypatch, lambda: ("building", None))
 
-    def get_state() -> tuple[str, str | None]:
-        return "building", None
-
-    lines = asyncio.run(_collect(log_stream._follow_build_until_container(str(build), get_state)))
+    lines = asyncio.run(_collect(log_stream._follow_build_until_container("app-1", str(build))))
     assert lines == ["late line"]
 
 
@@ -201,9 +204,7 @@ def test_follow_build_gives_up_when_build_ends_before_log_appears(monkeypatch: p
     # without ever spawning tail.
     monkeypatch.setattr(log_stream, "_BUILD_POLL_SECONDS", 0)
     states = iter([("building", None), ("error", None)])
+    _fake_state(monkeypatch, lambda: next(states))
 
-    def get_state() -> tuple[str, str | None]:
-        return next(states)
-
-    lines = asyncio.run(_collect(log_stream._follow_build_until_container("/no/such/docker.log", get_state)))
+    lines = asyncio.run(_collect(log_stream._follow_build_until_container("app-1", "/no/such/docker.log")))
     assert lines == []

--- a/compute_space/src/compute_space/tests/test_memory_guard.py
+++ b/compute_space/src/compute_space/tests/test_memory_guard.py
@@ -278,7 +278,7 @@ def test_follow_lines_skips_blanks_and_reconnects_on_eof(monkeypatch: pytest.Mon
     # and the second connection supplies the next line.
     streams = iter([_agen([b"a", b""]), _agen([b"b"])])
 
-    def fake_stream(argv: list[str], *, merge_stderr: bool) -> AsyncIterator[bytes]:
+    def fake_stream(argv: list[str], *, merge_stderr: bool, stderr_sink: object = None) -> AsyncIterator[bytes]:
         return next(streams)
 
     async def no_sleep(_seconds: float) -> None:
@@ -298,11 +298,44 @@ def test_follow_lines_skips_blanks_and_reconnects_on_eof(monkeypatch: pytest.Mon
     assert asyncio.run(run()) == [b"a", b"b"]
 
 
+def test_follow_lines_surfaces_stderr_reason_when_stream_ends(monkeypatch: pytest.MonkeyPatch) -> None:
+    # A follow that ends after writing to stderr (e.g. journalctl "permission denied"
+    # because the journal grant didn't take) names that reason in the reconnect
+    # warning instead of a bare "stream ended".
+    class _Stop(Exception):
+        pass
+
+    def fake_stream(argv: list[str], *, merge_stderr: bool, stderr_sink: object = None) -> AsyncIterator[bytes]:
+        async def g() -> AsyncIterator[bytes]:
+            assert callable(stderr_sink)
+            stderr_sink(b"Failed to open journal: Permission denied")
+            return
+            yield b""  # pragma: no cover - marks g as an async generator
+
+        return g()
+
+    async def breaking_sleep(_seconds: float) -> None:
+        raise _Stop  # bail out after the first reconnect pause
+
+    monkeypatch.setattr(memory_guard, "stream_process_lines", fake_stream)
+    monkeypatch.setattr("asyncio.sleep", breaking_sleep)
+
+    async def run() -> None:
+        async for _ in memory_guard._follow_lines(["journalctl"], "Host OOM detection"):
+            pass
+
+    with patch("compute_space.core.memory_guard.logger.warning") as warn:
+        with pytest.raises(_Stop):
+            asyncio.run(run())
+    joined = " ".join(str(c.args) for c in warn.call_args_list)
+    assert "Permission denied" in joined
+
+
 def test_follow_lines_missing_binary_warns_once_and_retries(monkeypatch: pytest.MonkeyPatch) -> None:
     class _Stop(Exception):
         pass
 
-    def fake_stream(argv: list[str], *, merge_stderr: bool) -> AsyncIterator[bytes]:
+    def fake_stream(argv: list[str], *, merge_stderr: bool, stderr_sink: object = None) -> AsyncIterator[bytes]:
         async def g() -> AsyncIterator[bytes]:
             raise FileNotFoundError
             yield b""  # pragma: no cover - marks g as an async generator

--- a/compute_space/src/compute_space/tests/test_memory_guard.py
+++ b/compute_space/src/compute_space/tests/test_memory_guard.py
@@ -1,8 +1,9 @@
+import asyncio
 import json
 import sqlite3
+from collections.abc import AsyncIterator
 from pathlib import Path
 from typing import cast
-from unittest.mock import MagicMock
 from unittest.mock import patch
 
 import attr
@@ -46,16 +47,9 @@ def _reset_state() -> None:
     memory_guard._guard_thread = None
 
 
-def _make_guard() -> memory_guard._MemoryGuard:
-    """A _MemoryGuard with both OOM streams stubbed inert (no journalctl, no podman in tests)."""
-    with patch.object(memory_guard._JsonEventStream, "_start", lambda self: setattr(self, "_proc", None)):
-        return memory_guard._MemoryGuard()
-
-
-def _make_host_reader() -> memory_guard._HostOomReader:
-    """A _HostOomReader whose journalctl stream is inert; patch its ``drain_lines`` per test."""
-    with patch.object(memory_guard._JsonEventStream, "_start", lambda self: setattr(self, "_proc", None)):
-        return memory_guard._HostOomReader()
+def _guard() -> memory_guard._MemoryGuard:
+    """A guard with no live streams — construction no longer starts any subprocess."""
+    return memory_guard._MemoryGuard()
 
 
 def _journal_line(message: str) -> bytes:
@@ -65,11 +59,19 @@ def _journal_line(message: str) -> bytes:
 
 def _oom_event_line(container_id: str, name: str) -> bytes:
     """Build one `podman events --format json` line for a container OOM kill."""
-    return (json.dumps({"ID": container_id, "Name": name, "Status": "oom", "Type": "container"}) + "\n").encode()
+    return json.dumps({"ID": container_id, "Name": name, "Status": "oom", "Type": "container"}).encode()
+
+
+async def _agen(items: list[bytes]) -> AsyncIterator[bytes]:
+    for it in items:
+        yield it
+
+
+# ─── per-app memory pressure debounce ─────────────────────────────────────────
 
 
 def test_pressure_warns_once_then_debounces_until_recovery() -> None:
-    guard = _make_guard()
+    guard = _guard()
     row = _app_row()
     with (
         patch("compute_space.core.memory_guard.collect_app_resources", return_value=_usage(95.0)),
@@ -99,7 +101,7 @@ def test_pressure_warns_once_then_debounces_until_recovery() -> None:
 
 
 def test_pressure_below_threshold_never_warns() -> None:
-    guard = _make_guard()
+    guard = _guard()
     row = _app_row()
     with (
         patch("compute_space.core.memory_guard.collect_app_resources", return_value=_usage(89.9)),
@@ -119,24 +121,19 @@ def _pressure_warn_count(guard: memory_guard._MemoryGuard, row: sqlite3.Row, per
 
 
 def test_pressure_debounce_holds_through_band_and_rearms_below_clear() -> None:
-    guard = _make_guard()
+    guard = _guard()
     row = _app_row()
-    # Crossing the warn threshold notifies once.
     assert _pressure_warn_count(guard, row, 92.0) == 1
-    # Dancing around the line (89/92/88/91) and anywhere in [80, 90) must neither
-    # re-notify nor re-arm — a single sustained notification.
     for pct in (88.0, 91.0, 85.0, 89.9, 80.0):
         assert _pressure_warn_count(guard, row, pct) == 0
     assert "a1" in guard._pressure_notified
-    # A dip below the clear threshold re-arms (no warning on the way down)...
     assert _pressure_warn_count(guard, row, 79.0) == 0
     assert "a1" not in guard._pressure_notified
-    # ...so a later climb back over the warn threshold notifies again.
     assert _pressure_warn_count(guard, row, 95.0) == 1
 
 
 def test_pressure_unknown_usage_is_ignored() -> None:
-    guard = _make_guard()
+    guard = _guard()
     row = _app_row()
     with (
         patch("compute_space.core.memory_guard.collect_app_resources", return_value=_usage(None)),
@@ -146,11 +143,22 @@ def test_pressure_unknown_usage_is_ignored() -> None:
     assert warn.call_count == 0
 
 
+def test_check_pressure_once_checks_every_container_row() -> None:
+    guard = _guard()
+    rows = [_app_row(app_id="a1", name="one"), _app_row(app_id="a2", name="two")]
+    with (
+        patch("compute_space.core.memory_guard._query_container_rows", return_value=rows),
+        patch.object(guard, "_check_memory_pressure") as check,
+    ):
+        guard._check_pressure_once(cast(Config, object()))
+    assert check.call_count == 2
+
+
 # ─── per-app OOM (podman events) ──────────────────────────────────────────────
 
 
 def test_report_container_ooms_maps_to_app_and_falls_back() -> None:
-    guard = _make_guard()
+    guard = _guard()
     rows = [_app_row(app_id="a1", name="myapp")]  # container_id == "cid"
     known = memory_guard._ContainerOomKill(container_id="cid", container_name="myapp-ctr")
     unknown = memory_guard._ContainerOomKill(container_id="gone", container_name="ghost-ctr")
@@ -158,14 +166,12 @@ def test_report_container_ooms_maps_to_app_and_falls_back() -> None:
         guard._report_container_ooms([known, unknown], rows)
     assert warn.call_count == 2
     joined = " ".join(str(call.args) for call in warn.call_args_list)
-    # The mapped kill names the app and its limit; the unmapped one falls back to
-    # the container name from the event.
     assert "myapp" in joined
     assert "ghost-ctr" in joined
 
 
 def test_report_container_ooms_empty_is_noop() -> None:
-    guard = _make_guard()
+    guard = _guard()
     with patch("compute_space.core.memory_guard.logger.warning") as warn:
         guard._report_container_ooms([], [_app_row()])
     warn.assert_not_called()
@@ -179,95 +185,47 @@ def test_parse_podman_event_extracts_container() -> None:
 def test_parse_podman_event_raises_on_unrecognized_shape() -> None:
     # We commit to podman's documented top-level ID/Name keys and fail loudly on
     # anything else — every line is an OOM event, so a shape change we didn't parse
-    # is a dropped kill, and we'd rather see it than silently lose it. The raised
-    # error carries the offending line so a format change is debuggable.
+    # is a dropped kill, and we'd rather see it than silently lose it.
     with pytest.raises(ValueError, match="not json"):
         memory_guard._parse_podman_event(b"not json")
     with pytest.raises(ValueError):  # valid JSON, but a list rather than an object
         memory_guard._parse_podman_event(b'[{"ID": "abc", "Name": "x"}]')
     with pytest.raises(ValueError):  # object missing the ID key
-        memory_guard._parse_podman_event((json.dumps({"Name": "x", "Status": "oom"}) + "\n").encode())
+        memory_guard._parse_podman_event(json.dumps({"Name": "x", "Status": "oom"}).encode())
     with pytest.raises(ValueError):  # lowercase keys are no longer tolerated
-        memory_guard._parse_podman_event((json.dumps({"id": "abc", "name": "x"}) + "\n").encode())
+        memory_guard._parse_podman_event(json.dumps({"id": "abc", "name": "x"}).encode())
 
 
-def test_podman_oom_drain_skips_blank_lines() -> None:
-    # Blank lines carry no event, so drain filters them rather than parsing (which
-    # would raise). A real event on either side is still reported.
-    reader, _ = _make_events_reader()
-    reads = [_oom_event_line("cid1", "app1") + b"\n" + _oom_event_line("cid2", "app2"), BlockingIOError()]
-    with patch("compute_space.core.memory_guard.os.read", side_effect=reads):
-        kills = reader.drain()
-    assert [k.container_id for k in kills] == ["cid1", "cid2"]
+def test_run_podman_oom_reports_kill_and_maps_app() -> None:
+    guard = _guard()
+    rows = [_app_row(app_id="a1", name="myapp")]  # container_id == "cid"
 
+    def fake_follow(argv: list[str], detector: str) -> AsyncIterator[bytes]:
+        return _agen([_oom_event_line("cid", "myapp-ctr")])
 
-def _fake_events_proc(fileno: int = 7) -> MagicMock:
-    proc = MagicMock()
-    proc.stdout.fileno.return_value = fileno
-    proc.poll.return_value = None
-    return proc
-
-
-def _make_events_reader(proc: MagicMock | None = None) -> tuple[memory_guard._PodmanOomReader, MagicMock]:
-    """Construct a _PodmanOomReader whose `podman events` process is a controllable mock."""
-    proc = proc or _fake_events_proc()
     with (
-        patch("compute_space.core.memory_guard.subprocess.Popen", return_value=proc),
-        patch("compute_space.core.memory_guard.os.set_blocking"),
-    ):
-        reader = memory_guard._PodmanOomReader()
-    return reader, proc
-
-
-def test_podman_oom_drain_parses_events_until_blocking() -> None:
-    reader, _ = _make_events_reader()
-    reads = [_oom_event_line("cid1", "app1"), _oom_event_line("cid2", "app2"), BlockingIOError()]
-    with patch("compute_space.core.memory_guard.os.read", side_effect=reads):
-        kills = reader.drain()
-    assert [(k.container_id, k.container_name) for k in kills] == [("cid1", "app1"), ("cid2", "app2")]
-
-
-def test_podman_oom_drain_buffers_partial_lines_across_ticks() -> None:
-    reader, _ = _make_events_reader()
-    full = _oom_event_line("cid1", "app1")
-    head, tail = full[:12], full[12:]
-    # First tick delivers only half a line: nothing to report, remainder buffered.
-    with patch("compute_space.core.memory_guard.os.read", side_effect=[head, BlockingIOError()]):
-        assert reader.drain() == []
-    # Next tick delivers the rest, completing the line.
-    with patch("compute_space.core.memory_guard.os.read", side_effect=[tail, BlockingIOError()]):
-        kills = reader.drain()
-    assert [k.container_id for k in kills] == ["cid1"]
-
-
-def test_podman_oom_drain_reconnects_on_stream_end() -> None:
-    first = _fake_events_proc()
-    reader, _ = _make_events_reader(proc=first)
-    with (
-        patch("compute_space.core.memory_guard.subprocess.Popen", return_value=_fake_events_proc()) as popen,
-        patch("compute_space.core.memory_guard.os.set_blocking"),
-        patch("compute_space.core.memory_guard.os.read", side_effect=[b""]),  # EOF
-        patch("compute_space.core.memory_guard.logger.warning"),
-    ):
-        kills = reader.drain()
-    assert kills == []
-    # The dead stream was reaped and a fresh one started.
-    first.wait.assert_called_once()
-    popen.assert_called_once()
-    assert reader._stream._proc is not None
-
-
-def test_podman_oom_drain_disabled_when_podman_missing() -> None:
-    # podman absent: construction can't start the stream, and drain stays a no-op
-    # (retrying the start) rather than raising.
-    with (
-        patch("compute_space.core.memory_guard.subprocess.Popen", side_effect=FileNotFoundError()),
+        patch("compute_space.core.memory_guard._follow_lines", fake_follow),
+        patch("compute_space.core.memory_guard._query_container_rows", return_value=rows),
         patch("compute_space.core.memory_guard.logger.warning") as warn,
     ):
-        reader = memory_guard._PodmanOomReader()
-        assert reader.drain() == []
-    # Warned once about the missing binary, not once per retry.
+        asyncio.run(guard._run_podman_oom(cast(Config, object())))
     assert warn.call_count == 1
+    assert "myapp" in warn.call_args.args[1]
+
+
+def test_run_podman_oom_raises_loudly_on_bad_event() -> None:
+    # A shape we can't parse is a dropped kill; it must surface (to the guard loop's
+    # handler), not be swallowed.
+    guard = _guard()
+
+    def fake_follow(argv: list[str], detector: str) -> AsyncIterator[bytes]:
+        return _agen([b'{"unexpected": true}'])
+
+    with (
+        patch("compute_space.core.memory_guard._follow_lines", fake_follow),
+        pytest.raises(ValueError),
+    ):
+        asyncio.run(guard._run_podman_oom(cast(Config, object())))
 
 
 # ─── host OOM (journalctl) ────────────────────────────────────────────────────
@@ -282,95 +240,120 @@ def test_parse_journal_oom_global_kill() -> None:
 
 
 def test_parse_journal_oom_skips_memcg_kill() -> None:
-    # A cgroup-limit kill (an app hitting its --memory) is handled per-app, not here.
     line = _journal_line("Memory cgroup out of memory: Killed process 99 (node)")
     assert memory_guard._parse_journal_oom(line) is None
 
 
 def test_parse_journal_oom_ignores_non_oom_and_malformed_lines() -> None:
-    # The kernel log is a firehose, so a non-OOM line is the normal case, not an
-    # error — unlike the podman stream, this parser filters rather than raises.
     assert memory_guard._parse_journal_oom(_journal_line("usb 1-1: new high-speed USB device")) is None
-    # Non-JSON, or a JSON object without a string MESSAGE, is skipped (not raised).
     assert memory_guard._parse_journal_oom(b"not json") is None
     assert memory_guard._parse_journal_oom(json.dumps({"_TRANSPORT": "kernel"}).encode()) is None
 
 
-def test_host_oom_reader_warns_only_for_oom_lines() -> None:
-    reader = _make_host_reader()
+def test_run_host_oom_warns_only_for_oom_lines() -> None:
+    guard = _guard()
     lines = [
         _journal_line("usb 1-1: new high-speed USB device"),  # unrelated kernel line
         _journal_line("Out of memory: Killed process 4242 (python3)"),  # a global OOM kill
     ]
+
+    def fake_follow(argv: list[str], detector: str) -> AsyncIterator[bytes]:
+        return _agen(lines)
+
     with (
-        patch.object(reader._stream, "drain_lines", return_value=lines),
+        patch("compute_space.core.memory_guard._follow_lines", fake_follow),
         patch("compute_space.core.memory_guard.logger.warning") as warn,
     ):
-        reader.check()
+        asyncio.run(guard._run_host_oom())
     assert warn.call_count == 1  # only the OOM line, not the unrelated one
     assert warn.call_args.args[1] == 4242
     assert warn.call_args.args[2] == "python3"
 
-    # A tick with no new journal lines reports nothing (each kill surfaces once).
-    with (
-        patch.object(reader._stream, "drain_lines", return_value=[]),
-        patch("compute_space.core.memory_guard.logger.warning") as warn,
-    ):
-        reader.check()
-    assert warn.call_count == 0
+
+# ─── _follow_lines: the shared reconnect / missing-binary behaviour ───────────
 
 
-def test_host_oom_reader_disabled_when_journalctl_missing() -> None:
-    # No journalctl (e.g. macOS dev host): the stream can't start, so check() drains
-    # nothing and never raises — the missing binary is warned once, not per tick.
-    with (
-        patch("compute_space.core.memory_guard.subprocess.Popen", side_effect=FileNotFoundError()),
-        patch("compute_space.core.memory_guard.logger.warning") as warn,
-    ):
-        reader = memory_guard._HostOomReader()
-        reader.check()
-        reader.check()
-    assert warn.call_count == 1
+def test_follow_lines_skips_blanks_and_reconnects_on_eof(monkeypatch: pytest.MonkeyPatch) -> None:
+    # First connection: a real line then a blank (skipped), then EOF. It reconnects
+    # and the second connection supplies the next line.
+    streams = iter([_agen([b"a", b""]), _agen([b"b"])])
+
+    def fake_stream(argv: list[str], *, merge_stderr: bool) -> AsyncIterator[bytes]:
+        return next(streams)
+
+    async def no_sleep(_seconds: float) -> None:
+        return None
+
+    monkeypatch.setattr(memory_guard, "stream_process_lines", fake_stream)
+    monkeypatch.setattr("asyncio.sleep", no_sleep)
+
+    async def run() -> list[bytes]:
+        out: list[bytes] = []
+        async for line in memory_guard._follow_lines(["x"], "detector"):
+            out.append(line)
+            if len(out) >= 2:
+                break
+        return out
+
+    assert asyncio.run(run()) == [b"a", b"b"]
 
 
-# ─── check_once fan-out ───────────────────────────────────────────────────────
+def test_follow_lines_missing_binary_warns_once_and_retries(monkeypatch: pytest.MonkeyPatch) -> None:
+    class _Stop(Exception):
+        pass
+
+    def fake_stream(argv: list[str], *, merge_stderr: bool) -> AsyncIterator[bytes]:
+        async def g() -> AsyncIterator[bytes]:
+            raise FileNotFoundError
+            yield b""  # pragma: no cover - marks g as an async generator
+
+        return g()
+
+    sleeps = {"n": 0}
+
+    async def breaking_sleep(_seconds: float) -> None:
+        sleeps["n"] += 1
+        if sleeps["n"] >= 3:
+            raise _Stop  # bail out of the otherwise-infinite retry loop
+
+    monkeypatch.setattr(memory_guard, "stream_process_lines", fake_stream)
+    monkeypatch.setattr("asyncio.sleep", breaking_sleep)
+
+    async def run() -> None:
+        async for _ in memory_guard._follow_lines(["missing-binary"], "detector"):
+            pass
+
+    with patch("compute_space.core.memory_guard.logger.warning") as warn:
+        with pytest.raises(_Stop):
+            asyncio.run(run())
+    # Warned once about the missing binary despite several retries.
+    missing_warnings = [c for c in warn.call_args_list if "not installed" in c.args[0]]
+    assert len(missing_warnings) == 1
+
+
+# ─── query + thread lifecycle ─────────────────────────────────────────────────
 
 
 def _fake_config(db_path: str) -> Config:
-    # ensure_memory_guard / check_once only read config.db_path; a stub avoids
-    # building a full Config.
     return cast(Config, attr.make_class("_Cfg", ["db_path"], frozen=True)(db_path=db_path))
 
 
-def test_check_once_reports_container_oom_and_pressure(tmp_path: Path) -> None:
+def test_query_container_rows_only_returns_apps_with_a_container(tmp_path: Path) -> None:
     db_path = str(tmp_path / "apps.db")
     conn = sqlite3.connect(db_path)
     conn.execute("CREATE TABLE apps (app_id, name, container_id, cpu_cores, memory_mb)")
-    conn.execute("INSERT INTO apps VALUES ('a1', 'myapp', 'cid1', 0.5, 128)")
+    conn.execute("INSERT INTO apps VALUES ('a1', 'has', 'cid1', 0.5, 128)")
+    conn.execute("INSERT INTO apps VALUES ('a2', 'none', NULL, 0.5, 128)")
     conn.commit()
     conn.close()
 
-    guard = _make_guard()
-    kill = memory_guard._ContainerOomKill(container_id="cid1", container_name="myapp-ctr")
-    with (
-        patch.object(guard._host_oom, "check"),
-        patch.object(guard._podman_oom, "drain", return_value=[kill]),
-        patch("compute_space.core.memory_guard.collect_app_resources", return_value=_usage(95.0)),
-        patch("compute_space.core.memory_guard.logger.warning") as warn,
-    ):
-        guard.check_once(_fake_config(db_path))
-    messages = [call.args[0] for call in warn.call_args_list]
-    # Both the OOM event (mapped to the app) and the pressure warning fired.
-    assert any("OOM killer" in m for m in messages)
-    assert any("memory limit" in m and "keeps climbing" in m for m in messages)
+    rows = memory_guard._query_container_rows(_fake_config(db_path))
+    assert [r["app_id"] for r in rows] == ["a1"]
 
 
 def test_ensure_memory_guard_starts_thread() -> None:
     with patch("compute_space.core.memory_guard.threading.Thread") as thread:
         memory_guard.ensure_memory_guard(_fake_config("/tmp/start.db"))
-    # Starts the loop thread and records it as the single guard thread. The OOM
-    # readers (kmsg capability check + podman events stream) are created inside
-    # that thread, so ensure_memory_guard itself never touches them.
     thread.assert_called_once()
     assert thread.call_args.kwargs["target"] is memory_guard._memory_guard_loop
     thread.return_value.start.assert_called_once()
@@ -380,7 +363,6 @@ def test_ensure_memory_guard_starts_thread() -> None:
 def test_ensure_memory_guard_starts_only_one_thread() -> None:
     with patch("compute_space.core.memory_guard.threading.Thread") as thread:
         thread.return_value.is_alive.return_value = True
-        # Repeated calls — even with a different config — never start a second thread.
         memory_guard.ensure_memory_guard(_fake_config("/tmp/a.db"))
         memory_guard.ensure_memory_guard(_fake_config("/tmp/b.db"))
     assert thread.call_count == 1

--- a/compute_space/src/compute_space/tests/test_memory_guard.py
+++ b/compute_space/src/compute_space/tests/test_memory_guard.py
@@ -213,19 +213,25 @@ def test_run_podman_oom_reports_kill_and_maps_app() -> None:
     assert "myapp" in warn.call_args.args[1]
 
 
-def test_run_podman_oom_raises_loudly_on_bad_event() -> None:
-    # A shape we can't parse is a dropped kill; it must surface (to the guard loop's
-    # handler), not be swallowed.
+def test_run_podman_oom_skips_bad_event_and_keeps_going() -> None:
+    # A shape we can't parse is logged and skipped, not raised: raising would fail
+    # run()'s gather and take down the sibling detectors. A later valid event still lands.
     guard = _guard()
+    rows = [_app_row(app_id="a1", name="myapp")]  # container_id == "cid"
 
     def fake_follow(argv: list[str], detector: str) -> AsyncIterator[bytes]:
-        return _agen([b'{"unexpected": true}'])
+        return _agen([b'{"unexpected": true}', _oom_event_line("cid", "myapp-ctr")])
 
     with (
         patch("compute_space.core.memory_guard._follow_lines", fake_follow),
-        pytest.raises(ValueError),
+        patch("compute_space.core.memory_guard._query_container_rows", return_value=rows),
+        patch("compute_space.core.memory_guard.logger.exception") as log_exc,
+        patch("compute_space.core.memory_guard.logger.warning") as warn,
     ):
         asyncio.run(guard._run_podman_oom(cast(Config, object())))
+    log_exc.assert_called_once()  # the unparseable line surfaced, not silently dropped
+    assert warn.call_count == 1  # and the loop survived to report the good one
+    assert "myapp" in warn.call_args.args[1]
 
 
 # ─── host OOM (journalctl) ────────────────────────────────────────────────────

--- a/compute_space/src/compute_space/tests/test_process_stream.py
+++ b/compute_space/src/compute_space/tests/test_process_stream.py
@@ -48,6 +48,23 @@ def test_merge_stderr_false_discards_stderr() -> None:
     assert lines == [b"from-stdout"]
 
 
+def test_stderr_sink_diverts_stderr_and_keeps_stdout_clean() -> None:
+    # stderr goes to the sink (not folded into the yielded stdout), and a
+    # normally-exiting child's buffered stderr is fully delivered before teardown.
+    argv = [sys.executable, "-c", "import sys; print('out'); sys.stderr.write('err1\\nerr2\\n')"]
+    captured: list[bytes] = []
+    lines = asyncio.run(_collect(stream_process_lines(argv, merge_stderr=False, stderr_sink=captured.append)))
+    assert lines == [b"out"]
+    assert captured == [b"err1", b"err2"]
+
+
+def test_stderr_sink_conflicts_with_merge_stderr() -> None:
+    # merge_stderr folds stderr into stdout, so a sink couldn't also observe it —
+    # the combination is a programming error, caught loudly.
+    with pytest.raises(AssertionError):
+        asyncio.run(_collect(stream_process_lines(["printf", "x\n"], merge_stderr=True, stderr_sink=lambda _b: None)))
+
+
 def test_missing_binary_raises_loudly() -> None:
     # A missing binary is exactly the "weird" case we refuse to paper over: it
     # propagates instead of yielding an empty stream.

--- a/compute_space/src/compute_space/tests/test_process_stream.py
+++ b/compute_space/src/compute_space/tests/test_process_stream.py
@@ -1,0 +1,87 @@
+"""Unit tests for compute_space.core.process_stream.
+
+These drive real subprocesses (``printf``/``sh``/``sys``) rather than mocks, so the
+spawn, EOF, stderr-merge, error-propagation, and reap-on-early-exit paths are all
+exercised end to end.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from collections.abc import AsyncIterator
+
+import pytest
+
+from compute_space.core import process_stream
+from compute_space.core.process_stream import stream_process_lines
+
+
+async def _collect(gen: AsyncIterator[bytes], limit: int | None = None) -> list[bytes]:
+    out: list[bytes] = []
+    async for line in gen:
+        out.append(line)
+        if limit is not None and len(out) >= limit:
+            break
+    return out
+
+
+def test_yields_lines_until_eof() -> None:
+    lines = asyncio.run(_collect(stream_process_lines(["printf", "a\nb\nc\n"], merge_stderr=False)))
+    assert lines == [b"a", b"b", b"c"]
+
+
+def test_reaps_process_after_eof() -> None:
+    asyncio.run(_collect(stream_process_lines(["printf", "x\n"], merge_stderr=False)))
+    assert not process_stream._active
+
+
+def test_merge_stderr_true_includes_stderr() -> None:
+    argv = [sys.executable, "-c", "import sys; sys.stderr.write('from-stderr\\n')"]
+    lines = asyncio.run(_collect(stream_process_lines(argv, merge_stderr=True)))
+    assert b"from-stderr" in lines
+
+
+def test_merge_stderr_false_discards_stderr() -> None:
+    argv = [sys.executable, "-c", "import sys; sys.stderr.write('from-stderr\\n'); print('from-stdout')"]
+    lines = asyncio.run(_collect(stream_process_lines(argv, merge_stderr=False)))
+    assert lines == [b"from-stdout"]
+
+
+def test_missing_binary_raises_loudly() -> None:
+    # A missing binary is exactly the "weird" case we refuse to paper over: it
+    # propagates instead of yielding an empty stream.
+    with pytest.raises(FileNotFoundError):
+        asyncio.run(_collect(stream_process_lines(["definitely-not-a-real-binary-xyz"], merge_stderr=False)))
+
+
+# A child that emits one line then blocks forever, and is itself the process we
+# signal (no shell wrapper spawning a grandchild that would survive SIGTERM), so
+# terminate() reaps it promptly — matching the real podman/journalctl followers.
+_EMIT_THEN_BLOCK = [sys.executable, "-u", "-c", "print('one', flush=True); import time; time.sleep(30)"]
+
+
+def test_early_break_terminates_and_reaps_process() -> None:
+    # Consumer reads one line then stops; the still-running child must be killed
+    # and reaped rather than leaked.
+    async def run() -> None:
+        gen = stream_process_lines(_EMIT_THEN_BLOCK, merge_stderr=False)
+        got = await _collect(gen, limit=1)
+        assert got == [b"one"]
+        # Closing the generator runs its finally (terminate + wait).
+        await gen.aclose()
+
+    asyncio.run(run())
+    assert not process_stream._active
+
+
+def test_cleanup_all_terminates_live_process() -> None:
+    async def run() -> None:
+        gen = stream_process_lines(_EMIT_THEN_BLOCK, merge_stderr=False)
+        await _collect(gen, limit=1)  # leaves the child running, registered in _active
+        assert process_stream._active
+        process_stream.cleanup_all()
+        assert not process_stream._active
+        await gen.aclose()
+
+    asyncio.run(run())

--- a/compute_space/src/compute_space/tests/test_process_stream.py
+++ b/compute_space/src/compute_space/tests/test_process_stream.py
@@ -75,6 +75,34 @@ def test_early_break_terminates_and_reaps_process() -> None:
     assert not process_stream._active
 
 
+def test_raise_on_error_is_quiet_on_clean_exit() -> None:
+    lines = asyncio.run(_collect(stream_process_lines(["printf", "ok\n"], merge_stderr=False, raise_on_error=True)))
+    assert lines == [b"ok"]
+
+
+def test_raise_on_error_raises_on_nonzero_self_exit() -> None:
+    # The child streams a line then exits non-zero on its own: surfaced, not a
+    # silent EOF.
+    async def run() -> None:
+        await _collect(stream_process_lines(["sh", "-c", "echo hi; exit 3"], merge_stderr=True, raise_on_error=True))
+
+    with pytest.raises(RuntimeError, match="status 3"):
+        asyncio.run(run())
+
+
+def test_raise_on_error_does_not_raise_when_consumer_stops_early() -> None:
+    # We terminated it (early break), so a non-zero exit-from-signal is expected,
+    # not a failure — no raise.
+    async def run() -> None:
+        gen = stream_process_lines(_EMIT_THEN_BLOCK, merge_stderr=False, raise_on_error=True)
+        got = await _collect(gen, limit=1)
+        assert got == [b"one"]
+        await gen.aclose()
+
+    asyncio.run(run())
+    assert not process_stream._active
+
+
 def test_cleanup_all_terminates_live_process() -> None:
     async def run() -> None:
         gen = stream_process_lines(_EMIT_THEN_BLOCK, merge_stderr=False)

--- a/compute_space/src/compute_space/web/app.py
+++ b/compute_space/src/compute_space/web/app.py
@@ -34,6 +34,7 @@ from compute_space.core.image_pruner import start_image_pruner
 from compute_space.core.logging import logger
 from compute_space.core.memory_guard import ensure_memory_guard
 from compute_space.core.org_rename import reconcile_app_repo_urls
+from compute_space.core.process_stream import cleanup_all as cleanup_process_streams
 from compute_space.core.startup import check_app_status
 from compute_space.core.startup import retry_pending_default_apps
 from compute_space.core.storage import start_storage_guard
@@ -244,6 +245,7 @@ def create_app(config: Config) -> ASGIApp:
     static_router = create_static_files_router(path="/static", directories=[static_dir])
 
     atexit.register(cleanup_terminal)
+    atexit.register(cleanup_process_streams)
 
     litestar_app = Litestar(
         route_handlers=[

--- a/compute_space/src/compute_space/web/auth/auth.py
+++ b/compute_space/src/compute_space/web/auth/auth.py
@@ -8,6 +8,7 @@ from urllib.parse import urlparse
 
 from litestar import Request
 from litestar import Response
+from litestar import WebSocket
 from litestar.connection import ASGIConnection
 from litestar.exceptions import NotAuthorizedException
 from litestar.handlers.base import BaseRouteHandler
@@ -156,6 +157,22 @@ def verify_app_auth(connection: AnyConnection) -> str:
 def require_owner_auth(connection: AnyConnection, _route_handler: BaseRouteHandler) -> None:
     """Adapt verify_owner_auth to be used as a route guard."""
     verify_owner_auth(connection)
+
+
+async def verify_owner_ws(socket: WebSocket[Any, Any, Any]) -> bool:
+    """Owner-auth a WebSocket; on success return True and leave accepting to the caller.
+
+    Guards can't be used here: they signal failure by raising, which on a WS rejects the
+    handshake before the client can read why. So on failure we accept and send a 4401 close
+    frame the browser's ``onclose`` can see, then return False for the caller to bail on.
+    """
+    try:
+        verify_owner_auth(socket)
+        return True
+    except NotAuthorizedException:
+        await socket.accept()
+        await socket.close(code=4401, reason="Missing or invalid authorization")
+        return False
 
 
 def require_app_auth(connection: AnyConnection, _route_handler: BaseRouteHandler) -> None:

--- a/compute_space/src/compute_space/web/routes/api/apps.py
+++ b/compute_space/src/compute_space/web/routes/api/apps.py
@@ -20,7 +20,6 @@ from litestar import get
 from litestar import post
 from litestar import websocket
 from litestar.di import NamedDependency
-from litestar.exceptions import NotAuthorizedException
 from litestar.exceptions import WebSocketDisconnect
 from litestar.params import FromPath
 from litestar.params import FromQuery
@@ -72,7 +71,7 @@ from compute_space.core.services_v2 import ServiceNotAvailable
 from compute_space.core.updates import wait_for_shutdown
 from compute_space.db.connection import get_db
 from compute_space.web.auth.auth import require_owner_auth
-from compute_space.web.auth.auth import verify_owner_auth
+from compute_space.web.auth.auth import verify_owner_ws
 
 # ─── attrs request / response models ──────────────────────────────────────
 
@@ -566,21 +565,12 @@ async def app_logs_stream(
     --follow``) for the life of the connection, so the browser appends new lines
     instead of re-fetching the whole (possibly huge) log on a timer.
     """
-    # Guards on websocket handlers only raise HTTPException, which a WS client
-    # can't read; do the owner check inline and close cleanly on failure. Accept
-    # first so the browser sees a close frame rather than a bare handshake reset
-    # (mirrors ``terminal_ws`` / ``service_call_ws``).
-    try:
-        verify_owner_auth(socket)
-    except NotAuthorizedException:
-        await socket.accept()
-        await socket.close(code=4401, reason="Missing or invalid authorization")
+    if not await verify_owner_ws(socket):
         return
 
-    # Resolve the app to a build-log path (and a clean close before we accept). The
-    # request-scoped ``db`` dependency is closed once a handler returns, but the
-    # stream outlives that; stream_app_logs re-queries the app's state itself via
-    # its own short-lived connections.
+    # Unlike a normal route, this handler stays open for the life of the stream, so we
+    # must not leave a DB connection open across it — open one just to resolve the app
+    # to a build-log path, then close it before we accept.
     with contextlib.closing(get_db()) as conn:
         app_row, err = _resolve_app_or_error(app_id, conn)
     if err is not None:
@@ -605,11 +595,7 @@ async def app_logs_stream(
             # connection closes and the client reconnects.
             logger.exception("Streaming logs for app %s failed", app_id)
             return
-        # The stream ends when the container stops (or a build finished without
-        # producing a container). Hold the socket open so the client shows the
-        # final log without reconnecting; the race below tears everything down on
-        # client disconnect or server shutdown.
-        await asyncio.Event().wait()
+        await asyncio.Event().wait()  # hold open; let the client decide when to refresh after a restart
 
     async def watch_close() -> None:
         # This is a send-only stream, so any inbound frame — or, more usually, a

--- a/compute_space/src/compute_space/web/routes/api/apps.py
+++ b/compute_space/src/compute_space/web/routes/api/apps.py
@@ -577,35 +577,23 @@ async def app_logs_stream(
         await socket.close(code=4401, reason="Missing or invalid authorization")
         return
 
-    if not is_valid_app_id(app_id):
-        await socket.accept()
-        await socket.close(code=4404, reason="App not found")
-        return
-
-    # The request-scoped ``db`` dependency is closed once a handler returns, but
-    # this stream outlives that, so use fresh short-lived connections throughout.
+    # Resolve the app to a build-log path (and a clean close before we accept). The
+    # request-scoped ``db`` dependency is closed once a handler returns, but the
+    # stream outlives that; stream_app_logs re-queries the app's state itself via
+    # its own short-lived connections.
     with contextlib.closing(get_db()) as conn:
-        row = conn.execute("SELECT name FROM apps WHERE app_id = ?", (app_id,)).fetchone()
-    if row is None:
+        app_row, err = _resolve_app_or_error(app_id, conn)
+    if err is not None:
         await socket.accept()
         await socket.close(code=4404, reason="App not found")
         return
-    app_name = row["name"]
-    build_log_path = app_log_path(app_name, config)
-
-    def get_state() -> tuple[str, str | None]:
-        with contextlib.closing(get_db()) as state_conn:
-            state_row = state_conn.execute(
-                "SELECT status, container_id FROM apps WHERE app_id = ?", (app_id,)
-            ).fetchone()
-        if state_row is None:
-            return "removed", None
-        return state_row["status"], state_row["container_id"]
+    assert app_row is not None
+    build_log_path = app_log_path(app_row["name"], config)
 
     await socket.accept()
 
     async def pump() -> None:
-        async for chunk in stream_app_logs(app_name, build_log_path, get_state):
+        async for chunk in stream_app_logs(app_id, build_log_path):
             await socket.send_text(chunk)
         # The stream ends when the container stops (or a build finished without
         # producing a container). Hold the socket open so the client shows the

--- a/compute_space/src/compute_space/web/routes/api/apps.py
+++ b/compute_space/src/compute_space/web/routes/api/apps.py
@@ -1,4 +1,5 @@
 import asyncio
+import contextlib
 import os
 import re
 import shutil
@@ -14,9 +15,13 @@ import attr
 from litestar import MediaType
 from litestar import Response
 from litestar import Router
+from litestar import WebSocket
 from litestar import get
 from litestar import post
+from litestar import websocket
 from litestar.di import NamedDependency
+from litestar.exceptions import NotAuthorizedException
+from litestar.exceptions import WebSocketDisconnect
 from litestar.params import FromPath
 from litestar.params import FromQuery
 from litestar.params import Parameter
@@ -57,13 +62,17 @@ from compute_space.core.git_ops import is_dirty
 from compute_space.core.git_ops import is_github_repo_url
 from compute_space.core.git_ops import parse_repo_url
 from compute_space.core.git_ops import reset_hard
+from compute_space.core.log_stream import stream_app_logs
 from compute_space.core.logging import logger
 from compute_space.core.manifest import parse_manifest
 from compute_space.core.oauth import OAuthAuthorizationRequired
 from compute_space.core.oauth import get_oauth_token
 from compute_space.core.ports import check_port_available
 from compute_space.core.services_v2 import ServiceNotAvailable
+from compute_space.core.updates import wait_for_shutdown
+from compute_space.db.connection import get_db
 from compute_space.web.auth.auth import require_owner_auth
+from compute_space.web.auth.auth import verify_owner_auth
 
 # ─── attrs request / response models ──────────────────────────────────────
 
@@ -543,6 +552,84 @@ async def app_logs(
     assert app_row is not None
     logs = get_docker_logs(app_row["name"], config.temporary_data_dir, app_row["container_id"])
     return Response(content=logs, status_code=200, media_type=MediaType.TEXT)
+
+
+@websocket("/app_logs_stream/{app_id:str}")
+async def app_logs_stream(
+    socket: WebSocket[Any, Any, Any],
+    app_id: FromPath[str],
+    config: NamedDependency[Config],
+) -> None:
+    """Stream an app's logs to the detail page over a WebSocket.
+
+    Sends the build-log tail, then follows the live container log (``podman logs
+    --follow``) for the life of the connection, so the browser appends new lines
+    instead of re-fetching the whole (possibly huge) log on a timer.
+    """
+    # Guards on websocket handlers only raise HTTPException, which a WS client
+    # can't read; do the owner check inline and close cleanly on failure. Accept
+    # first so the browser sees a close frame rather than a bare handshake reset
+    # (mirrors ``terminal_ws`` / ``service_call_ws``).
+    try:
+        verify_owner_auth(socket)
+    except NotAuthorizedException:
+        await socket.accept()
+        await socket.close(code=4401, reason="Missing or invalid authorization")
+        return
+
+    if not is_valid_app_id(app_id):
+        await socket.accept()
+        await socket.close(code=4404, reason="App not found")
+        return
+
+    # The request-scoped ``db`` dependency is closed once a handler returns, but
+    # this stream outlives that, so use fresh short-lived connections throughout.
+    with contextlib.closing(get_db()) as conn:
+        row = conn.execute("SELECT name FROM apps WHERE app_id = ?", (app_id,)).fetchone()
+    if row is None:
+        await socket.accept()
+        await socket.close(code=4404, reason="App not found")
+        return
+    app_name = row["name"]
+    build_log_path = app_log_path(app_name, config)
+
+    def get_state() -> tuple[str, str | None]:
+        with contextlib.closing(get_db()) as state_conn:
+            state_row = state_conn.execute(
+                "SELECT status, container_id FROM apps WHERE app_id = ?", (app_id,)
+            ).fetchone()
+        if state_row is None:
+            return "removed", None
+        return state_row["status"], state_row["container_id"]
+
+    await socket.accept()
+
+    async def pump() -> None:
+        async for chunk in stream_app_logs(app_name, build_log_path, get_state):
+            await socket.send_text(chunk)
+        # The stream ends when the container stops (or a build finished without
+        # producing a container). Hold the socket open so the client shows the
+        # final log without reconnecting; the race below tears everything down on
+        # client disconnect or server shutdown.
+        await asyncio.Event().wait()
+
+    async def watch_close() -> None:
+        # This is a send-only stream, so any inbound frame — or, more usually, a
+        # disconnect — means the client is gone. Awaiting a receive lets us notice
+        # promptly and reap the podman follow instead of leaking it until shutdown.
+        with contextlib.suppress(WebSocketDisconnect):
+            while True:
+                await socket.receive()
+
+    tasks = [asyncio.create_task(t) for t in (pump(), watch_close(), wait_for_shutdown())]
+    try:
+        await asyncio.wait(tasks, return_when=asyncio.FIRST_COMPLETED)
+    finally:
+        for t in tasks:
+            t.cancel()
+        # Let the cancellations propagate into stream_app_logs' finally blocks so
+        # the podman follow subprocess is terminated before we return.
+        await asyncio.gather(*tasks, return_exceptions=True)
 
 
 @post("/stop_app/{app_id:str}", status_code=200, guards=[require_owner_auth])
@@ -1174,6 +1261,7 @@ api_apps_routes = Router(
         app_status,
         app_diagnostics,
         app_logs,
+        app_logs_stream,
         stop_app,
         reload_app,
         reload_app_after_oauth,

--- a/compute_space/src/compute_space/web/routes/api/apps.py
+++ b/compute_space/src/compute_space/web/routes/api/apps.py
@@ -593,8 +593,18 @@ async def app_logs_stream(
     await socket.accept()
 
     async def pump() -> None:
-        async for chunk in stream_app_logs(app_id, build_log_path):
-            await socket.send_text(chunk)
+        try:
+            async for chunk in stream_app_logs(app_id, build_log_path):
+                await socket.send_text(chunk)
+        except WebSocketDisconnect:
+            return  # client vanished mid-send; watch_close tears the rest down
+        except Exception:
+            # An unexpected failure in the follow (e.g. tail hitting an unreadable
+            # build log) would otherwise be swallowed by the teardown gather below,
+            # closing the socket with no trace. Log it, then let pump finish so the
+            # connection closes and the client reconnects.
+            logger.exception("Streaming logs for app %s failed", app_id)
+            return
         # The stream ends when the container stops (or a build finished without
         # producing a container). Hold the socket open so the client shows the
         # final log without reconnecting; the race below tears everything down on

--- a/compute_space/src/compute_space/web/routes/pages/apps.py
+++ b/compute_space/src/compute_space/web/routes/pages/apps.py
@@ -17,7 +17,6 @@ from compute_space.core.app_id import is_valid_app_name
 from compute_space.core.apps import deserialize_links
 from compute_space.core.apps import manifest_ungranted_permissions_v2
 from compute_space.core.auth.permissions_v2 import get_all_permissions_v2
-from compute_space.core.containers import get_docker_logs
 from compute_space.core.domains import Domain
 from compute_space.core.git_ops import UnsupportedRepoUrlError
 from compute_space.core.git_ops import get_head_sha
@@ -68,7 +67,8 @@ async def app_detail(
         "SELECT service_url, service_version FROM service_providers_v2 WHERE app_id = ? ORDER BY service_url",
         (app_id,),
     ).fetchall()
-    logs = get_docker_logs(app_name, config.temporary_data_dir, app_row["container_id"])
+    # Logs are streamed to the page over a WebSocket (see /app_logs_stream), so
+    # the initial render no longer reads the whole (possibly huge) log up front.
 
     # User-facing links the app advertised in its manifest's [[links]].
     links = deserialize_links(app_row["links"])
@@ -108,7 +108,6 @@ async def app_detail(
             "databases": databases,
             "port_mappings": port_mappings,
             "services_provided": services_provided,
-            "logs": logs,
             "next_url": next,
             "granted_permissions": granted_perms,
             "ungranted_permissions": ungranted_perms,

--- a/compute_space/src/compute_space/web/routes/pages/system.py
+++ b/compute_space/src/compute_space/web/routes/pages/system.py
@@ -5,12 +5,11 @@ from litestar import Router
 from litestar import WebSocket
 from litestar import get
 from litestar import websocket
-from litestar.exceptions import NotAuthorizedException
 from litestar.response import Template
 
 from compute_space.core.terminal import handle_terminal_ws
 from compute_space.web.auth.auth import require_owner_auth
-from compute_space.web.auth.auth import verify_owner_auth
+from compute_space.web.auth.auth import verify_owner_ws
 
 
 @get("/system/", guards=[require_owner_auth])
@@ -48,16 +47,8 @@ class _LitestarTerminalAdapter:
 
 @websocket("/terminal/ws")
 async def terminal_ws(socket: WebSocket[Any, Any, Any]) -> None:
-    """WebSocket endpoint for the terminal PTY bridge.
-
-    Guards currently only signal failure via HTTPException, so the auth check is
-    inline: accept first so the client gets a clean close on failure.
-    """
-    try:
-        verify_owner_auth(socket)
-    except NotAuthorizedException:
-        await socket.accept()
-        await socket.close(code=4401, reason="Missing or invalid authorization")
+    """WebSocket endpoint for the terminal PTY bridge."""
+    if not await verify_owner_ws(socket):
         return
     await socket.accept()
     await handle_terminal_ws(_LitestarTerminalAdapter(socket))

--- a/compute_space/src/compute_space/web/static/js/app-detail.js
+++ b/compute_space/src/compute_space/web/static/js/app-detail.js
@@ -192,6 +192,9 @@ function clearCacheAndReload() {
 
     var MAX_LOG_CHARS = 2 * 1024 * 1024;
     var logPrimed = false;
+    // Set when a (re)connect's first message arrives; the next flush replaces the pane's
+    // contents in one paint rather than blanking it first (which flashed the scroll to top).
+    var needsReset = false;
 
     // Buffer incoming lines and flush once per animation frame: the backlog arrives
     // one WebSocket message per line, so batching avoids reflowing the <pre> each line.
@@ -216,9 +219,17 @@ function clearCacheAndReload() {
         var text = pending.join('');
         pending = [];
         pendingLen = 0;
-        // A text node leaves existing content and any active selection intact.
-        logEl.appendChild(document.createTextNode(text));
-        logLen += text.length;
+        if (needsReset) {
+            // Replace the stale contents in the same flush that refills them, so the
+            // emptied <pre> never paints on its own and jerks the scroll to the top.
+            needsReset = false;
+            logEl.textContent = text;
+            logLen = text.length;
+        } else {
+            // A text node leaves existing content and any active selection intact.
+            logEl.appendChild(document.createTextNode(text));
+            logLen += text.length;
+        }
         if (logLen > MAX_LOG_CHARS && !hasSelectionIn(logEl)) {
             var trimmed = logEl.textContent.slice(-MAX_LOG_CHARS);
             logEl.textContent = trimmed;
@@ -249,12 +260,12 @@ function clearCacheAndReload() {
         var ws = new WebSocket(proto + '//' + window.location.host + config.appLogsStreamUrl);
         currentWs = ws;
         ws.onmessage = function(e) {
-            // Clear on the first message so the replayed tail replaces the
-            // placeholder (or, on reconnect, stale contents) instead of appending.
+            // First message of a (re)connect replays the tail: drop anything buffered from
+            // the old socket and let the next flush swap in the fresh contents atomically.
             if (!logPrimed) {
-                logEl.textContent = ''; logLen = 0;
-                pending = []; pendingLen = 0;
                 logPrimed = true;
+                needsReset = true;
+                pending = []; pendingLen = 0;
             }
             appendLog(e.data + '\n');
         };

--- a/compute_space/src/compute_space/web/static/js/app-detail.js
+++ b/compute_space/src/compute_space/web/static/js/app-detail.js
@@ -264,15 +264,26 @@ function clearCacheAndReload() {
         var proto = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
         var ws = new WebSocket(proto + '//' + window.location.host + config.appLogsStreamUrl);
         ws.onmessage = function(e) {
-            if (!logPrimed) { logEl.textContent = ''; logLen = 0; logPrimed = true; }
+            // Priming clears the placeholder (first connect) or the previous
+            // stream's contents (a reconnect, see onclose) so the replayed tail
+            // replaces the old log instead of appending a duplicate copy. Drop any
+            // buffered-but-unflushed lines too, so they can't land on the cleared
+            // <pre> on the next flush.
+            if (!logPrimed) {
+                logEl.textContent = ''; logLen = 0;
+                pending = []; pendingLen = 0;
+                logPrimed = true;
+            }
             appendLog(e.data + '\n');
         };
         ws.onclose = function() {
             // Unlike EventSource, a WebSocket doesn't auto-reconnect. The server
             // holds the socket open even after the log stream ends, so a close
             // here means a real drop (network blip or server restart) — retry
-            // after a short delay. The server replays the recent tail on
-            // reconnect, which the front-trim above keeps bounded.
+            // after a short delay. The reconnected stream replays the recent tail
+            // from the start, so re-prime to replace the old contents rather than
+            // appending a second copy below them.
+            logPrimed = false;
             setTimeout(startLogStream, 2000);
         };
         ws.onerror = function() { ws.close(); };

--- a/compute_space/src/compute_space/web/static/js/app-detail.js
+++ b/compute_space/src/compute_space/web/static/js/app-detail.js
@@ -260,6 +260,7 @@ function clearCacheAndReload() {
         var ws = new WebSocket(proto + '//' + window.location.host + config.appLogsStreamUrl);
         currentWs = ws;
         ws.onmessage = function(e) {
+            if (ws !== currentWs) return;  // superseded by a reset; don't consume the reprime
             // First message of a (re)connect replays the tail: drop anything buffered from
             // the old socket and let the next flush swap in the fresh contents atomically.
             if (!logPrimed) {

--- a/compute_space/src/compute_space/web/static/js/app-detail.js
+++ b/compute_space/src/compute_space/web/static/js/app-detail.js
@@ -193,19 +193,15 @@ function clearCacheAndReload() {
     var nextUrl = config.nextUrl;
     var toastKey = 'cache-toast-shown-' + config.appStatusUrl;
 
-    // Keep the <pre> bounded so a long-lived stream can't grow the DOM without
-    // limit. Trimming is a full rewrite, so it only runs when we exceed the cap.
+    // Cap the <pre> so a long-lived stream can't grow the DOM unbounded.
     var MAX_LOG_CHARS = 2 * 1024 * 1024;
     var logPrimed = false;
 
-    // Incoming lines are buffered and flushed to the DOM once per animation
-    // frame, not appended one-at-a-time. The container backlog replays as one
-    // WebSocket message *per line* (podman `--tail 2000`), so on connect a
-    // per-line append — each reading isNearBottom/textContent.length and writing
-    // scrollTop, all of which force a synchronous reflow of a growing <pre> —
-    // would be O(N^2). Coalescing a whole burst into a single append + one layout
-    // read + one layout write keeps the initial render linear. logLen is tracked
-    // in JS so we never serialize logEl.textContent just to measure it.
+    // Buffer incoming lines and flush once per animation frame. The backlog
+    // arrives as one WebSocket message per line (podman `--tail 2000`), and
+    // appending each one individually would reflow the <pre> per line; batching a
+    // burst into one append keeps the initial render cheap. logLen is tracked in
+    // JS so measuring the length never serializes logEl.textContent.
     var pending = [];
     var pendingLen = 0;
     var flushQueued = false;
@@ -228,9 +224,8 @@ function clearCacheAndReload() {
         var text = pending.join('');
         pending = [];
         pendingLen = 0;
-        // Append a single text node for the batch: the browser lays out only the
-        // new lines and leaves existing content (and any active text selection)
-        // untouched.
+        // One text node per batch leaves existing content — and any active text
+        // selection — untouched.
         logEl.appendChild(document.createTextNode(text));
         logLen += text.length;
         if (logLen > MAX_LOG_CHARS && !hasSelectionIn(logEl)) {
@@ -258,17 +253,14 @@ function clearCacheAndReload() {
 
     function startLogStream() {
         // Same-origin WebSocket; the session cookie authenticates the handshake.
-        // The server pushes the build-log tail, then follows the live container
-        // log, so the browser only appends new lines instead of re-fetching the
-        // whole log on a timer.
+        // The server replays the log tail then follows live output, so we append
+        // new lines instead of re-fetching the whole log on a timer.
         var proto = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
         var ws = new WebSocket(proto + '//' + window.location.host + config.appLogsStreamUrl);
         ws.onmessage = function(e) {
-            // Priming clears the placeholder (first connect) or the previous
-            // stream's contents (a reconnect, see onclose) so the replayed tail
-            // replaces the old log instead of appending a duplicate copy. Drop any
-            // buffered-but-unflushed lines too, so they can't land on the cleared
-            // <pre> on the next flush.
+            // Clear on the first message so the replayed tail replaces the
+            // placeholder (or, on reconnect, the old contents) instead of
+            // duplicating it; drop buffered lines too so none land post-clear.
             if (!logPrimed) {
                 logEl.textContent = ''; logLen = 0;
                 pending = []; pendingLen = 0;
@@ -277,12 +269,10 @@ function clearCacheAndReload() {
             appendLog(e.data + '\n');
         };
         ws.onclose = function() {
-            // Unlike EventSource, a WebSocket doesn't auto-reconnect. The server
-            // holds the socket open even after the log stream ends, so a close
-            // here means a real drop (network blip or server restart) — retry
-            // after a short delay. The reconnected stream replays the recent tail
-            // from the start, so re-prime to replace the old contents rather than
-            // appending a second copy below them.
+            // A WebSocket won't auto-reconnect, and the server holds the socket
+            // open past end-of-log, so a close means a real drop (network blip or
+            // server restart) — retry. Re-prime because the reconnected stream
+            // replays the tail from the start.
             logPrimed = false;
             setTimeout(startLogStream, 2000);
         };
@@ -365,9 +355,8 @@ function clearCacheAndReload() {
 
     logEl.scrollTop = logEl.scrollHeight;
 
-    // Logs stream continuously over a WebSocket regardless of status (a
-    // stopped/errored app still streams its build log, then the stream ends and
-    // the server holds the socket open at the final state).
+    // Stream regardless of status: a stopped/errored app still has a build log to
+    // replay, after which the server holds the socket open at the final state.
     startLogStream();
 
     // 'removing' polls so the page learns when the row vanishes (404).

--- a/compute_space/src/compute_space/web/static/js/app-detail.js
+++ b/compute_space/src/compute_space/web/static/js/app-detail.js
@@ -193,22 +193,89 @@ function clearCacheAndReload() {
     var nextUrl = config.nextUrl;
     var toastKey = 'cache-toast-shown-' + config.appStatusUrl;
 
+    // Keep the <pre> bounded so a long-lived stream can't grow the DOM without
+    // limit. Trimming is a full rewrite, so it only runs when we exceed the cap.
+    var MAX_LOG_CHARS = 2 * 1024 * 1024;
+    var logPrimed = false;
+
+    // Incoming lines are buffered and flushed to the DOM once per animation
+    // frame, not appended one-at-a-time. The container backlog replays as one
+    // WebSocket message *per line* (podman `--tail 2000`), so on connect a
+    // per-line append — each reading isNearBottom/textContent.length and writing
+    // scrollTop, all of which force a synchronous reflow of a growing <pre> —
+    // would be O(N^2). Coalescing a whole burst into a single append + one layout
+    // read + one layout write keeps the initial render linear. logLen is tracked
+    // in JS so we never serialize logEl.textContent just to measure it.
+    var pending = [];
+    var pendingLen = 0;
+    var flushQueued = false;
+    var logLen = 0;
+
     function isNearBottom(el) {
         return el.scrollHeight - el.scrollTop - el.clientHeight < 50;
     }
 
-    function updateLog(el, text) {
+    function hasSelectionIn(el) {
         var sel = window.getSelection();
-        if (sel && !sel.isCollapsed && el.contains(sel.anchorNode)) return;
-        var wasAtBottom = isNearBottom(el);
-        el.textContent = text || 'No log output available.';
-        if (wasAtBottom) el.scrollTop = el.scrollHeight;
+        return !!(sel && !sel.isCollapsed && el.contains(sel.anchorNode));
     }
 
-    function fetchLogs() {
-        fetch(config.appLogsUrl)
-            .then(function(r) { return r.text(); })
-            .then(function(text) { updateLog(logEl, text); });
+    function flushLog() {
+        flushQueued = false;
+        if (!pending.length) return;
+        // One layout read for the whole batch, before we touch the DOM.
+        var wasAtBottom = isNearBottom(logEl);
+        var text = pending.join('');
+        pending = [];
+        pendingLen = 0;
+        // Append a single text node for the batch: the browser lays out only the
+        // new lines and leaves existing content (and any active text selection)
+        // untouched.
+        logEl.appendChild(document.createTextNode(text));
+        logLen += text.length;
+        if (logLen > MAX_LOG_CHARS && !hasSelectionIn(logEl)) {
+            var trimmed = logEl.textContent.slice(-MAX_LOG_CHARS);
+            logEl.textContent = trimmed;
+            logLen = trimmed.length;
+        }
+        if (wasAtBottom) logEl.scrollTop = logEl.scrollHeight;
+    }
+
+    function appendLog(text) {
+        if (!text) return;
+        pending.push(text);
+        pendingLen += text.length;
+        // If frames are paused (e.g. a backgrounded tab) the buffer could grow
+        // unbounded, so keep only the most recent MAX_LOG_CHARS worth.
+        while (pending.length > 1 && pendingLen - pending[0].length > MAX_LOG_CHARS) {
+            pendingLen -= pending.shift().length;
+        }
+        if (!flushQueued) {
+            flushQueued = true;
+            requestAnimationFrame(flushLog);
+        }
+    }
+
+    function startLogStream() {
+        // Same-origin WebSocket; the session cookie authenticates the handshake.
+        // The server pushes the build-log tail, then follows the live container
+        // log, so the browser only appends new lines instead of re-fetching the
+        // whole log on a timer.
+        var proto = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
+        var ws = new WebSocket(proto + '//' + window.location.host + config.appLogsStreamUrl);
+        ws.onmessage = function(e) {
+            if (!logPrimed) { logEl.textContent = ''; logLen = 0; logPrimed = true; }
+            appendLog(e.data + '\n');
+        };
+        ws.onclose = function() {
+            // Unlike EventSource, a WebSocket doesn't auto-reconnect. The server
+            // holds the socket open even after the log stream ends, so a close
+            // here means a real drop (network blip or server restart) — retry
+            // after a short delay. The server replays the recent tail on
+            // reconnect, which the front-trim above keeps bounded.
+            setTimeout(startLogStream, 2000);
+        };
+        ws.onerror = function() { ws.close(); };
     }
 
     function showCacheCorruptToast() {
@@ -287,6 +354,11 @@ function clearCacheAndReload() {
 
     logEl.scrollTop = logEl.scrollHeight;
 
+    // Logs stream continuously over a WebSocket regardless of status (a
+    // stopped/errored app still streams its build log, then the stream ends and
+    // the server holds the socket open at the final state).
+    startLogStream();
+
     // 'removing' polls so the page learns when the row vanishes (404).
     if (
         appStatus === 'running' ||
@@ -295,7 +367,6 @@ function clearCacheAndReload() {
         appStatus === 'removing'
     ) {
         var interval = (appStatus === 'building') ? 1000 : 3000;
-        setInterval(fetchLogs, interval);
         setInterval(pollStatus, interval);
     }
 })();

--- a/compute_space/src/compute_space/web/static/js/app-detail.js
+++ b/compute_space/src/compute_space/web/static/js/app-detail.js
@@ -193,6 +193,15 @@ function clearCacheAndReload() {
     var nextUrl = config.nextUrl;
     var toastKey = 'cache-toast-shown-' + config.appStatusUrl;
 
+    // The container the log stream is currently following. The server-side follow
+    // is bound to one container and holds the socket open at its final line when
+    // that container stops, so a reload/restart from elsewhere (CLI, another tab, a
+    // crash-restart) would otherwise freeze the view on the dead container's logs.
+    // pollStatus watches app_status.container_id and re-points the stream when it
+    // changes. Seeded from the first poll (the id the initial stream already
+    // follows) so only a *change* triggers a reset.
+    var streamContainerId = null;
+
     // Cap the <pre> so a long-lived stream can't grow the DOM unbounded.
     var MAX_LOG_CHARS = 2 * 1024 * 1024;
     var logPrimed = false;
@@ -251,12 +260,18 @@ function clearCacheAndReload() {
         }
     }
 
+    // The socket the page is currently following. Tracked so a deliberate reset
+    // can silence the old socket's auto-reconnect instead of racing a second
+    // stream against the new one.
+    var currentWs = null;
+
     function startLogStream() {
         // Same-origin WebSocket; the session cookie authenticates the handshake.
         // The server replays the log tail then follows live output, so we append
         // new lines instead of re-fetching the whole log on a timer.
         var proto = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
         var ws = new WebSocket(proto + '//' + window.location.host + config.appLogsStreamUrl);
+        currentWs = ws;
         ws.onmessage = function(e) {
             // Clear on the first message so the replayed tail replaces the
             // placeholder (or, on reconnect, the old contents) instead of
@@ -269,6 +284,9 @@ function clearCacheAndReload() {
             appendLog(e.data + '\n');
         };
         ws.onclose = function() {
+            // Superseded by a reset (a fresh stream already took over) — don't
+            // reconnect this dead socket on top of the new one.
+            if (ws !== currentWs) return;
             // A WebSocket won't auto-reconnect, and the server holds the socket
             // open past end-of-log, so a close means a real drop (network blip or
             // server restart) — retry. Re-prime because the reconnected stream
@@ -277,6 +295,18 @@ function clearCacheAndReload() {
             setTimeout(startLogStream, 2000);
         };
         ws.onerror = function() { ws.close(); };
+    }
+
+    // Tear down the current stream and start a fresh one, pointed at the app's
+    // current state. Used when the container changes under us: the old follow is
+    // held open at the dead container's final line, so we replace it. Re-priming
+    // makes the new stream's replayed tail overwrite the stale contents rather
+    // than append to them.
+    function resetLogStream() {
+        var old = currentWs;
+        logPrimed = false;
+        startLogStream();  // reassigns currentWs to the new socket
+        if (old && old !== currentWs) old.close();  // its onclose sees it's superseded
     }
 
     function showCacheCorruptToast() {
@@ -321,6 +351,15 @@ function clearCacheAndReload() {
                     appStatus = data.status;
                     statusEl.textContent = appStatus;
                     statusEl.className = 'status-' + appStatus;
+                }
+                // Re-point the log stream when the container changes. The first
+                // non-null id is the one the initial stream already follows, so we
+                // adopt it silently; only a change to a *different* container (a
+                // reload/restart from elsewhere, or a crash-restart) resets — an app
+                // that simply stops keeps its final logs held open as before.
+                if (data.container_id && data.container_id !== streamContainerId) {
+                    if (streamContainerId !== null) resetLogStream();
+                    streamContainerId = data.container_id;
                 }
                 if (appStatus === 'removing') {
                     applyRemovingChrome();

--- a/compute_space/src/compute_space/web/static/js/app-detail.js
+++ b/compute_space/src/compute_space/web/static/js/app-detail.js
@@ -61,8 +61,7 @@ function saveRemote() {
         errEl.textContent = (res.data && res.data.error) || 'Failed to save';
         return;
       }
-      // Upstream persisted; now pull the new ref and rebuild. Reuses the
-      // oauth-aware /reload_app?update flow (it may redirect for github auth).
+      // Reuse the oauth-aware update flow, which may redirect for github auth.
       appAction(config.reloadAppUrl, {update: true}, {label: 'Updating & reloading'});
     })
     .catch(function() { errEl.textContent = 'Failed to save'; });
@@ -94,9 +93,8 @@ function setActionsBusy(label) {
 }
 
 function appAction(url, data, opts) {
-  // opts: { isRemove?: bool, label?: string }. isRemove navigates to
-  // /dashboard on success; otherwise location.reload(). label is the
-  // text shown next to the action buttons while the request is in flight.
+  // opts: { isRemove?: bool, label?: string }. isRemove navigates to /dashboard
+  // on success rather than reloading the (now-gone) detail page.
   opts = opts || {};
   var label = opts.label || (opts.isRemove ? 'Removing' : 'Working');
   var clear = setActionsBusy(label);
@@ -108,10 +106,8 @@ function appAction(url, data, opts) {
   })
     .then(function(r) { return r.json().then(function(d) { return {ok: r.ok, data: d}; }); })
     .then(function(res) {
-      // An update whose manifest declares new service permissions is refused
-      // until the owner explicitly approves them (mirrors install-time
-      // approval). Prompt, and on confirmation re-issue the request with
-      // approve_new_permissions so the grants are written before the reload.
+      // An update declaring new permissions is refused until the owner approves;
+      // re-issue with approve_new_permissions so the grants are written first.
       if (res.ok && res.data && res.data.permissions_required) {
         if (clear) clear();
         if (confirmNewPermissions(res.data.permissions_required)) {
@@ -135,8 +131,6 @@ function appAction(url, data, opts) {
     });
 }
 
-// Show the owner exactly which new permissions an update wants and get an
-// explicit yes/no. Returns true if the owner approved.
 function confirmNewPermissions(perms) {
   var lines = perms.map(function(p) {
     var label = p.shortname ? (p.shortname + ' (' + p.service_url + ')') : p.service_url;
@@ -193,24 +187,14 @@ function clearCacheAndReload() {
     var nextUrl = config.nextUrl;
     var toastKey = 'cache-toast-shown-' + config.appStatusUrl;
 
-    // The container the log stream is currently following. The server-side follow
-    // is bound to one container and holds the socket open at its final line when
-    // that container stops, so a reload/restart from elsewhere (CLI, another tab, a
-    // crash-restart) would otherwise freeze the view on the dead container's logs.
-    // pollStatus watches app_status.container_id and re-points the stream when it
-    // changes. Seeded from the first poll (the id the initial stream already
-    // follows) so only a *change* triggers a reset.
+    // The container the stream follows; when it changes we reset to the new logs.
     var streamContainerId = null;
 
-    // Cap the <pre> so a long-lived stream can't grow the DOM unbounded.
     var MAX_LOG_CHARS = 2 * 1024 * 1024;
     var logPrimed = false;
 
-    // Buffer incoming lines and flush once per animation frame. The backlog
-    // arrives as one WebSocket message per line (podman `--tail 2000`), and
-    // appending each one individually would reflow the <pre> per line; batching a
-    // burst into one append keeps the initial render cheap. logLen is tracked in
-    // JS so measuring the length never serializes logEl.textContent.
+    // Buffer incoming lines and flush once per animation frame: the backlog arrives
+    // one WebSocket message per line, so batching avoids reflowing the <pre> each line.
     var pending = [];
     var pendingLen = 0;
     var flushQueued = false;
@@ -228,13 +212,11 @@ function clearCacheAndReload() {
     function flushLog() {
         flushQueued = false;
         if (!pending.length) return;
-        // One layout read for the whole batch, before we touch the DOM.
         var wasAtBottom = isNearBottom(logEl);
         var text = pending.join('');
         pending = [];
         pendingLen = 0;
-        // One text node per batch leaves existing content — and any active text
-        // selection — untouched.
+        // A text node leaves existing content and any active selection intact.
         logEl.appendChild(document.createTextNode(text));
         logLen += text.length;
         if (logLen > MAX_LOG_CHARS && !hasSelectionIn(logEl)) {
@@ -249,8 +231,7 @@ function clearCacheAndReload() {
         if (!text) return;
         pending.push(text);
         pendingLen += text.length;
-        // If frames are paused (e.g. a backgrounded tab) the buffer could grow
-        // unbounded, so keep only the most recent MAX_LOG_CHARS worth.
+        // If frames are paused (backgrounded tab) drop all but the most recent MAX_LOG_CHARS.
         while (pending.length > 1 && pendingLen - pending[0].length > MAX_LOG_CHARS) {
             pendingLen -= pending.shift().length;
         }
@@ -260,22 +241,16 @@ function clearCacheAndReload() {
         }
     }
 
-    // The socket the page is currently following. Tracked so a deliberate reset
-    // can silence the old socket's auto-reconnect instead of racing a second
-    // stream against the new one.
+    // Tracked so a reset can tell the old socket's onclose not to reconnect.
     var currentWs = null;
 
     function startLogStream() {
-        // Same-origin WebSocket; the session cookie authenticates the handshake.
-        // The server replays the log tail then follows live output, so we append
-        // new lines instead of re-fetching the whole log on a timer.
         var proto = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
         var ws = new WebSocket(proto + '//' + window.location.host + config.appLogsStreamUrl);
         currentWs = ws;
         ws.onmessage = function(e) {
             // Clear on the first message so the replayed tail replaces the
-            // placeholder (or, on reconnect, the old contents) instead of
-            // duplicating it; drop buffered lines too so none land post-clear.
+            // placeholder (or, on reconnect, stale contents) instead of appending.
             if (!logPrimed) {
                 logEl.textContent = ''; logLen = 0;
                 pending = []; pendingLen = 0;
@@ -284,29 +259,20 @@ function clearCacheAndReload() {
             appendLog(e.data + '\n');
         };
         ws.onclose = function() {
-            // Superseded by a reset (a fresh stream already took over) — don't
-            // reconnect this dead socket on top of the new one.
-            if (ws !== currentWs) return;
-            // A WebSocket won't auto-reconnect, and the server holds the socket
-            // open past end-of-log, so a close means a real drop (network blip or
-            // server restart) — retry. Re-prime because the reconnected stream
-            // replays the tail from the start.
+            if (ws !== currentWs) return;  // superseded by a reset
+            // The server holds the socket open past end-of-log, so a close is a real
+            // drop — reconnect (which re-primes to replay the tail).
             logPrimed = false;
             setTimeout(startLogStream, 2000);
         };
         ws.onerror = function() { ws.close(); };
     }
 
-    // Tear down the current stream and start a fresh one, pointed at the app's
-    // current state. Used when the container changes under us: the old follow is
-    // held open at the dead container's final line, so we replace it. Re-priming
-    // makes the new stream's replayed tail overwrite the stale contents rather
-    // than append to them.
     function resetLogStream() {
         var old = currentWs;
         logPrimed = false;
-        startLogStream();  // reassigns currentWs to the new socket
-        if (old && old !== currentWs) old.close();  // its onclose sees it's superseded
+        startLogStream();  // reassigns currentWs
+        if (old && old !== currentWs) old.close();
     }
 
     function showCacheCorruptToast() {
@@ -321,10 +287,8 @@ function clearCacheAndReload() {
         );
     }
 
-    // While status='removing', disable the action buttons and show
-    // "Removing…". Re-enable on transition to 'error' (failed teardown);
-    // a successful teardown deletes the row and we redirect via the
-    // 404 branch in pollStatus.
+    // Disables the action buttons while removing; re-enabled only if teardown
+    // fails (status 'error'). A successful teardown 404s and redirects instead.
     var clearRemovingChrome = null;
     function applyRemovingChrome() {
         if (clearRemovingChrome) return;
@@ -352,11 +316,7 @@ function clearCacheAndReload() {
                     statusEl.textContent = appStatus;
                     statusEl.className = 'status-' + appStatus;
                 }
-                // Re-point the log stream when the container changes. The first
-                // non-null id is the one the initial stream already follows, so we
-                // adopt it silently; only a change to a *different* container (a
-                // reload/restart from elsewhere, or a crash-restart) resets — an app
-                // that simply stops keeps its final logs held open as before.
+                // Adopt the first container_id silently; reset only on a later change.
                 if (data.container_id && data.container_id !== streamContainerId) {
                     if (streamContainerId !== null) resetLogStream();
                     streamContainerId = data.container_id;
@@ -386,16 +346,13 @@ function clearCacheAndReload() {
             });
     }
 
-    // If the page loads with the app already in 'removing', reflect
-    // that before the first poll fires.
     if (appStatus === 'removing') {
         applyRemovingChrome();
     }
 
     logEl.scrollTop = logEl.scrollHeight;
 
-    // Stream regardless of status: a stopped/errored app still has a build log to
-    // replay, after which the server holds the socket open at the final state.
+    // Stream regardless of status: a stopped/errored app still has a build log to replay.
     startLogStream();
 
     // 'removing' polls so the page learns when the row vanishes (404).

--- a/compute_space/src/compute_space/web/templates/app_detail.html
+++ b/compute_space/src/compute_space/web/templates/app_detail.html
@@ -136,7 +136,7 @@
 {% endif %}
 
 <h3>Logs</h3>
-<pre class="log-output" id="app-logs">{{ logs or "No log output available." }}</pre>
+<pre class="log-output" id="app-logs">Connecting to log stream…</pre>
 
 <br>
 <style>
@@ -245,6 +245,7 @@ async function copyAppDiagnostics(btn) {
   "renameAppUrl": "/rename_app/{{ app.app_id }}",
   "appDetailUrl": "/app_detail/{{ app.name }}",
   "appLogsUrl": "/app_logs/{{ app.app_id }}",
+  "appLogsStreamUrl": "/app_logs_stream/{{ app.app_id }}",
   "appStatusUrl": "/api/app_status/{{ app.app_id }}",
   "appStatus": {{ app.status | tojson }},
   "nextUrl": {{ next_url | default("", true) | tojson }},

--- a/compute_space/src/compute_space/web/templates/app_detail.html
+++ b/compute_space/src/compute_space/web/templates/app_detail.html
@@ -244,7 +244,6 @@ async function copyAppDiagnostics(btn) {
 {
   "renameAppUrl": "/rename_app/{{ app.app_id }}",
   "appDetailUrl": "/app_detail/{{ app.name }}",
-  "appLogsUrl": "/app_logs/{{ app.app_id }}",
   "appLogsStreamUrl": "/app_logs_stream/{{ app.app_id }}",
   "appStatusUrl": "/api/app_status/{{ app.app_id }}",
   "appStatus": {{ app.status | tojson }},


### PR DESCRIPTION
Stacked on #280 — base is that branch, so this PR's diff is only the log-streaming work.

## What & why
The app-detail page re-fetched the **entire** container log every 1–3s and rewrote the whole `<pre>`, so a large log (bifrost's ran to several MB) made the page lag badly. This replaces the poll with a live WebSocket stream, and extracts the "follow a subprocess for log lines" plumbing so the memory guard shares it.

## Changes
- **`core/process_stream.py`** (new): `stream_process_lines(argv)` — spawns a command and yields stdout line-by-line until EOF, terminating/reaping the child on early exit or shutdown. Errors aren't papered over: EOF is the only normal terminator; a missing binary / read error propagates for the caller to classify.
- **`core/log_stream.py`** (new): build-log tail (Python file-existence guard so a permission error fails loud instead of `tail`'s silent retry) followed by the live container log via `podman logs --follow` through the shared helper.
- **`GET /app_logs_stream/{app_id}`** (WebSocket): inline owner-auth, races client-disconnect + shutdown to reap the follow. The detail page no longer reads the whole log up front.
- **`app-detail.js`**: consume over a WebSocket, appending batched line(s) once per animation frame (bounded + front-trimmed) so the ~2000-line replay renders in linear time instead of O(n²) layout thrash. Reconnect re-primes so the replayed tail replaces (not duplicates) the visible log.
- **`core/memory_guard.py`**: converted onto the same shared helper — its `journalctl` and `podman events` readers are now reconnecting async followers, and the guard runs its own asyncio loop on its daemon thread (separate from the request loop, so its blocking `podman stats`/sqlite work can't stall requests).
- Lower the container-log `max-size` safety net from 10mb to 1mb.

## Tests
New unit coverage for `process_stream`, `log_stream`, the WS route, and the reworked memory guard (44 tests); full `compute_space` suite green (1255 passed / 43 skipped), ruff + mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)