### PR TITLE
Roll the design system out across the rest of the compute space

### DIFF
--- a/compute_space/src/compute_space/web/static/css/base.css
+++ b/compute_space/src/compute_space/web/static/css/base.css
@@ -130,32 +130,50 @@ pre {
   font-size: 0.92em;
 }
 
-/* Tables. Wide tables scroll horizontally rather than forcing the page wide;
-   .spec-list is the responsive replacement for key/value tables. */
+/* Tables share the app list's vocabulary: horizontal rules only, so columns are
+   carried by mono alignment rather than a grid of borders. Wide tables scroll
+   inside .table-scroll rather than forcing the page wide; .spec-list is the
+   responsive replacement for key/value tables. */
 table {
   border-collapse: collapse;
   width: 100%;
   margin: var(--space-4) 0;
   background: var(--color-surface);
+  border: var(--border-w) solid var(--color-border);
   font-size: var(--text-xs);
 }
 
 th,
 td {
-  border: var(--border-w) solid var(--color-border);
   padding: var(--space-2) var(--space-4);
+  border-bottom: var(--border-w) solid var(--color-border);
   text-align: left;
   vertical-align: top;
 }
 
+tr:last-child td {
+  border-bottom: 0;
+}
+
 th {
-  font-weight: var(--weight-semibold);
-  background: #f4f4f4;
+  background: var(--color-surface-raised);
+  font-size: var(--text-xs);
+  font-weight: var(--weight-medium);
+  letter-spacing: var(--tracking-label);
+  text-transform: uppercase;
+  white-space: nowrap;
+  opacity: 0.8;
 }
 
 .table-scroll {
+  margin: var(--space-4) 0;
   overflow-x: auto;
   -webkit-overflow-scrolling: touch;
+  box-shadow: var(--shadow-card);
+}
+
+.table-scroll table {
+  margin: 0;
 }
 
 /* Forms */

--- a/compute_space/src/compute_space/web/static/css/components.css
+++ b/compute_space/src/compute_space/web/static/css/components.css
@@ -101,7 +101,9 @@
 }
 
 .section-label {
+  margin: 0;
   font-size: var(--text-xs);
+  font-weight: var(--weight-medium);
   line-height: var(--leading-tight);
   letter-spacing: var(--tracking-label);
   text-transform: uppercase;
@@ -706,4 +708,322 @@ th.sortable:hover {
 .info-tip:hover,
 .info-tip:focus {
   color: var(--color-text);
+}
+
+/* ── Badge ──────────────────────────────────────────────────────────────
+   Square status chip, derived from the "+ NEW" button in the Figma: flat
+   pastel fill, 1px border, uppercase and tracked. Replaces the ad-hoc
+   coloured <span>s the page scripts used to emit. */
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
+  padding: 1px var(--space-2);
+  border: var(--border-w) solid var(--color-border);
+  background: #efefef;
+  color: var(--color-text-subtle);
+  font-size: var(--text-xs);
+  line-height: var(--leading-tight);
+  letter-spacing: var(--tracking-label);
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
+.badge--ok {
+  background: var(--color-accent-alt);
+  border-color: #9fdd7a;
+  color: #1d5c00;
+}
+
+.badge--info {
+  background: var(--color-accent);
+  border-color: #6fbdf0;
+  color: #073b5c;
+}
+
+.badge--warn {
+  background: #fff0c2;
+  border-color: #e8c860;
+  color: #6b4c00;
+}
+
+.badge--error {
+  background: var(--color-danger-bg);
+  border-color: var(--color-danger-border);
+  color: var(--color-danger-text);
+}
+
+/* ── Notices ────────────────────────────────────────────────────────────
+   Same tints as the badges at panel scale, with a 3px bar carrying the
+   status so the message itself stays plain text. */
+
+.notice {
+  padding: var(--space-3) var(--space-4);
+  margin: var(--space-3) 0;
+  background: #e6f2ff;
+  border: var(--border-w) solid #b8d8f5;
+  border-left-width: 3px;
+  font-size: var(--text-xs);
+}
+
+.notice--ok {
+  background: #f2ffe9;
+  border-color: #9fdd7a;
+}
+
+.notice--warn {
+  background: #fff8e6;
+  border-color: #e8c860;
+}
+
+.notice--error {
+  background: var(--color-danger-bg);
+  border-color: var(--color-danger-border);
+  color: var(--color-danger-text);
+}
+
+/* ── Meter ──────────────────────────────────────────────────────────────
+   Blocky progress bar. The segmented fill echoes the pixel-art clouds and
+   grass rather than reading as a smooth modern progress bar. */
+
+.meter {
+  height: 12px;
+  margin: var(--space-2) 0;
+  background: var(--color-surface-raised);
+  border: var(--border-w) solid var(--color-border);
+  overflow: hidden;
+}
+
+.meter__fill {
+  height: 100%;
+  background: repeating-linear-gradient(to right,
+    var(--color-accent) 0 10px, transparent 10px 14px);
+}
+
+.meter__fill--ok { background: repeating-linear-gradient(to right, var(--color-status-running) 0 10px, transparent 10px 14px); }
+.meter__fill--warn { background: repeating-linear-gradient(to right, var(--color-status-pending) 0 10px, transparent 10px 14px); }
+.meter__fill--error { background: repeating-linear-gradient(to right, var(--color-status-error) 0 10px, transparent 10px 14px); }
+
+/* ── Form controls ──────────────────────────────────────────────────────
+   Native checkboxes and selects arrive rounded and OS-tinted, which fights
+   the sharp-cornered flat treatment everywhere else. */
+
+input[type="checkbox"],
+input[type="radio"] {
+  appearance: none;
+  width: 14px;
+  height: 14px;
+  margin: 0;
+  flex: none;
+  background: var(--color-surface-raised);
+  border: var(--border-w) solid var(--color-border-strong);
+  display: inline-grid;
+  place-content: center;
+  cursor: pointer;
+}
+
+input[type="checkbox"]:checked,
+input[type="radio"]:checked {
+  background: var(--color-accent);
+  border-color: #6fbdf0;
+}
+
+input[type="checkbox"]:checked::before {
+  content: "";
+  width: 6px;
+  height: 6px;
+  background: var(--color-text);
+}
+
+input[type="radio"]:checked::before {
+  content: "";
+  width: 4px;
+  height: 4px;
+  background: var(--color-text);
+}
+
+select {
+  appearance: none;
+  padding-right: var(--space-6);
+  background-image: linear-gradient(45deg, transparent 50%, var(--color-text) 50%),
+                    linear-gradient(135deg, var(--color-text) 50%, transparent 50%);
+  background-position: right 12px top 55%, right 7px top 55%;
+  background-size: 5px 5px, 5px 5px;
+  background-repeat: no-repeat;
+}
+
+/* ── Field rows ─────────────────────────────────────────────────────────
+   .field stacks a tracked uppercase label over its control; .field-row is
+   the inline variant used by the "add domain" / "create token" bars. */
+
+.field-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-end;
+  gap: var(--space-3);
+  margin: var(--space-4) 0;
+}
+
+.field-row .field {
+  flex: 0 1 auto;
+  margin-bottom: 0;
+}
+
+/* Inputs default to width:100%, which in a field-row consumed the whole line
+   and pushed the adjacent button onto its own row. */
+.field-row > input,
+.field-row > select {
+  flex: 1 1 16rem;
+  width: auto;
+  min-width: 0;
+  max-width: 26rem;
+}
+
+.field > input,
+.field > select,
+.field > .field-row {
+  max-width: 32rem;
+}
+
+.field--check {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  font-size: var(--text-xs);
+}
+
+.field--check > span {
+  margin: 0;
+  letter-spacing: normal;
+  text-transform: none;
+  opacity: 1;
+}
+
+/* ── Copyable value ─────────────────────────────────────────────────────
+   One-time secrets (API tokens) shown for copying. */
+
+.copy-field {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--space-2);
+  margin-top: var(--space-2);
+}
+
+.copy-field code {
+  flex: 1 1 20rem;
+  min-width: 0;
+  padding: var(--space-1) var(--space-2);
+  background: var(--color-surface-raised);
+  border: var(--border-w) solid var(--color-border);
+  user-select: all;
+  word-break: break-all;
+}
+
+/* ── Charts (system info) ───────────────────────────────────────────────
+   Donuts stay for multi-segment breakdowns, where proportion between parts
+   is the point; single values use .meter instead. Flat fills, no gradients. */
+
+.chart-legend {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: var(--space-1) var(--space-3);
+  margin-top: var(--space-2);
+  font-size: var(--text-xs);
+}
+
+.chart-legend__swatch {
+  display: inline-block;
+  width: 8px;
+  height: 8px;
+  margin-right: var(--space-1);
+}
+
+/* ── Log list (update progress) ─────────────────────────────────────────── */
+
+.log-list {
+  margin: 0;
+  padding: var(--space-3);
+  list-style: none;
+  background: #1e1e1e;
+  color: #d4d4d4;
+  font-size: var(--text-xs);
+  max-height: 30em;
+  overflow-y: auto;
+}
+
+.log-list li {
+  display: flex;
+  gap: var(--space-3);
+  padding: 1px 0;
+}
+
+.log-list .ts {
+  flex: none;
+  color: #7f7f7f;
+}
+
+.is-expired td {
+  color: var(--color-text-muted);
+}
+
+/* ── Inline status messages ─────────────────────────────────────────────
+   The one-line feedback beside a control. Page scripts used to set a raw
+   hex on style.color for these; they set a variant class now. */
+
+.msg {
+  font-size: var(--text-xs);
+}
+
+.msg--ok { color: #1d5c00; }
+.msg--warn { color: #6b4c00; }
+.msg--error { color: var(--color-danger-text); }
+
+/* Key/value form tables keep a plain label column -- the uppercase tracked
+   treatment on `th` is for data tables, where the header names a column. */
+table.form-table th {
+  background: var(--color-surface-raised);
+  letter-spacing: normal;
+  text-transform: none;
+  opacity: 1;
+}
+
+.rule {
+  height: 0;
+  margin: var(--space-5) 0;
+  border: 0;
+  border-top: var(--border-w) solid var(--color-border);
+}
+
+.panel .field:last-child {
+  margin-bottom: 0;
+}
+
+.log-output--tall {
+  max-height: 120em;
+  white-space: pre-wrap;
+  word-break: break-all;
+}
+
+/* ── Terminal ───────────────────────────────────────────────────────────
+   Breaks out of the content column to the full viewport width; sharp
+   corners, matching the log-output surface. */
+
+.terminal-frame {
+  width: calc(100vw - 2 * var(--layout-gutter));
+  margin-left: calc((100% - 100vw) / 2 + var(--layout-gutter));
+  height: calc(100vh - 220px);
+  min-height: 20em;
+  padding: var(--space-2);
+  background: #1e1e1e;
+  border: var(--border-w) solid var(--color-border);
+  box-shadow: var(--shadow-card);
+  overflow: hidden;
+}
+
+.terminal-frame > #terminal {
+  width: 100%;
+  height: 100%;
 }

--- a/compute_space/src/compute_space/web/static/css/update-progress.css
+++ b/compute_space/src/compute_space/web/static/css/update-progress.css
@@ -1,11 +1,98 @@
-/* Shared by the compute_space /updating template and the updater's inline page. */
-body { font-family: -apple-system, system-ui, sans-serif; max-width: 640px; margin: 3em auto; padding: 0 1em; color: #222; }
-h1 { font-size: 1.4em; display: flex; align-items: center; gap: 0.5em; }
-.sp { display: inline-block; width: 1em; height: 1em; border: 2px solid #ddd; border-top-color: #36c; border-radius: 50%; animation: r 1s linear infinite; }
-@keyframes r { to { transform: rotate(360deg); } }
-ul { list-style: none; padding: 0; }
-li { padding: 0.4em 0.6em; border-left: 2px solid #ddd; margin: 0.2em 0; }
-li.done { border-color: #080; }
-li.failed { border-color: #c00; color: #c00; }
-.ts { color: #888; font-size: 0.8em; margin-right: 0.6em; }
-.hint { color: #666; font-size: 0.9em; margin-top: 1.5em; }
+/* Shared by the compute_space /updating template and the updater's inline page.
+ *
+ * Values are literal rather than var(--token): the updater inlines this file
+ * into a self-contained page it serves while compute_space is down, so neither
+ * tokens.css nor the webfont is reachable. Keep it in visual step with
+ * tokens.css by hand, and stick to the system mono stack. */
+
+body {
+  margin: 0;
+  padding: 3em 1em;
+  color: #000;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 14px;
+  font-weight: 500;
+  background: linear-gradient(180deg, #eef8ff 0%, #eef8ff 80%, #ecffe1 100%) fixed;
+}
+
+.update-page {
+  max-width: 640px;
+  margin: 0 auto;
+}
+
+h1 {
+  display: flex;
+  align-items: center;
+  gap: 0.6em;
+  margin: 0 0 1.2em;
+  font-size: 16px;
+  font-weight: 500;
+  letter-spacing: 0.48px;
+  text-transform: uppercase;
+}
+
+/* Blocky three-cell pulse rather than a rotating ring — sharp corners
+ * everywhere else, and it still reads as "working" at a glance. */
+.sp {
+  display: inline-flex;
+  gap: 3px;
+}
+
+.sp::before,
+.sp::after,
+.sp > i {
+  content: "";
+  display: block;
+  width: 6px;
+  height: 12px;
+  background: #a2d9ff;
+  animation: sp-pulse 1.2s steps(1) infinite;
+}
+
+.sp > i { animation-delay: 0.4s; }
+.sp::after { animation-delay: 0.8s; }
+
+@keyframes sp-pulse {
+  0%, 33% { background: #a2d9ff; }
+  34%, 100% { background: #dadada; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .sp::before,
+  .sp::after,
+  .sp > i { animation: none; }
+}
+
+ul {
+  margin: 0;
+  padding: 12px;
+  list-style: none;
+  background: #1e1e1e;
+  color: #d4d4d4;
+  border: 1px solid #dadada;
+  box-shadow: 2px 2px 0 rgba(0, 0, 0, 0.1);
+  font-size: 12px;
+  max-height: 30em;
+  overflow-y: auto;
+}
+
+li {
+  display: flex;
+  gap: 10px;
+  padding: 1px 0 1px 8px;
+  border-left: 2px solid transparent;
+}
+
+li.done { border-left-color: #76ff2d; }
+li.failed { border-left-color: #ff4d4d; color: #ff9d9d; }
+
+.ts {
+  flex: none;
+  color: #7f7f7f;
+}
+
+.hint {
+  margin-top: 1.5em;
+  color: #5c5c5c;
+  font-size: 12px;
+}

--- a/compute_space/src/compute_space/web/static/js/add-app.js
+++ b/compute_space/src/compute_space/web/static/js/add-app.js
@@ -12,11 +12,11 @@ if (initialRepo) {
 function showError(msg) {
   const el = document.getElementById('error');
   el.textContent = msg;
-  el.style.display = '';
+  el.hidden = false;
 }
 
 function clearError() {
-  document.getElementById('error').style.display = 'none';
+  document.getElementById('error').hidden = true;
 }
 
 function show(id) { document.getElementById(id).style.display = ''; }
@@ -227,22 +227,22 @@ function onPortInput(el) {
   const statusEl = document.querySelector(`.port-status[data-label="${label}"]`);
 
   if (isNaN(val) || val === 0) {
-    statusEl.innerHTML = '<span style="color:#888">auto-assign</span>';
+    dom.replace(statusEl, dom.badge('Auto-assign'));
     portConflicts.delete(label);
     updateDeployButton();
     return;
   }
 
   // Debounce: check after 400ms of no typing
-  statusEl.innerHTML = '<span style="color:#888">checking…</span>';
+  dom.replace(statusEl, dom.badge('Checking…'));
   if (portDebounceTimers[label]) clearTimeout(portDebounceTimers[label]);
   portDebounceTimers[label] = setTimeout(() => checkPortAvailability(label, val), 400);
 }
 
 function formatUsedBy(usedBy) {
   if (!usedBy) return 'unknown';
-  if (usedBy.type === 'main_port') return `${esc(usedBy.app_name)} (main port)`;
-  if (usedBy.type === 'port_mapping') return `${esc(usedBy.app_name)} (port '${esc(usedBy.label)}')`;
+  if (usedBy.type === 'main_port') return `${usedBy.app_name} (main port)`;
+  if (usedBy.type === 'port_mapping') return `${usedBy.app_name} (port '${usedBy.label}')`;
   return 'host-level service';
 }
 
@@ -252,14 +252,14 @@ async function checkPortAvailability(label, port) {
     const resp = await fetch(`/api/check_port?port=${port}`);
     const data = await resp.json();
     if (data.available) {
-      statusEl.innerHTML = '<span style="color:green">✓ available</span>';
+      dom.replace(statusEl, dom.badge('Available', 'ok'));
       portConflicts.delete(label);
     } else {
-      statusEl.innerHTML = `<span style="color:red">✗ in use by ${formatUsedBy(data.used_by)}</span>`;
+      dom.replace(statusEl, dom.badge('In use', 'error', 'In use by ' + formatUsedBy(data.used_by)));
       portConflicts.add(label);
     }
   } catch (e) {
-    statusEl.innerHTML = '<span style="color:orange">check failed</span>';
+    dom.replace(statusEl, dom.badge('Check failed', 'warn'));
     portConflicts.delete(label);
   }
   updateDeployButton();
@@ -279,7 +279,7 @@ async function recheckAllPorts() {
 }
 
 function updateDeployButton() {
-  const btn = document.querySelector('#confirm-section .btn-primary');
+  const btn = document.querySelector('#confirm-section .btn--primary');
   if (btn) btn.disabled = portConflicts.size > 0;
 }
 

--- a/compute_space/src/compute_space/web/static/js/app-detail.js
+++ b/compute_space/src/compute_space/web/static/js/app-detail.js
@@ -163,7 +163,7 @@ function showToast(message, actions) {
     actionsDiv.className = 'toast-actions';
     actions.forEach(function(a) {
         var btn = document.createElement('button');
-        btn.className = 'btn' + (a.primary ? ' btn-primary' : '');
+        btn.className = 'btn' + (a.primary ? ' btn--primary' : '');
         btn.textContent = a.label;
         btn.onclick = function() { toast.remove(); a.onClick(); };
         actionsDiv.appendChild(btn);

--- a/compute_space/src/compute_space/web/static/js/chart.js
+++ b/compute_space/src/compute_space/web/static/js/chart.js
@@ -15,13 +15,16 @@ function escAttr(s) {
 // Golden-angle hue steps keep adjacent app slices distinct at any app count;
 // fixed low saturation keeps the palette muted. Shared by every app-colored
 // donut so the same app gets a consistent hue slot across charts.
+// Golden-angle hue rotation so adjacent apps stay distinguishable, pitched at
+// the lightness/saturation of the brand pastels (#a2d9ff, #d4ffbc) so the
+// charts read as part of the same palette rather than a separate one.
 function appColor(i) {
-  return 'hsl(' + ((215 + i * 137.5) % 360).toFixed(1) + ', 45%, 62%)';
+  return 'hsl(' + ((205 + i * 137.5) % 360).toFixed(1) + ', 72%, 78%)';
 }
 
 // Neutral greys for the non-app slices of a usage donut.
-var COLOR_UNUSED = '#e3e6ea';   // free headroom on the box
-var COLOR_OTHER = '#b9c0c9';    // used by the host but not attributed to an app
+var COLOR_UNUSED = '#ececec';   // free headroom on the box
+var COLOR_OTHER = '#c4c4c4';    // used by the host but not attributed to an app
 
 // Generic donut chart. `segments` is [{name, value, valueText, color}] drawn in
 // order from 12 o'clock; hovering a slice shows its name + valueText in the

--- a/compute_space/src/compute_space/web/static/js/diagnostics.js
+++ b/compute_space/src/compute_space/web/static/js/diagnostics.js
@@ -75,10 +75,10 @@ function renderSummary(data) {
 }
 
 function healthCell(h) {
-  if (!h || !h.checked) return '<span class="muted">n/a</span>';
-  if (h.healthy) return '<span class="status-running">OK' + (h.status_code ? ' (' + escHtml(h.status_code) + ')' : '') + '</span>';
+  if (!h || !h.checked) return '<span class="badge">n/a</span>';
+  if (h.healthy) return '<span class="badge badge--ok">OK' + (h.status_code ? ' ' + escHtml(h.status_code) : '') + '</span>';
   var detail = h.status_code ? String(h.status_code) : (h.error || 'unreachable');
-  return '<span class="status-error">FAIL (' + escHtml(detail) + ')</span>';
+  return '<span class="badge badge--error" title="' + escAttr(detail) + '">Fail</span>';
 }
 
 function cpuCell(r) {
@@ -126,14 +126,16 @@ function renderApps(data) {
 function renderAppRows() {
   var body = document.getElementById('apps-body');
   if (!appsData.length) {
-    body.innerHTML = '<tr><td colspan="7" class="muted">No apps installed.</td></tr>';
+    dom.replace(body, dom.el('tr', null, dom.el('td', {colspan: '7', class: 'muted', text: 'No apps installed.'})));
     return;
   }
   body.innerHTML = appsData.map(function(a) {
-    var statusCls = a.status === 'running' ? 'status-running' : (a.status === 'error' ? 'status-error' : 'status-stopped');
+    var statusVariant = a.status === 'running' ? 'ok'
+      : a.status === 'error' ? 'error'
+      : (a.status === 'building' || a.status === 'starting' || a.status === 'removing') ? 'warn' : '';
     return '<tr><td>' + escHtml(a.name) + '</td>'
       + '<td>' + escHtml(a.version || '') + '</td>'
-      + '<td class="' + statusCls + '">' + escHtml(a.status) + '</td>'
+      + '<td><span class="badge' + (statusVariant ? ' badge--' + statusVariant : '') + '">' + escHtml(a.status) + '</span></td>'
       + '<td>' + healthCell(a.health) + '</td>'
       + '<td>' + cpuCell(a.resources) + '</td>'
       + '<td>' + memCell(a.resources) + '</td>'
@@ -176,18 +178,20 @@ function renderReachability(data) {
   var targets = data.reachability || [];
   var body = document.getElementById('reachability-body');
   if (!targets.length) {
-    body.innerHTML = '<tr><td colspan="4" class="muted">No reachability data.</td></tr>';
+    dom.replace(body, dom.el('tr', null, dom.el('td', {colspan: '4', class: 'muted', text: 'No reachability data.'})));
     return;
   }
-  body.innerHTML = targets.map(function(t) {
-    var cls = t.reachable ? 'status-running' : 'status-error';
-    var label = t.reachable ? ('yes' + (t.status_code ? ' (' + escHtml(t.status_code) + ')' : '')) : ('no' + (t.error ? ' (' + escHtml(t.error) + ')' : ''));
-    var latency = (t.latency_ms != null) ? (t.latency_ms + ' ms') : '';
-    return '<tr><td>' + escHtml(t.label) + '</td>'
-      + '<td><code>' + escHtml(t.url) + '</code></td>'
-      + '<td class="' + cls + '">' + label + '</td>'
-      + '<td>' + escHtml(latency) + '</td></tr>';
-  }).join('');
+  dom.replace(body, targets.map(function(t) {
+    var detail = t.reachable ? t.status_code : t.error;
+    return dom.el('tr', null, [
+      dom.el('td', {text: t.label}),
+      dom.el('td', null, dom.el('code', {text: t.url})),
+      dom.el('td', null, dom.badge(t.reachable ? 'Yes' : 'No',
+                                   t.reachable ? 'ok' : 'error',
+                                   detail ? String(detail) : null)),
+      dom.el('td', {text: t.latency_ms != null ? t.latency_ms + ' ms' : ''}),
+    ]);
+  }));
 }
 
 function loadDiagnostics() {

--- a/compute_space/src/compute_space/web/static/js/dom.js
+++ b/compute_space/src/compute_space/web/static/js/dom.js
@@ -1,0 +1,64 @@
+// Minimal DOM builders shared by the page scripts.
+//
+// These replace innerHTML string concatenation, which needed a hand-rolled HTML
+// escaper (there were three near-identical copies) and made every interpolation
+// a place to forget it. Text goes in as text here, so there is nothing to
+// escape. No dependencies and no build step, so this survives whatever the
+// frontend eventually settles on.
+(function (global) {
+  function append(node, children) {
+    if (children == null || children === false) return;
+    if (Array.isArray(children)) {
+      children.forEach(function (c) { append(node, c); });
+      return;
+    }
+    node.appendChild(children.nodeType ? children : document.createTextNode(String(children)));
+  }
+
+  // el('td', {class: 'x', text: name}, [childNode, 'literal text'])
+  //
+  // Recognised attrs: `text` sets textContent, `class` the class list,
+  // `dataset` an object of data-* values, `on<event>` a listener, `true` a
+  // bare boolean attribute. Anything else is setAttribute.
+  function el(tag, attrs, children) {
+    var node = document.createElement(tag);
+    if (attrs) {
+      Object.keys(attrs).forEach(function (key) {
+        var value = attrs[key];
+        if (value == null || value === false) return;
+        if (key === 'text') node.textContent = value;
+        else if (key === 'class') node.className = value;
+        else if (key === 'dataset') {
+          Object.keys(value).forEach(function (d) { node.dataset[d] = value[d]; });
+        } else if (key.slice(0, 2) === 'on' && typeof value === 'function') {
+          node.addEventListener(key.slice(2), value);
+        } else if (value === true) node.setAttribute(key, '');
+        else node.setAttribute(key, value);
+      });
+    }
+    append(node, children);
+    return node;
+  }
+
+  function clear(node) {
+    while (node.firstChild) node.removeChild(node.firstChild);
+    return node;
+  }
+
+  // Swap a container's contents in one go — the common shape for "repaint this
+  // table body from a fresh API response".
+  function replace(node, children) {
+    append(clear(node), children);
+    return node;
+  }
+
+  function badge(label, variant, title) {
+    return el('span', {
+      class: 'badge' + (variant ? ' badge--' + variant : ''),
+      text: label,
+      title: title || null,
+    });
+  }
+
+  global.dom = {el: el, clear: clear, replace: replace, badge: badge};
+})(window);

--- a/compute_space/src/compute_space/web/static/js/domains.js
+++ b/compute_space/src/compute_space/web/static/js/domains.js
@@ -5,54 +5,53 @@
 
 var DOMAINS_URL = '/api/domains';
 
-// Self-contained HTML/attribute escape (don't depend on settings.js load order).
-function dEsc(s) {
-  return String(s == null ? '' : s).replace(/[&<>"']/g, function(c) {
-    return {'&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;'}[c];
-  });
-}
+var CERT_BADGES = {
+  active: {label: 'Active', variant: 'ok'},
+  acquiring: {label: 'Acquiring', variant: 'warn'},
+  error: {label: 'Error', variant: 'error'},
+};
 
-function domainCertBadge(d) {
-  if (!d.tls) { return '<span class="muted">—</span>'; }
-  var color = d.cert_status === 'active' ? '#28a745'
-    : d.cert_status === 'acquiring' ? '#d08700'
-    : d.cert_status === 'error' ? '#c00' : '#888';
-  var label = d.cert_status === 'active' ? 'Active'
-    : d.cert_status === 'acquiring' ? 'Acquiring…'
-    : d.cert_status === 'error' ? 'Error' : 'None';
-  var title = d.error_message ? ' title="' + dEsc(d.error_message) + '"' : '';
-  return '<span style="color:' + color + ';"' + title + '>' + label + '</span>';
+function domainCertCell(d) {
+  if (!d.tls) return dom.el('span', {class: 'muted', text: '—'});
+  var spec = CERT_BADGES[d.cert_status] || {label: 'None', variant: null};
+  return dom.badge(spec.label, spec.variant, d.error_message);
 }
 
 // Repaint the table from a domain list (as returned by GET/POST/DELETE /api/domains).
 function renderDomains(domains) {
   var tbody = document.getElementById('domains-body');
-  var table = document.getElementById('domains-table');
+  var wrap = document.getElementById('domains-table-wrap');
   var none = document.getElementById('no-domains');
   if (!domains.length) {
-    table.style.display = 'none';
-    none.style.display = '';
+    wrap.hidden = true;
+    none.hidden = false;
     none.textContent = 'No domains.';
     return;
   }
-  table.style.display = '';
-  none.style.display = 'none';
+  wrap.hidden = false;
+  none.hidden = true;
   var anyAcquiring = false;
-  tbody.innerHTML = domains.map(function(d) {
-    if (d.tls && d.cert_status === 'acquiring') { anyAcquiring = true; }
-    var name = dEsc(d.name) + (d.is_primary ? ' <span class="muted">(primary)</span>' : '');
-    var discovery = d.mdns ? 'mDNS (.local)' : 'Public DNS';
-    var actions = d.is_primary
-      ? '<span class="muted">—</span>'
-      : '<button class="btn btn-danger" onclick="removeDomain(\'' + dEsc(d.name) + '\')">Remove</button>';
-    return '<tr><td>' + name + '</td>'
-      + '<td>' + dEsc(d.scheme) + '</td>'
-      + '<td>' + discovery + '</td>'
-      + '<td>' + domainCertBadge(d) + '</td>'
-      + '<td>' + actions + '</td></tr>';
-  }).join('');
+  dom.replace(tbody, domains.map(function(d) {
+    if (d.tls && d.cert_status === 'acquiring') anyAcquiring = true;
+    return dom.el('tr', null, [
+      dom.el('td', null, [
+        d.name,
+        d.is_primary ? dom.el('span', {class: 'muted', text: ' (primary)'}) : null,
+      ]),
+      dom.el('td', {text: d.scheme}),
+      dom.el('td', {text: d.mdns ? 'mDNS (.local)' : 'Public DNS'}),
+      dom.el('td', null, domainCertCell(d)),
+      dom.el('td', null, d.is_primary
+        ? dom.el('span', {class: 'muted', text: '—'})
+        : dom.el('button', {
+            class: 'btn btn--danger',
+            text: 'Remove',
+            onclick: function() { removeDomain(d.name); },
+          })),
+    ]);
+  }));
   // A cert acquisition (DNS-01) runs in the background; poll until it settles.
-  if (anyAcquiring) { setTimeout(loadDomains, 4000); }
+  if (anyAcquiring) setTimeout(loadDomains, 4000);
 }
 
 function loadDomains() {
@@ -81,8 +80,8 @@ function addDomain() {
       if (body.tls) {
         msg.textContent = 'Added. Acquiring a TLS certificate in the background — '
           + 'its DNS must be delegated to this instance for acquisition to succeed.';
-        msg.className = 'hint';
-        msg.style.display = '';
+        msg.className = 'notice';
+        msg.hidden = false;
       }
       // Repaint from the POST response (the full list) — no follow-up GET to race the Caddy restart.
       renderDomains((data && data.domains) || []);

--- a/compute_space/src/compute_space/web/static/js/settings.js
+++ b/compute_space/src/compute_space/web/static/js/settings.js
@@ -9,10 +9,10 @@ function showError(msg) {
     if (pageHidden) return;
     const el = document.getElementById('error');
     el.textContent = msg;
-    el.style.display = '';
+    el.hidden = false;
   }, 100);
 }
-function clearError() { document.getElementById('error').style.display = 'none'; }
+function clearError() { document.getElementById('error').hidden = true; }
 function esc(s) { const d = document.createElement('div'); d.textContent = s; return d.innerHTML; }
 
 async function checkForUpdates() {
@@ -26,23 +26,23 @@ async function checkForUpdates() {
       const err = await resp.json();
       el.innerHTML = '<p class="error">Repo is in an invalid state for updating (no .git perhaps?)</p>'
         + (err.detail ? '<div class="error-inline">' + esc(err.detail) + '</div>' : '')
-        + '<button onclick="checkForUpdates()" class="btn" style="margin-top:0.5em;">Retry</button>';
+        + '<button onclick="checkForUpdates()" class="btn">Retry</button>';
       return;
     }
     const data = await resp.json();
 
-    const checkAgainBtn = '<button onclick="checkForUpdates()" class="btn" style="margin-top:0.5em;">Check again</button>';
+    const checkAgainBtn = '<button onclick="checkForUpdates()" class="btn">Check again</button>';
 
     if (data.state === 'UP_TO_DATE') {
-      el.innerHTML = '<p style="color:#080;">Up to date.</p>' + checkAgainBtn;
+      el.innerHTML = '<p class="notice notice--ok">Up to date.</p>' + checkAgainBtn;
     } else if (data.state === 'UPDATE_AVAILABLE') {
       const notice = data.error ? '<div class="error-inline">' + esc(data.error) + '</div>' : '';
-      el.innerHTML = '<p>Updates available.</p>'
+      el.innerHTML = '<p class="notice">Updates available.</p>'
         + notice
-        + '<button onclick="applyUpdate()" class="btn btn-primary" style="margin-top:0.5em;">Update &amp; restart</button> '
+        + '<button onclick="applyUpdate()" class="btn btn--primary">Update &amp; restart</button> '
         + checkAgainBtn;
     } else if (data.state === 'ERROR') {
-      el.innerHTML = '<p class="error">Update check failed.</p>'
+      el.innerHTML = '<p class="notice notice--error">Update check failed.</p>'
         + '<div class="error-inline">' + esc(data.error || 'Unknown error') + '</div>'
         + checkAgainBtn;
     }
@@ -66,14 +66,14 @@ async function applyUpdate() {
     if (!resp.ok) {
       const err = await resp.json();
       el.innerHTML = '<p class="error">' + esc(err.detail || '') + '</p>'
-        + '<button onclick="checkForUpdates()" class="btn" style="margin-top:0.5em;">Retry</button>';
+        + '<button onclick="checkForUpdates()" class="btn">Retry</button>';
       return;
     }
     const data = await resp.json();
     token = data.token;
   } catch (e) {
     el.innerHTML = '<p class="error">Update failed: ' + esc(e.message) + '</p>'
-      + '<button onclick="checkForUpdates()" class="btn" style="margin-top:0.5em;">Retry</button>';
+      + '<button onclick="checkForUpdates()" class="btn">Retry</button>';
     return;
   }
 
@@ -84,8 +84,8 @@ async function applyUpdate() {
 }
 
 function showRestartOverlay() {
-  document.getElementById('restart-overlay').style.display = '';
-  document.getElementById('update-status').style.display = 'none';
+  document.getElementById('restart-overlay').hidden = false;
+  document.getElementById('update-status').hidden = true;
   document.getElementById('restart-status').innerHTML = '<strong>Waiting for shutdown&hellip;</strong>';
   pollShutdown();
 }
@@ -138,8 +138,8 @@ async function loadRemote() {
     input.placeholder = '';
     const msg = document.getElementById('remote-msg');
     msg.textContent = 'Failed to load current remote. Reload the page to retry.';
-    msg.className = 'error';
-    msg.style.display = '';
+    msg.className = 'msg msg--error';
+    msg.hidden = false;
   }
 }
 
@@ -152,7 +152,7 @@ async function setRemote() {
   if (!url) return;
 
   btn.disabled = true;
-  msg.style.display = 'none';
+  msg.hidden = true;
 
   try {
     const resp = await fetch('/api/settings/set-remote', {
@@ -168,14 +168,14 @@ async function setRemote() {
     // ref is the update walk's job (checkout+migrate+install+restart, in order),
     // so surface it as an available update instead of rebooting onto unmigrated code.
     msg.textContent = 'Remote saved.';
-    msg.className = '';
-    msg.style.display = '';
+    msg.className = 'msg';
+    msg.hidden = false;
     btn.disabled = false;
     await checkForUpdates();
   } catch (e) {
     msg.textContent = e.message;
-    msg.className = 'error';
-    msg.style.display = '';
+    msg.className = 'msg msg--error';
+    msg.hidden = false;
     btn.disabled = false;
   }
 }
@@ -208,17 +208,16 @@ async function changePassword() {
       throw new Error(err.detail || 'failed to change password');
     }
     msg.textContent = 'Password changed successfully';
-    msg.className = '';
-    msg.style.display = '';
-    msg.style.color = '#080';
+    msg.className = 'msg';
+    msg.hidden = false;
+    msg.className = 'msg msg--ok';
     document.getElementById('current-pw').value = '';
     document.getElementById('new-pw').value = '';
     document.getElementById('confirm-pw').value = '';
   } catch (e) {
     msg.textContent = e.message;
-    msg.className = 'error';
-    msg.style.display = '';
-    msg.style.color = '';
+    msg.className = 'msg msg--error';
+    msg.hidden = false;
   }
 }
 
@@ -253,11 +252,10 @@ async function loadOwnerUsername() {
       const err = usernameError(v);
       if (err) {
         msg.textContent = err;
-        msg.className = 'error';
-        msg.style.color = '';
-        msg.style.display = '';
+        msg.className = 'msg msg--error';
+        msg.hidden = false;
       } else {
-        msg.style.display = 'none';
+        msg.hidden = true;
       }
       // Save stays disabled when the value matches what's stored,
       // is empty, OR fails client-side validation.  Server-side
@@ -272,8 +270,8 @@ async function loadOwnerUsername() {
     // even if they've scrolled past the top of the page.
     showError('Failed to load owner username: ' + e.message);
     msg.textContent = 'Failed to load. Reload the page to retry.';
-    msg.className = 'error';
-    msg.style.display = '';
+    msg.className = 'msg msg--error';
+    msg.hidden = false;
     input.placeholder = 'Failed to load — reload to retry';
   }
 }
@@ -289,14 +287,13 @@ async function setOwnerUsername() {
   const clientErr = usernameError(username);
   if (clientErr) {
     msg.textContent = clientErr;
-    msg.className = 'error';
-    msg.style.color = '';
-    msg.style.display = '';
+    msg.className = 'msg msg--error';
+    msg.hidden = false;
     return;
   }
 
   btn.disabled = true;
-  msg.style.display = 'none';
+  msg.hidden = true;
 
   try {
     const resp = await fetch('/api/settings/owner_username', {
@@ -311,15 +308,13 @@ async function setOwnerUsername() {
     const data = await resp.json();
     savedUsername = data.username;
     msg.textContent = 'Saved.';
-    msg.className = '';
-    msg.style.color = '#080';
-    msg.style.display = '';
-    setTimeout(() => { msg.style.display = 'none'; }, 4000);
+    msg.className = 'msg msg--ok';
+    msg.hidden = false;
+    setTimeout(() => { msg.hidden = true; }, 4000);
   } catch (e) {
     msg.textContent = e.message;
-    msg.className = 'error';
-    msg.style.color = '';
-    msg.style.display = '';
+    msg.className = 'msg msg--error';
+    msg.hidden = false;
     btn.disabled = false;
   }
 }
@@ -356,7 +351,7 @@ function dropBuildCache() {
     .then(function(r) { return r.json(); })
     .then(function(data) {
       if (data.error) {
-        msg.className = 'error';
+        msg.className = 'msg msg--error';
         msg.textContent = 'Drop failed: ' + data.error;
         return;
       }
@@ -367,11 +362,11 @@ function dropBuildCache() {
           reclaimed = ' Freed ' + match[1] + '.';
         }
       }
-      msg.className = 'status-running';
+      msg.className = 'msg msg--ok';
       msg.textContent = 'Build cache dropped.' + reclaimed;
     })
     .catch(function() {
-      msg.className = 'error';
+      msg.className = 'msg msg--error';
       msg.textContent = 'Drop failed: request error';
     })
     .then(function() {
@@ -390,7 +385,7 @@ function updateSshStatus() {
       btn.disabled = false;
       if (data.ssh_enabled) {
         btn.textContent = 'Disable SSH';
-        btn.className = 'btn btn-danger';
+        btn.className = 'btn btn--danger';
         status.textContent = 'SSH active';
         status.className = 'status-error';
       } else {
@@ -420,7 +415,7 @@ function renderArchiveBackend(state) {
   var rows = '';
   if (state.backend === 's3') {
     rows += '<tr><th>Backend</th>'
-      + '<td><span class="status-running">S3 (JuiceFS)</span>'
+      + '<td><span class="badge badge--ok">S3 (JuiceFS)</span>'
       + (state.state_message ? ' <span class="error">' + escSettingsHtml(state.state_message) + '</span>' : '')
       + '</td></tr>';
     var bucketLine = escSettingsHtml(state.s3_bucket || '?')
@@ -451,13 +446,13 @@ function renderArchiveBackend(state) {
     rows += '<tr><th>Latest meta dump</th><td>' + dumpLine + '</td></tr>';
   } else if (state.backend === 'local') {
     rows += '<tr><th>Backend</th>'
-      + '<td><span class="status-running">Local disk (JuiceFS)</span>'
+      + '<td><span class="badge">Local disk (JuiceFS)</span>'
       + (state.state_message ? ' <span class="error">' + escSettingsHtml(state.state_message) + '</span>' : '')
       + '</td></tr>';
     if (state.archive_dir) {
       rows += '<tr><th>Host path</th><td><code>' + escSettingsHtml(state.archive_dir) + '</code></td></tr>';
     }
-    rows += '<tr><th>Durability</th><td><span class="error">Local disk only.</span> '
+    rows += '<tr><th>Durability</th><td><span class="badge badge--warn">Local disk only</span> '
       + 'The archive is a JuiceFS volume whose objects live on this instance\u2019s local disk '
       + '(included in backups) but NOT on durable object storage. Configure S3 below for elastic, durable storage.</td></tr>';
     var apps = state.local_archive_apps || [];
@@ -483,11 +478,11 @@ function renderArchiveBackend(state) {
   // 's3' backend (data is migrated to a new bucket/provider).
   var configureBtn = '';
   if (state.backend === 'local') {
-    configureBtn = '<div class="control-row"><button class="btn" id="archive-backend-configure-btn">Upgrade to S3 backend…</button></div>';
+    configureBtn = '<div class="action-bar"><button class="btn" id="archive-backend-configure-btn">Upgrade to S3 backend…</button></div>';
   } else if (state.backend === 'disabled') {
-    configureBtn = '<div class="control-row"><button class="btn" id="archive-backend-configure-btn">Configure S3 backend…</button></div>';
+    configureBtn = '<div class="action-bar"><button class="btn" id="archive-backend-configure-btn">Configure S3 backend…</button></div>';
   } else if (state.backend === 's3') {
-    configureBtn = '<div class="control-row"><button class="btn" id="archive-backend-configure-btn">Migrate to a new bucket…</button></div>';
+    configureBtn = '<div class="action-bar"><button class="btn" id="archive-backend-configure-btn">Migrate to a new bucket…</button></div>';
   }
 
   el.innerHTML = '<table id="archive-backend-table" class="form-table"><tbody>' + rows + '</tbody></table>'
@@ -508,19 +503,19 @@ function showConfigureForm(state) {
     var appsLine = localApps.length
       ? ' Apps whose archive data will be migrated: ' + localApps.map(function(a){ return '<code>' + escSettingsHtml(a) + '</code>'; }).join(', ') + '.'
       : ' There is no local archive data yet, so nothing will be migrated.';
-    migrateNote = '<p class="error"><strong>This migrates your existing LOCAL archive data into S3.</strong> '
+    migrateNote = '<p class="notice notice--warn"><strong>This migrates your existing LOCAL archive data into S3.</strong> '
       + 'JuiceFS copies the archive objects into the bucket (verified with <code>--check-all</code>) and re-points the volume; if anything fails the switch is aborted and your local data is left intact (fail-open). '
       + 'After a successful migration the local copy is removed and the switch to S3 is <strong>one-way</strong>.'
       + appsLine + '</p>';
   } else if (state.backend === 's3') {
-    migrateNote = '<p class="error"><strong>This migrates your archive from the current bucket (<code>'
+    migrateNote = '<p class="notice notice--warn"><strong>This migrates your archive from the current bucket (<code>'
       + escSettingsHtml(state.s3_bucket || '?') + '</code>) to the NEW bucket below.</strong> '
       + 'JuiceFS copies every archive object to the new bucket (verified with <code>--check-all</code>) and re-points the volume; if anything fails the switch is aborted and your current bucket is left intact (fail-open). '
       + 'After a successful migration the old bucket\u2019s objects (under this zone\u2019s prefix only) are reclaimed.</p>';
   }
   formEl.innerHTML = '<p><strong>Configure S3 archive storage.</strong> JuiceFS will format the bucket and mount it locally; this is a one-time operation.</p>'
     + migrateNote
-    + '<p class="error"><strong>Experimental.</strong> Filename-to-S3-chunk mappings live in a SQLite metadata DB on this zone’s local disk, not in the bucket. If the local disk is wiped, the bucket bytes can be recovered only from JuiceFS\'s periodic meta dumps in S3 (replayed via <code>juicefs load</code>).</p>'
+    + '<p class="notice notice--warn"><strong>Experimental.</strong> Filename-to-S3-chunk mappings live in a SQLite metadata DB on this zone’s local disk, not in the bucket. If the local disk is wiped, the bucket bytes can be recovered only from JuiceFS\'s periodic meta dumps in S3 (replayed via <code>juicefs load</code>).</p>'
     + '<p class="hint">JuiceFS will automatically dump the metadata DB to <code>&lt;bucket&gt;/&lt;prefix&gt;/meta/dump-*.json.gz</code> once an hour. These dumps are the recovery anchor for reattaching a freshly-installed zone to an existing bucket.</p>'
     + '<table class="form-table"><tbody>'
     + '<tr><th><label for="ab-bucket">S3 bucket</label></th><td><input id="ab-bucket" type="text" placeholder="my-openhost-archive"></td></tr>'
@@ -535,16 +530,16 @@ function showConfigureForm(state) {
     + '<tr><th><label for="ab-access-key">Access key ID</label></th><td><input id="ab-access-key" type="text"></td></tr>'
     + '<tr><th><label for="ab-secret-key">Secret access key</label></th><td><input id="ab-secret-key" type="password"></td></tr>'
     + '</tbody></table>'
-    + '<p><label><input type="checkbox" id="ab-confirm"> I understand the S3 archive backend is experimental'
+    + '<p><label class="field--check"><input type="checkbox" id="ab-confirm"><span> I understand the S3 archive backend is experimental'
     + (state.backend === 'local'
         ? ' and that my existing local archive data will be migrated into S3.'
         : state.backend === 's3'
         ? ' and that my archive will be migrated to the new bucket and the old bucket reclaimed.'
         : ' and that this configures S3 for the archive tier.')
-    + '</label></p>'
-    + '<div class="control-row">'
+    + '</span></label></p>'
+    + '<div class="action-bar">'
     + '<button class="btn" id="ab-test-btn">Test connection</button>'
-    + '<button class="btn btn-primary" id="ab-submit-btn">Configure</button>'
+    + '<button class="btn btn--primary" id="ab-submit-btn">Configure</button>'
     + '<button class="btn" id="ab-cancel-btn">Cancel</button>'
     + '<span id="ab-msg" class="hint"></span>'
     + '</div>';
@@ -579,7 +574,7 @@ function _archiveBackendBody() {
 function testArchiveConnection() {
   var msg = document.getElementById('ab-msg');
   msg.textContent = 'Testing…';
-  msg.style.color = '';
+  msg.className = 'hint';
   fetch('/api/storage/archive_backend/test_connection', {
     method: 'POST',
     credentials: 'same-origin',
@@ -589,11 +584,11 @@ function testArchiveConnection() {
     .then(function(r) { return r.json().then(function(b) { return [r.status, b]; }); })
     .then(function(pair) {
       var ok = pair[0] === 200 && pair[1].ok;
-      msg.style.color = ok ? '#16a34a' : '#dc3545';
+      msg.className = ok ? 'msg msg--ok' : 'msg msg--error';
       msg.textContent = ok ? 'Bucket reachable' : ('Failed: ' + (pair[1].error || ''));
     })
     .catch(function(err) {
-      msg.style.color = '#dc3545';
+      msg.className = 'msg msg--error';
       msg.textContent = 'Network error: ' + err;
     });
 }
@@ -601,11 +596,11 @@ function testArchiveConnection() {
 function submitConfigure() {
   var msg = document.getElementById('ab-msg');
   if (!document.getElementById('ab-confirm').checked) {
-    msg.style.color = '#dc3545';
+    msg.className = 'msg msg--error';
     msg.textContent = 'Tick the confirmation checkbox first.';
     return;
   }
-  msg.style.color = '';
+  msg.className = 'hint';
   msg.textContent = 'Configuring (may take 10-30s)…';
   document.getElementById('ab-submit-btn').disabled = true;
   fetch('/api/storage/archive_backend/configure', {
@@ -619,13 +614,13 @@ function submitConfigure() {
       if (pair[0] === 200) {
         loadArchiveBackend();
       } else {
-        msg.style.color = '#dc3545';
+        msg.className = 'msg msg--error';
         msg.textContent = 'Failed: ' + (pair[1].error || pair[1]);
         document.getElementById('ab-submit-btn').disabled = false;
       }
     })
     .catch(function(err) {
-      msg.style.color = '#dc3545';
+      msg.className = 'msg msg--error';
       msg.textContent = 'Network error: ' + err;
       document.getElementById('ab-submit-btn').disabled = false;
     });
@@ -646,8 +641,9 @@ function loadArchiveBackend() {
     .catch(function(err) {
       var el = document.getElementById('archive-backend-status');
       if (el) {
-        el.innerHTML = '<p class="error"><strong>Archive backend status unavailable.</strong> '
-          + escSettingsHtml(String(err)) + '</p>';
+        dom.replace(el, dom.el('p', {class: 'notice notice--error'}, [
+          dom.el('strong', {text: 'Archive backend status unavailable.'}), ' ', String(err),
+        ]));
       }
     });
 }
@@ -663,7 +659,7 @@ async function loadConnectImbueStatus() {
     if (!resp.ok) return;  // feature not present; leave the section hidden
     const data = await resp.json();
     if (!data.available) return;  // no Imbue URL configured
-    section.style.display = '';
+    section.hidden = false;
     if (data.connected) {
       state.textContent = 'Connected to Imbue.';
       btn.textContent = 'Reconnect to Imbue';
@@ -671,7 +667,7 @@ async function loadConnectImbueStatus() {
       state.textContent = 'Not connected.';
       btn.textContent = 'Connect to Imbue';
     }
-    btn.style.display = '';
+    btn.hidden = false;
   } catch (e) {
     // Non-fatal: the section just stays hidden.
   }
@@ -695,8 +691,8 @@ async function connectImbue() {
   } catch (e) {
     btn.disabled = false;
     msg.textContent = 'Could not start connect: ' + e.message;
-    msg.className = 'error';
-    msg.style.display = '';
+    msg.className = 'msg msg--error';
+    msg.hidden = false;
   }
 }
 
@@ -709,13 +705,12 @@ async function connectImbue() {
   if (!msg) return;
   if (result === 'ok') {
     msg.textContent = 'Connected to Imbue.';
-    msg.className = '';
-    msg.style.color = '#2ea043';
+    msg.className = 'msg msg--ok';
   } else {
     msg.textContent = 'Connecting to Imbue failed. Please try again.';
-    msg.className = 'error';
+    msg.className = 'msg msg--error';
   }
-  msg.style.display = '';
+  msg.hidden = false;
 })();
 
 loadOwnerUsername();

--- a/compute_space/src/compute_space/web/static/js/system.js
+++ b/compute_space/src/compute_space/web/static/js/system.js
@@ -164,10 +164,10 @@ function renderStorageStatus(data) {
   // Guard toggle button (separate row below the table for clarity)
   var guardRow = document.getElementById('storage-guard-row');
   if (hasMinFree && guardPaused) {
-    guardRow.innerHTML = '<div class="control-row"><button class="btn" onclick="toggleStorageGuard(false)">Resume Guard</button>'
+    guardRow.innerHTML = '<div class="action-bar"><button class="btn" onclick="toggleStorageGuard(false)">Resume Guard</button>'
       + '<span class="hint">Apps will not be stopped while paused.</span></div>';
   } else if (hasMinFree && isLow) {
-    guardRow.innerHTML = '<div class="control-row"><button class="btn" onclick="toggleStorageGuard(true)">Pause Guard</button>'
+    guardRow.innerHTML = '<div class="action-bar"><button class="btn" onclick="toggleStorageGuard(true)">Pause Guard</button>'
       + '<span class="hint">Pause to start an app for cleanup.</span></div>';
   } else {
     guardRow.innerHTML = '';

--- a/compute_space/src/compute_space/web/static/js/tokens.js
+++ b/compute_space/src/compute_space/web/static/js/tokens.js
@@ -7,18 +7,25 @@ function loadTokens() {
     .then(function(r) { return r.json(); })
     .then(function(tokens) {
       var tbody = document.getElementById('tokens-body');
-      var table = document.getElementById('tokens-table');
+      var wrap = document.getElementById('tokens-table-wrap');
       var noTokens = document.getElementById('no-tokens');
-      if (!tokens.length) { table.style.display = 'none'; noTokens.style.display = ''; return; }
-      table.style.display = ''; noTokens.style.display = 'none';
-      tbody.innerHTML = tokens.map(function(t) {
-        var style = t.expired ? ' style="color:#888;text-decoration:line-through;"' : '';
-        var expiresDisplay = t.expires_at ? t.expires_at : 'Never';
-        return '<tr><td' + style + '>' + t.name + '</td>'
-          + '<td>' + t.created_at + '</td>'
-          + '<td' + (t.expired ? ' style="color:#c00;"' : '') + '>' + expiresDisplay + '</td>'
-          + '<td><button class="btn btn-danger" onclick="deleteToken(' + t.id + ')">Delete</button></td></tr>';
-      }).join('');
+      if (!tokens.length) { wrap.hidden = true; noTokens.hidden = false; return; }
+      wrap.hidden = false;
+      noTokens.hidden = true;
+      dom.replace(tbody, tokens.map(function(t) {
+        return dom.el('tr', {class: t.expired ? 'is-expired' : null}, [
+          dom.el('td', {text: t.name}),
+          dom.el('td', {text: t.created_at}),
+          dom.el('td', null, t.expires_at
+            ? (t.expired ? dom.badge('Expired', 'error', t.expires_at) : t.expires_at)
+            : dom.badge('Never', null)),
+          dom.el('td', null, dom.el('button', {
+            class: 'btn btn--danger',
+            text: 'Delete',
+            onclick: function() { deleteToken(t.id); },
+          })),
+        ]);
+      }));
     });
 }
 
@@ -39,7 +46,7 @@ function createToken() {
     .then(function(data) {
       if (data.error) { alert(data.error); return; }
       document.getElementById('token-value').textContent = data.token;
-      document.getElementById('token-created').style.display = '';
+      document.getElementById('token-created').hidden = false;
       document.getElementById('token-name').value = '';
       loadTokens();
     });

--- a/compute_space/src/compute_space/web/static/js/update-progress.js
+++ b/compute_space/src/compute_space/web/static/js/update-progress.js
@@ -24,27 +24,26 @@
     try { sessionStorage.removeItem('openhost_update_token'); } catch (e) { /* ignore */ }
   }
 
-  function esc(s) {
-    var d = document.createElement('div');
-    d.textContent = (s == null) ? '' : String(s);
-    return d.innerHTML;
-  }
-
+  // Built node-by-node rather than via innerHTML: this file is also inlined
+  // into the updater's standalone page, where dom.js is not available.
   function render(entries) {
     if (!entries || !entries.length) return;
-    logEl.innerHTML = '';
+    while (logEl.firstChild) logEl.removeChild(logEl.firstChild);
     entries.forEach(function (e) {
       var li = document.createElement('li');
       if (e.phase === 'done') li.className = 'done';
       if (e.phase === 'failed') li.className = 'failed';
-      var ts = (e.ts || '').substr(11, 8);
-      li.innerHTML = '<span class="ts">' + esc(ts) + '</span>' + esc(e.message || e.phase || '');
+      var ts = document.createElement('span');
+      ts.className = 'ts';
+      ts.textContent = (e.ts || '').substr(11, 8);
+      li.appendChild(ts);
+      li.appendChild(document.createTextNode(e.message || e.phase || ''));
       logEl.appendChild(li);
     });
   }
 
   function finish() {
-    if (spEl) spEl.style.display = 'none';
+    if (spEl) spEl.hidden = true;
     clearToken();
     window.location.href = '/settings';
   }
@@ -86,7 +85,7 @@
 
   function handleTerminal(d) {
     terminalSeen = true;
-    if (spEl) spEl.style.display = 'none';
+    if (spEl) spEl.hidden = true;
     var last = d.entries && d.entries.length ? d.entries[d.entries.length - 1] : null;
     var failed = last && last.phase === 'failed';
     if (failed && failedShownAt === null) {

--- a/compute_space/src/compute_space/web/templates/_components/section.html
+++ b/compute_space/src/compute_space/web/templates/_components/section.html
@@ -1,8 +1,10 @@
 {#- Section label plus an optional right-hand action cluster, supplied by
-    wrapping the call in {% call section_head("...") %}...{% endcall %}. -#}
-{% macro section_head(label) -%}
+    wrapping the call in {% call section_head("...") %}...{% endcall %}.
+    The label is a real heading so the page keeps a navigable outline; the
+    Figma's small uppercase treatment is styling, not a demotion to <span>. -#}
+{% macro section_head(label, level=2) -%}
 <div class="section-head">
-  <span class="section-label">{{ label }}</span>
+  <h{{ level }} class="section-label">{{ label }}</h{{ level }}>
   {%- if caller %}
   <div class="section-actions">{{ caller() }}</div>
   {%- endif %}

--- a/compute_space/src/compute_space/web/templates/_update_progress_body.html
+++ b/compute_space/src/compute_space/web/templates/_update_progress_body.html
@@ -1,4 +1,6 @@
-<h1><span class="sp" id="sp"></span> Updating this instance&hellip;</h1>
-<ul id="log"><li>Working&hellip;</li></ul>
-<p class="hint">This instance is updating and will be back shortly. This page refreshes
-  automatically &mdash; please keep this tab open.</p>
+<div class="update-page">
+  <h1><span class="sp" id="sp"><i></i></span> Updating this instance&hellip;</h1>
+  <ul id="log"><li>Working&hellip;</li></ul>
+  <p class="hint">This instance is updating and will be back shortly. This page refreshes
+    automatically &mdash; please keep this tab open.</p>
+</div>

--- a/compute_space/src/compute_space/web/templates/add_app.html
+++ b/compute_space/src/compute_space/web/templates/add_app.html
@@ -1,11 +1,12 @@
 {% extends "layout.html" %}
 {% block title_suffix %} - Deploy App{% endblock %}
 {% block layout_class %}layout--wide{% endblock %}
+{% from "_components/section.html" import section_head %}
 {% block content %}
 
-<h2>Deploy New App</h2>
+{% call section_head("Deploy New App") %}{% endcall %}
 
-<p id="error" class="error" style="display:none;"></p>
+<p id="error" class="notice notice--error" hidden></p>
 
 <div id="clone-form">
 
@@ -16,19 +17,19 @@
       <p>Discover new apps for your compute space and install them with a click.</p>
     </div>
     {% if catalog_installed %}
-    <a class="btn btn-primary callout-action" href="{{ app_url(catalog_app_name) }}" target="_blank" rel="noopener">Browse the catalog</a>
+    <a class="btn btn--primary callout-action" href="{{ app_url(catalog_app_name) }}" target="_blank" rel="noopener">Browse the catalog</a>
     {% else %}
-    <button class="btn btn-primary callout-action" onclick="cloneApp('{{ catalog_repo_url }}')">Install the catalog</button>
+    <button class="btn btn--primary callout-action" onclick="cloneApp('{{ catalog_repo_url }}')">Install the catalog</button>
     {% endif %}
   </div>
 
-  <h3>Deploy from Git URL</h3>
-  <p>Clone a git repository containing an <code>openhost.toml</code> manifest file.
+  {% call section_head("Deploy from Git URL", level=3) %}{% endcall %}
+  <p class="hint">Clone a git repository containing an <code>openhost.toml</code> manifest file.
   Private GitHub repos are supported automatically &mdash; you'll be prompted to connect your
   GitHub account if needed.</p>
   <div class="repo-url-row">
     <input type="text" id="repo-url" required placeholder="https://github.com/user/my-app@branch">
-    <button onclick="cloneApp()" class="btn btn-primary">Deploy</button>
+    <button onclick="cloneApp()" class="btn btn--primary">Deploy</button>
   </div>
   <details class="url-help">
     <summary>URL format examples</summary>
@@ -56,8 +57,8 @@
   <table id="manifest-table"></table>
 
   <div id="port-mappings-section" style="display:none; margin-top:1em;">
-    <h3>Port Mappings</h3>
-    <p>This app declares extra port mappings. You can set specific host ports or leave them as 0 for auto-assignment.</p>
+    {% call section_head("Port Mappings", level=3) %}{% endcall %}
+    <p class="hint">This app declares extra port mappings. You can set specific host ports or leave them as 0 for auto-assignment.</p>
     <table>
       <thead>
         <tr><th>Label</th><th>Container Port</th><th>Host Port</th><th>Status</th></tr>
@@ -70,7 +71,7 @@
   <label>App name: </label>
   <input type="text" id="app-name" style="font-family:monospace; width:12em; display:inline-block;">
   <br><br>
-  <button onclick="deployApp()" class="btn btn-primary">Authorize &amp; Deploy</button>
+  <button onclick="deployApp()" class="btn btn--primary">Authorize &amp; Deploy</button>
   <button onclick="cancelDeploy()" class="btn" style="margin-left:0.5em;">Cancel</button>
 </div>
 
@@ -81,5 +82,6 @@
   "nextUrl": {{ next_url | tojson }}
 }
 </script>
+<script src="{{ static_url('js/dom.js') }}"></script>
 <script src="{{ static_url('js/add-app.js') }}"></script>
 {% endblock %}

--- a/compute_space/src/compute_space/web/templates/app_detail.html
+++ b/compute_space/src/compute_space/web/templates/app_detail.html
@@ -70,7 +70,7 @@
 </section>
 
 {% if links %}
-<h3>Links</h3>
+{% call section_head("Links", level=3) %}{% endcall %}
 <div class="table-scroll">
   <table>
     <tr><th>Name</th><th>Path</th></tr>
@@ -85,7 +85,7 @@
 {% endif %}
 
 {% if port_mappings %}
-<h3>Port Mappings</h3>
+{% call section_head("Port Mappings", level=3) %}{% endcall %}
 <div class="table-scroll">
   <table>
     <tr><th>Label</th><th>Container Port</th><th>Host Port</th></tr>
@@ -101,7 +101,7 @@
 {% endif %}
 
 {% if services_provided %}
-<h3>Services Provided</h3>
+{% call section_head("Services Provided", level=3) %}{% endcall %}
 <div class="table-scroll">
   <table>
     <tr><th>Service URL</th><th>Version</th></tr>
@@ -116,7 +116,7 @@
 {% endif %}
 
 {% if databases %}
-<h3>SQLite Databases</h3>
+{% call section_head("SQLite Databases", level=3) %}{% endcall %}
 <div class="table-scroll">
   <table>
     <tr><th>Name</th><th>Path</th></tr>
@@ -128,7 +128,7 @@
 {% endif %}
 
 {% if granted_permissions or ungranted_permissions %}
-<h3>Service Permissions</h3>
+{% call section_head("Service Permissions", level=3) %}{% endcall %}
 {% if granted_permissions %}
 <div class="table-scroll">
   <table>
@@ -163,10 +163,10 @@
 {% endif %}
 {% endif %}
 
-<h3>Logs</h3>
+{% call section_head("Logs", level=3) %}{% endcall %}
 <pre class="log-output" id="app-logs">{{ logs or "No log output available." }}</pre>
 
-<h3>Actions</h3>
+{% call section_head("Actions", level=3) %}{% endcall %}
 <div id="app-action-buttons" class="action-bar">
   <button class="btn" onclick="appAction('/stop_app/{{ app.app_id }}', null, {label: 'Stopping'})">Stop App</button>
   <button class="btn" onclick="appAction('/reload_app/{{ app.app_id }}', null, {label: 'Reloading'})">Reload App</button>

--- a/compute_space/src/compute_space/web/templates/approve_permissions_v2.html
+++ b/compute_space/src/compute_space/web/templates/approve_permissions_v2.html
@@ -1,17 +1,25 @@
 {% extends "layout.html" %}
 {% block title_suffix %} — Approve Permission{% endblock %}
 {% block layout_class %}layout--wide{% endblock %}
+{% from "_components/section.html" import section_head %}
+{% from "_components/spec.html" import spec_list, spec_row %}
 {% block content %}
-<h2>{{ app_name }} is requesting a permission</h2>
+{% call section_head("Permission request") %}{% endcall %}
 
-<p>Service: <code>{{ service_url }}</code></p>
+<div class="panel">
+  <p><strong>{{ app_name }}</strong> is requesting a permission.</p>
+
+  {% call spec_list() %}
+    {{ spec_row("Service", service_url) }}
+    {% if not already_granted %}<dt>Grant</dt><dd><code>{{ grant | tojson }}</code></dd>{% endif %}
+  {% endcall %}
 
 {% if already_granted %}
-<p>This permission is already granted.</p>
+  <p class="notice notice--ok">This permission is already granted.</p>
 {% else %}
-<p>Grant: <code>{{ grant | tojson }}</code></p>
-
-<button type="button" class="btn btn-primary" id="grant-btn">Grant</button>
+  <div class="actions">
+    <button type="button" class="btn btn--primary" id="grant-btn">Grant</button>
+  </div>
 <script>
 document.getElementById("grant-btn").addEventListener("click", async () => {
   const btn = document.getElementById("grant-btn");
@@ -42,4 +50,5 @@ document.getElementById("grant-btn").addEventListener("click", async () => {
 });
 </script>
 {% endif %}
+</div>
 {% endblock %}

--- a/compute_space/src/compute_space/web/templates/design.html
+++ b/compute_space/src/compute_space/web/templates/design.html
@@ -80,6 +80,72 @@ that preserves newlines.</div>
 </section>
 
 <section class="section">
+  {% call section_head("Badges") %}{% endcall %}
+  <div class="action-bar">
+    <span class="badge">Neutral</span>
+    <span class="badge badge--ok">Active</span>
+    <span class="badge badge--info">Primary</span>
+    <span class="badge badge--warn">Acquiring</span>
+    <span class="badge badge--error">Error</span>
+  </div>
+</section>
+
+<section class="section">
+  {% call section_head("Notices") %}{% endcall %}
+  <p class="notice">Neutral &mdash; informational.</p>
+  <p class="notice notice--ok">Success &mdash; up to date.</p>
+  <p class="notice notice--warn">Warning &mdash; this operation is one-way.</p>
+  <p class="notice notice--error">Error &mdash; the update check failed.</p>
+  <p class="msg msg--ok">Inline ok message</p>
+  <p class="msg msg--error">Inline error message</p>
+</section>
+
+<section class="section">
+  {% call section_head("Meters") %}{% endcall %}
+  <div class="meter"><div class="meter__fill" style="width:35%"></div></div>
+  <div class="meter"><div class="meter__fill meter__fill--ok" style="width:60%"></div></div>
+  <div class="meter"><div class="meter__fill meter__fill--warn" style="width:80%"></div></div>
+  <div class="meter"><div class="meter__fill meter__fill--error" style="width:96%"></div></div>
+</section>
+
+<section class="section">
+  {% call section_head("Form controls") %}{% endcall %}
+  <div class="panel">
+    <label class="field">
+      <span>Text input</span>
+      <input type="text" placeholder="host.example.com">
+    </label>
+    <label class="field">
+      <span>Select</span>
+      <select><option>Public (HTTPS)</option><option>Local mDNS</option></select>
+    </label>
+    <label class="field field--check">
+      <input type="checkbox" checked><span>Checkbox</span>
+    </label>
+    <div class="field-row">
+      <label class="field"><span>Inline field</span><input type="text"></label>
+      {{ button("Add", variant="primary") }}
+    </div>
+  </div>
+</section>
+
+<section class="section">
+  {% call section_head("Data table") %}{% endcall %}
+  <div class="table-scroll">
+    <table>
+      <thead><tr><th>Domain</th><th>Scheme</th><th>Certificate</th><th>Actions</th></tr></thead>
+      <tbody>
+        <tr><td>host.example.com <span class="muted">(primary)</span></td><td>https</td>
+            <td><span class="badge badge--ok">Active</span></td><td><span class="muted">—</span></td></tr>
+        <tr><td>second.example.com</td><td>https</td>
+            <td><span class="badge badge--warn">Acquiring</span></td>
+            <td>{{ button("Remove", variant="danger") }}</td></tr>
+      </tbody>
+    </table>
+  </div>
+</section>
+
+<section class="section">
   {% call section_head("Icons") %}{% endcall %}
   <div class="action-bar">
     {% for name in ["code", "box", "gear", "search"] %}

--- a/compute_space/src/compute_space/web/templates/diagnostics.html
+++ b/compute_space/src/compute_space/web/templates/diagnostics.html
@@ -1,28 +1,32 @@
 {% extends "layout.html" %}
 {% block title_suffix %} - Diagnostics{% endblock %}
 {% block layout_class %}layout--wide{% endblock %}
+{% from "_components/section.html" import section_head %}
 {% block content %}
-<h2>Diagnostics</h2>
+{% call section_head("Diagnostics") %}{% endcall %}
 <p class="hint">A snapshot of this instance for debugging: Cloud in a Bottle version, host system
 info, installed dependency versions, container runtime, disk usage, and every
 installed app. Copy or download it and include it in a bug report.</p>
 
-<div class="control-row">
-  <button class="btn btn-primary" id="copy-btn">Copy to clipboard</button>
+<div class="action-bar">
+  <button class="btn btn--primary" id="copy-btn">Copy to clipboard</button>
   <a class="btn" id="download-btn" href="/api/diagnostics?download=1">Download JSON</a>
   <button class="btn" id="refresh-btn">Refresh</button>
   <span class="hint" id="copy-status"></span>
 </div>
 
-<h2>Summary</h2>
+{% call section_head("Summary") %}{% endcall %}
+<div class="table-scroll">
 <table id="summary-table">
   <tbody id="summary-body">
     <tr><td colspan="2" class="muted">Loading&hellip;</td></tr>
   </tbody>
 </table>
+</div>
 
-<h2>Installed Apps</h2>
+{% call section_head("Installed Apps") %}{% endcall %}
 <p class="hint">Click a column header to sort.</p>
+<div class="table-scroll">
 <table id="apps-table">
   <thead><tr>
     <th class="sortable" data-sort-key="name">App</th>
@@ -37,16 +41,19 @@ installed app. Copy or download it and include it in a bug report.</p>
     <tr><td colspan="7" class="muted">Loading&hellip;</td></tr>
   </tbody>
 </table>
+</div>
 
-<h2>Outbound Reachability</h2>
+{% call section_head("Outbound Reachability") %}{% endcall %}
+<div class="table-scroll">
 <table id="reachability-table">
   <thead><tr><th>Target</th><th>URL</th><th>Reachable</th><th>Latency</th></tr></thead>
   <tbody id="reachability-body">
     <tr><td colspan="4" class="muted">Loading&hellip;</td></tr>
   </tbody>
 </table>
+</div>
 
-<h2>Raw JSON</h2>
+{% call section_head("Raw JSON") %}{% endcall %}
 <pre class="log-output" id="diag-json" style="max-height: 40em; white-space: pre-wrap; word-break: break-all;">Loading...</pre>
 
 <script id="page-config" type="application/json">
@@ -55,5 +62,6 @@ installed app. Copy or download it and include it in a bug report.</p>
 }
 </script>
 <script src="{{ static_url('js/chart.js') }}"></script>
+<script src="{{ static_url('js/dom.js') }}"></script>
 <script src="{{ static_url('js/diagnostics.js') }}"></script>
 {% endblock %}

--- a/compute_space/src/compute_space/web/templates/logs.html
+++ b/compute_space/src/compute_space/web/templates/logs.html
@@ -1,6 +1,7 @@
 {% extends "layout.html" %}
 {% block title_suffix %} - Logs{% endblock %}
 {% block layout_class %}layout--wide{% endblock %}
+{% from "_components/section.html" import section_head %}
 {% block content %}
 <style>
   /* Full-height log viewer: the layout column becomes the flex parent so the
@@ -11,7 +12,7 @@
   .layout > * { flex: none; }
   #cs-logs { flex: 1 1 auto; min-height: 0; max-height: none; white-space: pre-wrap; word-break: break-all; }
 </style>
-<h2>Compute Space Logs</h2>
+{% call section_head("Compute Space Logs") %}{% endcall %}
 <pre class="log-output" id="cs-logs">Loading...</pre>
 
 <script>

--- a/compute_space/src/compute_space/web/templates/settings.html
+++ b/compute_space/src/compute_space/web/templates/settings.html
@@ -1,172 +1,212 @@
 {% extends "layout.html" %}
+{% from "_components/button.html" import button %}
+{% from "_components/section.html" import section_head %}
+
 {% block title_suffix %} - Settings{% endblock %}
 {% block layout_class %}layout--wide{% endblock %}
+
 {% block content %}
-<p id="error" class="error" style="display:none;"></p>
+<p id="error" class="notice notice--error" hidden></p>
 
-<h2 class="section-title">Account</h2>
-<table class="form-table">
-  <tr>
-    <th><label for="username-input">Owner username</label></th>
-    <td>
-      <input type="text" id="username-input"
-             pattern="[a-z0-9][a-z0-9._\-]{0,29}" maxlength="30"
-             aria-describedby="username-msg"
-             placeholder="Loading…" disabled>
-      <button onclick="setOwnerUsername()" class="btn btn-primary"
-              id="set-username-btn" disabled>Save</button>
-      <p class="hint">Used as your account name inside installed apps.</p>
-      <p id="username-msg" style="display:none;"></p>
-    </td>
-  </tr>
-  <tr>
-    <th>Password</th>
-    <td>
-      <button id="show-pw-form-btn" class="btn"
-              onclick="this.style.display = 'none'; document.getElementById('pw-form').hidden = false;">Change password</button>
+<section class="section">
+  {% call section_head("Account") %}{% endcall %}
+  <div class="panel">
+    <label class="field" for="username-input">
+      <span>Owner username</span>
+      <div class="field-row">
+        <input type="text" id="username-input"
+               pattern="[a-z0-9][a-z0-9._\-]{0,29}" maxlength="30"
+               aria-describedby="username-msg" placeholder="Loading…" disabled>
+        {{ button("Save", variant="primary", id="set-username-btn", onclick="setOwnerUsername()", disabled=true) }}
+      </div>
+    </label>
+    <p class="hint">Used as your account name inside installed apps.</p>
+    <p id="username-msg" hidden></p>
+
+    <hr class="rule">
+
+    <div class="field">
+      <span>Password</span>
+      {{ button("Change password", id="show-pw-form-btn",
+                onclick="this.hidden = true; document.getElementById('pw-form').hidden = false;") }}
       <div id="pw-form" hidden>
-        <input type="password" id="current-pw" placeholder="Current password" style="display:block; margin-bottom:0.3em;">
-        <input type="password" id="new-pw" placeholder="New password" style="display:block; margin-bottom:0.3em;">
-        <input type="password" id="confirm-pw" placeholder="Confirm new password" style="display:block; margin-bottom:0.5em;">
-        <button onclick="changePassword()" class="btn btn-primary">Change password</button>
-        <span id="pw-msg" style="display:none;"></span>
+        <input type="password" id="current-pw" placeholder="Current password" autocomplete="current-password">
+        <input type="password" id="new-pw" placeholder="New password" autocomplete="new-password">
+        <input type="password" id="confirm-pw" placeholder="Confirm new password" autocomplete="new-password">
+        <div class="actions">
+          {{ button("Change password", variant="primary", onclick="changePassword()") }}
+        </div>
+        <span id="pw-msg" hidden></span>
       </div>
-    </td>
-  </tr>
-  <tr>
-    <th>Session</th>
-    <td>
-      <form method="post" action="/logout" style="margin:0;">
-        <button type="submit" class="btn btn-danger">Log out</button>
+    </div>
+
+    <hr class="rule">
+
+    <div class="field">
+      <span>Session</span>
+      <form method="post" action="/logout">
+        {{ button("Log out", variant="danger", type="submit") }}
       </form>
-    </td>
-  </tr>
-</table>
+    </div>
+  </div>
+</section>
 
-<div id="connect-imbue-section" style="display:none;">
-  <h2 class="section-title">Imbue account</h2>
-  <table class="form-table">
-    <tr>
-      <th>Connection</th>
-      <td>
-        <p id="connect-imbue-state" class="muted" style="margin-bottom:1em;">Checking&hellip;</p>
-        <button id="connect-imbue-btn" onclick="connectImbue()" class="btn btn-primary" style="display:none;">Connect to Imbue</button>
-        <p class="hint">Connect this instance to your Imbue account to enable Imbue services. Managed instances are connected automatically; use this if yours isn't, or to reconnect.</p>
-        <p id="connect-imbue-msg" style="display:none;"></p>
-      </td>
-    </tr>
-  </table>
-</div>
+<section class="section" id="connect-imbue-section" hidden>
+  {% call section_head("Imbue account") %}{% endcall %}
+  <div class="panel">
+    <p id="connect-imbue-state" class="muted">Checking&hellip;</p>
+    {{ button("Connect to Imbue", variant="primary", id="connect-imbue-btn", onclick="connectImbue()") }}
+    <p class="hint">Connect this instance to your Imbue account to enable Imbue services. Managed
+      instances are connected automatically; use this if yours isn't, or to reconnect.</p>
+    <p id="connect-imbue-msg" hidden></p>
+  </div>
+</section>
 
-<h2 class="section-title">Software updates</h2>
-<table class="form-table">
-  <tr>
-    <th><label for="remote-url">Git remote</label></th>
-    <td>
-      <input type="text" id="remote-url" placeholder="Loading…" disabled style="width:32em;">
-      <button onclick="setRemote()" class="btn btn-primary" id="set-remote-btn" disabled>Save remote</button>
-      <p class="hint">Repository this instance updates from. Saving pins the target; use Update below to apply it.</p>
-      <p id="remote-msg" style="display:none;"></p>
-    </td>
-  </tr>
-  <tr>
-    <th>Status</th>
-    <td>
-      <div id="update-status">
-        <p>Checking for updates&hellip;</p>
+<section class="section">
+  {% call section_head("Software updates") %}{% endcall %}
+  <div class="panel">
+    <label class="field" for="remote-url">
+      <span>Git remote</span>
+      <div class="field-row">
+        <input type="text" id="remote-url" placeholder="Loading…" disabled>
+        {{ button("Save remote", variant="primary", id="set-remote-btn", onclick="setRemote()", disabled=true) }}
       </div>
-      <div id="restart-overlay" style="display:none;">
+    </label>
+    <p class="hint">Repository this instance updates from. Saving pins the target; use Update
+      below to apply it.</p>
+    <p id="remote-msg" hidden></p>
+
+    <hr class="rule">
+
+    <div class="field">
+      <span>Status</span>
+      <div id="update-status"><p>Checking for updates&hellip;</p></div>
+      <div id="restart-overlay" hidden>
         <p id="restart-status"><strong>Waiting for shutdown&hellip;</strong></p>
       </div>
-    </td>
-  </tr>
-</table>
+    </div>
+  </div>
+</section>
 
-<h2 class="section-title">Domains</h2>
-<p class="hint">Hostnames this instance answers on. The primary is set at provisioning. Add a secondary
-  <strong>public</strong> domain (its DNS must be delegated to this instance — it then acquires a TLS
-  certificate automatically) or a local <code>.local</code> name served over plain HTTP. Removing a
-  domain takes effect immediately; the primary can't be removed.</p>
+<section class="section">
+  {% call section_head("Domains") %}{% endcall %}
+  <p class="hint">Hostnames this instance answers on. The primary is set at provisioning. Add a
+    secondary <strong>public</strong> domain (its DNS must be delegated to this instance — it then
+    acquires a TLS certificate automatically) or a local <code>.local</code> name served over plain
+    HTTP. Removing a domain takes effect immediately; the primary can't be removed.</p>
 
-<div class="control-row">
-  <label>Domain <input type="text" id="domain-name" placeholder="host.example.com" style="width: 20em;"></label>
-  <label>Type
-    <select id="domain-type">
-      <option value="public">Public (HTTPS)</option>
-      <option value="mdns">Local mDNS (.local, HTTP)</option>
-    </select>
-  </label>
-  <button class="btn btn-primary" onclick="addDomain()">Add domain</button>
-</div>
-<p id="domain-msg" style="display:none;"></p>
+  <div class="field-row">
+    <label class="field">
+      <span>Domain</span>
+      <input type="text" id="domain-name" placeholder="host.example.com">
+    </label>
+    <label class="field">
+      <span>Type</span>
+      <select id="domain-type">
+        <option value="public">Public (HTTPS)</option>
+        <option value="mdns">Local mDNS (.local, HTTP)</option>
+      </select>
+    </label>
+    {{ button("Add domain", variant="primary", onclick="addDomain()") }}
+  </div>
+  <p id="domain-msg" hidden></p>
 
-<div class="table-scroll">
-  <table id="domains-table" style="display:none;">
-  <thead><tr><th>Domain</th><th>Scheme</th><th>Discovery</th><th>Certificate</th><th>Actions</th></tr></thead>
-  <tbody id="domains-body"></tbody>
-</table>
-</div>
-<p id="no-domains" class="muted">Loading&hellip;</p>
+  <div class="table-scroll" id="domains-table-wrap" hidden>
+    <table>
+      <thead><tr><th>Domain</th><th>Scheme</th><th>Discovery</th><th>Certificate</th><th>Actions</th></tr></thead>
+      <tbody id="domains-body"></tbody>
+    </table>
+  </div>
+  <p id="no-domains" class="empty">Loading&hellip;</p>
+</section>
 
-<h2 class="section-title">API tokens</h2>
-<p class="hint">Bearer tokens for programmatic access (e.g. AI agents). Each token grants owner-level access until it expires.</p>
+<section class="section">
+  {% call section_head("API tokens") %}{% endcall %}
+  <p class="hint">Bearer tokens for programmatic access (e.g. AI agents). Each token grants
+    owner-level access until it expires.</p>
 
-<div class="control-row">
-  <label>Name <input type="text" id="token-name" style="width: 200px;"></label>
-  <label>Expires in
-    <input type="number" id="token-expiry" value="8" min="0.1" step="any" style="width: 70px;" disabled> hours
-  </label>
-  <label><input type="checkbox" id="token-no-expiry" checked onchange="document.getElementById('token-expiry').disabled = this.checked;"> Never expires</label>
-  <button class="btn btn-primary" onclick="createToken()">Create token</button>
-</div>
+  <div class="field-row">
+    <label class="field">
+      <span>Name</span>
+      <input type="text" id="token-name">
+    </label>
+    <label class="field">
+      <span>Expires in (hours)</span>
+      <input type="number" id="token-expiry" value="8" min="0.1" step="any" disabled>
+    </label>
+    <label class="field field--check">
+      <input type="checkbox" id="token-no-expiry" checked
+             onchange="document.getElementById('token-expiry').disabled = this.checked;">
+      <span>Never expires</span>
+    </label>
+    {{ button("Create token", variant="primary", onclick="createToken()") }}
+  </div>
 
-<div id="token-created" style="display:none; background: #d4edda; border: 1px solid #28a745; padding: 0.8em 1em; border-radius: 4px; margin-bottom: 1em;">
-  <strong>Token created.</strong> Copy it now — it won't be shown again.<br>
-  <code id="token-value" style="display: inline-block; margin-top: 0.4em; padding: 0.3em 0.5em; background: #f5f5f5; border: 1px solid #ddd; user-select: all; word-break: break-all;"></code>
-  <button class="btn" onclick="navigator.clipboard.writeText(document.getElementById('token-value').textContent)" style="margin-left: 0.5em;">Copy</button>
-</div>
+  <div id="token-created" class="notice notice--ok" hidden>
+    <strong>Token created.</strong> Copy it now — it won't be shown again.
+    <div class="copy-field">
+      <code id="token-value"></code>
+      {{ button("Copy", onclick="navigator.clipboard.writeText(document.getElementById('token-value').textContent)") }}
+    </div>
+  </div>
 
-<div class="table-scroll">
-  <table id="tokens-table" style="display:none;">
-  <thead><tr><th>Name</th><th>Created</th><th>Expires</th><th>Actions</th></tr></thead>
-  <tbody id="tokens-body"></tbody>
-</table>
-</div>
-<p id="no-tokens" class="muted">No API tokens.</p>
+  <div class="table-scroll" id="tokens-table-wrap" hidden>
+    <table>
+      <thead><tr><th>Name</th><th>Created</th><th>Expires</th><th>Actions</th></tr></thead>
+      <tbody id="tokens-body"></tbody>
+    </table>
+  </div>
+  <p id="no-tokens" class="empty">No API tokens.</p>
+</section>
 
-<h2 class="section-title">Archive backend</h2>
-<p class="hint">The archive data tier (<code>app_archive</code>) is used by apps that store large amounts of bulk data (e.g. file uploads, media). It is always available: by default it is backed by <strong>local disk</strong> on this instance. Configure an <strong>S3</strong> backend for durable, elastic object storage &mdash; any existing local archive data is migrated into the bucket when you do.</p>
-<div id="archive-backend-status">
-  <div class="muted">Loading&hellip;</div>
-</div>
+<section class="section">
+  {% call section_head("Archive backend") %}{% endcall %}
+  <p class="hint">The archive data tier (<code>app_archive</code>) is used by apps that store large
+    amounts of bulk data (e.g. file uploads, media). It is always available: by default it is backed
+    by <strong>local disk</strong> on this instance. Configure an <strong>S3</strong> backend for
+    durable, elastic object storage &mdash; any existing local archive data is migrated into the
+    bucket when you do.</p>
+  <div id="archive-backend-status">
+    <div class="muted">Loading&hellip;</div>
+  </div>
+</section>
 
-<h2 class="section-title">Maintenance</h2>
-<table class="form-table">
-  <tr>
-    <th>Restart compute space</th>
-    <td>
-      <button class="btn btn-danger" onclick="restartComputeSpace()">Restart compute space</button>
-      <span id="restart-msg" class="muted"></span>
+<section class="section">
+  {% call section_head("Maintenance") %}{% endcall %}
+  <div class="panel">
+    <div class="field">
+      <span>Restart compute space</span>
+      <div class="actions">
+        {{ button("Restart compute space", variant="danger", onclick="restartComputeSpace()") }}
+        <span id="restart-msg" class="muted"></span>
+      </div>
       <p class="hint">Restarts the router process; running apps are not interrupted.</p>
-    </td>
-  </tr>
-  <tr>
-    <th>Build cache</th>
-    <td>
-      <button class="btn btn-danger" id="drop-build-cache-btn" onclick="dropBuildCache()">Drop build cache</button>
-      <span id="drop-build-cache-msg" class="muted"></span>
-      <p class="hint">Removes images for stopped apps; they are rebuilt on next deploy.</p>
-    </td>
-  </tr>
-  <tr>
-    <th>SSH</th>
-    <td>
-      <button class="btn" id="ssh-btn" onclick="toggleSsh()" disabled>SSH</button>
-      <span id="ssh-status" class="muted"></span>
-    </td>
-  </tr>
-</table>
+    </div>
 
+    <hr class="rule">
+
+    <div class="field">
+      <span>Build cache</span>
+      <div class="actions">
+        {{ button("Drop build cache", variant="danger", id="drop-build-cache-btn", onclick="dropBuildCache()") }}
+        <span id="drop-build-cache-msg" class="muted"></span>
+      </div>
+      <p class="hint">Removes images for stopped apps; they are rebuilt on next deploy.</p>
+    </div>
+
+    <hr class="rule">
+
+    <div class="field">
+      <span>SSH</span>
+      <div class="actions">
+        {{ button("SSH", id="ssh-btn", onclick="toggleSsh()", disabled=true) }}
+        <span id="ssh-status" class="muted"></span>
+      </div>
+    </div>
+  </div>
+</section>
+
+<script src="{{ static_url('js/dom.js') }}"></script>
 <script src="{{ static_url('js/username-validation.js') }}"></script>
 <script src="{{ static_url('js/tokens.js') }}"></script>
 <script src="{{ static_url('js/domains.js') }}"></script>

--- a/compute_space/src/compute_space/web/templates/system.html
+++ b/compute_space/src/compute_space/web/templates/system.html
@@ -2,7 +2,8 @@
 {% block title_suffix %} - System Info{% endblock %}
 {% block layout_class %}layout--wide{% endblock %}
 {% block content %}
-<h2 class="section-title">Resource Usage</h2>
+{% from "_components/section.html" import section_head %}
+{% call section_head("Resource Usage") %}{% endcall %}
 <div class="usage-charts">
   <div class="usage-chart">
     <h3>Disk</h3>
@@ -22,21 +23,24 @@
   </div>
 </div>
 
-<h2 class="section-title">Storage</h2>
+{% call section_head("Storage") %}{% endcall %}
 <table id="storage-table" class="form-table">
   <tbody id="storage-body"></tbody>
 </table>
 <div id="storage-guard-row"></div>
 
-<h2 class="section-title">Externally Open Ports</h2>
+{% call section_head("Externally Open Ports") %}{% endcall %}
+<div class="table-scroll">
 <table id="ports-table">
   <thead><tr><th>Port</th><th>Address</th><th>Detail</th></tr></thead>
   <tbody id="ports-body"></tbody>
 </table>
+</div>
 
-<h2 class="section-title">Logs</h2>
-<pre class="log-output" id="cs-logs" style="max-height: 120em; white-space: pre-wrap; word-break: break-all;"></pre>
+{% call section_head("Logs") %}{% endcall %}
+<pre class="log-output log-output--tall" id="cs-logs"></pre>
 
+<script src="{{ static_url('js/dom.js') }}"></script>
 <script id="page-config" type="application/json">
 {
   "listeningPortsUrl": "/api/listening-ports",

--- a/compute_space/src/compute_space/web/templates/terminal.html
+++ b/compute_space/src/compute_space/web/templates/terminal.html
@@ -2,8 +2,8 @@
 {% block title_suffix %} - Terminal{% endblock %}
 {% block layout_class %}layout--wide{% endblock %}
 {% block content %}
-<div style="width:calc(100vw - 2em); margin-left:calc((100% - 100vw) / 2 + 1em); height:calc(100vh - 200px); background:#1e1e1e; border-radius:4px; overflow:hidden; padding:8px; box-sizing:border-box;">
-  <div id="terminal" style="width:100%; height:100%;"></div>
+<div class="terminal-frame">
+  <div id="terminal"></div>
 </div>
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@xterm/xterm@5.5.0/css/xterm.min.css">
 <script src="https://cdn.jsdelivr.net/npm/@xterm/xterm@5.5.0/lib/xterm.min.js"></script>


### PR DESCRIPTION
Stacked on #298 — review that one first; this PR's base is its branch.

Extends the component vocabulary to the parts the Figma doesn't cover, then
converts settings, system, diagnostics, add app, terminal, permissions and the
update page onto it.

## Extending the design language

There are no comps for most of these components, so rather than invent a second
style alongside the first, I derived them from what the Figma does fix:
monospace; sharp corners (radius 0 everywhere it matters); 1px `#dadada` borders
on `#fcfcfc` surfaces; a hard `2px 2px 0` unblurred shadow as the only "raised"
signal; uppercase + `0.72px` tracking as the "this is a label" signal; and flat
pastel fills used **only** to carry meaning, never decoratively.

What that produced:

| Component | Derivation |
|---|---|
| `.badge` | The "+ NEW" button is already a flat pastel square with tracked uppercase text — the badge is that, generalised to ok/info/warn/error. |
| `.notice` | Same tints at panel scale, with a 3px bar carrying the status so the message itself stays plain text. |
| `.meter` | Segmented, not smooth — the blocky fill echoes the pixel-art clouds and grass rather than reading as a modern progress bar. |
| Tables | Adopt the app list's vocabulary: horizontal rules only, columns carried by mono alignment, uppercase tracked `th`. |
| Checkbox / radio / select | Natives arrive rounded and OS-tinted, which fought the sharp flat treatment everywhere else; restyled square. |
| `.terminal-frame`, `.panel`, `.copy-field`, `.field-row` | Surface + 1px border + hard shadow, per the card. |

One place I kept the existing shape: the **donut charts**. A donut is genuinely
better than a bar for the multi-segment storage breakdown, where proportion
*between parts* is the point. I moved its palette onto the brand pastels instead.
The single-value CPU/memory/swap charts would read better as `.meter`s — worth
doing, but it's a behaviour change rather than a restyle, so I left it.

## Coding style

Adds `static/js/dom.js` — `el` / `replace` / `badge` builders replacing innerHTML
string concatenation.

The motivating detail: there were **three** near-identical hand-rolled HTML
escapers (`esc`, `dEsc`, `escSettingsHtml`), which exist precisely because every
interpolation was a place to forget escaping. And `tokens.js` had in fact
forgotten one — interpolating a user-controlled token name straight into
innerHTML. Text goes in as text now, so there is nothing to forget.

Also removes the last raw hex colours from the page scripts (`style.color =
'#dc3545'` and friends) in favour of `.msg--ok` / `.msg--error`.

I did **not** rewrite the page scripts wholesale. ~1,700 lines of working,
untested JS is a poor thing to churn for its own sake; I converted the sites
that emit styled markup (which had to change anyway) and left the logic alone.

## Accessibility fix

`section_head` emitted a `<span>`, so every page converted to it lost its
heading outline — caught by an existing test asserting `>Domains</h2>`. It emits
a real `h2`/`h3` now, with the small uppercase treatment as styling rather than
a demotion. I fixed the component instead of the test.

## Note on the update page

`update-progress.css` deliberately still uses literal values rather than tokens.
The updater inlines that file into a standalone page it serves *while
compute_space is down*, so neither `tokens.css` nor the webfont is reachable;
it also falls back to the system mono stack for the same reason. There's a
comment saying so.

## Testing

1594 passed, 63 skipped. ruff and mypy clean. Verified in a browser at 1280px
and 390px across settings, system, diagnostics, add app, terminal, dashboard,
app detail, docs and `/design`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)