### PR TITLE
Rename the oh CLI to bottle

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,11 +206,11 @@ An agent skill that gives an AI coding agent context for deploying and debugging
 npx skills add cloud-in-a-bottle/cloud-in-a-bottle --skill openhost-context
 ```
 
-The skill works best with the `oh` CLI installed and logged in:
+The skill works best with the `cb` CLI installed and logged in:
 
 ```bash
-uv tool install "oh @ git+https://github.com/cloud-in-a-bottle/cloud-in-a-bottle.git#subdirectory=compute_space_cli"
-oh instance login
+uv tool install "cb @ git+https://github.com/cloud-in-a-bottle/cloud-in-a-bottle.git#subdirectory=compute_space_cli"
+cb instance login
 ```
 
 Once set up, ask your coding agent to package any existing project for Cloud in a Bottle and deploy it directly — no manual manifest editing required.

--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ The user-facing manual lives in `docs/src/` and is served at `https://<zone>/doc
 
 ## Agent skill
 
-An agent skill that gives an AI coding agent context for deploying and debugging apps on Cloud in a Bottle via the `oh` CLI. Install with:
+An agent skill that gives an AI coding agent context for deploying and debugging apps on Cloud in a Bottle via the `cb` CLI. Install with:
 
 ```bash
 npx skills add cloud-in-a-bottle/cloud-in-a-bottle --skill openhost-context

--- a/README.md
+++ b/README.md
@@ -200,17 +200,17 @@ The user-facing manual lives in `docs/src/` and is served at `https://<zone>/doc
 
 ## Agent skill
 
-An agent skill that gives an AI coding agent context for deploying and debugging apps on Cloud in a Bottle via the `cb` CLI. Install with:
+An agent skill that gives an AI coding agent context for deploying and debugging apps on Cloud in a Bottle via the `bottle` CLI. Install with:
 
 ```bash
 npx skills add cloud-in-a-bottle/cloud-in-a-bottle --skill openhost-context
 ```
 
-The skill works best with the `cb` CLI installed and logged in:
+The skill works best with the `bottle` CLI installed and logged in:
 
 ```bash
-uv tool install "cb @ git+https://github.com/cloud-in-a-bottle/cloud-in-a-bottle.git#subdirectory=compute_space_cli"
-cb instance login
+uv tool install "bottle @ git+https://github.com/cloud-in-a-bottle/cloud-in-a-bottle.git#subdirectory=compute_space_cli"
+bottle instance login
 ```
 
 Once set up, ask your coding agent to package any existing project for Cloud in a Bottle and deploy it directly — no manual manifest editing required.

--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ npx skills add cloud-in-a-bottle/cloud-in-a-bottle --skill openhost-context
 The skill works best with the `bottle` CLI installed and logged in:
 
 ```bash
-uv tool install "bottle @ git+https://github.com/cloud-in-a-bottle/cloud-in-a-bottle.git#subdirectory=compute_space_cli"
+uv tool install "cloud-in-a-bottle-cli @ git+https://github.com/cloud-in-a-bottle/cloud-in-a-bottle.git#subdirectory=compute_space_cli"
 bottle instance login
 ```
 

--- a/compute_space_cli/README.md
+++ b/compute_space_cli/README.md
@@ -1,4 +1,4 @@
-# cb — Cloud in a Bottle CLI
+# bottle — Cloud in a Bottle CLI
 
 Command-line tool for managing apps on your Cloud in a Bottle compute space.
 
@@ -6,21 +6,21 @@ Command-line tool for managing apps on your Cloud in a Bottle compute space.
 
 HTTPS:
 ```bash
-uv tool install "cb @ git+https://github.com/cloud-in-a-bottle/cloud-in-a-bottle.git#subdirectory=compute_space_cli"
+uv tool install "bottle @ git+https://github.com/cloud-in-a-bottle/cloud-in-a-bottle.git#subdirectory=compute_space_cli"
 ```
 SSH:
 ```bash
-uv tool install "cb @ git+ssh://git@github.com/cloud-in-a-bottle/cloud-in-a-bottle.git#subdirectory=compute_space_cli"
+uv tool install "bottle @ git+ssh://git@github.com/cloud-in-a-bottle/cloud-in-a-bottle.git#subdirectory=compute_space_cli"
 ```
 
 ## Setup
 
 ```bash
-cb instance login                    # add an instance interactively
-cb instance set-default x.host.com   # set it as default
+bottle instance login                    # add an instance interactively
+bottle instance set-default x.host.com   # set it as default
 ```
 
-This will prompt you for your compute space URL and walk you through creating an API token. The instance is saved under its domain name (e.g. `x.host.com`) to `~/.cb/compute_space_cli.toml`.
+This will prompt you for your compute space URL and walk you through creating an API token. The instance is saved under its domain name (e.g. `x.host.com`) to `~/.bottle/compute_space_cli.toml`.
 
 For development, use an editable install so changes take effect immediately:
 
@@ -31,37 +31,37 @@ cd compute_space_cli && uv tool install --editable .
 ## Usage
 
 ```bash
-cb status                                    # check if compute space is reachable
-cb version                                   # show git branch/SHA of the running openhost
-cb logs                                      # view zone-level router logs
-cb logs --follow                             # tail router logs
+bottle status                                    # check if compute space is reachable
+bottle version                                   # show git branch/SHA of the running openhost
+bottle logs                                      # view zone-level router logs
+bottle logs --follow                             # tail router logs
 
-cb app list                                  # list apps and status
-cb app deploy https://github.com/you/myapp   # deploy from git repo
-cb app deploy https://github.com/you/myapp --name cool-app  # custom name
-cb app deploy https://github.com/you/myapp --wait           # block until running
-cb app deploy https://github.com/you/myapp --grant-permissions-v2  # auto-grant all manifest permissions
-cb app deploy https://github.com/you/myapp --port web=8080  # override a port mapping
-cb app status cool-app                       # check status
-cb app logs cool-app                         # view logs
-cb app logs cool-app --follow                # tail logs
-cb app reload cool-app                       # rebuild + restart
-cb app reload cool-app --update --wait       # git pull, rebuild, wait until running
-cb app ssh cool-app                          # open a shell inside the running container
-cb app ssh cool-app --shell bash             # use bash instead of sh (default: sh)
-cb app ssh cool-app -- ls -la /data          # run a command in the container and exit
-cb app ssh cool-app "cat /etc/os-release"    # ...or pass it as a single quoted string
-cb app stop cool-app                         # stop app
-cb app remove cool-app                       # remove app + data
-cb app remove cool-app --keep-data           # remove but keep data
-cb app rename cool-app new-name              # rename app
+bottle app list                                  # list apps and status
+bottle app deploy https://github.com/you/myapp   # deploy from git repo
+bottle app deploy https://github.com/you/myapp --name cool-app  # custom name
+bottle app deploy https://github.com/you/myapp --wait           # block until running
+bottle app deploy https://github.com/you/myapp --grant-permissions-v2  # auto-grant all manifest permissions
+bottle app deploy https://github.com/you/myapp --port web=8080  # override a port mapping
+bottle app status cool-app                       # check status
+bottle app logs cool-app                         # view logs
+bottle app logs cool-app --follow                # tail logs
+bottle app reload cool-app                       # rebuild + restart
+bottle app reload cool-app --update --wait       # git pull, rebuild, wait until running
+bottle app ssh cool-app                          # open a shell inside the running container
+bottle app ssh cool-app --shell bash             # use bash instead of sh (default: sh)
+bottle app ssh cool-app -- ls -la /data          # run a command in the container and exit
+bottle app ssh cool-app "cat /etc/os-release"    # ...or pass it as a single quoted string
+bottle app stop cool-app                         # stop app
+bottle app remove cool-app                       # remove app + data
+bottle app remove cool-app --keep-data           # remove but keep data
+bottle app rename cool-app new-name              # rename app
 
-cb tokens list                               # list API tokens
-cb tokens create --name "ci" --expiry-hours 72
-cb tokens delete 3                           # delete by token ID
+bottle tokens list                               # list API tokens
+bottle tokens create --name "ci" --expiry-hours 72
+bottle tokens delete 3                           # delete by token ID
 ```
 
-`cb logs` shows zone-level router logs (deploy errors, routing issues). `cb app logs` shows a specific app's container output.
+`bottle logs` shows zone-level router logs (deploy errors, routing issues). `bottle app logs` shows a specific app's container output.
 
 `--grant-permissions-v2` automatically grants all `[[services.v2.consumes]]` entries from the manifest at deploy time, skipping the manual approval step in the dashboard. See [cross_app_services.md](../docs/src/cross_app_services.md) for details on the permissions model.
 
@@ -74,50 +74,50 @@ The CLI supports managing multiple named instances.
 ### Instance management
 
 ```bash
-cb instance login                            # interactive login (saves as domain name)
-cb instance list                             # list all instances
-cb instance add user.host.com TOKEN          # add non-interactively
-cb instance alias user.host.com dev          # set a short alias
-cb instance set-default dev                  # set default (by hostname or alias)
-cb instance remove dev                       # remove (by hostname or alias)
-cb instance token                            # print stored token for current instance
+bottle instance login                            # interactive login (saves as domain name)
+bottle instance list                             # list all instances
+bottle instance add user.host.com TOKEN          # add non-interactively
+bottle instance alias user.host.com dev          # set a short alias
+bottle instance set-default dev                  # set default (by hostname or alias)
+bottle instance remove dev                       # remove (by hostname or alias)
+bottle instance token                            # print stored token for current instance
 ```
 
 ### Targeting instances
 
 ```bash
-cb --instance dev app list                   # target by alias
-cb --instance user.host.com app list         # target by hostname
-CB_INSTANCE=dev cb app list                  # same, via env var
+bottle --instance dev app list                   # target by alias
+bottle --instance user.host.com app list         # target by hostname
+BOTTLE_INSTANCE=dev bottle app list                  # same, via env var
 ```
 
-Resolution order: `--instance` flag > `CB_INSTANCE` env var > default instance.
+Resolution order: `--instance` flag > `BOTTLE_INSTANCE` env var > default instance.
 Names are resolved as hostnames first, then aliases.
 
 ## SSH access
 
 ```bash
-cb instance configure-ssh-key ~/.ssh/id_ed25519   # register SSH key for this instance
-cb instance ssh                                    # SSH into the zone server as the host user
-cb instance ssh -- -L 5432:localhost:5432          # SSH with extra arguments (port forward etc.)
-cb instance rsync -av ./local/ host@myzone.example.com:/path/  # rsync via the configured key
+bottle instance configure-ssh-key ~/.ssh/id_ed25519   # register SSH key for this instance
+bottle instance ssh                                    # SSH into the zone server as the host user
+bottle instance ssh -- -L 5432:localhost:5432          # SSH with extra arguments (port forward etc.)
+bottle instance rsync -av ./local/ host@myzone.example.com:/path/  # rsync via the configured key
 ```
 
-`cb instance ssh` is a shorthand for `ssh [-i key] host@<hostname>`. Without a key configured via `configure-ssh-key`, it falls back to your SSH agent or default key.
+`bottle instance ssh` is a shorthand for `ssh [-i key] host@<hostname>`. Without a key configured via `configure-ssh-key`, it falls back to your SSH agent or default key.
 
 Note: `podman` is installed via pixi, not system-wide. Use the full path above or `cd ~/openhost && pixi run -e dev podman ...` if pixi is on your PATH. App data lives at `~/.openhost/local_compute_space/persistent_data/app_data/`.
 
 ## Authenticated HTTP requests
 
 ```bash
-cb curl https://myzone.example.com/api/apps          # GET with bearer token injected
-cb curl -X POST https://myzone.example.com/api/...   # any curl args work
+bottle curl https://myzone.example.com/api/apps          # GET with bearer token injected
+bottle curl -X POST https://myzone.example.com/api/...   # any curl args work
 ```
 
-`cb curl` runs `curl` with `Authorization: Bearer <token>` pre-injected for the current instance. Useful for hitting the API or testing app endpoints without copying tokens by hand.
+`bottle curl` runs `curl` with `Authorization: Bearer <token>` pre-injected for the current instance. Useful for hitting the API or testing app endpoints without copying tokens by hand.
 
 ## Update
 
 ```bash
-uv tool upgrade cb
+uv tool upgrade bottle
 ```

--- a/compute_space_cli/README.md
+++ b/compute_space_cli/README.md
@@ -1,4 +1,4 @@
-# oh — Cloud in a Bottle CLI
+# cb — Cloud in a Bottle CLI
 
 Command-line tool for managing apps on your Cloud in a Bottle compute space.
 
@@ -6,21 +6,21 @@ Command-line tool for managing apps on your Cloud in a Bottle compute space.
 
 HTTPS:
 ```bash
-uv tool install "oh @ git+https://github.com/cloud-in-a-bottle/cloud-in-a-bottle.git#subdirectory=compute_space_cli"
+uv tool install "cb @ git+https://github.com/cloud-in-a-bottle/cloud-in-a-bottle.git#subdirectory=compute_space_cli"
 ```
 SSH:
 ```bash
-uv tool install "oh @ git+ssh://git@github.com/cloud-in-a-bottle/cloud-in-a-bottle.git#subdirectory=compute_space_cli"
+uv tool install "cb @ git+ssh://git@github.com/cloud-in-a-bottle/cloud-in-a-bottle.git#subdirectory=compute_space_cli"
 ```
 
 ## Setup
 
 ```bash
-oh instance login                    # add an instance interactively
-oh instance set-default x.host.com   # set it as default
+cb instance login                    # add an instance interactively
+cb instance set-default x.host.com   # set it as default
 ```
 
-This will prompt you for your compute space URL and walk you through creating an API token. The instance is saved under its domain name (e.g. `x.host.com`) to `~/.openhost/compute_space_cli.toml`.
+This will prompt you for your compute space URL and walk you through creating an API token. The instance is saved under its domain name (e.g. `x.host.com`) to `~/.cb/compute_space_cli.toml`.
 
 For development, use an editable install so changes take effect immediately:
 
@@ -31,37 +31,37 @@ cd compute_space_cli && uv tool install --editable .
 ## Usage
 
 ```bash
-oh status                                    # check if compute space is reachable
-oh version                                   # show git branch/SHA of the running openhost
-oh logs                                      # view zone-level router logs
-oh logs --follow                             # tail router logs
+cb status                                    # check if compute space is reachable
+cb version                                   # show git branch/SHA of the running openhost
+cb logs                                      # view zone-level router logs
+cb logs --follow                             # tail router logs
 
-oh app list                                  # list apps and status
-oh app deploy https://github.com/you/myapp   # deploy from git repo
-oh app deploy https://github.com/you/myapp --name cool-app  # custom name
-oh app deploy https://github.com/you/myapp --wait           # block until running
-oh app deploy https://github.com/you/myapp --grant-permissions-v2  # auto-grant all manifest permissions
-oh app deploy https://github.com/you/myapp --port web=8080  # override a port mapping
-oh app status cool-app                       # check status
-oh app logs cool-app                         # view logs
-oh app logs cool-app --follow                # tail logs
-oh app reload cool-app                       # rebuild + restart
-oh app reload cool-app --update --wait       # git pull, rebuild, wait until running
-oh app ssh cool-app                          # open a shell inside the running container
-oh app ssh cool-app --shell bash             # use bash instead of sh (default: sh)
-oh app ssh cool-app -- ls -la /data          # run a command in the container and exit
-oh app ssh cool-app "cat /etc/os-release"    # ...or pass it as a single quoted string
-oh app stop cool-app                         # stop app
-oh app remove cool-app                       # remove app + data
-oh app remove cool-app --keep-data           # remove but keep data
-oh app rename cool-app new-name              # rename app
+cb app list                                  # list apps and status
+cb app deploy https://github.com/you/myapp   # deploy from git repo
+cb app deploy https://github.com/you/myapp --name cool-app  # custom name
+cb app deploy https://github.com/you/myapp --wait           # block until running
+cb app deploy https://github.com/you/myapp --grant-permissions-v2  # auto-grant all manifest permissions
+cb app deploy https://github.com/you/myapp --port web=8080  # override a port mapping
+cb app status cool-app                       # check status
+cb app logs cool-app                         # view logs
+cb app logs cool-app --follow                # tail logs
+cb app reload cool-app                       # rebuild + restart
+cb app reload cool-app --update --wait       # git pull, rebuild, wait until running
+cb app ssh cool-app                          # open a shell inside the running container
+cb app ssh cool-app --shell bash             # use bash instead of sh (default: sh)
+cb app ssh cool-app -- ls -la /data          # run a command in the container and exit
+cb app ssh cool-app "cat /etc/os-release"    # ...or pass it as a single quoted string
+cb app stop cool-app                         # stop app
+cb app remove cool-app                       # remove app + data
+cb app remove cool-app --keep-data           # remove but keep data
+cb app rename cool-app new-name              # rename app
 
-oh tokens list                               # list API tokens
-oh tokens create --name "ci" --expiry-hours 72
-oh tokens delete 3                           # delete by token ID
+cb tokens list                               # list API tokens
+cb tokens create --name "ci" --expiry-hours 72
+cb tokens delete 3                           # delete by token ID
 ```
 
-`oh logs` shows zone-level router logs (deploy errors, routing issues). `oh app logs` shows a specific app's container output.
+`cb logs` shows zone-level router logs (deploy errors, routing issues). `cb app logs` shows a specific app's container output.
 
 `--grant-permissions-v2` automatically grants all `[[services.v2.consumes]]` entries from the manifest at deploy time, skipping the manual approval step in the dashboard. See [cross_app_services.md](../docs/src/cross_app_services.md) for details on the permissions model.
 
@@ -74,50 +74,50 @@ The CLI supports managing multiple named instances.
 ### Instance management
 
 ```bash
-oh instance login                            # interactive login (saves as domain name)
-oh instance list                             # list all instances
-oh instance add user.host.com TOKEN          # add non-interactively
-oh instance alias user.host.com dev          # set a short alias
-oh instance set-default dev                  # set default (by hostname or alias)
-oh instance remove dev                       # remove (by hostname or alias)
-oh instance token                            # print stored token for current instance
+cb instance login                            # interactive login (saves as domain name)
+cb instance list                             # list all instances
+cb instance add user.host.com TOKEN          # add non-interactively
+cb instance alias user.host.com dev          # set a short alias
+cb instance set-default dev                  # set default (by hostname or alias)
+cb instance remove dev                       # remove (by hostname or alias)
+cb instance token                            # print stored token for current instance
 ```
 
 ### Targeting instances
 
 ```bash
-oh --instance dev app list                   # target by alias
-oh --instance user.host.com app list         # target by hostname
-OH_INSTANCE=dev oh app list                  # same, via env var
+cb --instance dev app list                   # target by alias
+cb --instance user.host.com app list         # target by hostname
+CB_INSTANCE=dev cb app list                  # same, via env var
 ```
 
-Resolution order: `--instance` flag > `OH_INSTANCE` env var > default instance.
+Resolution order: `--instance` flag > `CB_INSTANCE` env var > default instance.
 Names are resolved as hostnames first, then aliases.
 
 ## SSH access
 
 ```bash
-oh instance configure-ssh-key ~/.ssh/id_ed25519   # register SSH key for this instance
-oh instance ssh                                    # SSH into the zone server as the host user
-oh instance ssh -- -L 5432:localhost:5432          # SSH with extra arguments (port forward etc.)
-oh instance rsync -av ./local/ host@myzone.example.com:/path/  # rsync via the configured key
+cb instance configure-ssh-key ~/.ssh/id_ed25519   # register SSH key for this instance
+cb instance ssh                                    # SSH into the zone server as the host user
+cb instance ssh -- -L 5432:localhost:5432          # SSH with extra arguments (port forward etc.)
+cb instance rsync -av ./local/ host@myzone.example.com:/path/  # rsync via the configured key
 ```
 
-`oh instance ssh` is a shorthand for `ssh [-i key] host@<hostname>`. Without a key configured via `configure-ssh-key`, it falls back to your SSH agent or default key.
+`cb instance ssh` is a shorthand for `ssh [-i key] host@<hostname>`. Without a key configured via `configure-ssh-key`, it falls back to your SSH agent or default key.
 
 Note: `podman` is installed via pixi, not system-wide. Use the full path above or `cd ~/openhost && pixi run -e dev podman ...` if pixi is on your PATH. App data lives at `~/.openhost/local_compute_space/persistent_data/app_data/`.
 
 ## Authenticated HTTP requests
 
 ```bash
-oh curl https://myzone.example.com/api/apps          # GET with bearer token injected
-oh curl -X POST https://myzone.example.com/api/...   # any curl args work
+cb curl https://myzone.example.com/api/apps          # GET with bearer token injected
+cb curl -X POST https://myzone.example.com/api/...   # any curl args work
 ```
 
-`oh curl` runs `curl` with `Authorization: Bearer <token>` pre-injected for the current instance. Useful for hitting the API or testing app endpoints without copying tokens by hand.
+`cb curl` runs `curl` with `Authorization: Bearer <token>` pre-injected for the current instance. Useful for hitting the API or testing app endpoints without copying tokens by hand.
 
 ## Update
 
 ```bash
-uv tool upgrade oh
+uv tool upgrade cb
 ```

--- a/compute_space_cli/README.md
+++ b/compute_space_cli/README.md
@@ -6,11 +6,11 @@ Command-line tool for managing apps on your Cloud in a Bottle compute space.
 
 HTTPS:
 ```bash
-uv tool install "bottle @ git+https://github.com/cloud-in-a-bottle/cloud-in-a-bottle.git#subdirectory=compute_space_cli"
+uv tool install "cloud-in-a-bottle-cli @ git+https://github.com/cloud-in-a-bottle/cloud-in-a-bottle.git#subdirectory=compute_space_cli"
 ```
 SSH:
 ```bash
-uv tool install "bottle @ git+ssh://git@github.com/cloud-in-a-bottle/cloud-in-a-bottle.git#subdirectory=compute_space_cli"
+uv tool install "cloud-in-a-bottle-cli @ git+ssh://git@github.com/cloud-in-a-bottle/cloud-in-a-bottle.git#subdirectory=compute_space_cli"
 ```
 
 ## Setup
@@ -20,7 +20,7 @@ bottle instance login                    # add an instance interactively
 bottle instance set-default x.host.com   # set it as default
 ```
 
-This will prompt you for your compute space URL and walk you through creating an API token. The instance is saved under its domain name (e.g. `x.host.com`) to `~/.bottle/compute_space_cli.toml`.
+This will prompt you for your compute space URL and walk you through creating an API token. The instance is saved under its domain name (e.g. `x.host.com`) to `~/.cloud_in_a_bottle_cli/compute_space_cli.toml`.
 
 For development, use an editable install so changes take effect immediately:
 
@@ -119,5 +119,5 @@ bottle curl -X POST https://myzone.example.com/api/...   # any curl args work
 ## Update
 
 ```bash
-uv tool upgrade bottle
+uv tool upgrade cloud-in-a-bottle-cli
 ```

--- a/compute_space_cli/pyproject.toml
+++ b/compute_space_cli/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "cb"
+name = "bottle"
 version = "0.1.0"
 description = "Cloud in a Bottle CLI — manage apps on your compute space"
 requires-python = ">=3.12"
@@ -11,7 +11,7 @@ dependencies = [
 ]
 
 [project.scripts]
-cb = "compute_space_cli.main:main"
+bottle = "compute_space_cli.main:main"
 
 [build-system]
 requires = ["hatchling"]

--- a/compute_space_cli/pyproject.toml
+++ b/compute_space_cli/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "oh"
+name = "cb"
 version = "0.1.0"
 description = "Cloud in a Bottle CLI — manage apps on your compute space"
 requires-python = ">=3.12"
@@ -11,7 +11,7 @@ dependencies = [
 ]
 
 [project.scripts]
-oh = "compute_space_cli.main:main"
+cb = "compute_space_cli.main:main"
 
 [build-system]
 requires = ["hatchling"]

--- a/compute_space_cli/pyproject.toml
+++ b/compute_space_cli/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "bottle"
+name = "cloud-in-a-bottle-cli"
 version = "0.1.0"
 description = "Cloud in a Bottle CLI — manage apps on your compute space"
 requires-python = ">=3.12"

--- a/compute_space_cli/src/compute_space_cli/config.py
+++ b/compute_space_cli/src/compute_space_cli/config.py
@@ -10,9 +10,9 @@ import tomli_w
 CONFIG_DIR = Path.home() / ".cb"
 CONFIG_FILE = CONFIG_DIR / "compute_space_cli.toml"
 
-# Legacy location used before the CLI was renamed oh -> cb. Still read as a
-# fallback so existing logins keep working; the config migrates forward to
-# CONFIG_FILE on the next save.
+# Read-only fallback location: when ~/.cb doesn't exist yet, config is loaded
+# from here (the legacy ~/.openhost path) and migrated forward to CONFIG_FILE
+# on the next save.
 LEGACY_CONFIG_DIR = Path.home() / ".openhost"
 LEGACY_CONFIG_FILE = LEGACY_CONFIG_DIR / "compute_space_cli.toml"
 
@@ -86,9 +86,9 @@ class MultiConfig:
 
     @classmethod
     def load(cls, path: Path | None = None) -> Self:
-        # When no explicit path is given, prefer the current config file but
-        # fall back to the legacy ~/.openhost location so users who logged in
-        # before the oh -> cb rename keep working (the next save migrates it).
+        # When no explicit path is given, prefer the current config file and
+        # otherwise fall back to the legacy ~/.openhost location (read-only) so
+        # a config written there still loads; the next save migrates it forward.
         if path is None:
             if CONFIG_FILE.exists():
                 path = CONFIG_FILE

--- a/compute_space_cli/src/compute_space_cli/config.py
+++ b/compute_space_cli/src/compute_space_cli/config.py
@@ -10,9 +10,9 @@ import tomli_w
 CONFIG_DIR = Path.home() / ".bottle"
 CONFIG_FILE = CONFIG_DIR / "compute_space_cli.toml"
 
-# Read-only fallback location: when ~/.bottle doesn't exist yet, config is loaded
-# from here (the legacy ~/.openhost path) and migrated forward to CONFIG_FILE
-# on the next save.
+# Legacy config location (pre-``bottle``), used as a migration source: it is
+# read as a fallback when ~/.bottle is absent. The default save path never
+# writes here — the next save() writes to CONFIG_FILE, migrating config forward.
 LEGACY_CONFIG_DIR = Path.home() / ".openhost"
 LEGACY_CONFIG_FILE = LEGACY_CONFIG_DIR / "compute_space_cli.toml"
 
@@ -87,8 +87,8 @@ class MultiConfig:
     @classmethod
     def load(cls, path: Path | None = None) -> Self:
         # When no explicit path is given, prefer the current config file and
-        # otherwise fall back to the legacy ~/.openhost location (read-only) so
-        # a config written there still loads; the next save migrates it forward.
+        # otherwise fall back to the legacy ~/.openhost location so a config
+        # written there still loads; the next save migrates it forward.
         if path is None:
             if CONFIG_FILE.exists():
                 path = CONFIG_FILE

--- a/compute_space_cli/src/compute_space_cli/config.py
+++ b/compute_space_cli/src/compute_space_cli/config.py
@@ -7,8 +7,14 @@ from typing import Self
 import attr
 import tomli_w
 
-CONFIG_DIR = Path.home() / ".openhost"
+CONFIG_DIR = Path.home() / ".cb"
 CONFIG_FILE = CONFIG_DIR / "compute_space_cli.toml"
+
+# Legacy location used before the CLI was renamed oh -> cb. Still read as a
+# fallback so existing logins keep working; the config migrates forward to
+# CONFIG_FILE on the next save.
+LEGACY_CONFIG_DIR = Path.home() / ".openhost"
+LEGACY_CONFIG_FILE = LEGACY_CONFIG_DIR / "compute_space_cli.toml"
 
 
 class ConfigFileNotFoundError(Exception):
@@ -80,7 +86,16 @@ class MultiConfig:
 
     @classmethod
     def load(cls, path: Path | None = None) -> Self:
-        path = path or CONFIG_FILE
+        # When no explicit path is given, prefer the current config file but
+        # fall back to the legacy ~/.openhost location so users who logged in
+        # before the oh -> cb rename keep working (the next save migrates it).
+        if path is None:
+            if CONFIG_FILE.exists():
+                path = CONFIG_FILE
+            elif LEGACY_CONFIG_FILE.exists():
+                path = LEGACY_CONFIG_FILE
+            else:
+                path = CONFIG_FILE
         try:
             with open(path, "rb") as f:
                 data = tomllib.load(f)
@@ -140,7 +155,7 @@ class MultiConfig:
             if inst.alias == name:
                 return hostname
         raise InstanceNotFoundError(
-            f"Instance '{name}' not found. Run 'oh instance list' to see configured instances."
+            f"Instance '{name}' not found. Run 'cb instance list' to see configured instances."
         )
 
     def get_instance(self, name: str) -> Instance:
@@ -150,21 +165,21 @@ class MultiConfig:
     def resolve(self, instance_name: str | None = None) -> Instance:
         """Resolve which instance to use.
 
-        Priority: explicit name > OH_INSTANCE env var > default_instance.
+        Priority: explicit name > CB_INSTANCE env var > default_instance.
         """
         name = instance_name
         if not name:
-            name = os.environ.get("OH_INSTANCE")
+            name = os.environ.get("CB_INSTANCE")
         if not name:
             name = self.default_instance
 
         if not name:
             if not self.instances:
-                raise InstanceNotFoundError("No instances configured. Run 'oh instance login' first.")
+                raise InstanceNotFoundError("No instances configured. Run 'cb instance login' first.")
             raise InstanceNotFoundError(
                 "No default instance set. Use --instance <name>, or set a default with:\n"
-                "  oh instance set-default <name>\n"
-                "Run 'oh instance list' to see configured instances."
+                "  cb instance set-default <name>\n"
+                "Run 'cb instance list' to see configured instances."
             )
 
         return self.get_instance(name)

--- a/compute_space_cli/src/compute_space_cli/config.py
+++ b/compute_space_cli/src/compute_space_cli/config.py
@@ -7,12 +7,12 @@ from typing import Self
 import attr
 import tomli_w
 
-CONFIG_DIR = Path.home() / ".bottle"
+CONFIG_DIR = Path.home() / ".cloud_in_a_bottle_cli"
 CONFIG_FILE = CONFIG_DIR / "compute_space_cli.toml"
 
-# Legacy config location (pre-``bottle``), used as a migration source: it is
-# read as a fallback when ~/.bottle is absent. The default save path never
-# writes here — the next save() writes to CONFIG_FILE, migrating config forward.
+# Legacy config location, used as a migration source: it is read as a fallback
+# when ~/.cloud_in_a_bottle_cli is absent. The default save path never writes
+# here — the next save() writes to CONFIG_FILE, migrating config forward.
 LEGACY_CONFIG_DIR = Path.home() / ".openhost"
 LEGACY_CONFIG_FILE = LEGACY_CONFIG_DIR / "compute_space_cli.toml"
 

--- a/compute_space_cli/src/compute_space_cli/config.py
+++ b/compute_space_cli/src/compute_space_cli/config.py
@@ -7,10 +7,10 @@ from typing import Self
 import attr
 import tomli_w
 
-CONFIG_DIR = Path.home() / ".cb"
+CONFIG_DIR = Path.home() / ".bottle"
 CONFIG_FILE = CONFIG_DIR / "compute_space_cli.toml"
 
-# Read-only fallback location: when ~/.cb doesn't exist yet, config is loaded
+# Read-only fallback location: when ~/.bottle doesn't exist yet, config is loaded
 # from here (the legacy ~/.openhost path) and migrated forward to CONFIG_FILE
 # on the next save.
 LEGACY_CONFIG_DIR = Path.home() / ".openhost"
@@ -155,7 +155,7 @@ class MultiConfig:
             if inst.alias == name:
                 return hostname
         raise InstanceNotFoundError(
-            f"Instance '{name}' not found. Run 'cb instance list' to see configured instances."
+            f"Instance '{name}' not found. Run 'bottle instance list' to see configured instances."
         )
 
     def get_instance(self, name: str) -> Instance:
@@ -165,21 +165,21 @@ class MultiConfig:
     def resolve(self, instance_name: str | None = None) -> Instance:
         """Resolve which instance to use.
 
-        Priority: explicit name > CB_INSTANCE env var > default_instance.
+        Priority: explicit name > BOTTLE_INSTANCE env var > default_instance.
         """
         name = instance_name
         if not name:
-            name = os.environ.get("CB_INSTANCE")
+            name = os.environ.get("BOTTLE_INSTANCE")
         if not name:
             name = self.default_instance
 
         if not name:
             if not self.instances:
-                raise InstanceNotFoundError("No instances configured. Run 'cb instance login' first.")
+                raise InstanceNotFoundError("No instances configured. Run 'bottle instance login' first.")
             raise InstanceNotFoundError(
                 "No default instance set. Use --instance <name>, or set a default with:\n"
-                "  cb instance set-default <name>\n"
-                "Run 'cb instance list' to see configured instances."
+                "  bottle instance set-default <name>\n"
+                "Run 'bottle instance list' to see configured instances."
             )
 
         return self.get_instance(name)

--- a/compute_space_cli/src/compute_space_cli/helpers.py
+++ b/compute_space_cli/src/compute_space_cli/helpers.py
@@ -87,7 +87,7 @@ def wait_for_app_removed(url: str, token: str, app_id: str, app_name: str, timeo
         if time.time() > deadline:
             print(
                 f"Timed out waiting for {app_name} to finish removing after {timeout:.0f}s. "
-                "The server may still be working — re-run 'cb app status' to check.",
+                "The server may still be working — re-run 'bottle app status' to check.",
                 file=sys.stderr,
             )
             raise SystemExit(1)

--- a/compute_space_cli/src/compute_space_cli/helpers.py
+++ b/compute_space_cli/src/compute_space_cli/helpers.py
@@ -87,7 +87,7 @@ def wait_for_app_removed(url: str, token: str, app_id: str, app_name: str, timeo
         if time.time() > deadline:
             print(
                 f"Timed out waiting for {app_name} to finish removing after {timeout:.0f}s. "
-                "The server may still be working — re-run 'oh app status' to check.",
+                "The server may still be working — re-run 'cb app status' to check.",
                 file=sys.stderr,
             )
             raise SystemExit(1)

--- a/compute_space_cli/src/compute_space_cli/main.py
+++ b/compute_space_cli/src/compute_space_cli/main.py
@@ -45,11 +45,11 @@ def _load_or_create() -> config.MultiConfig:
         return config.MultiConfig()
 
 
-def resolve_instance(cb: Cb) -> config.Instance:
+def resolve_instance(root: Cb) -> config.Instance:
     """Resolve which instance to target, respecting --instance."""
     multi = _load_or_exit()
     try:
-        return multi.resolve(instance_name=cb.instance)
+        return multi.resolve(instance_name=root.instance)
     except config.InstanceNotFoundError as e:
         print(str(e), file=sys.stderr)
         raise SystemExit(1) from None

--- a/compute_space_cli/src/compute_space_cli/main.py
+++ b/compute_space_cli/src/compute_space_cli/main.py
@@ -27,7 +27,7 @@ def _load_or_exit() -> config.MultiConfig:
     try:
         return config.get_multi_config()
     except config.ConfigFileNotFoundError:
-        print("No config file. Run 'cb instance login' first.", file=sys.stderr)
+        print("No config file. Run 'bottle instance login' first.", file=sys.stderr)
         raise SystemExit(1) from None
     except config.ConfigInvalidError as e:
         print(f"Invalid config file: {e}", file=sys.stderr)
@@ -45,7 +45,7 @@ def _load_or_create() -> config.MultiConfig:
         return config.MultiConfig()
 
 
-def resolve_instance(root: Cb) -> config.Instance:
+def resolve_instance(root: Bottle) -> config.Instance:
     """Resolve which instance to target, respecting --instance."""
     multi = _load_or_exit()
     try:
@@ -429,9 +429,9 @@ class InstanceCmd:
                 _load_or_exit().evolve(default_instance=hostname).save()
                 print(f"Default instance set to '{display_name}'")
             else:
-                print(f"Use with: cb --instance {display_name} <command>")
+                print(f"Use with: bottle --instance {display_name} <command>")
         else:
-            print(f"Use with: cb --instance {display_name} <command>")
+            print(f"Use with: bottle --instance {display_name} <command>")
 
     @cappa.command(name="list")
     def list_instances(self) -> None:
@@ -627,9 +627,9 @@ class Curl:
         raise SystemExit(subprocess.call(cmd))
 
 
-@cappa.command(name="cb", help="Cloud in a Bottle compute space CLI — manage things in your compute space.")
+@cappa.command(name="bottle", help="Cloud in a Bottle compute space CLI — manage things in your compute space.")
 @attrs.define
-class Cb:
+class Bottle:
     subcommand: cappa.Subcommands[Status | AppCmd | TokensCmd | LogsCmd | InstanceCmd | Curl | Version | Diagnostics]
     instance: Annotated[
         str | None,
@@ -640,4 +640,4 @@ class Cb:
 def main() -> None:
     if len(sys.argv) == 1:
         sys.argv.append("--help")
-    cappa.invoke(Cb, color=False)
+    cappa.invoke(Bottle, color=False)

--- a/compute_space_cli/src/compute_space_cli/main.py
+++ b/compute_space_cli/src/compute_space_cli/main.py
@@ -45,11 +45,11 @@ def _load_or_create() -> config.MultiConfig:
         return config.MultiConfig()
 
 
-def resolve_instance(root: Bottle) -> config.Instance:
+def resolve_instance(bottle: Bottle) -> config.Instance:
     """Resolve which instance to target, respecting --instance."""
     multi = _load_or_exit()
     try:
-        return multi.resolve(instance_name=root.instance)
+        return multi.resolve(instance_name=bottle.instance)
     except config.InstanceNotFoundError as e:
         print(str(e), file=sys.stderr)
         raise SystemExit(1) from None

--- a/compute_space_cli/src/compute_space_cli/main.py
+++ b/compute_space_cli/src/compute_space_cli/main.py
@@ -27,7 +27,7 @@ def _load_or_exit() -> config.MultiConfig:
     try:
         return config.get_multi_config()
     except config.ConfigFileNotFoundError:
-        print("No config file. Run 'oh instance login' first.", file=sys.stderr)
+        print("No config file. Run 'cb instance login' first.", file=sys.stderr)
         raise SystemExit(1) from None
     except config.ConfigInvalidError as e:
         print(f"Invalid config file: {e}", file=sys.stderr)
@@ -45,11 +45,11 @@ def _load_or_create() -> config.MultiConfig:
         return config.MultiConfig()
 
 
-def resolve_instance(oh: Oh) -> config.Instance:
+def resolve_instance(cb: Cb) -> config.Instance:
     """Resolve which instance to target, respecting --instance."""
     multi = _load_or_exit()
     try:
-        return multi.resolve(instance_name=oh.instance)
+        return multi.resolve(instance_name=cb.instance)
     except config.InstanceNotFoundError as e:
         print(str(e), file=sys.stderr)
         raise SystemExit(1) from None
@@ -429,9 +429,9 @@ class InstanceCmd:
                 _load_or_exit().evolve(default_instance=hostname).save()
                 print(f"Default instance set to '{display_name}'")
             else:
-                print(f"Use with: oh --instance {display_name} <command>")
+                print(f"Use with: cb --instance {display_name} <command>")
         else:
-            print(f"Use with: oh --instance {display_name} <command>")
+            print(f"Use with: cb --instance {display_name} <command>")
 
     @cappa.command(name="list")
     def list_instances(self) -> None:
@@ -627,9 +627,9 @@ class Curl:
         raise SystemExit(subprocess.call(cmd))
 
 
-@cappa.command(name="oh", help="Cloud in a Bottle compute space CLI — manage things in your compute space.")
+@cappa.command(name="cb", help="Cloud in a Bottle compute space CLI — manage things in your compute space.")
 @attrs.define
-class Oh:
+class Cb:
     subcommand: cappa.Subcommands[Status | AppCmd | TokensCmd | LogsCmd | InstanceCmd | Curl | Version | Diagnostics]
     instance: Annotated[
         str | None,
@@ -640,4 +640,4 @@ class Oh:
 def main() -> None:
     if len(sys.argv) == 1:
         sys.argv.append("--help")
-    cappa.invoke(Oh, color=False)
+    cappa.invoke(Cb, color=False)

--- a/compute_space_cli/src/compute_space_cli/tests/e2e.py
+++ b/compute_space_cli/src/compute_space_cli/tests/e2e.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python3
-"""End-to-end test for the oh CLI - runs against a real compute space backend.
+"""End-to-end test for the cb CLI - runs against a real compute space backend.
 
-Assumes `oh login` has already been done (legacy or multi-instance config).
+Assumes `cb login` has already been done (legacy or multi-instance config).
 Deploys a test app, exercises all commands, then cleans up.
 
-Usage: python test_e2e.py
+Usage: python e2e.py
 """
 
 import os
@@ -27,12 +27,12 @@ def _default_instance() -> Instance:
     return get_multi_config().resolve()
 
 
-def oh(*args: str, env: dict[str, str] | None = None) -> str:
-    """Run an oh command and return stdout. Raises on non-zero exit."""
+def cb(*args: str, env: dict[str, str] | None = None) -> str:
+    """Run a cb command and return stdout. Raises on non-zero exit."""
     run_env = {**os.environ, **(env or {})}
-    result = subprocess.run(["oh", *args], capture_output=True, text=True, timeout=300, env=run_env)
+    result = subprocess.run(["cb", *args], capture_output=True, text=True, timeout=300, env=run_env)
     if result.returncode != 0:
-        raise AssertionError(f"oh {' '.join(args)} failed (exit {result.returncode}):\n{result.stderr}")
+        raise AssertionError(f"cb {' '.join(args)} failed (exit {result.returncode}):\n{result.stderr}")
     return result.stdout
 
 
@@ -40,12 +40,12 @@ def test_legacy_compat() -> None:
     """Existing commands work with legacy single-instance config."""
     print("=== legacy compatibility ===")
 
-    print("--- oh status ---")
-    oh("status")
+    print("--- cb status ---")
+    cb("status")
     print("  ok: compute space reachable")
 
-    print("--- oh instance list ---")
-    output = oh("instance", "list")
+    print("--- cb instance list ---")
+    output = cb("instance", "list")
     assert "default" in output, f"legacy config should show as 'default': {output}"
     print("  ok: legacy config listed as 'default' instance")
 
@@ -55,15 +55,15 @@ def test_instance_management() -> None:
     print("\n=== instance management ===")
     cfg = _default_instance()
 
-    print("--- oh instance add ---")
-    oh("instance", "add", "test-inst", cfg.url, cfg.token)
-    output = oh("instance", "list")
+    print("--- cb instance add ---")
+    cb("instance", "add", "test-inst", cfg.url, cfg.token)
+    output = cb("instance", "list")
     assert "test-inst" in output, f"test-inst not in list: {output}"
     print("  ok: instance added")
 
-    print("--- oh instance set-default ---")
-    oh("instance", "set-default", "test-inst")
-    output = oh("instance", "list")
+    print("--- cb instance set-default ---")
+    cb("instance", "set-default", "test-inst")
+    output = cb("instance", "list")
     for line in output.splitlines():
         if "test-inst" in line:
             assert "default" in line, f"test-inst not marked default: {line}"
@@ -72,18 +72,18 @@ def test_instance_management() -> None:
         raise AssertionError("test-inst not found in list")
     print("  ok: default instance changed")
 
-    print("--- oh --instance test-inst status ---")
-    oh("--instance", "test-inst", "status")
+    print("--- cb --instance test-inst status ---")
+    cb("--instance", "test-inst", "status")
     print("  ok: --instance flag works")
 
-    print("--- OH_INSTANCE=test-inst oh status ---")
-    oh("status", env={"OH_INSTANCE": "test-inst"})
-    print("  ok: OH_INSTANCE env var works")
+    print("--- CB_INSTANCE=test-inst cb status ---")
+    cb("status", env={"CB_INSTANCE": "test-inst"})
+    print("  ok: CB_INSTANCE env var works")
 
-    print("--- oh instance remove ---")
-    oh("instance", "set-default", "default")
-    oh("instance", "remove", "test-inst")
-    output = oh("instance", "list")
+    print("--- cb instance remove ---")
+    cb("instance", "set-default", "default")
+    cb("instance", "remove", "test-inst")
+    output = cb("instance", "list")
     assert "test-inst" not in output, f"test-inst still present: {output}"
     print("  ok: instance removed")
 
@@ -98,25 +98,25 @@ def test_app_lifecycle() -> None:
     print(f"app name: {app_name}")
 
     # ── status ──
-    print("--- oh status ---")
-    oh("status")
+    print("--- cb status ---")
+    cb("status")
     print("  ok: compute space reachable")
 
     # ── app deploy (--wait) ──
-    print("--- oh app deploy ---")
-    oh("app", "deploy", REPO_URL, "--name", app_name, "--wait")
+    print("--- cb app deploy ---")
+    cb("app", "deploy", REPO_URL, "--name", app_name, "--wait")
     print("  ok: app deployed and running")
 
     try:
         # ── app list ──
-        print("--- oh app list ---")
-        output = oh("app", "list")
+        print("--- cb app list ---")
+        output = cb("app", "list")
         assert app_name in output, f"app not in list: {output}"
         print("  ok: app appears in list")
 
         # ── app status ──
-        print("--- oh app status ---")
-        output = oh("app", "status", app_name)
+        print("--- cb app status ---")
+        output = cb("app", "status", app_name)
         assert "running" in output, f"app not running: {output}"
         print("  ok: app status is running")
 
@@ -133,8 +133,8 @@ def test_app_lifecycle() -> None:
         print("  ok: app / returned 200")
 
         # ── app logs ──
-        print("--- oh app logs ---")
-        output = oh("app", "logs", app_name)
+        print("--- cb app logs ---")
+        output = cb("app", "logs", app_name)
         lines = output.rstrip().split("\n")
         if len(lines) > 10:
             print(f"  ... ({len(lines) - 10} lines truncated)")
@@ -142,53 +142,53 @@ def test_app_lifecycle() -> None:
         print("  ok: app logs returned")
 
         # ── app stop ──
-        print("--- oh app stop ---")
-        oh("app", "stop", app_name)
-        output = oh("app", "status", app_name)
+        print("--- cb app stop ---")
+        cb("app", "stop", app_name)
+        output = cb("app", "status", app_name)
         assert "stopped" in output, f"app not stopped: {output}"
         print("  ok: app stopped")
 
         # ── app reload (--wait) ──
-        print("--- oh app reload ---")
-        oh("app", "reload", app_name, "--wait")
-        output = oh("app", "status", app_name)
+        print("--- cb app reload ---")
+        cb("app", "reload", app_name, "--wait")
+        output = cb("app", "status", app_name)
         assert "running" in output, f"app not running after reload: {output}"
         print("  ok: app reloaded and running")
 
         # ── app rename ──
-        print("--- oh app rename ---")
-        oh("app", "rename", app_name, renamed_app)
-        output = oh("app", "list")
+        print("--- cb app rename ---")
+        cb("app", "rename", app_name, renamed_app)
+        output = cb("app", "list")
         assert renamed_app in output, f"renamed app not in list: {output}"
         print(f"  ok: app renamed to {renamed_app}")
         # from here on, cleanup uses renamed_app
         app_name = renamed_app
 
         # ── tokens create ──
-        print("--- oh tokens create ---")
-        output = oh("tokens", "create", "--name", "test-token", "--expiry-hours", "1")
+        print("--- cb tokens create ---")
+        output = cb("tokens", "create", "--name", "test-token", "--expiry-hours", "1")
         assert "Token:" in output, f"token not created: {output}"
         print("  ok: token created")
 
         # ── tokens list ──
-        print("--- oh tokens list ---")
-        output = oh("tokens", "list")
+        print("--- cb tokens list ---")
+        output = cb("tokens", "list")
         assert "test-token" in output, f"token not in list: {output}"
         m = re.search(r"\[(\d+)\] test-token", output)
         assert m, f"could not extract token id from: {output}"
         token_id = m.group(1)
         print(f"  ok: token appears in list (id={token_id})")
 
-        print("--- oh tokens delete ---")
-        oh("tokens", "delete", token_id)
+        print("--- cb tokens delete ---")
+        cb("tokens", "delete", token_id)
         print("  ok: token deleted")
 
     finally:
         # ── app remove (always clean up) ──
-        print("--- oh app remove ---")
+        print("--- cb app remove ---")
         try:
-            oh("app", "remove", app_name)
-            output = oh("app", "list")
+            cb("app", "remove", app_name)
+            output = cb("app", "list")
             assert app_name not in output, "app still in list after remove"
             print("  ok: app removed")
         except Exception as e:
@@ -196,14 +196,14 @@ def test_app_lifecycle() -> None:
 
 
 def main() -> None:
-    if not shutil.which("oh"):
+    if not shutil.which("cb"):
         print(
-            "Error: 'oh' command not found.\nInstall it with: cd compute_space_cli && uv tool install --editable .",
+            "Error: 'cb' command not found.\nInstall it with: cd compute_space_cli && uv tool install --editable .",
             file=sys.stderr,
         )
         sys.exit(1)
 
-    print("=== oh CLI e2e test ===\n")
+    print("=== cb CLI e2e test ===\n")
 
     test_legacy_compat()
     test_instance_management()

--- a/compute_space_cli/src/compute_space_cli/tests/e2e.py
+++ b/compute_space_cli/src/compute_space_cli/tests/e2e.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
-"""End-to-end test for the cb CLI - runs against a real compute space backend.
+"""End-to-end test for the bottle CLI - runs against a real compute space backend.
 
-Assumes `cb login` has already been done (legacy or multi-instance config).
+Assumes `bottle login` has already been done (legacy or multi-instance config).
 Deploys a test app, exercises all commands, then cleans up.
 
 Usage: python e2e.py
@@ -27,12 +27,12 @@ def _default_instance() -> Instance:
     return get_multi_config().resolve()
 
 
-def cb(*args: str, env: dict[str, str] | None = None) -> str:
-    """Run a cb command and return stdout. Raises on non-zero exit."""
+def bottle(*args: str, env: dict[str, str] | None = None) -> str:
+    """Run a bottle command and return stdout. Raises on non-zero exit."""
     run_env = {**os.environ, **(env or {})}
-    result = subprocess.run(["cb", *args], capture_output=True, text=True, timeout=300, env=run_env)
+    result = subprocess.run(["bottle", *args], capture_output=True, text=True, timeout=300, env=run_env)
     if result.returncode != 0:
-        raise AssertionError(f"cb {' '.join(args)} failed (exit {result.returncode}):\n{result.stderr}")
+        raise AssertionError(f"bottle {' '.join(args)} failed (exit {result.returncode}):\n{result.stderr}")
     return result.stdout
 
 
@@ -40,12 +40,12 @@ def test_legacy_compat() -> None:
     """Existing commands work with legacy single-instance config."""
     print("=== legacy compatibility ===")
 
-    print("--- cb status ---")
-    cb("status")
+    print("--- bottle status ---")
+    bottle("status")
     print("  ok: compute space reachable")
 
-    print("--- cb instance list ---")
-    output = cb("instance", "list")
+    print("--- bottle instance list ---")
+    output = bottle("instance", "list")
     assert "default" in output, f"legacy config should show as 'default': {output}"
     print("  ok: legacy config listed as 'default' instance")
 
@@ -55,15 +55,15 @@ def test_instance_management() -> None:
     print("\n=== instance management ===")
     cfg = _default_instance()
 
-    print("--- cb instance add ---")
-    cb("instance", "add", "test-inst", cfg.url, cfg.token)
-    output = cb("instance", "list")
+    print("--- bottle instance add ---")
+    bottle("instance", "add", "test-inst", cfg.url, cfg.token)
+    output = bottle("instance", "list")
     assert "test-inst" in output, f"test-inst not in list: {output}"
     print("  ok: instance added")
 
-    print("--- cb instance set-default ---")
-    cb("instance", "set-default", "test-inst")
-    output = cb("instance", "list")
+    print("--- bottle instance set-default ---")
+    bottle("instance", "set-default", "test-inst")
+    output = bottle("instance", "list")
     for line in output.splitlines():
         if "test-inst" in line:
             assert "default" in line, f"test-inst not marked default: {line}"
@@ -72,18 +72,18 @@ def test_instance_management() -> None:
         raise AssertionError("test-inst not found in list")
     print("  ok: default instance changed")
 
-    print("--- cb --instance test-inst status ---")
-    cb("--instance", "test-inst", "status")
+    print("--- bottle --instance test-inst status ---")
+    bottle("--instance", "test-inst", "status")
     print("  ok: --instance flag works")
 
-    print("--- CB_INSTANCE=test-inst cb status ---")
-    cb("status", env={"CB_INSTANCE": "test-inst"})
-    print("  ok: CB_INSTANCE env var works")
+    print("--- BOTTLE_INSTANCE=test-inst bottle status ---")
+    bottle("status", env={"BOTTLE_INSTANCE": "test-inst"})
+    print("  ok: BOTTLE_INSTANCE env var works")
 
-    print("--- cb instance remove ---")
-    cb("instance", "set-default", "default")
-    cb("instance", "remove", "test-inst")
-    output = cb("instance", "list")
+    print("--- bottle instance remove ---")
+    bottle("instance", "set-default", "default")
+    bottle("instance", "remove", "test-inst")
+    output = bottle("instance", "list")
     assert "test-inst" not in output, f"test-inst still present: {output}"
     print("  ok: instance removed")
 
@@ -98,25 +98,25 @@ def test_app_lifecycle() -> None:
     print(f"app name: {app_name}")
 
     # ── status ──
-    print("--- cb status ---")
-    cb("status")
+    print("--- bottle status ---")
+    bottle("status")
     print("  ok: compute space reachable")
 
     # ── app deploy (--wait) ──
-    print("--- cb app deploy ---")
-    cb("app", "deploy", REPO_URL, "--name", app_name, "--wait")
+    print("--- bottle app deploy ---")
+    bottle("app", "deploy", REPO_URL, "--name", app_name, "--wait")
     print("  ok: app deployed and running")
 
     try:
         # ── app list ──
-        print("--- cb app list ---")
-        output = cb("app", "list")
+        print("--- bottle app list ---")
+        output = bottle("app", "list")
         assert app_name in output, f"app not in list: {output}"
         print("  ok: app appears in list")
 
         # ── app status ──
-        print("--- cb app status ---")
-        output = cb("app", "status", app_name)
+        print("--- bottle app status ---")
+        output = bottle("app", "status", app_name)
         assert "running" in output, f"app not running: {output}"
         print("  ok: app status is running")
 
@@ -133,8 +133,8 @@ def test_app_lifecycle() -> None:
         print("  ok: app / returned 200")
 
         # ── app logs ──
-        print("--- cb app logs ---")
-        output = cb("app", "logs", app_name)
+        print("--- bottle app logs ---")
+        output = bottle("app", "logs", app_name)
         lines = output.rstrip().split("\n")
         if len(lines) > 10:
             print(f"  ... ({len(lines) - 10} lines truncated)")
@@ -142,53 +142,53 @@ def test_app_lifecycle() -> None:
         print("  ok: app logs returned")
 
         # ── app stop ──
-        print("--- cb app stop ---")
-        cb("app", "stop", app_name)
-        output = cb("app", "status", app_name)
+        print("--- bottle app stop ---")
+        bottle("app", "stop", app_name)
+        output = bottle("app", "status", app_name)
         assert "stopped" in output, f"app not stopped: {output}"
         print("  ok: app stopped")
 
         # ── app reload (--wait) ──
-        print("--- cb app reload ---")
-        cb("app", "reload", app_name, "--wait")
-        output = cb("app", "status", app_name)
+        print("--- bottle app reload ---")
+        bottle("app", "reload", app_name, "--wait")
+        output = bottle("app", "status", app_name)
         assert "running" in output, f"app not running after reload: {output}"
         print("  ok: app reloaded and running")
 
         # ── app rename ──
-        print("--- cb app rename ---")
-        cb("app", "rename", app_name, renamed_app)
-        output = cb("app", "list")
+        print("--- bottle app rename ---")
+        bottle("app", "rename", app_name, renamed_app)
+        output = bottle("app", "list")
         assert renamed_app in output, f"renamed app not in list: {output}"
         print(f"  ok: app renamed to {renamed_app}")
         # from here on, cleanup uses renamed_app
         app_name = renamed_app
 
         # ── tokens create ──
-        print("--- cb tokens create ---")
-        output = cb("tokens", "create", "--name", "test-token", "--expiry-hours", "1")
+        print("--- bottle tokens create ---")
+        output = bottle("tokens", "create", "--name", "test-token", "--expiry-hours", "1")
         assert "Token:" in output, f"token not created: {output}"
         print("  ok: token created")
 
         # ── tokens list ──
-        print("--- cb tokens list ---")
-        output = cb("tokens", "list")
+        print("--- bottle tokens list ---")
+        output = bottle("tokens", "list")
         assert "test-token" in output, f"token not in list: {output}"
         m = re.search(r"\[(\d+)\] test-token", output)
         assert m, f"could not extract token id from: {output}"
         token_id = m.group(1)
         print(f"  ok: token appears in list (id={token_id})")
 
-        print("--- cb tokens delete ---")
-        cb("tokens", "delete", token_id)
+        print("--- bottle tokens delete ---")
+        bottle("tokens", "delete", token_id)
         print("  ok: token deleted")
 
     finally:
         # ── app remove (always clean up) ──
-        print("--- cb app remove ---")
+        print("--- bottle app remove ---")
         try:
-            cb("app", "remove", app_name)
-            output = cb("app", "list")
+            bottle("app", "remove", app_name)
+            output = bottle("app", "list")
             assert app_name not in output, "app still in list after remove"
             print("  ok: app removed")
         except Exception as e:
@@ -196,14 +196,14 @@ def test_app_lifecycle() -> None:
 
 
 def main() -> None:
-    if not shutil.which("cb"):
+    if not shutil.which("bottle"):
         print(
-            "Error: 'cb' command not found.\nInstall it with: cd compute_space_cli && uv tool install --editable .",
+            "Error: 'bottle' command not found.\nInstall it with: cd compute_space_cli && uv tool install --editable .",
             file=sys.stderr,
         )
         sys.exit(1)
 
-    print("=== cb CLI e2e test ===\n")
+    print("=== bottle CLI e2e test ===\n")
 
     test_legacy_compat()
     test_instance_management()

--- a/compute_space_cli/src/compute_space_cli/tests/test_config.py
+++ b/compute_space_cli/src/compute_space_cli/tests/test_config.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import pytest
 import tomli_w
 
+from compute_space_cli import config as cli_config
 from compute_space_cli.config import ConfigFileNotFoundError
 from compute_space_cli.config import ConfigInvalidError
 from compute_space_cli.config import Instance
@@ -119,6 +120,54 @@ class TestMultiConfigSaveLoad:
         assert loaded.instances["x.com"].hostname == "x.com"
 
 
+class TestLegacyConfigFallback:
+    """Default-path resolution across the ~/.openhost -> ~/.cb (oh -> cb) rename.
+
+    When ``load()`` is called with no explicit path it must prefer the new
+    ``~/.cb`` config file but transparently fall back to the legacy
+    ``~/.openhost`` file so users who logged in before the rename keep working.
+    """
+
+    @pytest.fixture
+    def paths(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> tuple[Path, Path]:
+        new = tmp_path / "cb" / "compute_space_cli.toml"
+        legacy = tmp_path / "openhost" / "compute_space_cli.toml"
+        monkeypatch.setattr(cli_config, "CONFIG_FILE", new)
+        monkeypatch.setattr(cli_config, "LEGACY_CONFIG_FILE", legacy)
+        return new, legacy
+
+    def _write(self, path: Path, hostname: str) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with open(path, "wb") as f:
+            tomli_w.dump({"instances": {hostname: {"token": "t"}}, "default_instance": hostname}, f)
+
+    def test_prefers_new_path(self, paths: tuple[Path, Path]) -> None:
+        new, legacy = paths
+        self._write(new, "new.com")
+        self._write(legacy, "legacy.com")
+        assert MultiConfig.load().default_instance == "new.com"
+
+    def test_falls_back_to_legacy(self, paths: tuple[Path, Path]) -> None:
+        new, legacy = paths
+        self._write(legacy, "legacy.com")
+        assert not new.exists()
+        assert MultiConfig.load().default_instance == "legacy.com"
+
+    def test_missing_both_raises_pointing_at_new(self, paths: tuple[Path, Path]) -> None:
+        new, _legacy = paths
+        with pytest.raises(ConfigFileNotFoundError, match=str(new)):
+            MultiConfig.load()
+
+    def test_save_migrates_forward_to_new_path(self, paths: tuple[Path, Path]) -> None:
+        """Loading a legacy config then saving writes to the new ~/.cb path."""
+        new, legacy = paths
+        self._write(legacy, "legacy.com")
+        loaded = MultiConfig.load()
+        loaded.save()
+        assert new.exists()
+        assert MultiConfig.load(new).default_instance == "legacy.com"
+
+
 class TestMultiConfigResolve:
     def test_explicit_name(self) -> None:
         multi = _make_multi(
@@ -139,11 +188,11 @@ class TestMultiConfigResolve:
             instances={"a.com": _inst("a.com"), "b.com": _inst("b.com")},
             default="a.com",
         )
-        monkeypatch.setenv("OH_INSTANCE", "b.com")
+        monkeypatch.setenv("CB_INSTANCE", "b.com")
         assert multi.resolve().url == "https://b.com"
 
     def test_default_instance(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.delenv("OH_INSTANCE", raising=False)
+        monkeypatch.delenv("CB_INSTANCE", raising=False)
         multi = _make_multi(
             instances={"a.com": _inst("a.com"), "b.com": _inst("b.com")},
             default="a.com",
@@ -151,7 +200,7 @@ class TestMultiConfigResolve:
         assert multi.resolve().url == "https://a.com"
 
     def test_no_default_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.delenv("OH_INSTANCE", raising=False)
+        monkeypatch.delenv("CB_INSTANCE", raising=False)
         multi = _make_multi(instances={"only.com": _inst("only.com")})
         with pytest.raises(InstanceNotFoundError, match="No default instance set"):
             multi.resolve()
@@ -166,7 +215,7 @@ class TestMultiConfigResolve:
             instances={"a.com": _inst("a.com"), "b.com": _inst("b.com")},
             default="a.com",
         )
-        monkeypatch.setenv("OH_INSTANCE", "a.com")
+        monkeypatch.setenv("CB_INSTANCE", "a.com")
         assert multi.resolve(instance_name="b.com").url == "https://b.com"
 
     def test_env_overrides_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -174,7 +223,7 @@ class TestMultiConfigResolve:
             instances={"a.com": _inst("a.com"), "b.com": _inst("b.com")},
             default="a.com",
         )
-        monkeypatch.setenv("OH_INSTANCE", "b.com")
+        monkeypatch.setenv("CB_INSTANCE", "b.com")
         assert multi.resolve().url == "https://b.com"
 
 

--- a/compute_space_cli/src/compute_space_cli/tests/test_config.py
+++ b/compute_space_cli/src/compute_space_cli/tests/test_config.py
@@ -121,16 +121,16 @@ class TestMultiConfigSaveLoad:
 
 
 class TestLegacyConfigFallback:
-    """Default-path resolution prefers ``~/.bottle`` and falls back to ``~/.openhost``.
+    """Default-path resolution prefers ``~/.cloud_in_a_bottle_cli`` and falls back to ``~/.openhost``.
 
-    When ``load()`` is called with no explicit path it must prefer the ``~/.bottle``
-    config file but transparently read the legacy ``~/.openhost`` file when the
-    former is absent, then migrate forward to ``~/.bottle`` on the next save.
+    When ``load()`` is called with no explicit path it must prefer the
+    ``~/.cloud_in_a_bottle_cli`` config file but transparently read the legacy
+    ``~/.openhost`` file when the former is absent, then migrate forward on the next save.
     """
 
     @pytest.fixture
     def paths(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> tuple[Path, Path]:
-        new = tmp_path / "bottle" / "compute_space_cli.toml"
+        new = tmp_path / "new" / "compute_space_cli.toml"
         legacy = tmp_path / "openhost" / "compute_space_cli.toml"
         monkeypatch.setattr(cli_config, "CONFIG_FILE", new)
         monkeypatch.setattr(cli_config, "LEGACY_CONFIG_FILE", legacy)
@@ -175,7 +175,7 @@ class TestLegacyConfigFallback:
             MultiConfig.load()
 
     def test_save_migrates_forward_to_new_path(self, paths: tuple[Path, Path]) -> None:
-        """Loading a legacy config then saving writes to the new ~/.bottle path,
+        """Loading a legacy config then saving writes to the new ~/.cloud_in_a_bottle_cli path,
         preserves instance fields, and leaves the legacy file untouched."""
         new, legacy = paths
         self._write(legacy, "legacy.com")

--- a/compute_space_cli/src/compute_space_cli/tests/test_config.py
+++ b/compute_space_cli/src/compute_space_cli/tests/test_config.py
@@ -121,16 +121,16 @@ class TestMultiConfigSaveLoad:
 
 
 class TestLegacyConfigFallback:
-    """Default-path resolution prefers ``~/.cb`` and falls back to ``~/.openhost``.
+    """Default-path resolution prefers ``~/.bottle`` and falls back to ``~/.openhost``.
 
-    When ``load()`` is called with no explicit path it must prefer the ``~/.cb``
+    When ``load()`` is called with no explicit path it must prefer the ``~/.bottle``
     config file but transparently read the legacy ``~/.openhost`` file when the
-    former is absent, then migrate forward to ``~/.cb`` on the next save.
+    former is absent, then migrate forward to ``~/.bottle`` on the next save.
     """
 
     @pytest.fixture
     def paths(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> tuple[Path, Path]:
-        new = tmp_path / "cb" / "compute_space_cli.toml"
+        new = tmp_path / "bottle" / "compute_space_cli.toml"
         legacy = tmp_path / "openhost" / "compute_space_cli.toml"
         monkeypatch.setattr(cli_config, "CONFIG_FILE", new)
         monkeypatch.setattr(cli_config, "LEGACY_CONFIG_FILE", legacy)
@@ -159,7 +159,7 @@ class TestLegacyConfigFallback:
             MultiConfig.load()
 
     def test_save_migrates_forward_to_new_path(self, paths: tuple[Path, Path]) -> None:
-        """Loading a legacy config then saving writes to the new ~/.cb path."""
+        """Loading a legacy config then saving writes to the new ~/.bottle path."""
         new, legacy = paths
         self._write(legacy, "legacy.com")
         loaded = MultiConfig.load()
@@ -188,11 +188,11 @@ class TestMultiConfigResolve:
             instances={"a.com": _inst("a.com"), "b.com": _inst("b.com")},
             default="a.com",
         )
-        monkeypatch.setenv("CB_INSTANCE", "b.com")
+        monkeypatch.setenv("BOTTLE_INSTANCE", "b.com")
         assert multi.resolve().url == "https://b.com"
 
     def test_default_instance(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.delenv("CB_INSTANCE", raising=False)
+        monkeypatch.delenv("BOTTLE_INSTANCE", raising=False)
         multi = _make_multi(
             instances={"a.com": _inst("a.com"), "b.com": _inst("b.com")},
             default="a.com",
@@ -200,7 +200,7 @@ class TestMultiConfigResolve:
         assert multi.resolve().url == "https://a.com"
 
     def test_no_default_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.delenv("CB_INSTANCE", raising=False)
+        monkeypatch.delenv("BOTTLE_INSTANCE", raising=False)
         multi = _make_multi(instances={"only.com": _inst("only.com")})
         with pytest.raises(InstanceNotFoundError, match="No default instance set"):
             multi.resolve()
@@ -215,7 +215,7 @@ class TestMultiConfigResolve:
             instances={"a.com": _inst("a.com"), "b.com": _inst("b.com")},
             default="a.com",
         )
-        monkeypatch.setenv("CB_INSTANCE", "a.com")
+        monkeypatch.setenv("BOTTLE_INSTANCE", "a.com")
         assert multi.resolve(instance_name="b.com").url == "https://b.com"
 
     def test_env_overrides_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -223,16 +223,16 @@ class TestMultiConfigResolve:
             instances={"a.com": _inst("a.com"), "b.com": _inst("b.com")},
             default="a.com",
         )
-        monkeypatch.setenv("CB_INSTANCE", "b.com")
+        monkeypatch.setenv("BOTTLE_INSTANCE", "b.com")
         assert multi.resolve().url == "https://b.com"
 
     def test_legacy_oh_instance_env_is_ignored(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """The pre-rename OH_INSTANCE env var is intentionally no longer honored.
 
-        Only CB_INSTANCE is read; a stale OH_INSTANCE must not silently select an
+        Only BOTTLE_INSTANCE is read; a stale OH_INSTANCE must not silently select an
         instance, so resolution falls through to the configured default.
         """
-        monkeypatch.delenv("CB_INSTANCE", raising=False)
+        monkeypatch.delenv("BOTTLE_INSTANCE", raising=False)
         monkeypatch.setenv("OH_INSTANCE", "b.com")
         multi = _make_multi(
             instances={"a.com": _inst("a.com"), "b.com": _inst("b.com")},

--- a/compute_space_cli/src/compute_space_cli/tests/test_config.py
+++ b/compute_space_cli/src/compute_space_cli/tests/test_config.py
@@ -139,7 +139,13 @@ class TestLegacyConfigFallback:
     def _write(self, path: Path, hostname: str) -> None:
         path.parent.mkdir(parents=True, exist_ok=True)
         with open(path, "wb") as f:
-            tomli_w.dump({"instances": {hostname: {"token": "t"}}, "default_instance": hostname}, f)
+            tomli_w.dump({"instances": {hostname: {"token": "tok", "alias": "al"}}, "default_instance": hostname}, f)
+
+    def _write_flat_legacy(self, path: Path, url: str) -> None:
+        """Write the pre-multi-instance flat format (top-level url/token)."""
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with open(path, "wb") as f:
+            tomli_w.dump({"url": url, "token": "flat-tok"}, f)
 
     def test_prefers_new_path(self, paths: tuple[Path, Path]) -> None:
         new, legacy = paths
@@ -153,19 +159,39 @@ class TestLegacyConfigFallback:
         assert not new.exists()
         assert MultiConfig.load().default_instance == "legacy.com"
 
+    def test_falls_back_to_legacy_flat_format(self, paths: tuple[Path, Path]) -> None:
+        """The real migration case: an original ~/.openhost in the pre-multi-instance
+        flat (url/token) format must load via the default-path fallback."""
+        new, legacy = paths
+        self._write_flat_legacy(legacy, "https://old.com")
+        assert not new.exists()
+        loaded = MultiConfig.load()
+        assert loaded.default_instance == "old.com"
+        assert loaded.instances["old.com"].token == "flat-tok"
+
     def test_missing_both_raises_pointing_at_new(self, paths: tuple[Path, Path]) -> None:
         new, _legacy = paths
         with pytest.raises(ConfigFileNotFoundError, match=str(new)):
             MultiConfig.load()
 
     def test_save_migrates_forward_to_new_path(self, paths: tuple[Path, Path]) -> None:
-        """Loading a legacy config then saving writes to the new ~/.bottle path."""
+        """Loading a legacy config then saving writes to the new ~/.bottle path,
+        preserves instance fields, and leaves the legacy file untouched."""
         new, legacy = paths
         self._write(legacy, "legacy.com")
+        legacy_bytes_before = legacy.read_bytes()
+
         loaded = MultiConfig.load()
         loaded.save()
+
         assert new.exists()
-        assert MultiConfig.load(new).default_instance == "legacy.com"
+        migrated = MultiConfig.load(new)
+        assert migrated.default_instance == "legacy.com"
+        # Instance fields survive the migration round-trip.
+        assert migrated.instances["legacy.com"].token == "tok"
+        assert migrated.instances["legacy.com"].alias == "al"
+        # save() must not touch the legacy file.
+        assert legacy.read_bytes() == legacy_bytes_before
 
 
 class TestMultiConfigResolve:

--- a/compute_space_cli/src/compute_space_cli/tests/test_config.py
+++ b/compute_space_cli/src/compute_space_cli/tests/test_config.py
@@ -121,11 +121,11 @@ class TestMultiConfigSaveLoad:
 
 
 class TestLegacyConfigFallback:
-    """Default-path resolution across the ~/.openhost -> ~/.cb (oh -> cb) rename.
+    """Default-path resolution prefers ``~/.cb`` and falls back to ``~/.openhost``.
 
-    When ``load()`` is called with no explicit path it must prefer the new
-    ``~/.cb`` config file but transparently fall back to the legacy
-    ``~/.openhost`` file so users who logged in before the rename keep working.
+    When ``load()`` is called with no explicit path it must prefer the ``~/.cb``
+    config file but transparently read the legacy ``~/.openhost`` file when the
+    former is absent, then migrate forward to ``~/.cb`` on the next save.
     """
 
     @pytest.fixture

--- a/compute_space_cli/src/compute_space_cli/tests/test_config.py
+++ b/compute_space_cli/src/compute_space_cli/tests/test_config.py
@@ -226,6 +226,20 @@ class TestMultiConfigResolve:
         monkeypatch.setenv("CB_INSTANCE", "b.com")
         assert multi.resolve().url == "https://b.com"
 
+    def test_legacy_oh_instance_env_is_ignored(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The pre-rename OH_INSTANCE env var is intentionally no longer honored.
+
+        Only CB_INSTANCE is read; a stale OH_INSTANCE must not silently select an
+        instance, so resolution falls through to the configured default.
+        """
+        monkeypatch.delenv("CB_INSTANCE", raising=False)
+        monkeypatch.setenv("OH_INSTANCE", "b.com")
+        multi = _make_multi(
+            instances={"a.com": _inst("a.com"), "b.com": _inst("b.com")},
+            default="a.com",
+        )
+        assert multi.resolve().url == "https://a.com"
+
 
 class TestUpsertInstance:
     def test_add_to_empty_no_default(self) -> None:

--- a/compute_space_cli/src/compute_space_cli/tests/test_diagnostics_cli.py
+++ b/compute_space_cli/src/compute_space_cli/tests/test_diagnostics_cli.py
@@ -1,4 +1,4 @@
-"""Tests for the ``cb diagnostics`` and ``cb app diagnostics`` CLI commands."""
+"""Tests for the ``bottle diagnostics`` and ``bottle app diagnostics`` CLI commands."""
 
 from __future__ import annotations
 

--- a/compute_space_cli/src/compute_space_cli/tests/test_diagnostics_cli.py
+++ b/compute_space_cli/src/compute_space_cli/tests/test_diagnostics_cli.py
@@ -1,4 +1,4 @@
-"""Tests for the ``oh diagnostics`` and ``oh app diagnostics`` CLI commands."""
+"""Tests for the ``cb diagnostics`` and ``cb app diagnostics`` CLI commands."""
 
 from __future__ import annotations
 

--- a/docs/src/creating_an_app.md
+++ b/docs/src/creating_an_app.md
@@ -182,7 +182,7 @@ this will automatically get updates if you pull new changes from the openhost re
 
 or if not,
 ```bash
-uv tool install "bottle @ git+https://github.com/cloud-in-a-bottle/cloud-in-a-bottle.git#subdirectory=compute_space_cli"
+uv tool install "cloud-in-a-bottle-cli @ git+https://github.com/cloud-in-a-bottle/cloud-in-a-bottle.git#subdirectory=compute_space_cli"
 ```
 Run `bottle instance login` to login to your compute space.
 

--- a/docs/src/creating_an_app.md
+++ b/docs/src/creating_an_app.md
@@ -172,7 +172,7 @@ then point them at that checkout and tell them to read this doc.
 
 ## CLI
 
-There is a CLI interface, `cb`, that can be used for interacting with your compute space, if you prefer that style of workflow.
+There is a CLI interface, `bottle`, that can be used for interacting with your compute space, if you prefer that style of workflow.
 
 If you have a local clone, do
 ```bash
@@ -182,35 +182,35 @@ this will automatically get updates if you pull new changes from the openhost re
 
 or if not,
 ```bash
-uv tool install "cb @ git+https://github.com/cloud-in-a-bottle/cloud-in-a-bottle.git#subdirectory=compute_space_cli"
+uv tool install "bottle @ git+https://github.com/cloud-in-a-bottle/cloud-in-a-bottle.git#subdirectory=compute_space_cli"
 ```
-Run `cb instance login` to login to your compute space.
+Run `bottle instance login` to login to your compute space.
 
 ## AI Agent Development
 
-We'd suggest letting your AI agent do the full "fix bugs, commit+push, update and reload, test" loop. The `cb` CLI makes this easy to automate, although the CLI will need to be logged in by the user manually first.
+We'd suggest letting your AI agent do the full "fix bugs, commit+push, update and reload, test" loop. The `bottle` CLI makes this easy to automate, although the CLI will need to be logged in by the user manually first.
 
-Here's some example `cb` commands, although you should run `cb --help` to get the most up-to-date command list.
+Here's some example `bottle` commands, although you should run `bottle --help` to get the most up-to-date command list.
 
 ```bash
-cb status                                    # check if compute space is reachable
+bottle status                                    # check if compute space is reachable
 
-cb app list                                  # list apps and status
-cb app deploy https://github.com/you/myapp   # deploy from git repo
-cb app deploy https://github.com/you/myapp --name cool-app --wait
-cb app status cool-app                       # check status
-cb app logs cool-app                         # view logs
-cb app logs cool-app --follow                # tail logs
-cb app reload cool-app                       # rebuild + restart
-cb app reload cool-app --update --wait       # git pull, rebuild, wait
-cb app stop cool-app                         # stop app
-cb app remove cool-app                       # remove app + data
-cb app remove cool-app --keep-data           # remove but keep data
-cb app rename cool-app new-name              # rename app
+bottle app list                                  # list apps and status
+bottle app deploy https://github.com/you/myapp   # deploy from git repo
+bottle app deploy https://github.com/you/myapp --name cool-app --wait
+bottle app status cool-app                       # check status
+bottle app logs cool-app                         # view logs
+bottle app logs cool-app --follow                # tail logs
+bottle app reload cool-app                       # rebuild + restart
+bottle app reload cool-app --update --wait       # git pull, rebuild, wait
+bottle app stop cool-app                         # stop app
+bottle app remove cool-app                       # remove app + data
+bottle app remove cool-app --keep-data           # remove but keep data
+bottle app rename cool-app new-name              # rename app
 
-cb tokens list                               # list API tokens
-cb tokens create --name "ci" --expiry-hours 72
-cb tokens delete 3                           # delete by token ID
+bottle tokens list                               # list API tokens
+bottle tokens create --name "ci" --expiry-hours 72
+bottle tokens delete 3                           # delete by token ID
 ```
 
 Note: cloning a private GitHub repo for the first time requires an OAuth flow in the browser. The CLI will print a link to authorize. After that, subsequent deploys and updates work without browser interaction.

--- a/docs/src/creating_an_app.md
+++ b/docs/src/creating_an_app.md
@@ -172,7 +172,7 @@ then point them at that checkout and tell them to read this doc.
 
 ## CLI
 
-There is a CLI interface, `oh`, that can be used for interacting with your compute space, if you prefer that style of workflow.
+There is a CLI interface, `cb`, that can be used for interacting with your compute space, if you prefer that style of workflow.
 
 If you have a local clone, do
 ```bash

--- a/docs/src/creating_an_app.md
+++ b/docs/src/creating_an_app.md
@@ -182,35 +182,35 @@ this will automatically get updates if you pull new changes from the openhost re
 
 or if not,
 ```bash
-uv tool install "oh @ git+https://github.com/cloud-in-a-bottle/cloud-in-a-bottle.git#subdirectory=compute_space_cli"
+uv tool install "cb @ git+https://github.com/cloud-in-a-bottle/cloud-in-a-bottle.git#subdirectory=compute_space_cli"
 ```
-Run `oh instance login` to login to your compute space.
+Run `cb instance login` to login to your compute space.
 
 ## AI Agent Development
 
-We'd suggest letting your AI agent do the full "fix bugs, commit+push, update and reload, test" loop. The `oh` CLI makes this easy to automate, although the CLI will need to be logged in by the user manually first.
+We'd suggest letting your AI agent do the full "fix bugs, commit+push, update and reload, test" loop. The `cb` CLI makes this easy to automate, although the CLI will need to be logged in by the user manually first.
 
-Here's some example `oh` commands, although you should run `oh --help` to get the most up-to-date command list.
+Here's some example `cb` commands, although you should run `cb --help` to get the most up-to-date command list.
 
 ```bash
-oh status                                    # check if compute space is reachable
+cb status                                    # check if compute space is reachable
 
-oh app list                                  # list apps and status
-oh app deploy https://github.com/you/myapp   # deploy from git repo
-oh app deploy https://github.com/you/myapp --name cool-app --wait
-oh app status cool-app                       # check status
-oh app logs cool-app                         # view logs
-oh app logs cool-app --follow                # tail logs
-oh app reload cool-app                       # rebuild + restart
-oh app reload cool-app --update --wait       # git pull, rebuild, wait
-oh app stop cool-app                         # stop app
-oh app remove cool-app                       # remove app + data
-oh app remove cool-app --keep-data           # remove but keep data
-oh app rename cool-app new-name              # rename app
+cb app list                                  # list apps and status
+cb app deploy https://github.com/you/myapp   # deploy from git repo
+cb app deploy https://github.com/you/myapp --name cool-app --wait
+cb app status cool-app                       # check status
+cb app logs cool-app                         # view logs
+cb app logs cool-app --follow                # tail logs
+cb app reload cool-app                       # rebuild + restart
+cb app reload cool-app --update --wait       # git pull, rebuild, wait
+cb app stop cool-app                         # stop app
+cb app remove cool-app                       # remove app + data
+cb app remove cool-app --keep-data           # remove but keep data
+cb app rename cool-app new-name              # rename app
 
-oh tokens list                               # list API tokens
-oh tokens create --name "ci" --expiry-hours 72
-oh tokens delete 3                           # delete by token ID
+cb tokens list                               # list API tokens
+cb tokens create --name "ci" --expiry-hours 72
+cb tokens delete 3                           # delete by token ID
 ```
 
 Note: cloning a private GitHub repo for the first time requires an OAuth flow in the browser. The CLI will print a link to authorize. After that, subsequent deploys and updates work without browser interaction.

--- a/docs/src/logs.md
+++ b/docs/src/logs.md
@@ -13,7 +13,7 @@ The router writes to two sinks simultaneously via loguru:
 - Written at INFO level and above.
 - Truncated on each process restart, so it always contains only the current invocation's logs.
 - Rotates automatically at 10 MB mid-run; up to 5 rotated files kept (named `compute_space.YYYY-MM-DD_HH-MM-SS_ffffff.log` alongside the active file). Note: rotation-based retention only fires when the 10 MB limit is actually hit — rotated files from old runs are not pruned until the next mid-run rotation.
-- Access via `cb logs` or `cb logs --instance <name>`.
+- Access via `bottle logs` or `bottle logs --instance <name>`.
 
 **Stderr sink** — journald (via systemd)
 
@@ -38,7 +38,7 @@ Container stdout and stderr are written to a per-app file via podman's `k8s-file
 - Archived (not deleted) at the start of each reload. Both logs have the build time appended: `docker.log.20240101_120000`.
 - Up to 5 archived build logs are kept per app; older ones are deleted when the limit is exceeded.
 - Deleted entirely when the app is removed.
-- Access via `cb app logs <name>` (the current runtime log is appended to the build log).
+- Access via `bottle app logs <name>` (the current runtime log is appended to the build log).
 - Runtime logs do not appear in journald, which is used for Cloud in a Bottle status logs
 
 ---
@@ -59,7 +59,7 @@ journalctl -u openhost-juicefs
 
 - Diagnosing startup failures (before the file sink is initialised)
 - Viewing logs across restarts in one stream
-- Checking recent router activity without `cb` access: `systemctl status openhost` shows the last few lines
+- Checking recent router activity without `bottle` access: `systemctl status openhost` shows the last few lines
 
 `journalctl -u openhost` does **not** contain:
 - App container stdout/stderr (now written to `container.log` via k8s-file)

--- a/docs/src/logs.md
+++ b/docs/src/logs.md
@@ -13,7 +13,7 @@ The router writes to two sinks simultaneously via loguru:
 - Written at INFO level and above.
 - Truncated on each process restart, so it always contains only the current invocation's logs.
 - Rotates automatically at 10 MB mid-run; up to 5 rotated files kept (named `compute_space.YYYY-MM-DD_HH-MM-SS_ffffff.log` alongside the active file). Note: rotation-based retention only fires when the 10 MB limit is actually hit — rotated files from old runs are not pruned until the next mid-run rotation.
-- Access via `oh logs` or `oh logs --instance <name>`.
+- Access via `cb logs` or `cb logs --instance <name>`.
 
 **Stderr sink** — journald (via systemd)
 
@@ -38,7 +38,7 @@ Container stdout and stderr are written to a per-app file via podman's `k8s-file
 - Archived (not deleted) at the start of each reload. Both logs have the build time appended: `docker.log.20240101_120000`.
 - Up to 5 archived build logs are kept per app; older ones are deleted when the limit is exceeded.
 - Deleted entirely when the app is removed.
-- Access via `oh app logs <name>` (the current runtime log is appended to the build log).
+- Access via `cb app logs <name>` (the current runtime log is appended to the build log).
 - Runtime logs do not appear in journald, which is used for Cloud in a Bottle status logs
 
 ---
@@ -59,7 +59,7 @@ journalctl -u openhost-juicefs
 
 - Diagnosing startup failures (before the file sink is initialised)
 - Viewing logs across restarts in one stream
-- Checking recent router activity without `oh` access: `systemctl status openhost` shows the last few lines
+- Checking recent router activity without `cb` access: `systemctl status openhost` shows the last few lines
 
 `journalctl -u openhost` does **not** contain:
 - App container stdout/stderr (now written to `container.log` via k8s-file)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ test-harness = [
 
 [project.scripts]
 openhost = "self_host_cli.main:main"
-oh = "compute_space_cli.main:main"
+cb = "compute_space_cli.main:main"
 openhost_system_agent = "openhost_system_agent.cli:main"
 
 [build-system]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ test-harness = [
 
 [project.scripts]
 openhost = "self_host_cli.main:main"
-cb = "compute_space_cli.main:main"
+bottle = "compute_space_cli.main:main"
 openhost_system_agent = "openhost_system_agent.cli:main"
 
 [build-system]

--- a/skills/openhost-context/SKILL.md
+++ b/skills/openhost-context/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: openhost-context
-description: Deploy and debug apps on Cloud in a Bottle, a platform for self-hosting apps. Use when working with the `cb` CLI, deploying or reloading an app on a Cloud in a Bottle zone, or building a Cloud in a Bottle app.
+description: Deploy and debug apps on Cloud in a Bottle, a platform for self-hosting apps. Use when working with the `bottle` CLI, deploying or reloading an app on a Cloud in a Bottle zone, or building a Cloud in a Bottle app.
 ---
 
 # Cloud in a Bottle
@@ -9,28 +9,28 @@ Cloud in a Bottle is a platform for self-hosting apps. Each app runs in its own
 container; the Cloud in a Bottle router terminates TLS, handles auth, and
 proxies requests to apps by subdomain (`https://{app_name}.{zone_domain}/`).
 
-You interact with a zone through the `cb` CLI, which injects auth for you.
-Prefer `cb` over raw HTTP requests so you never have to handle tokens by hand.
+You interact with a zone through the `bottle` CLI, which injects auth for you.
+Prefer `bottle` over raw HTTP requests so you never have to handle tokens by hand.
 
 ## First time: install and log in
 
-If `cb` isn't installed:
+If `bottle` isn't installed:
 
 ```bash
-uv tool install "cb @ git+https://github.com/cloud-in-a-bottle/cloud-in-a-bottle.git#subdirectory=compute_space_cli"
+uv tool install "bottle @ git+https://github.com/cloud-in-a-bottle/cloud-in-a-bottle.git#subdirectory=compute_space_cli"
 ```
 
 Then the **user** logs in (this is interactive — ask them to run it):
 
 ```bash
-cb instance login
+bottle instance login
 ```
 
 A zone you've logged into is called an **instance**. List configured
-instances and the URL each is reachable at (if none are listed, the user needs to do `cb instance login`)
+instances and the URL each is reachable at (if none are listed, the user needs to do `bottle instance login`)
 
 ```bash
-cb instance list
+bottle instance list
 ```
 
 ## Targeting an instance
@@ -42,8 +42,8 @@ otherwise modify instances you weren't asked to.
 Pass `--instance <name>` to target a specific one (works on any subcommand):
 
 ```bash
-cb status --instance my-zone
-cb app list --instance my-zone
+bottle status --instance my-zone
+bottle app list --instance my-zone
 ```
 
 If a single default instance is configured, `--instance` can be omitted.
@@ -57,15 +57,15 @@ unauthenticated access:
   listed in `public_paths` in `openhost.toml` are reachable by **anyone** —
   only expose paths that are meant to be public.
 - Don't put API tokens in code, commits, or anything that might be pushed.
-  `cb` already injects auth; reach for a raw token only if truly necessary
-  (`cb instance token --instance <name>`), and keep it out of the repo.
+  `bottle` already injects auth; reach for a raw token only if truly necessary
+  (`bottle instance token --instance <name>`), and keep it out of the repo.
 
 ## Deploy / update workflow
 
 Deploy an app from a git repo URL (public, or private with auth):
 
 ```bash
-cb app deploy https://github.com/you/my-app --name my-app --wait --instance my-zone
+bottle app deploy https://github.com/you/my-app --name my-app --wait --instance my-zone
 ```
 
 You can deploy from a branch with `https://github.com/you/my-app@branch_name`.
@@ -78,25 +78,25 @@ on the zone:
 
 ```bash
 git commit -am "..." && git push
-cb app reload my-app --update --wait --instance my-zone   # --update = git pull first
-cb app logs my-app --instance my-zone                     # check the result
+bottle app reload my-app --update --wait --instance my-zone   # --update = git pull first
+bottle app logs my-app --instance my-zone                     # check the result
 ```
 
-Other app commands: `cb app status|list|stop|rename|remove`. Run
-`cb --help` (or `cb app --help`) for the current, complete list.
+Other app commands: `bottle app status|list|stop|rename|remove`. Run
+`bottle --help` (or `bottle app --help`) for the current, complete list.
 
 ## Debugging
 
-- **Logs**: `cb app logs my-app --follow --instance my-zone` (app logs);
-  `cb logs --instance my-zone` (zone/router logs).
-- **Shell on the zone**: `cb instance ssh --instance my-zone`.
-- **Authenticated HTTP**: `cb curl https://my-app.<zone-domain>/some/path`
+- **Logs**: `bottle app logs my-app --follow --instance my-zone` (app logs);
+  `bottle logs --instance my-zone` (zone/router logs).
+- **Shell on the zone**: `bottle instance ssh --instance my-zone`.
+- **Authenticated HTTP**: `bottle curl https://my-app.<zone-domain>/some/path`
   — runs `curl` with the user's API token token injected, so it behaves like an
   owner-logged-in request.
 - **Test a page in a browser** the way a logged-in owner sees it: drive it
   with Playwright and inject the API token as an `Authorization: Bearer
   <token>` header. This matches the behavior of a request carrying the
-  owner's login cookies. Get a token with `cb instance token` (handle it
+  owner's login cookies. Get a token with `bottle instance token` (handle it
   carefully — see Safety).
 
 ## Building a new app

--- a/skills/openhost-context/SKILL.md
+++ b/skills/openhost-context/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: openhost-context
-description: Deploy and debug apps on Cloud in a Bottle, a platform for self-hosting apps. Use when working with the `oh` CLI, deploying or reloading an app on a Cloud in a Bottle zone, or building a Cloud in a Bottle app.
+description: Deploy and debug apps on Cloud in a Bottle, a platform for self-hosting apps. Use when working with the `cb` CLI, deploying or reloading an app on a Cloud in a Bottle zone, or building a Cloud in a Bottle app.
 ---
 
 # Cloud in a Bottle
@@ -9,28 +9,28 @@ Cloud in a Bottle is a platform for self-hosting apps. Each app runs in its own
 container; the Cloud in a Bottle router terminates TLS, handles auth, and
 proxies requests to apps by subdomain (`https://{app_name}.{zone_domain}/`).
 
-You interact with a zone through the `oh` CLI, which injects auth for you.
-Prefer `oh` over raw HTTP requests so you never have to handle tokens by hand.
+You interact with a zone through the `cb` CLI, which injects auth for you.
+Prefer `cb` over raw HTTP requests so you never have to handle tokens by hand.
 
 ## First time: install and log in
 
-If `oh` isn't installed:
+If `cb` isn't installed:
 
 ```bash
-uv tool install "oh @ git+https://github.com/cloud-in-a-bottle/cloud-in-a-bottle.git#subdirectory=compute_space_cli"
+uv tool install "cb @ git+https://github.com/cloud-in-a-bottle/cloud-in-a-bottle.git#subdirectory=compute_space_cli"
 ```
 
 Then the **user** logs in (this is interactive — ask them to run it):
 
 ```bash
-oh instance login
+cb instance login
 ```
 
 A zone you've logged into is called an **instance**. List configured
-instances and the URL each is reachable at (if none are listed, the user needs to do `oh instance login`)
+instances and the URL each is reachable at (if none are listed, the user needs to do `cb instance login`)
 
 ```bash
-oh instance list
+cb instance list
 ```
 
 ## Targeting an instance
@@ -42,8 +42,8 @@ otherwise modify instances you weren't asked to.
 Pass `--instance <name>` to target a specific one (works on any subcommand):
 
 ```bash
-oh status --instance my-zone
-oh app list --instance my-zone
+cb status --instance my-zone
+cb app list --instance my-zone
 ```
 
 If a single default instance is configured, `--instance` can be omitted.
@@ -57,15 +57,15 @@ unauthenticated access:
   listed in `public_paths` in `openhost.toml` are reachable by **anyone** —
   only expose paths that are meant to be public.
 - Don't put API tokens in code, commits, or anything that might be pushed.
-  `oh` already injects auth; reach for a raw token only if truly necessary
-  (`oh instance token --instance <name>`), and keep it out of the repo.
+  `cb` already injects auth; reach for a raw token only if truly necessary
+  (`cb instance token --instance <name>`), and keep it out of the repo.
 
 ## Deploy / update workflow
 
 Deploy an app from a git repo URL (public, or private with auth):
 
 ```bash
-oh app deploy https://github.com/you/my-app --name my-app --wait --instance my-zone
+cb app deploy https://github.com/you/my-app --name my-app --wait --instance my-zone
 ```
 
 You can deploy from a branch with `https://github.com/you/my-app@branch_name`.
@@ -78,25 +78,25 @@ on the zone:
 
 ```bash
 git commit -am "..." && git push
-oh app reload my-app --update --wait --instance my-zone   # --update = git pull first
-oh app logs my-app --instance my-zone                     # check the result
+cb app reload my-app --update --wait --instance my-zone   # --update = git pull first
+cb app logs my-app --instance my-zone                     # check the result
 ```
 
-Other app commands: `oh app status|list|stop|rename|remove`. Run
-`oh --help` (or `oh app --help`) for the current, complete list.
+Other app commands: `cb app status|list|stop|rename|remove`. Run
+`cb --help` (or `cb app --help`) for the current, complete list.
 
 ## Debugging
 
-- **Logs**: `oh app logs my-app --follow --instance my-zone` (app logs);
-  `oh logs --instance my-zone` (zone/router logs).
-- **Shell on the zone**: `oh instance ssh --instance my-zone`.
-- **Authenticated HTTP**: `oh curl https://my-app.<zone-domain>/some/path`
+- **Logs**: `cb app logs my-app --follow --instance my-zone` (app logs);
+  `cb logs --instance my-zone` (zone/router logs).
+- **Shell on the zone**: `cb instance ssh --instance my-zone`.
+- **Authenticated HTTP**: `cb curl https://my-app.<zone-domain>/some/path`
   — runs `curl` with the user's API token token injected, so it behaves like an
   owner-logged-in request.
 - **Test a page in a browser** the way a logged-in owner sees it: drive it
   with Playwright and inject the API token as an `Authorization: Bearer
   <token>` header. This matches the behavior of a request carrying the
-  owner's login cookies. Get a token with `oh instance token` (handle it
+  owner's login cookies. Get a token with `cb instance token` (handle it
   carefully — see Safety).
 
 ## Building a new app

--- a/skills/openhost-context/SKILL.md
+++ b/skills/openhost-context/SKILL.md
@@ -17,7 +17,7 @@ Prefer `bottle` over raw HTTP requests so you never have to handle tokens by han
 If `bottle` isn't installed:
 
 ```bash
-uv tool install "bottle @ git+https://github.com/cloud-in-a-bottle/cloud-in-a-bottle.git#subdirectory=compute_space_cli"
+uv tool install "cloud-in-a-bottle-cli @ git+https://github.com/cloud-in-a-bottle/cloud-in-a-bottle.git#subdirectory=compute_space_cli"
 ```
 
 Then the **user** logs in (this is interactive — ask them to run it):


### PR DESCRIPTION
Renames the compute-space CLI to bottle. The executable command and console script are bottle; the Python distribution is named cloud-in-a-bottle-cli (unique/descriptive for a possible PyPI publish). The env var is BOTTLE_INSTANCE and the config directory is ~/.cloud_in_a_bottle_cli.

What changed:
main.py: cappa command name is now bottle; class Oh becomes Bottle.
config.py: CONFIG_DIR is ~/.cloud_in_a_bottle_cli, with a read-fallback to the legacy ~/.openhost config that migrates forward on the next save; OH_INSTANCE becomes BOTTLE_INSTANCE.
pyproject.toml: the console script is bottle (root and compute_space_cli); the compute_space_cli distribution name is cloud-in-a-bottle-cli.
Updates every command example in help text, docs, README, and the openhost-context skill; install/upgrade commands reference the distribution name cloud-in-a-bottle-cli.
Tests: BOTTLE_INSTANCE resolution, the legacy OH_INSTANCE now being ignored, and config-dir fallback/migration coverage including the pre-multi-instance flat (url/token) legacy format; e2e helper and diagnostics tests updated.

Backward compatibility: existing logins keep working because load() reads ~/.openhost when ~/.cloud_in_a_bottle_cli is absent, then migrates forward on the next save.

Scope: the separate openhost self-host/router CLI is intentionally unaffected. Server-side ~/.openhost data paths (router data dir, PID dir) are unrelated to the client CLI config and are left as-is.
