### PR TITLE
Rebrand the drift that landed after the sweep

### DIFF
--- a/compute_space/src/compute_space/core/diagnostics.py
+++ b/compute_space/src/compute_space/core/diagnostics.py
@@ -876,7 +876,7 @@ def _zone_domain(db: sqlite3.Connection) -> str:
 
 
 async def _collect_openhost_git_info() -> GitInfo:
-    """Git checkout state for the running OpenHost install.
+    """Git checkout state for the running Cloud in a Bottle install.
 
     Falls back to an empty-but-stable :class:`GitInfo` when OPENHOST_PROJECT_DIR
     isn't a git checkout (e.g. a tarball deploy) so the field shape is stable for

--- a/compute_space/src/compute_space/web/static/js/system.js
+++ b/compute_space/src/compute_space/web/static/js/system.js
@@ -89,7 +89,8 @@ function toggleStorageGuard(pause) {
 }
 
 // Donut of disk usage: per-app data as coloured slices (largest first), then the
-// rest of the used disk — OS / OpenHost / build cache — as "OS + OpenHost" and
+// rest of the used disk — OS / Cloud in a Bottle / build cache — as
+// "OS + Cloud in a Bottle" and
 // the free space as "Unused", so the ring sums to the whole disk and shows how
 // full the box is. Falls back to app-only proportions if disk totals are absent.
 function renderStorageDonut(data) {
@@ -112,7 +113,7 @@ function renderStorageDonut(data) {
   if (total && disk.free_bytes != null) {
     var free = disk.free_bytes;
     var other = Math.max(0, total - free - appSum);
-    if (other > 0) segments.push({name: 'OS + OpenHost', value: other, valueText: formatBytes(other), color: COLOR_OTHER});
+    if (other > 0) segments.push({name: 'OS + Cloud in a Bottle', value: other, valueText: formatBytes(other), color: COLOR_OTHER});
     segments.push({name: 'Unused', value: free, valueText: formatBytes(free), color: COLOR_UNUSED});
     centerText = formatBytes(total - free) + ' / ' + formatBytes(total);
   } else {


### PR DESCRIPTION
Three occurrences of the old name landed on main after #289 branched, from a diagnostics/system PR.

One is user-visible: the System Info disk donut pushes a segment named 'OS + OpenHost', which renders in the chart legend. The other two are a docstring in diagnostics.py and the comment above the donut code.

Nothing functional changes; the JSON keys behind that chart (openhost_data_used_bytes and friends) are untouched.

Note the pattern rather than just the instance: this will keep happening while the identifiers are still OPENHOST_* / X-OpenHost-* and the product reads naturally as OpenHost in prose. A CI check that flags new display strings would stop the recurrence, but it is hard to express until the identifier freeze lifts.