### PR TITLE
Retire the org-rename rewrite, leaving an inert no-op

### DIFF
--- a/compute_space/src/compute_space/core/org_rename.py
+++ b/compute_space/src/compute_space/core/org_rename.py
@@ -1,195 +1,48 @@
-"""Move persisted GitHub owner references off the old org onto the new one.
+"""Retired: the org-rename reconcile.
 
-An instance stores the URL it installed each app from in ``apps.repo_url``, and
-the app's checkout carries the same URL as its git ``origin``.  Both outlive the
-install, so after the GitHub org is renamed every deployed instance keeps
-fetching through the old owner name.
+This module used to rewrite persisted app repo URLs (``apps.repo_url`` and the
+matching git ``origin``) whenever the GitHub owner changed.  It was built for one
+threat: GitHub releases an organization's old name when you rename it, and per
+GitHub's documentation whoever claims that name can create repositories that
+override the redirect entries.  An instance still pointing at the old owner would
+then fetch and build someone else's code.
 
-That works -- GitHub redirects a renamed owner for both git and the API -- but
-only until someone claims the freed-up name.  GitHub releases the old
-organization name for anyone to register, and per GitHub's documentation the new
-holder "can create repositories that override the redirect entries".  An
-instance that still points at the old owner would then fetch an attacker's
-repository and build it, so the redirect is a migration window, not a
-destination.
+That threat is closed.  ``imbue-openhost`` is now held by us as an empty
+organization, so nobody else can take it, and holding a name does not break its
+redirects -- only creating a colliding repository does.  Every path an instance
+can be holding still resolves, including multi-hop chains such as
+``imbue-openhost/openhost-catalog`` (old owner plus two subsequent repo renames).
 
-Hence this reconcile.  It runs on every boot rather than as a one-shot versioned
-migration so that it can land inert (see ``ORG_RENAME_COMPLETE``) and start
-working on whichever release an owner eventually installs.  It is idempotent, and
-it never raises: a boot must not fail because a rewrite did not apply.
+The reconcile could never have protected the instances that mattered in any case.
+Updates are owner-initiated -- the only triggers are ``POST /api/settings/update``
+behind owner auth and the ``openhost update`` CLI, with nothing scheduling either
+-- so it only ever ran on instances whose owners actively update, which is exactly
+the population least at risk.  What remained was cosmetic: making a stored URL
+match the current repo path.  That is not worth code which mutates persisted
+state and git remotes on every boot across the fleet, particularly given the
+rewrite had a correctness bug: it moved only the owner segment, so a stored
+``imbue-openhost/openhost-nextcloud`` (any instance that installed before the repo
+renames) would have become ``cloud-in-a-bottle/openhost-nextcloud``, which does
+not exist -- breaking the very updates it was meant to protect.
 
-What this reconcile is NOT is a guarantee.  Updates are owner-initiated -- the
-only triggers are ``POST /api/settings/update`` behind owner auth and the
-``openhost update`` CLI, and nothing schedules them -- so an instance can sit on
-pre-rename code indefinitely and never run this code at all.  Any instance that
-never updates keeps resolving through the owner redirect forever.
-
-That means the redirect, not this reconcile, is what protects the long tail, so
-the old organization name must stay in our hands.  The plan is to re-register
-``imbue-openhost`` immediately after the rename and hold it empty.  Holding the
-name does not break the redirects -- only creating a repository that collides with
-one does -- so a never-updating instance keeps resolving indefinitely.  Precedent:
-``dotcloud`` and ``elasticsearch`` both still exist with zero public repos while
-their redirects still resolve.
-
-The load-bearing assumption is therefore that we win that re-registration.  If we
-ever lose it, instances still on the old owner would fetch and build whatever the
-new holder publishes, so treat the gap between renaming and re-registering as an
-incident window: have the placeholder ready before renaming.
-
-This reconcile is hygiene on top of that: it moves the instances that do update
-off the old namespace, so the redirect stops being load-bearing for them.
-
-Sequencing matters, and is why the owner name and the decision to act on it are
-separate constants.  ``NEW_ORG`` is settled data; ``ORG_RENAME_COMPLETE`` is the
-switch.  Rewriting before the org is actually renamed would point instances at
-an owner that does not exist yet, which is strictly worse than the redirect
-dependency it is meant to remove.  Flip ``ORG_RENAME_COMPLETE`` only in the
-release that ships with (or after) the rename.
+``reconcile_app_repo_urls`` is kept as an explicit no-op only because
+``web/app.py`` still calls it, and that file is CODEOWNERS-gated.  Removing the
+call and deleting this module is a small follow-up that needs that review.
 """
 
 import sqlite3
-import urllib.parse
 
-import git
-
-from compute_space.core.git_ops import is_github_repo_url
-from compute_space.core.git_ops import is_ssh_url
-from compute_space.core.logging import logger
-
-# The owner every currently-deployed instance has persisted.
+# The owner that instances installed from before the rename. Retained only so the
+# history above is legible; nothing reads it.
 OLD_ORG = "imbue-openhost"
-
-# The owner to move to.  Decided; the GitHub org has not been renamed yet.
-NEW_ORG = "cloud-in-a-bottle"
-
-# The activation switch, deliberately separate from the name above.  While this
-# is False the reconcile is a total no-op, which is the correct state until the
-# org has actually been renamed: rewriting early would point instances at an
-# owner that does not resolve.  Flip this in the release that ships with (or
-# after) the rename.
-ORG_RENAME_COMPLETE = False
-
-
-def enabled() -> bool:
-    """True when persisted owners should be rewritten.
-
-    Read at call time so flipping ``ORG_RENAME_COMPLETE`` (and patching it in
-    tests) takes effect.
-    """
-    return bool(ORG_RENAME_COMPLETE and NEW_ORG and NEW_ORG != OLD_ORG)
-
-
-def rewrite_owner(repo_url: str, old_org: str | None = None, new_org: str | None = None) -> str | None:
-    """Return ``repo_url`` with its GitHub owner moved ``old_org`` -> ``new_org``.
-
-    ``old_org``/``new_org`` default to the module constants, read at call time
-    rather than bound as default arguments so that flipping ``NEW_ORG`` (and
-    patching it in tests) takes effect.
-
-    Returns None when the URL should be left alone, which covers: the reconcile
-    being disabled (``new_org`` empty), a non-GitHub host, a look-alike host
-    such as ``github.com.evil.example``, an SSH URL, and any owner other than
-    ``old_org``.
-
-    Only the owner segment is touched.  The repository name, any ``@ref``
-    suffix, a ``.git`` suffix, and any query or fragment are preserved --
-    including for a repository whose *name* happens to contain the old owner
-    string.
-    """
-    old_org = OLD_ORG if old_org is None else old_org
-    new_org = NEW_ORG if new_org is None else new_org
-    if not new_org or not old_org or new_org == old_org:
-        return None
-    if not repo_url or is_ssh_url(repo_url):
-        return None
-    if not is_github_repo_url(repo_url):
-        return None
-
-    # Normalise a scheme-less "github.com/owner/repo" so the owner is always
-    # the first path segment, then restore the original shape afterwards.
-    had_scheme = "://" in repo_url
-    parsed = urllib.parse.urlparse(repo_url if had_scheme else "https://" + repo_url)
-    segments = parsed.path.split("/")
-    # path is "/owner/repo..." so segments == ["", owner, repo, ...]
-    if len(segments) < 3 or not segments[1]:
-        return None
-    # GitHub owner names are case-insensitive; compare accordingly but write the
-    # new owner exactly as configured.
-    if segments[1].casefold() != old_org.casefold():
-        return None
-
-    segments[1] = new_org
-    rebuilt = parsed._replace(path="/".join(segments)).geturl()
-    if not had_scheme:
-        rebuilt = rebuilt.removeprefix("https://")
-    return rebuilt if rebuilt != repo_url else None
-
-
-def _reconcile_checkout(repo_path: str, expected_url: str) -> str | None:
-    """Point an app checkout's origin at ``expected_url``.
-
-    Returns a description of what changed, or None if nothing needed doing.
-    Never raises: a missing or broken checkout is not a reason to fail boot,
-    and the DB row is the value that matters for the next clone.
-
-    Uses gitpython directly rather than git_ops.get_remote_url/set_remote_url
-    because those are @async_wrap coroutines and this runs on the sync boot
-    path; bridging an event loop here would buy nothing over four lines of
-    gitpython.
-    """
-    if not repo_path:
-        return None
-    try:
-        repo = git.Repo(repo_path)
-        current = repo.remotes.origin.url
-    except Exception:
-        return None
-    rewritten = rewrite_owner(current)
-    if rewritten is None:
-        return None
-    try:
-        with repo.remotes.origin.config_writer as cw:
-            cw.set("url", rewritten)
-    except Exception as exc:
-        logger.warning("org_rename: could not update origin in %s: %s", repo_path, exc)
-        return None
-    return f"{current} -> {rewritten}"
 
 
 def reconcile_app_repo_urls(db: sqlite3.Connection) -> int:
-    """Rewrite persisted app repo URLs (and their checkouts' origin) to NEW_ORG.
+    """Do nothing, and return zero rows changed.
 
-    Idempotent, and a no-op until ``ORG_RENAME_COMPLETE``.  Returns the number
-    of app rows changed.  Never raises.
+    Persisted URLs under the old owner keep resolving through GitHub's redirects,
+    which are safe now that we hold the old organization name. See the module
+    docstring for why the rewrite was removed rather than fixed.
     """
-    if not enabled():
-        return 0
-
-    changed = 0
-    try:
-        rows = list(db.execute("SELECT app_id, name, repo_url, repo_path FROM apps WHERE repo_url IS NOT NULL"))
-    except Exception as exc:
-        logger.warning("org_rename: could not read apps: %s", exc)
-        return 0
-
-    for row in rows:
-        repo_url = row["repo_url"]
-        rewritten = rewrite_owner(repo_url)
-        if rewritten is None:
-            continue
-        try:
-            db.execute("UPDATE apps SET repo_url = ? WHERE app_id = ?", (rewritten, row["app_id"]))
-            db.commit()
-        except Exception as exc:
-            logger.warning("org_rename: could not update repo_url for %s: %s", row["name"], exc)
-            continue
-        changed += 1
-        logger.info("org_rename: %s repo_url %s -> %s", row["name"], repo_url, rewritten)
-        moved = _reconcile_checkout(row["repo_path"], rewritten)
-        if moved:
-            logger.info("org_rename: %s origin %s", row["name"], moved)
-
-    if changed:
-        logger.info("org_rename: moved %d app(s) from %s to %s", changed, OLD_ORG, NEW_ORG)
-    return changed
+    del db  # unused: intentionally inert
+    return 0

--- a/compute_space/src/compute_space/tests/test_org_rename.py
+++ b/compute_space/src/compute_space/tests/test_org_rename.py
@@ -1,130 +1,22 @@
-"""Tests for moving persisted app repo URLs off a renamed GitHub org.
+"""The org-rename reconcile is retired; this asserts it stays inert.
 
-The rewrite runs against URLs that instances have already stored, so the
-dangerous failure is over-matching: rewriting a URL that points somewhere else
-would silently redirect an app's source to a repository we do not control.
-Most of these cases are therefore about what must *not* change.
+The rewrite was removed rather than fixed, because the threat it addressed is
+closed (we hold the old organization name, so its redirects cannot be hijacked)
+and because it only ever ran on instances whose owners actively update. See
+``core/org_rename`` for the full reasoning.
+
+These tests exist so that nobody reintroduces the rewrite by accident. The
+deleted version had a correctness bug worth remembering: it moved only the owner
+segment, so a stored ``imbue-openhost/openhost-nextcloud`` would have become
+``cloud-in-a-bottle/openhost-nextcloud``, which does not exist. The old-owner path
+resolves; that one does not.
 """
 
 import sqlite3
-from pathlib import Path
-from unittest import mock
 
-import git
 import pytest
 
-from compute_space.core import org_rename
-from compute_space.core.org_rename import OLD_ORG
-from compute_space.core.org_rename import enabled
 from compute_space.core.org_rename import reconcile_app_repo_urls
-from compute_space.core.org_rename import rewrite_owner
-
-NEW = "cloud-in-a-bottle"
-
-
-def _rw(url: str, new_org: str = NEW) -> str | None:
-    return rewrite_owner(url, old_org=OLD_ORG, new_org=new_org)
-
-
-# --- the sequencing guard ------------------------------------------------
-
-
-def test_ships_inert_until_the_rename_is_done() -> None:
-    """The owner name is settled data; acting on it is a separate switch.
-
-    Rewriting before the org is actually renamed would point instances at an
-    owner that does not resolve, which is worse than the redirect dependency
-    this removes. So ORG_RENAME_COMPLETE must ship False.
-    """
-    assert org_rename.ORG_RENAME_COMPLETE is False, "flip this only in the release that ships with the rename"
-    assert enabled() is False
-
-
-def test_reconcile_is_inert_with_the_real_shipped_constants(db: sqlite3.Connection) -> None:
-    """The regression that matters: NEW_ORG is now a real name, so nothing but
-    the switch stands between a released build and a fleet-wide rewrite."""
-    url = f"https://github.com/{OLD_ORG}/bottled-navidrome@master"
-    _insert(db, "a1", "navidrome", url)
-    assert reconcile_app_repo_urls(db) == 0
-    assert _urls(db)["navidrome"] == url
-
-
-def test_rewrite_is_a_no_op_without_a_target() -> None:
-    assert _rw(f"https://github.com/{OLD_ORG}/bottled-navidrome", new_org="") is None
-
-
-def test_no_op_when_new_equals_old() -> None:
-    assert _rw(f"https://github.com/{OLD_ORG}/x", new_org=OLD_ORG) is None
-
-
-# --- what must be rewritten ---------------------------------------------
-
-
-def test_rewrites_the_owner_segment() -> None:
-    assert _rw(f"https://github.com/{OLD_ORG}/bottled-navidrome") == f"https://github.com/{NEW}/bottled-navidrome"
-
-
-def test_preserves_ref_suffix() -> None:
-    """apps.repo_url stores a pip-style @ref; losing it would change the
-    installed revision."""
-    assert (
-        _rw(f"https://github.com/{OLD_ORG}/bottled-navidrome@master")
-        == f"https://github.com/{NEW}/bottled-navidrome@master"
-    )
-
-
-def test_preserves_git_suffix_and_subpaths() -> None:
-    assert _rw(f"https://github.com/{OLD_ORG}/openhost.git") == f"https://github.com/{NEW}/openhost.git"
-    assert _rw(f"https://github.com/{OLD_ORG}/openhost/tree/main") == f"https://github.com/{NEW}/openhost/tree/main"
-
-
-def test_owner_match_is_case_insensitive() -> None:
-    """GitHub owner names are case-insensitive, so a stored Imbue-OpenHost must
-    still be migrated."""
-    assert _rw("https://github.com/Imbue-OpenHost/bottled-lila") == f"https://github.com/{NEW}/bottled-lila"
-
-
-def test_scheme_less_url_keeps_its_shape() -> None:
-    assert _rw(f"github.com/{OLD_ORG}/bottled-lila") == f"github.com/{NEW}/bottled-lila"
-
-
-# --- what must NOT be rewritten -----------------------------------------
-
-
-def test_leaves_other_owners_alone() -> None:
-    assert _rw("https://github.com/imbue-ai/sculptor") is None
-    assert _rw("https://github.com/CarlKho-Minerva/openhost-cap") is None
-
-
-def test_leaves_look_alike_hosts_alone() -> None:
-    """github.com.evil.example is not GitHub; rewriting it would hand an
-    attacker-controlled host our new owner name."""
-    assert _rw(f"https://github.com.evil.example/{OLD_ORG}/x") is None
-    assert _rw(f"https://notgithub.com/{OLD_ORG}/x") is None
-
-
-def test_leaves_other_forges_alone() -> None:
-    assert _rw(f"https://gitlab.com/{OLD_ORG}/x") is None
-
-
-def test_leaves_ssh_urls_alone() -> None:
-    assert _rw(f"git@github.com:{OLD_ORG}/x.git") is None
-    assert _rw(f"ssh://git@github.com/{OLD_ORG}/x.git") is None
-
-
-def test_does_not_touch_a_repo_named_after_the_owner() -> None:
-    """Only the owner segment moves. A repo whose *name* contains the old org
-    keeps its name."""
-    assert _rw(f"https://github.com/{OLD_ORG}/{OLD_ORG}-tools") == f"https://github.com/{NEW}/{OLD_ORG}-tools"
-    assert _rw(f"https://github.com/someone/{OLD_ORG}") is None
-
-
-def test_leaves_local_and_file_urls_alone() -> None:
-    assert _rw("file:///home/host/openhost/apps/oauth_provider") is None
-    assert _rw("") is None
-
-
-# --- the DB reconcile ----------------------------------------------------
 
 
 @pytest.fixture
@@ -137,71 +29,45 @@ def db() -> sqlite3.Connection:
     return conn
 
 
-def _insert(conn: sqlite3.Connection, app_id: str, name: str, url: str | None, path: str = "") -> None:
-    conn.execute("INSERT INTO apps (app_id, name, repo_url, repo_path) VALUES (?, ?, ?, ?)", (app_id, name, url, path))
+def _insert(conn: sqlite3.Connection, app_id: str, name: str, url: str) -> None:
+    conn.execute("INSERT INTO apps (app_id, name, repo_url) VALUES (?, ?, ?)", (app_id, name, url))
     conn.commit()
 
 
-def _urls(conn: sqlite3.Connection) -> dict[str, str | None]:
-    return {r["name"]: r["repo_url"] for r in conn.execute("SELECT name, repo_url FROM apps")}
+def _url(conn: sqlite3.Connection, name: str) -> str:
+    return str(conn.execute("SELECT repo_url FROM apps WHERE name = ?", (name,)).fetchone()[0])
 
 
-def test_reconcile_is_a_no_op_while_the_switch_is_off(db: sqlite3.Connection) -> None:
-    _insert(db, "a1", "navidrome", f"https://github.com/{OLD_ORG}/bottled-navidrome@master")
+def test_leaves_a_pre_rename_owner_alone(db: sqlite3.Connection) -> None:
+    """A URL under the old owner still resolves via redirect, so it must not move."""
+    url = "https://github.com/imbue-openhost/bottled-navidrome@master"
+    _insert(db, "a1", "navidrome", url)
     assert reconcile_app_repo_urls(db) == 0
-    assert _urls(db)["navidrome"] == f"https://github.com/{OLD_ORG}/bottled-navidrome@master"
+    assert _url(db, "navidrome") == url
 
 
-def test_reconcile_rewrites_only_matching_rows(db: sqlite3.Connection) -> None:
-    _insert(db, "a1", "navidrome", f"https://github.com/{OLD_ORG}/bottled-navidrome@master")
-    _insert(db, "a2", "sculptor", "https://github.com/imbue-ai/sculptor")
-    _insert(db, "a3", "oauth-provider", "file:///home/host/openhost/apps/oauth_provider")
-    _insert(db, "a4", "nourl", None)
+def test_leaves_a_pre_rename_repo_name_alone(db: sqlite3.Connection) -> None:
+    """The case the deleted rewrite got wrong.
 
-    with mock.patch.object(org_rename, "ORG_RENAME_COMPLETE", True):
-        assert reconcile_app_repo_urls(db) == 1
-
-    urls = _urls(db)
-    assert urls["navidrome"] == f"https://github.com/{NEW}/bottled-navidrome@master"
-    assert urls["sculptor"] == "https://github.com/imbue-ai/sculptor"
-    assert urls["oauth-provider"] == "file:///home/host/openhost/apps/oauth_provider"
-    assert urls["nourl"] is None
+    imbue-openhost/openhost-nextcloud resolves (old owner, old repo name).
+    Rewriting only the owner would have produced
+    cloud-in-a-bottle/openhost-nextcloud, which does not exist.
+    """
+    url = "https://github.com/imbue-openhost/openhost-nextcloud"
+    _insert(db, "a2", "nextcloud", url)
+    assert reconcile_app_repo_urls(db) == 0
+    assert _url(db, "nextcloud") == url
 
 
-def test_reconcile_is_idempotent(db: sqlite3.Connection) -> None:
-    _insert(db, "a1", "navidrome", f"https://github.com/{OLD_ORG}/bottled-navidrome")
-    with mock.patch.object(org_rename, "ORG_RENAME_COMPLETE", True):
-        assert reconcile_app_repo_urls(db) == 1
-        assert reconcile_app_repo_urls(db) == 0
-    assert _urls(db)["navidrome"] == f"https://github.com/{NEW}/bottled-navidrome"
+def test_leaves_current_urls_alone(db: sqlite3.Connection) -> None:
+    url = "https://github.com/cloud-in-a-bottle/bottled-filestash"
+    _insert(db, "a3", "filestash", url)
+    assert reconcile_app_repo_urls(db) == 0
+    assert _url(db, "filestash") == url
 
 
-def test_reconcile_updates_the_checkout_origin(db: sqlite3.Connection, tmp_path: Path) -> None:
-    """The checkout's origin is what an update actually fetches from, so it has
-    to move with the DB row."""
-    checkout = tmp_path / "repo"
-    checkout.mkdir()
-    repo = git.Repo.init(checkout)
-    repo.create_remote("origin", f"https://github.com/{OLD_ORG}/bottled-navidrome")
-
-    _insert(db, "a1", "navidrome", f"https://github.com/{OLD_ORG}/bottled-navidrome", str(checkout))
-    with mock.patch.object(org_rename, "ORG_RENAME_COMPLETE", True):
-        assert reconcile_app_repo_urls(db) == 1
-
-    assert repo.remotes.origin.url == f"https://github.com/{NEW}/bottled-navidrome"
-
-
-def test_reconcile_survives_a_missing_checkout(db: sqlite3.Connection, tmp_path: Path) -> None:
-    """A broken checkout must not stop the DB rewrite, and must not raise: this
-    runs during boot."""
-    _insert(db, "a1", "navidrome", f"https://github.com/{OLD_ORG}/bottled-navidrome", str(tmp_path / "gone"))
-    with mock.patch.object(org_rename, "ORG_RENAME_COMPLETE", True):
-        assert reconcile_app_repo_urls(db) == 1
-    assert _urls(db)["navidrome"] == f"https://github.com/{NEW}/bottled-navidrome"
-
-
-def test_reconcile_never_raises_on_a_broken_db() -> None:
-    conn = sqlite3.connect(":memory:")
-    conn.row_factory = sqlite3.Row  # no apps table at all
-    with mock.patch.object(org_rename, "ORG_RENAME_COMPLETE", True):
-        assert reconcile_app_repo_urls(conn) == 0
+def test_never_raises_on_a_broken_db() -> None:
+    """It runs during boot, so it must not be able to fail one."""
+    conn = sqlite3.connect(":memory:")  # no apps table at all
+    conn.row_factory = sqlite3.Row
+    assert reconcile_app_repo_urls(conn) == 0


### PR DESCRIPTION
Removes the rewriting logic from core/org_rename and keeps reconcile_app_repo_urls as an explicit no-op. No gated files touched, so this needs no code-owner review.

The rewrite moved only the owner segment. A stored imbue-openhost/openhost-nextcloud (any instance that installed before the repo renames) would have become cloud-in-a-bottle/openhost-nextcloud, which does not exist -- repo-name redirects live under the old owner only. Verified: the old-owner path resolves via git and the API; the rewritten one 404s on both. Enabling it would have broken the app updates it was meant to protect.