### PR TITLE
Return GitHub URL in app status api

### DIFF
--- a/compute_space/src/compute_space/tests/test_app_status.py
+++ b/compute_space/src/compute_space/tests/test_app_status.py
@@ -111,6 +111,43 @@ def test_unrelated_error_message_has_no_error_kind(
     assert payload["error_kind"] is None
 
 
+def test_app_status_returns_repo_url(cfg: Any, client: TestClient[Litestar], cookies: dict[str, str]) -> None:
+    """app_status response includes the git repo_url with branch/ref pin."""
+    app_id = new_app_id()
+    db = sqlite3.connect(cfg.db_path)
+    try:
+        db.execute(
+            """INSERT INTO apps (app_id, name, version, repo_path, repo_url, local_port, status)
+               VALUES (?, 'myapp', '1.0', '/repo/myapp', 'https://github.com/owner/repo@main', 20113, 'running')""",
+            (app_id,),
+        )
+        db.commit()
+    finally:
+        db.close()
+    client.cookies.update(cookies)
+    resp = client.get(f"/api/app_status/{app_id}")
+    assert resp.status_code == 200
+    assert resp.json()["repo_url"] == "https://github.com/owner/repo@main"
+
+
+def test_app_status_repo_url_none_when_unset(cfg: Any, client: TestClient[Litestar], cookies: dict[str, str]) -> None:
+    app_id = new_app_id()
+    db = sqlite3.connect(cfg.db_path)
+    try:
+        db.execute(
+            """INSERT INTO apps (app_id, name, version, repo_path, repo_url, local_port, status)
+               VALUES (?, 'builtin', '1.0', '/repo/builtin', NULL, 20114, 'running')""",
+            (app_id,),
+        )
+        db.commit()
+    finally:
+        db.close()
+    client.cookies.update(cookies)
+    resp = client.get(f"/api/app_status/{app_id}")
+    assert resp.status_code == 200
+    assert resp.json()["repo_url"] is None
+
+
 def test_import_wiring() -> None:
     """Make sure the module under test is still importing BUILD_CACHE_CORRUPT_MARKER
     the way app_status expects; a rename in core/containers.py that

--- a/compute_space/src/compute_space/web/routes/api/apps.py
+++ b/compute_space/src/compute_space/web/routes/api/apps.py
@@ -136,14 +136,11 @@ class AppStatusResponse:
     status: str
     error: str | None
     error_kind: str | None
-    # Git info for the app's checked-out repo. All None when the app has no
-    # git repo on disk (e.g. builtin apps copied from the apps/ directory)
-    # or when the .git read fails for any reason. ``git_branch`` is None when
-    # HEAD is detached even if ``git_sha`` is populated.
     git_branch: str | None = None
     git_sha: str | None = None
     git_dirty: bool | None = None
     container_id: str | None = None
+    repo_url: str | None = None
 
 
 @attr.s(auto_attribs=True, frozen=True)
@@ -461,7 +458,7 @@ async def app_status(app_id: FromPath[str], db: NamedDependency[sqlite3.Connecti
     if not is_valid_app_id(app_id):
         raise ValidationException(detail="Invalid app_id")
     app_row = db.execute(
-        "SELECT status, error_message, repo_path, container_id FROM apps WHERE app_id = ?", (app_id,)
+        "SELECT status, error_message, repo_path, repo_url, container_id FROM apps WHERE app_id = ?", (app_id,)
     ).fetchone()
     if not app_row:
         raise NotFoundException(detail="App not found")
@@ -483,6 +480,7 @@ async def app_status(app_id: FromPath[str], db: NamedDependency[sqlite3.Connecti
             git_sha=git_sha,
             git_dirty=git_dirty,
             container_id=app_row["container_id"],
+            repo_url=app_row["repo_url"],
         ),
         status_code=200,
         media_type=MediaType.JSON,

--- a/compute_space_cli/src/compute_space_cli/main.py
+++ b/compute_space_cli/src/compute_space_cli/main.py
@@ -141,6 +141,9 @@ class AppCmd:
         print(f"{app_name}: {result.get('status', 'unknown')}")
         if result.get("error"):
             print(f"  error: {result['error']}")
+        repo_url = result.get("repo_url")
+        if repo_url:
+            print(f"  git url: {repo_url}")
         sha = result.get("git_sha")
         if sha:
             branch = result.get("git_branch") or "(detached HEAD)"

--- a/compute_space_cli/src/compute_space_cli/main.py
+++ b/compute_space_cli/src/compute_space_cli/main.py
@@ -148,7 +148,7 @@ class AppCmd:
         if sha:
             branch = result.get("git_branch") or "(detached HEAD)"
             dirty = " (dirty)" if result.get("git_dirty") else ""
-            print(f"  git: {branch} @ {sha}{dirty}")
+            print(f"  git commit: {branch} @ {sha}{dirty}")
 
     @cappa.command(name="logs")
     def logs(


### PR DESCRIPTION
Add repo_url as part of the response in `/api/app_status/<id>`
In the CLI, if repo_url is returned, then it now prints out as part of `oh app status`