### PR TITLE
Bound build swap to the memory limit instead of leaving it unlimited

### DIFF
--- a/compute_space/src/compute_space/core/containers.py
+++ b/compute_space/src/compute_space/core/containers.py
@@ -192,13 +192,13 @@ def build_image(
         dockerfile_path,
     ]
     if memory_mb is not None:
-        # Cap build RAM at the app's declared limit for isolation. We pass only
-        # --memory and leave --memory-swap unset, so podman applies its default
-        # of memory-swap == 2*memory: swap is bounded to the same size as the
-        # memory limit rather than being unlimited. A build that needs more
-        # than memory_mb can spill up to memory_mb into swap before OOMing,
-        # without letting a "small" app hog unbounded host swap.
+        # Cap build RAM at the app's declared limit for isolation. --memory-swap
+        # is the combined memory+swap ceiling; setting it equal to --memory
+        # gives the build zero swap, so it stays within memory_mb or OOMs rather
+        # than spilling onto host swap. (Left unset, podman would default it to
+        # 2*memory, allowing memory_mb of swap.)
         cmd.append(f"--memory={memory_mb}m")
+        cmd.append(f"--memory-swap={memory_mb}m")
     cmd.append(repo_path)
     logger.info("Building container image: %s", " ".join(cmd))
 

--- a/compute_space/src/compute_space/core/containers.py
+++ b/compute_space/src/compute_space/core/containers.py
@@ -192,13 +192,13 @@ def build_image(
         dockerfile_path,
     ]
     if memory_mb is not None:
-        # Cap build RAM at the app's declared limit for isolation, but allow
-        # unlimited swap (the host has a large swap file). A build that needs
-        # more than memory_mb then spills to swap instead of OOM-killing —
-        # keeping most builds working even with a small memory_mb, without
-        # letting a "small" app hog host RAM. --memory-swap=-1 requires --memory.
+        # Cap build RAM at the app's declared limit for isolation. We pass only
+        # --memory and leave --memory-swap unset, so podman applies its default
+        # of memory-swap == 2*memory: swap is bounded to the same size as the
+        # memory limit rather than being unlimited. A build that needs more
+        # than memory_mb can spill up to memory_mb into swap before OOMing,
+        # without letting a "small" app hog unbounded host swap.
         cmd.append(f"--memory={memory_mb}m")
-        cmd.append("--memory-swap=-1")
     cmd.append(repo_path)
     logger.info("Building container image: %s", " ".join(cmd))
 

--- a/compute_space/src/compute_space/tests/test_containers.py
+++ b/compute_space/src/compute_space/tests/test_containers.py
@@ -75,9 +75,10 @@ def test_build_image_applies_memory_limit(monkeypatch: pytest.MonkeyPatch) -> No
     _patch_subprocess_run(monkeypatch, fake_run)
 
     build_image("myapp", "/tmp/repo", "Dockerfile", temp_data_dir=None, memory_mb=512)
-    # --memory caps build RAM; --memory-swap=-1 allows unlimited swap so a
-    # build that needs more spills to swap instead of OOMing. Both go to
-    # `podman build`, before the build context path.
+    # --memory caps build RAM. --memory-swap is left unset so podman defaults
+    # it to 2*memory, bounding swap to the same size as the memory limit
+    # (rather than unlimited). The flag goes to `podman build`, before the
+    # build context path.
     assert calls[0] == [
         "podman",
         "build",
@@ -86,7 +87,6 @@ def test_build_image_applies_memory_limit(monkeypatch: pytest.MonkeyPatch) -> No
         "-f",
         "/tmp/repo/Dockerfile",
         "--memory=512m",
-        "--memory-swap=-1",
         "/tmp/repo",
     ]
 

--- a/compute_space/src/compute_space/tests/test_containers.py
+++ b/compute_space/src/compute_space/tests/test_containers.py
@@ -75,10 +75,9 @@ def test_build_image_applies_memory_limit(monkeypatch: pytest.MonkeyPatch) -> No
     _patch_subprocess_run(monkeypatch, fake_run)
 
     build_image("myapp", "/tmp/repo", "Dockerfile", temp_data_dir=None, memory_mb=512)
-    # --memory caps build RAM. --memory-swap is left unset so podman defaults
-    # it to 2*memory, bounding swap to the same size as the memory limit
-    # (rather than unlimited). The flag goes to `podman build`, before the
-    # build context path.
+    # --memory caps build RAM; --memory-swap set equal to --memory gives the
+    # build zero swap (the combined memory+swap ceiling == the memory limit).
+    # Both go to `podman build`, before the build context path.
     assert calls[0] == [
         "podman",
         "build",
@@ -87,6 +86,7 @@ def test_build_image_applies_memory_limit(monkeypatch: pytest.MonkeyPatch) -> No
         "-f",
         "/tmp/repo/Dockerfile",
         "--memory=512m",
+        "--memory-swap=512m",
         "/tmp/repo",
     ]
 


### PR DESCRIPTION
## What

`build_image` passed `--memory-swap=-1` alongside `--memory`, giving each app build **unlimited** host swap. This sets `--memory-swap` equal to `--memory` so builds get **zero swap**.

`--memory-swap` is the combined memory+swap ceiling ([podman-build.1](https://docs.podman.io/en/latest/markdown/podman-build.1.html)). Setting it equal to `--memory` makes that ceiling the memory limit itself, so there is no swap headroom — a build stays within `build_memory_mb` or OOMs. (Left unset, podman defaults it to `2 × memory`, which would allow `memory_mb` of swap.)

## Why

Follows the pass through the catalog setting per-app `build_memory_mb`. Per review (Zack), builds should not touch swap at all — a hard memory ceiling with no disk spill.

## Caveat

A build needing more than `build_memory_mb` now OOMs immediately (no swap spill). If any catalog app's `build_memory_mb` is set too tight for its actual build footprint, its build will fail — worth watching the first heavy build after this lands.

## Tests

Updated `test_build_image_applies_memory_limit` to assert the argv contains `--memory=512m` and `--memory-swap=512m`. `test_build_image_omits_memory_flag_when_unset` still holds. All `build_image` tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)