### PR TITLE
docs: give the env var table a real heading

### DIFF
--- a/docs/src/creating_an_app.md
+++ b/docs/src/creating_an_app.md
@@ -111,6 +111,8 @@ if __name__ == "__main__":
 - For apps that implement their own auth, routes can be set as public, and requests that have been authenticated by the router will bear a `X-OpenHost-Is-Owner=true` header.
 - To surface interesting paths on your app (e.g. an admin console) to the user on the dashboard, declare them in `[[links]]` (each with a `name` and `path`). See the [manifest spec](manifest_spec.md).
 
+### Environment variables
+
 The router injects these environment variables into your app:
 
 | Variable | Example | Description                                                                                                     |


### PR DESCRIPTION
`creating_an_app.md` links to `[Environment variables](#environment-variables)` from its Notes
section, but the manual has no heading by that name — so the link goes nowhere in the rendered
book. The table it means to point at sits unheaded at the tail of Notes.

This adds the `### Environment variables` heading the link already assumes, which both makes the
anchor resolve and gives the table its own entry in the page contents.

Found by a new dead-link test on the [landing page](https://github.com/cloud-in-a-bottle/open-source-project-landing-page),
which renders this manual and crawls it; it was the only dead link on the whole site.

Verified by rendering the manual with the pinned mdBook 0.4.40 from this branch — the heading emits
`id="environment-variables"`, and the crawl comes back clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)