### PR TITLE
Repoint repo URLs at cloud-in-a-bottle/cloud-in-a-bottle

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,13 +203,13 @@ The user-facing manual lives in `docs/src/` and is served at `https://<zone>/doc
 An agent skill that gives an AI coding agent context for deploying and debugging apps on Cloud in a Bottle via the `oh` CLI. Install with:
 
 ```bash
-npx skills add imbue-openhost/openhost --skill openhost-context
+npx skills add cloud-in-a-bottle/cloud-in-a-bottle --skill openhost-context
 ```
 
 The skill works best with the `oh` CLI installed and logged in:
 
 ```bash
-uv tool install "oh @ git+https://github.com/imbue-openhost/openhost.git#subdirectory=compute_space_cli"
+uv tool install "oh @ git+https://github.com/cloud-in-a-bottle/cloud-in-a-bottle.git#subdirectory=compute_space_cli"
 oh instance login
 ```
 

--- a/ansible/tasks/sync_code.yml
+++ b/ansible/tasks/sync_code.yml
@@ -12,7 +12,7 @@
 
 - name: Clone or update openhost repo
   ansible.builtin.git:
-    repo: https://github.com/imbue-openhost/openhost.git
+    repo: https://github.com/cloud-in-a-bottle/cloud-in-a-bottle.git
     dest: /home/host/openhost
     version: "{{ openhost_branch | default(openhost_commit | default('main'), true) }}"
     refspec: "{{ openhost_refspec | default(omit) }}"

--- a/compute_space/src/compute_space/config.py
+++ b/compute_space/src/compute_space/config.py
@@ -90,7 +90,7 @@ class Config:
     # Each entry is either:
     #   - a bare dirname under apps_dir (vendored builtin, e.g. "secrets_v2"), or
     #   - a remote git URL the router will clone on first boot
-    #     (e.g. "https://github.com/imbue-openhost/app-catalog").
+    #     (e.g. "https://github.com/cloud-in-a-bottle/app-catalog").
     # Remote URLs are dispatched through the same clone path as
     # /api/add_app and do not need to be present on disk ahead of time.
     default_apps: list[str]
@@ -348,12 +348,12 @@ class DefaultConfig(Config):
     #   - a remote git URL cloned on demand (see core/default_apps).
     default_apps: list[str] = attr.Factory(
         lambda: [
-            "https://github.com/imbue-openhost/secrets",
-            "https://github.com/imbue-openhost/bottled-filestash",
+            "https://github.com/cloud-in-a-bottle/secrets",
+            "https://github.com/cloud-in-a-bottle/bottled-filestash",
             "oauth_provider",
-            "https://github.com/imbue-openhost/app-catalog",
-            "https://github.com/imbue-openhost/backup",
-            "https://github.com/imbue-openhost/bottled-community-chat",
+            "https://github.com/cloud-in-a-bottle/app-catalog",
+            "https://github.com/cloud-in-a-bottle/backup",
+            "https://github.com/cloud-in-a-bottle/bottled-community-chat",
         ]
     )
 

--- a/compute_space/src/compute_space/core/default_apps.py
+++ b/compute_space/src/compute_space/core/default_apps.py
@@ -6,7 +6,7 @@ Each entry in ``config.default_apps`` is either:
   ``"file_browser"``) — copied from disk, same as the original
   default-apps behavior.
 - A remote git URL (e.g.
-  ``"https://github.com/imbue-openhost/app-catalog"``) — cloned
+  ``"https://github.com/cloud-in-a-bottle/app-catalog"``) — cloned
   on demand via the same path used by ``/api/add_app``.  The repo
   does not need to be present on disk ahead of time.
 """

--- a/compute_space/src/compute_space/core/system_agent/client.py
+++ b/compute_space/src/compute_space/core/system_agent/client.py
@@ -86,7 +86,7 @@ def _run_system_agent(*args: str, timeout: int = 300) -> str:
                 "\n"
                 "The openhost_system_agent binary is not on sudo's PATH. "
                 "Re-running the ansible deploy against this host will reinstall it — "
-                "see https://github.com/imbue-openhost/openhost/blob/main/ansible/readme.md"
+                "see https://github.com/cloud-in-a-bottle/cloud-in-a-bottle/blob/main/ansible/readme.md"
             )
         raise SystemAgentError(str(error))
 

--- a/compute_space/src/compute_space/core/tls/cert_api_client.py
+++ b/compute_space/src/compute_space/core/tls/cert_api_client.py
@@ -8,7 +8,7 @@ Requests are authenticated with a per-instance bearer token from a TokenProvider
 (Keycloak client-credentials in production); the header is set per-request so a
 token can refresh mid-flow during the long finalize-poll loop.
 
-See the broker contract: github.com/imbue-openhost/openhost-cert-api.
+See the broker contract: github.com/cloud-in-a-bottle/cert-api.
 """
 
 from __future__ import annotations

--- a/compute_space/src/compute_space/tests/test_add_app_page.py
+++ b/compute_space/src/compute_space/tests/test_add_app_page.py
@@ -92,5 +92,5 @@ def test_callout_offers_install_when_catalog_missing(cfg: Any) -> None:
     assert resp.status_code == 200
     assert "Explore the App Catalog" in resp.text
     assert "Install the catalog" in resp.text
-    assert "https://github.com/imbue-openhost/app-catalog" in resp.text
+    assert "https://github.com/cloud-in-a-bottle/app-catalog" in resp.text
     assert f"http://catalog.{primary_of(cfg).name}/" not in resp.text

--- a/compute_space/src/compute_space/tests/test_default_apps.py
+++ b/compute_space/src/compute_space/tests/test_default_apps.py
@@ -208,7 +208,7 @@ def test_remote_url_entry_dispatches_to_clone_path(cfg_with_apps, monkeypatch):
     monkeypatch.setattr(da, "clone_and_read_manifest", fake_clone)
 
     # Replace the config's default_apps with a single remote URL entry.
-    cfg = cfg_with_apps.evolve(default_apps=["https://github.com/imbue-openhost/app-catalog"])
+    cfg = cfg_with_apps.evolve(default_apps=["https://github.com/cloud-in-a-bottle/app-catalog"])
 
     db = sqlite3.connect(cfg.db_path)
     try:
@@ -216,15 +216,15 @@ def test_remote_url_entry_dispatches_to_clone_path(cfg_with_apps, monkeypatch):
     finally:
         db.close()
 
-    assert calls == ["https://github.com/imbue-openhost/app-catalog"]
+    assert calls == ["https://github.com/cloud-in-a-bottle/app-catalog"]
     assert len(result) == 1
     assert result[0].status == "ok"
-    assert result[0].name == "https://github.com/imbue-openhost/app-catalog"
+    assert result[0].name == "https://github.com/cloud-in-a-bottle/app-catalog"
 
     # The sentinel keys on the spec string (the URL), not the manifest name.
     with open(cfg.default_apps_sentinel_path) as f:
         sentinel = json.load(f)
-    assert "https://github.com/imbue-openhost/app-catalog" in sentinel
+    assert "https://github.com/cloud-in-a-bottle/app-catalog" in sentinel
 
 
 def test_remote_url_clone_failure_is_retried(cfg_with_apps, monkeypatch):

--- a/compute_space/src/compute_space/tests/test_installer.py
+++ b/compute_space/src/compute_space/tests/test_installer.py
@@ -26,16 +26,16 @@ class TestCheckInstallAllowed:
         grants = [
             {
                 GRANT_KEY_CAPABILITY: INSTALL_CAPABILITY,
-                GRANT_KEY_REPO_URL_PREFIX: "https://github.com/imbue-openhost/",
+                GRANT_KEY_REPO_URL_PREFIX: "https://github.com/cloud-in-a-bottle/",
             },
         ]
-        assert check_install_allowed("https://github.com/imbue-openhost/app-catalog", grants) is None
+        assert check_install_allowed("https://github.com/cloud-in-a-bottle/app-catalog", grants) is None
 
     def test_non_matching_prefix_denied(self) -> None:
         grants = [
             {
                 GRANT_KEY_CAPABILITY: INSTALL_CAPABILITY,
-                GRANT_KEY_REPO_URL_PREFIX: "https://github.com/imbue-openhost/",
+                GRANT_KEY_REPO_URL_PREFIX: "https://github.com/cloud-in-a-bottle/",
             },
         ]
         assert check_install_allowed("https://github.com/evil/badapp", grants) is not None
@@ -68,10 +68,10 @@ class TestCheckInstallAllowed:
             {GRANT_KEY_CAPABILITY: "noop", GRANT_KEY_REPO_URL_PREFIX: "*"},
             {
                 GRANT_KEY_CAPABILITY: INSTALL_CAPABILITY,
-                GRANT_KEY_REPO_URL_PREFIX: "https://github.com/imbue-openhost/",
+                GRANT_KEY_REPO_URL_PREFIX: "https://github.com/cloud-in-a-bottle/",
             },
         ]
-        assert check_install_allowed("https://github.com/imbue-openhost/app-catalog", grants) is None
+        assert check_install_allowed("https://github.com/cloud-in-a-bottle/app-catalog", grants) is None
         assert check_install_allowed("https://github.com/other/", grants) is not None
 
     def test_service_url_constant_is_stable(self) -> None:

--- a/compute_space/src/compute_space/tests/test_installer_route.py
+++ b/compute_space/src/compute_space/tests/test_installer_route.py
@@ -146,7 +146,7 @@ def test_install_without_grant_returns_permission_required(client: TestClient[Li
     resp = client.post(
         _url("install"),
         headers=_headers(),
-        content=json.dumps({"repo_url": "https://github.com/imbue-openhost/app-catalog"}),
+        content=json.dumps({"repo_url": "https://github.com/cloud-in-a-bottle/app-catalog"}),
     )
     assert resp.status_code == 403
     body = resp.json()
@@ -159,7 +159,7 @@ def test_install_without_grant_returns_permission_required(client: TestClient[Li
 
 
 def test_install_with_non_matching_grant_denied(client: TestClient[Litestar], cfg: Any) -> None:
-    _grant_installer(cfg.db_path, CALLER_APP_ID, repo_url_prefix="https://github.com/imbue-openhost/")
+    _grant_installer(cfg.db_path, CALLER_APP_ID, repo_url_prefix="https://github.com/cloud-in-a-bottle/")
     resp = client.post(
         _url("install"),
         headers=_headers(),
@@ -188,7 +188,7 @@ port = 8080
 service = "github.com/imbue-openhost/openhost/services/installer"
 shortname = "installer"
 version = ">=0.1.0"
-grants = [{capability = "install", repo_url_prefix = "https://github.com/imbue-openhost/"}]
+grants = [{capability = "install", repo_url_prefix = "https://github.com/cloud-in-a-bottle/"}]
 """
 
 
@@ -207,13 +207,13 @@ def test_proposed_grant_uses_manifest_declared_prefix(cfg: Any) -> None:
         resp = client.post(
             _url("install"),
             headers={"Authorization": f"Bearer {NARROW_CALLER_TOKEN}", "Content-Type": "application/json"},
-            content=json.dumps({"repo_url": "https://github.com/imbue-openhost/bottled-gemini"}),
+            content=json.dumps({"repo_url": "https://github.com/cloud-in-a-bottle/bottled-gemini"}),
         )
     assert resp.status_code == 403
     body = resp.json()
     assert body["required_grant"]["grant"] == {
         "capability": "install",
-        "repo_url_prefix": "https://github.com/imbue-openhost/",
+        "repo_url_prefix": "https://github.com/cloud-in-a-bottle/",
     }
 
 

--- a/compute_space/src/compute_space/tests/test_source_link.py
+++ b/compute_space/src/compute_space/tests/test_source_link.py
@@ -39,9 +39,9 @@ from .conftest import _make_test_config
     [
         # HTTPS clone URL, with and without the .git suffix.
         (
-            "https://github.com/imbue-openhost/openhost.git",
+            "https://github.com/cloud-in-a-bottle/cloud-in-a-bottle.git",
             "main",
-            "https://github.com/imbue-openhost/openhost/tree/main",
+            "https://github.com/cloud-in-a-bottle/cloud-in-a-bottle/tree/main",
         ),
         ("https://github.com/owner/repo", "dev", "https://github.com/owner/repo/tree/dev"),
         # SCP-style SSH shorthand.

--- a/compute_space/src/compute_space/web/routes/pages/apps.py
+++ b/compute_space/src/compute_space/web/routes/pages/apps.py
@@ -30,13 +30,13 @@ from compute_space.core.services_v2 import resolve_provider
 from compute_space.web.auth.auth import require_owner_auth
 from compute_space.web.helpers.zone import zone_for_request
 
-EDIT_APP_SERVICE_URL = "github.com/imbue-openhost/claude-code-container/services/open-workspace"
+EDIT_APP_SERVICE_URL = "github.com/cloud-in-a-bottle/claude-code-container/services/open-workspace"
 EDIT_APP_VERSION_SPEC = "<1.0"
 
 # The app catalog ships as a default app (see Config.default_apps); the Deploy
 # page links to it when installed and offers to install it otherwise.
 CATALOG_APP_NAME = "catalog"
-CATALOG_REPO_URL = "https://github.com/imbue-openhost/app-catalog"
+CATALOG_REPO_URL = "https://github.com/cloud-in-a-bottle/app-catalog"
 
 
 @get(["/", "/dashboard"], guards=[require_owner_auth])
@@ -129,7 +129,7 @@ async def _resolve_edit_app(
     Returns one of:
       - ``{"mode": "service", "action": ..., "repo": ..., "ref": ...}`` — POST to
         a provider of the open-workspace service (see
-        github.com/imbue-openhost/claude-code-container/services/open-workspace).
+        github.com/cloud-in-a-bottle/claude-code-container/services/open-workspace).
       - ``{"mode": "repo", "href": ...}`` — fallback link to the repo URL.
       - ``None`` — no actionable URL available.
     """

--- a/compute_space_cli/README.md
+++ b/compute_space_cli/README.md
@@ -6,11 +6,11 @@ Command-line tool for managing apps on your Cloud in a Bottle compute space.
 
 HTTPS:
 ```bash
-uv tool install "oh @ git+https://github.com/imbue-openhost/openhost.git#subdirectory=compute_space_cli"
+uv tool install "oh @ git+https://github.com/cloud-in-a-bottle/cloud-in-a-bottle.git#subdirectory=compute_space_cli"
 ```
 SSH:
 ```bash
-uv tool install "oh @ git+ssh://git@github.com/imbue-openhost/openhost.git#subdirectory=compute_space_cli"
+uv tool install "oh @ git+ssh://git@github.com/cloud-in-a-bottle/cloud-in-a-bottle.git#subdirectory=compute_space_cli"
 ```
 
 ## Setup

--- a/docs/book.toml
+++ b/docs/book.toml
@@ -6,8 +6,8 @@ src = "src"
 language = "en"
 
 [output.html]
-git-repository-url = "https://github.com/imbue-openhost/openhost"
-edit-url-template = "https://github.com/imbue-openhost/openhost/edit/main/docs/{path}"
+git-repository-url = "https://github.com/cloud-in-a-bottle/cloud-in-a-bottle"
+edit-url-template = "https://github.com/cloud-in-a-bottle/cloud-in-a-bottle/edit/main/docs/{path}"
 default-theme = "rust"
 
 [output.html.search]

--- a/docs/src/creating_an_app.md
+++ b/docs/src/creating_an_app.md
@@ -17,7 +17,7 @@ An `openhost.toml` manifest must be placed at the root of your repo, to indicate
 
 ## App template
 
-Cloud in a Bottle has a standard app template available as a starting point: [https://github.com/imbue-openhost/app-template](https://github.com/imbue-openhost/app-template)
+Cloud in a Bottle has a standard app template available as a starting point: [https://github.com/cloud-in-a-bottle/app-template](https://github.com/cloud-in-a-bottle/app-template)
 
 This repo contains a Python 3.12 server using Litestar and Hypercorn, managed with uv. It includes pre-commit hooks (ruff formatting, mypy strict type checking), and an integration test suite using pytest, httpx, and Playwright. Tests run both locally and as a full containerized app, building the Dockerfile and fronting it with the real Cloud in a Bottle router. 
 
@@ -167,7 +167,7 @@ In general, the debugging flow is something like:
 6. Retest and repeat
 
 We find AI tools work best when they can directly reference Cloud in a Bottle code+docs. So we'd suggest:
-```cd some_dir && git clone https://github.com/imbue-openhost/openhost.git```
+```cd some_dir && git clone https://github.com/cloud-in-a-bottle/cloud-in-a-bottle.git```
 then point them at that checkout and tell them to read this doc.
 
 ## CLI
@@ -182,7 +182,7 @@ this will automatically get updates if you pull new changes from the openhost re
 
 or if not,
 ```bash
-uv tool install "oh @ git+https://github.com/imbue-openhost/openhost.git#subdirectory=compute_space_cli"
+uv tool install "oh @ git+https://github.com/cloud-in-a-bottle/cloud-in-a-bottle.git#subdirectory=compute_space_cli"
 ```
 Run `oh instance login` to login to your compute space.
 

--- a/docs/src/deploying.md
+++ b/docs/src/deploying.md
@@ -1,7 +1,7 @@
 # Running Cloud in a Bottle in a local QEMU VM
 
 > The authoritative deployment reference is
-> **[`ansible/readme.md`](https://github.com/imbue-openhost/openhost/blob/main/ansible/readme.md)**
+> **[`ansible/readme.md`](https://github.com/cloud-in-a-bottle/cloud-in-a-bottle/blob/main/ansible/readme.md)**
 > and `ansible/setup.yml`; this guide walks the local-VM path end to end.
 >
 > Upstream docs for the tools used here:
@@ -188,7 +188,7 @@ still running.
 uv tool install ansible-core        # or: pipx install ansible-core
 
 # A checkout of this repo (skip if you already have $OPENHOST_REPO)
-git clone https://github.com/imbue-openhost/openhost.git "$OPENHOST_REPO"
+git clone https://github.com/cloud-in-a-bottle/cloud-in-a-bottle.git "$OPENHOST_REPO"
 ```
 
 ### 2. Run the playbook (HTTP-only)
@@ -288,4 +288,4 @@ over SSH as `root`) and turning on TLS by dropping `local_http_only`:
 
 Your instance comes up at `https://host.example.com/`. Full options and the
 authoritative reference are in
-**[`ansible/readme.md`](https://github.com/imbue-openhost/openhost/blob/main/ansible/readme.md)**.
+**[`ansible/readme.md`](https://github.com/cloud-in-a-bottle/cloud-in-a-bottle/blob/main/ansible/readme.md)**.

--- a/docs/src/introduction.md
+++ b/docs/src/introduction.md
@@ -32,7 +32,7 @@ to know which knob in `openhost.toml` controls what, jump to the
 ## How this manual is built and shipped
 
 The Markdown source for this manual lives in `docs/src/` in the
-[imbue-openhost/openhost](https://github.com/imbue-openhost/openhost)
+[cloud-in-a-bottle/cloud-in-a-bottle](https://github.com/cloud-in-a-bottle/cloud-in-a-bottle)
 repository.  The pages are rendered server-side on every request
 (with an mtime-keyed cache), so a `git pull` on the zone is enough
 to ship doc changes — no build step required.  When you're reading
@@ -59,5 +59,5 @@ Manual** in the sidebar copies the whole thing.
 ## Improving the docs
 
 PRs against `docs/src/*.md` in the
-[openhost repo](https://github.com/imbue-openhost/openhost)
+[openhost repo](https://github.com/cloud-in-a-bottle/cloud-in-a-bottle)
 are welcome.

--- a/openhost_app_test_harness/readme.md
+++ b/openhost_app_test_harness/readme.md
@@ -11,7 +11,7 @@ v2 service interface behave exactly as on a real server.
 ```toml
 [dependency-groups]
 dev = [
-    "openhost[test-harness] @ git+https://github.com/imbue-openhost/openhost@main",
+    "openhost[test-harness] @ git+https://github.com/cloud-in-a-bottle/cloud-in-a-bottle@main",
 ]
 ```
 
@@ -98,7 +98,7 @@ Deploy a real provider next to it and grant permissions:
 
 ```python
 def test_my_app_reads_secrets(stack):
-    stack.deploy_app("https://github.com/imbue-openhost/secrets")
+    stack.deploy_app("https://github.com/cloud-in-a-bottle/secrets")
     stack.grant(stack.app_id, "github.com/imbue-openhost/openhost/services/secrets", {"key": "DB_URL"})
     ...  # exercise your app; its service calls go through the real router proxy
 ```
@@ -114,7 +114,7 @@ server before installing the app:
 
 ```python
 def _seed(s: OpenhostStack) -> None:
-    s.deploy_app("https://github.com/imbue-openhost/secrets")
+    s.deploy_app("https://github.com/cloud-in-a-bottle/secrets")
     s.owner_session.post(f"{s.url_for('secrets')}/api/secrets", json={"key": "DB_URL", "value": "..."})
 
 @pytest.fixture(scope="session")

--- a/openhost_system_agent/src/openhost_system_agent/migrations/README.md
+++ b/openhost_system_agent/src/openhost_system_agent/migrations/README.md
@@ -74,7 +74,7 @@ step through tags that are ancestors of the pinned target. Without both, a targe
 ## Pinning to a target ref
 
 By default the destination is the latest release tag. To pin a host to a specific branch or commit, append `@<ref>` to
-the remote URL (e.g. via `update set_remote` or the dashboard): `https://github.com/imbue-openhost/openhost@my-branch`.
+the remote URL (e.g. via `update set_remote` or the dashboard): `https://github.com/cloud-in-a-bottle/cloud-in-a-bottle@my-branch`.
 This persists `openhost.target-ref` in git config. Updates then walk the release tags the target contains as stepping
 stones and end on the target's tip instead of the latest tag. Passing a URL with no `@<ref>` clears the pin and
 restores latest-tag behavior.

--- a/scripts/provision.sh
+++ b/scripts/provision.sh
@@ -2,7 +2,7 @@
 # provision.sh — Bootstrap a fresh Ubuntu 24.04 server into a running Cloud in a Bottle instance.
 #
 # Usage (run as root on the target server):
-#   curl -fsSL https://raw.githubusercontent.com/imbue-openhost/openhost/main/scripts/provision.sh | bash -s -- --domain myhost.example.com
+#   curl -fsSL https://raw.githubusercontent.com/cloud-in-a-bottle/cloud-in-a-bottle/main/scripts/provision.sh | bash -s -- --domain myhost.example.com
 #
 # Prerequisites:
 #   - Fresh Ubuntu 24.04 server with root access
@@ -22,7 +22,7 @@ set -euo pipefail
 
 DOMAIN=""
 BRANCH="main"
-REPO_URL="https://github.com/imbue-openhost/openhost.git"
+REPO_URL="https://github.com/cloud-in-a-bottle/cloud-in-a-bottle.git"
 OPENHOST_DIR="/home/host/openhost"
 LOCAL_HTTP_ONLY="false"
 
@@ -33,7 +33,7 @@ usage() {
     echo "                      In --local-http-only mode this is only used for app"
     echo "                      subdomain routing (e.g. lvh.me), not TLS/DNS."
     echo "  --branch            Git branch to deploy (default: main)"
-    echo "  --repo              Git repo URL (default: imbue-openhost/openhost)"
+    echo "  --repo              Git repo URL (default: cloud-in-a-bottle/cloud-in-a-bottle)"
     echo "  --local-http-only   HTTP-only localhost mode: no TLS, CoreDNS, or Caddy."
     echo "                      For bringing an instance up before a public domain +"
     echo "                      DNS are ready.  Reach it via an SSH tunnel to :8080."

--- a/skills/deployment/SKILL.md
+++ b/skills/deployment/SKILL.md
@@ -30,7 +30,7 @@ This delegates `*.host.example.com` to the CoreDNS instance that Cloud in a Bott
 SSH into the server as root and run:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/imbue-openhost/openhost/main/scripts/provision.sh | bash -s -- --domain host.example.com
+curl -fsSL https://raw.githubusercontent.com/cloud-in-a-bottle/cloud-in-a-bottle/main/scripts/provision.sh | bash -s -- --domain host.example.com
 ```
 
 Optional flags:

--- a/skills/openhost-context/SKILL.md
+++ b/skills/openhost-context/SKILL.md
@@ -17,7 +17,7 @@ Prefer `oh` over raw HTTP requests so you never have to handle tokens by hand.
 If `oh` isn't installed:
 
 ```bash
-uv tool install "oh @ git+https://github.com/imbue-openhost/openhost.git#subdirectory=compute_space_cli"
+uv tool install "oh @ git+https://github.com/cloud-in-a-bottle/cloud-in-a-bottle.git#subdirectory=compute_space_cli"
 ```
 
 Then the **user** logs in (this is interactive — ask them to run it):
@@ -104,7 +104,7 @@ Other app commands: `oh app status|list|stop|rename|remove`. Run
 Start from the template and build on top of it:
 
 ```
-github.com/imbue-openhost/app-template
+github.com/cloud-in-a-bottle/app-template
 ```
 
 An app is any OCI container reachable over HTTP. It needs an `openhost.toml`
@@ -117,11 +117,11 @@ contract, injected env vars, data storage, auth, cross-app services):
 - Read the manual on your own zone at `https://<zone-domain>/docs/` — it
   always matches the Cloud in a Bottle version you're running.
 - Or read the source docs at
-  `github.com/imbue-openhost/openhost/tree/main/docs/src` (start with
+  `github.com/cloud-in-a-bottle/cloud-in-a-bottle/tree/main/docs/src` (start with
   `creating_an_app.md` and `manifest_spec.md`).
-- You can also always clone `github.com/imbue-openhost/openhost
+- You can also always clone `github.com/cloud-in-a-bottle/cloud-in-a-bottle
 
 To reference Cloud in a Bottle's code and docs directly, you can always just clone the openhost repo locally:
 ```bash
-git clone https://github.com/imbue-openhost/openhost.git
+git clone https://github.com/cloud-in-a-bottle/cloud-in-a-bottle.git
 ```

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -721,7 +721,7 @@ class TestSelfHost:
         """Deploy MinIO from its public GitHub repo."""
         r = session.post(
             f"{router_url}/api/add_app",
-            json={"repo_url": "https://github.com/imbue-openhost/bottled-minio"},
+            json={"repo_url": "https://github.com/cloud-in-a-bottle/bottled-minio"},
             timeout=120,
         )
         assert r.status_code == 200, f"add_app minio failed: {r.status_code}: {r.text[:500]}"

--- a/tests/test_services_e2e.py
+++ b/tests/test_services_e2e.py
@@ -27,7 +27,7 @@ from compute_space.tests.utils import managed_router
 
 ROUTER_PORT = 28180
 
-SECRETS_REPO_URL = "https://github.com/imbue-openhost/secrets"
+SECRETS_REPO_URL = "https://github.com/cloud-in-a-bottle/secrets"
 SECRETS_SERVICE_URL = "github.com/imbue-openhost/openhost/services/secrets"
 TEST_APP_REPO_URL = f"file://{OPENHOST_PROJECT_DIR / 'apps' / 'test_app'}"
 


### PR DESCRIPTION
Follow-up to the org rename (imbue-openhost -> cloud-in-a-bottle) and this repo's rename (openhost -> cloud-in-a-bottle).