### PR TITLE
Local dev stack: justfile, random port, and macOS archive-tier fix

### DIFF
--- a/compute_space/src/compute_space/core/archive_backend.py
+++ b/compute_space/src/compute_space/core/archive_backend.py
@@ -49,6 +49,7 @@ from compute_space.core.domains import primary_domain_or_none
 from compute_space.core.logging import logger
 from compute_space.core.pinned_binary import get_pinned_binary
 from compute_space.core.pinned_binary import install_pinned_binary
+from compute_space.core.pinned_binary import is_linux_host
 
 # Name of the systemd unit that manages the JuiceFS FUSE mount.
 # Installed by ansible (disabled); enabled by compute_space when the
@@ -290,7 +291,7 @@ def format_local_volume(config: Config, juicefs_volume_name: str) -> None:
         _format_meta_dsn(config),
         juicefs_volume_name,
     ]
-    logger.info("Running juicefs format (local file backend) at %s", store_dir)
+    logger.info("Running juicefs format (local file backend) at {}", store_dir)
     result = subprocess.run(cmd, capture_output=True, text=True, timeout=60)
     if result.returncode != 0:
         raise RuntimeError(
@@ -336,7 +337,7 @@ def format_s3_volume(
     env = os.environ.copy()
     env["ACCESS_KEY"] = s3_access_key_id
     env["SECRET_KEY"] = s3_secret_access_key
-    logger.info("Running juicefs format against %s", bucket_url)
+    logger.info("Running juicefs format against {}", bucket_url)
     result = subprocess.run(cmd, env=env, capture_output=True, text=True, timeout=60)
     if result.returncode != 0:
         raise RuntimeError(
@@ -387,7 +388,7 @@ def _write_env_file(
     finally:
         os.close(fd)
     os.rename(tmp_path, env_path)
-    logger.info("Wrote JuiceFS env file at %s", env_path)
+    logger.info("Wrote JuiceFS env file at {}", env_path)
 
 
 def _systemctl(*args: str, timeout: int = 30) -> subprocess.CompletedProcess[str]:
@@ -442,12 +443,12 @@ def mount(
     os.makedirs(mount_point, exist_ok=True)
 
     if is_mounted(mount_point):
-        logger.info("juicefs already mounted at %s", mount_point)
+        logger.info("juicefs already mounted at {}", mount_point)
         return
 
     _write_env_file(config, s3_access_key_id, s3_secret_access_key)
 
-    logger.info("Starting %s systemd service", JUICEFS_SERVICE)
+    logger.info("Starting {} systemd service", JUICEFS_SERVICE)
     # daemon-reload in case the unit file was just installed or updated.
     _systemctl("daemon-reload")
     _systemctl("enable", "--now", JUICEFS_SERVICE)
@@ -458,7 +459,7 @@ def mount(
     deadline = time.time() + 30
     while time.time() < deadline:
         if is_mounted(mount_point):
-            logger.info("juicefs mount ready at %s (via systemd)", mount_point)
+            logger.info("juicefs mount ready at {} (via systemd)", mount_point)
             return
         time.sleep(0.5)
 
@@ -496,7 +497,7 @@ def umount(config: Config) -> None:
             pass  # already stopped/disabled
         return
 
-    logger.info("Stopping %s systemd service", JUICEFS_SERVICE)
+    logger.info("Stopping {} systemd service", JUICEFS_SERVICE)
     try:
         # Give the stop generous headroom: JuiceFS's own umount flushes
         # buffered data and its signal handler only force-exits after ~30s, so
@@ -512,7 +513,7 @@ def umount(config: Config) -> None:
         ) from exc
 
     _systemctl("disable", JUICEFS_SERVICE)
-    logger.info("juicefs unmounted from %s (via systemd)", mount_point)
+    logger.info("juicefs unmounted from {} (via systemd)", mount_point)
 
 
 def _remount(config: Config, s3_access_key_id: str | None, s3_secret_access_key: str | None) -> None:
@@ -655,6 +656,16 @@ def attach_on_startup(config: Config, db: sqlite3.Connection) -> None:
     so the archive tier is available with zero operator configuration.
     """
     state = read_state(db)
+    if state.backend in ("local", "s3") and not is_linux_host():
+        # JuiceFS is pinned as a Linux release only, so the archive tier can't run here (local
+        # dev on macOS).  Everything else works; say so once instead of raising on every boot.
+        logger.warning(
+            "Archive tier disabled: JuiceFS has no {} build, so the '{}' backend can't be brought up.",
+            os.uname().sysname,
+            state.backend,
+        )
+        _set_state_message(db, f"Archive tier unavailable: no JuiceFS build for {os.uname().sysname}.")
+        return
     if state.backend == "local":
         try:
             if not is_juicefs_installed(config):
@@ -888,7 +899,7 @@ def _sync_objects(
     if s3_access_key_id is not None and s3_secret_access_key is not None:
         env["AWS_ACCESS_KEY_ID"] = s3_access_key_id
         env["AWS_SECRET_ACCESS_KEY"] = s3_secret_access_key
-    logger.info("juicefs sync %s -> %s", src, dst)
+    logger.info("juicefs sync {} -> {}", src, dst)
     # Generous but bounded timeout: large archives on slow S3 links take a
     # while, but a wedged sync must not hang the configure request forever.
     result = subprocess.run(cmd, env=env, capture_output=True, text=True, timeout=6 * 60 * 60)
@@ -953,7 +964,7 @@ def _sync_objects_s3_to_s3(
         _s3_url_with_creds(dst, dst_access_key_id, dst_secret_access_key),
     ]
     # Log without the credential-bearing URLs.
-    logger.info("juicefs sync (s3->s3) %s -> %s", src, dst)
+    logger.info("juicefs sync (s3->s3) {} -> {}", src, dst)
     result = subprocess.run(cmd, capture_output=True, text=True, timeout=6 * 60 * 60)
     if result.returncode != 0:
         detail = (result.stderr or "").strip() or (result.stdout or "").strip() or f"exit {result.returncode}"
@@ -1000,7 +1011,7 @@ def _reconfigure_volume_storage(
         # an acceptable trade on a single-tenant, root-only host, and the
         # secret is already stored (encrypted) in the meta DB afterwards.
         cmd += ["--secret-key", s3_secret_access_key]
-    logger.info("juicefs config: re-point volume storage -> %s (%s)", storage, bucket)
+    logger.info("juicefs config: re-point volume storage -> {} ({})", storage, bucket)
     result = subprocess.run(cmd, env=env, capture_output=True, text=True, timeout=120)
     if result.returncode != 0:
         detail = (result.stderr or "").strip() or (result.stdout or "").strip() or f"exit {result.returncode}"

--- a/compute_space/src/compute_space/core/archive_backend.py
+++ b/compute_space/src/compute_space/core/archive_backend.py
@@ -659,12 +659,13 @@ def attach_on_startup(config: Config, db: sqlite3.Connection) -> None:
     if state.backend in ("local", "s3") and not is_linux_host():
         # JuiceFS is pinned as a Linux release only, so the archive tier can't run here (local
         # dev on macOS).  Everything else works; say so once instead of raising on every boot.
+        host_os = os.uname().sysname
         logger.warning(
-            "Archive tier disabled: JuiceFS has no {} build, so the '{}' backend can't be brought up.",
-            os.uname().sysname,
+            "Archive tier unavailable: JuiceFS has no {} build, so the '{}' backend can't be brought up.",
+            host_os,
             state.backend,
         )
-        _set_state_message(db, f"Archive tier unavailable: no JuiceFS build for {os.uname().sysname}.")
+        _set_state_message(db, f"Archive tier unavailable: no JuiceFS build for {host_os}.")
         return
     if state.backend == "local":
         try:

--- a/compute_space/src/compute_space/core/pinned_binary.py
+++ b/compute_space/src/compute_space/core/pinned_binary.py
@@ -85,12 +85,20 @@ _MANIFEST: dict[str, PinnedBinary] = {
 }
 
 
+class UnsupportedHostPlatformError(RuntimeError):
+    """No pinned build exists for this host OS (every pin below is a Linux release)."""
+
+
 def host_arch() -> str:
     """Return the release-asset arch string ("amd64" / "arm64") for this host."""
     machine = os.uname().machine
     if machine in ("aarch64", "arm64"):
         return "arm64"
     return "amd64"
+
+
+def is_linux_host() -> bool:
+    return os.uname().sysname == "Linux"
 
 
 def get_pinned_binary(name: str) -> PinnedBinary:
@@ -102,12 +110,18 @@ def get_pinned_binary(name: str) -> PinnedBinary:
 
 def install_pinned_binary(binary: PinnedBinary, dest_path: str) -> None:
     """Download + verify sha256 + extract ``binary`` to ``dest_path``.  Idempotent."""
+    if not is_linux_host():
+        # Checked before the "already installed" shortcut: a Linux binary left on disk by an
+        # earlier run looks installed but dies with "Exec format error" when run.
+        raise UnsupportedHostPlatformError(
+            f"{binary.name} is only pinned as a Linux release; this host is {os.uname().sysname}."
+        )
     if os.path.isfile(dest_path) and os.access(dest_path, os.X_OK):
         return
     os.makedirs(os.path.dirname(dest_path), exist_ok=True)
     arch = host_arch()
     asset = binary.asset_for(arch)
-    logger.info("Downloading %s %s for %s", binary.name, binary.version, arch)
+    logger.info("Downloading {} {} for {}", binary.name, binary.version, arch)
     try:
         with urllib.request.urlopen(asset.url, timeout=120) as resp:
             tarball_bytes = resp.read()
@@ -130,4 +144,4 @@ def install_pinned_binary(binary: PinnedBinary, dest_path: str) -> None:
         with f, open(dest_path, "wb") as out:
             shutil.copyfileobj(f, out)
     os.chmod(dest_path, 0o700)
-    logger.info("%s installed at %s", binary.name, dest_path)
+    logger.info("{} installed at {}", binary.name, dest_path)

--- a/compute_space/src/compute_space/tests/local_stack.py
+++ b/compute_space/src/compute_space/tests/local_stack.py
@@ -98,9 +98,14 @@ def make_local_stack_config(
         config = config.evolve(default_apps=default_apps)
     config.make_all_dirs()
     init_db(config.db_path)
+    zone_domain = f"{zone_name}.localhost:{port}"
     with closing(sqlite3.connect(config.db_path)) as db:
         db.row_factory = sqlite3.Row
-        seed_domains(db, Domain(name=f"{zone_name}.localhost:{port}", tls=False), [])
+        if not seed_domains(db, Domain(name=zone_domain, tls=False), []):
+            # a reused data dir: the DB is authoritative once seeded, so move the primary to the
+            # port we actually bind this run, or every outbound link points at the old one.
+            db.execute("UPDATE domains SET name = ? WHERE is_primary = 1", (zone_domain,))
+            db.commit()
     return config
 
 

--- a/compute_space/src/compute_space/tests/test_archive_backend.py
+++ b/compute_space/src/compute_space/tests/test_archive_backend.py
@@ -478,6 +478,7 @@ def test_attach_on_startup_local_formats_and_mounts(cfg, db):
     """Fresh DB defaults to local: attach must format the local file volume
     (first boot) and start the mount, clearing state_message."""
     with (
+        mock.patch.object(archive_backend, "is_linux_host", return_value=True),
         mock.patch.object(archive_backend, "is_juicefs_installed", return_value=True),
         mock.patch.object(archive_backend, "_local_volume_formatted", return_value=False),
         mock.patch.object(archive_backend, "format_local_volume") as fmt,
@@ -493,6 +494,7 @@ def test_attach_on_startup_local_skips_format_when_already_formatted(cfg, db):
     """If the local volume was already formatted (meta.db present), attach
     just mounts — it must not re-format."""
     with (
+        mock.patch.object(archive_backend, "is_linux_host", return_value=True),
         mock.patch.object(archive_backend, "is_juicefs_installed", return_value=True),
         mock.patch.object(archive_backend, "_local_volume_formatted", return_value=True),
         mock.patch.object(archive_backend, "format_local_volume") as fmt,
@@ -520,6 +522,7 @@ def test_attach_on_startup_local_selfheals_unformatted_metadb(cfg, db):
     db.execute("UPDATE archive_backend SET juicefs_volume_name='openhost' WHERE id=1")
     db.commit()
     with (
+        mock.patch.object(archive_backend, "is_linux_host", return_value=True),
         mock.patch.object(archive_backend, "is_juicefs_installed", return_value=True),
         mock.patch.object(archive_backend, "format_local_volume") as fmt,
         mock.patch.object(archive_backend, "mount") as mnt,
@@ -541,6 +544,7 @@ def test_attach_on_startup_local_records_error_on_failure(cfg, db):
     """A failure bringing up the local mount is recorded in state_message and
     doesn't crash boot."""
     with (
+        mock.patch.object(archive_backend, "is_linux_host", return_value=True),
         mock.patch.object(archive_backend, "is_juicefs_installed", return_value=True),
         mock.patch.object(archive_backend, "_local_volume_formatted", return_value=True),
         mock.patch.object(archive_backend, "mount", side_effect=RuntimeError("mount boom")),
@@ -557,7 +561,10 @@ def test_attach_on_startup_s3_happy_path(cfg, db):
         "s3_access_key_id='ak', s3_secret_access_key='sk' WHERE id=1"
     )
     db.commit()
-    with mock.patch.object(archive_backend, "is_juicefs_installed", return_value=True):
+    with (
+        mock.patch.object(archive_backend, "is_juicefs_installed", return_value=True),
+        mock.patch.object(archive_backend, "is_linux_host", return_value=True),
+    ):
         with mock.patch.object(archive_backend, "mount") as mnt:
             archive_backend.attach_on_startup(cfg, db)
     mnt.assert_called_once()
@@ -567,10 +574,40 @@ def test_attach_on_startup_s3_happy_path(cfg, db):
 def test_attach_on_startup_s3_missing_creds_records_error(cfg, db):
     db.execute("UPDATE archive_backend SET backend='s3', s3_bucket='b' WHERE id=1")
     db.commit()
-    archive_backend.attach_on_startup(cfg, db)
+    with (
+        mock.patch.object(archive_backend, "is_juicefs_installed", return_value=True),
+        mock.patch.object(archive_backend, "is_linux_host", return_value=True),
+    ):
+        archive_backend.attach_on_startup(cfg, db)
     state = read_state(db)
     assert state.state_message is not None
     assert "credentials" in state.state_message.lower()
+
+
+def test_attach_on_startup_skips_when_host_has_no_juicefs_build(cfg, db):
+    """Off Linux (dev on macOS) there's no JuiceFS build, so attach must record why and skip
+    rather than exec'ing a Linux binary and raising 'Exec format error' on every boot."""
+    with (
+        mock.patch.object(archive_backend, "is_linux_host", return_value=False),
+        mock.patch.object(archive_backend, "install_juicefs") as inst,
+        mock.patch.object(archive_backend, "format_local_volume") as fmt,
+        mock.patch.object(archive_backend, "mount") as mnt,
+    ):
+        archive_backend.attach_on_startup(cfg, db)
+    inst.assert_not_called()
+    fmt.assert_not_called()
+    mnt.assert_not_called()
+    assert "no juicefs build" in (read_state(db).state_message or "").lower()
+
+
+def test_attach_on_startup_disabled_backend_stays_quiet_off_linux(cfg, db):
+    """A disabled backend has nothing to bring up, so the host-OS gate must not
+    invent a state_message for it."""
+    db.execute("UPDATE archive_backend SET backend='disabled' WHERE id=1")
+    db.commit()
+    with mock.patch.object(archive_backend, "is_linux_host", return_value=False):
+        archive_backend.attach_on_startup(cfg, db)
+    assert read_state(db).state_message is None
 
 
 # --- effective_archive_dir -------------------------------------------------

--- a/compute_space/src/compute_space/web/start.py
+++ b/compute_space/src/compute_space/web/start.py
@@ -114,21 +114,10 @@ def _ensure_tls_cert(config: Config, db: sqlite3.Connection) -> None:
 
 
 def _ensure_coredns_binary(config: Config) -> str:
-    """Return the CoreDNS binary to launch, self-healing a missing one.
-
-    Provisioning installs CoreDNS at /usr/local/bin/coredns (on the service
-    PATH).  Hosts upgraded in place can lose it -- it used to come from pixi,
-    which no longer ships it -- leaving ``coredns`` on no PATH directory and
-    crashing startup.  When that happens, download the pinned release (same
-    version as ansible/tasks/coredns.yml) into the data dir and launch it by
-    absolute path.  Binding :53 works without setcap thanks to the provisioned
-    net.ipv4.ip_unprivileged_port_start=25 sysctl.
-    """
-    found = shutil.which("coredns")
-    if found:
+    """Return the CoreDNS binary to launch, self-healing a missing one."""
+    if found := shutil.which("coredns"):
         return found
     dest = str(config.openhost_data_path / "coredns")
-    logger.warning(f"coredns not found on PATH; installing pinned release to {dest}")
     install_pinned_binary(get_pinned_binary("coredns"), dest)
     return dest
 

--- a/justfile
+++ b/justfile
@@ -1,7 +1,10 @@
+# `just` ships in the dev environment: `pixi run -e dev just <recipe>`.
+# (Or install it yourself and run `just <recipe>` directly.)
+
 _default:
     @just --list
 
-# run a local compute space on a random port (extra args pass through, eg --port 8080 --default-apps)
+# run a local compute space on a random port (extra args pass through, eg --port 3000 --default-apps)
 local-stack *args:
     pixi run -e dev python scripts/run_local_stack.py {{args}}
 

--- a/justfile
+++ b/justfile
@@ -1,0 +1,10 @@
+_default:
+    @just --list
+
+# run a local compute space on a random port (extra args pass through, eg --port 8080 --default-apps)
+local-stack *args:
+    pixi run -e dev python scripts/run_local_stack.py {{args}}
+
+# same, but wipe the persisted data dir first so setup starts over
+local-stack-fresh *args:
+    pixi run -e dev python scripts/run_local_stack.py --fresh {{args}}

--- a/pixi.lock
+++ b/pixi.lock
@@ -388,6 +388,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/crun-1.27-h528521a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gpgme-1.18.0-h27087fc_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/jq-1.8.1-h73b1eb8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/just-1.58.0-hb17b654_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.45.1-default_hbd61a6d_102.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libassuan-2.5.7-h59595ed_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libcap-2.77-hd0affe5_1.conda
@@ -561,6 +562,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gpgme-1.18.0-h4de3ea5_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/icu-78.3-hcab7f73_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/jq-1.8.2-h80f16a2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/just-1.58.0-h069e38c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ld_impl_linux-aarch64-2.45.1-default_h1979696_102.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libassuan-2.5.6-h2f0025b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libcap-2.77-hf9559e3_1.conda
@@ -753,6 +755,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-hd037594_9.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/caddy-2.11.4-hf76c51c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/icu-78.3-hef89b57_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/just-1.58.0-h6fdd925_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.8.1-hf6b4638_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.5.2-hcf2aa1b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblzma-5.8.3-h8088a28_0.conda
@@ -984,6 +987,19 @@ packages:
   purls: []
   size: 313184
   timestamp: 1751447310552
+- conda: https://conda.anaconda.org/conda-forge/linux-64/just-1.58.0-hb17b654_1.conda
+  sha256: d26da5e1699c632f056dbdc8854ae074596da4a8e49614bacd16234e823dcc7d
+  md5: 4a9614cd015b2b395ae1bacf9e83fcf5
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  constrains:
+  - __glibc >=2.17
+  license: CC0-1.0
+  purls: []
+  run_exports: {}
+  size: 1995667
+  timestamp: 1785875895002
 - conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.45.1-default_hbd61a6d_102.conda
   sha256: 3d584956604909ff5df353767f3a2a2f60e07d070b328d109f30ac40cd62df6c
   md5: 18335a698559cdbcd86150a48bf54ba6
@@ -1601,6 +1617,18 @@ packages:
   run_exports: {}
   size: 350428
   timestamp: 1782115224470
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/just-1.58.0-h069e38c_1.conda
+  sha256: 47570c2470276e45f4b5525b40b289eb022097ff00011ed210fda9d01e02e501
+  md5: 34e9cd604e5e07d2602222b3a49aa20d
+  depends:
+  - libgcc >=14
+  constrains:
+  - __glibc >=2.17
+  license: CC0-1.0
+  purls: []
+  run_exports: {}
+  size: 1889732
+  timestamp: 1785875886637
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ld_impl_linux-aarch64-2.45.1-default_h1979696_102.conda
   sha256: 7abd913d81a9bf00abb699e8987966baa2065f5132e37e815f92d90fc6bba530
   md5: a21644fc4a83da26452a718dc9468d5f
@@ -2631,6 +2659,18 @@ packages:
   purls: []
   size: 12361647
   timestamp: 1773822915649
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/just-1.58.0-h6fdd925_1.conda
+  sha256: c583b7c8095fc7ad128f3d331dd5c94a53e772cc27fbad419b0d5882b0c71e86
+  md5: 4a15751033d141eca6540798c820c2a4
+  depends:
+  - __osx >=11.0
+  constrains:
+  - __osx >=11.0
+  license: CC0-1.0
+  purls: []
+  run_exports: {}
+  size: 1791788
+  timestamp: 1785875896056
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.8.1-hf6b4638_1.conda
   sha256: 5af74261101e3c777399c6294b2b5d290e508153268eb2e9ff99c4d69834612f
   md5: a915151d5d3c5bf039f5ccc8402a436f

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -160,6 +160,10 @@ openhost = { path = ".", editable = true }
 default = { solve-group = "default" }
 dev = { features = ["dev"], solve-group = "default" }
 
+[tool.pixi.feature.dev.dependencies]
+# `just` runs the recipes in ./justfile; keep it in the env so a fresh clone has it.
+just = "*"
+
 [tool.pixi.feature.dev.pypi-dependencies]
 pytest = ">=8.0"
 requests = ">=2.31"

--- a/scripts/run_local_stack.py
+++ b/scripts/run_local_stack.py
@@ -5,10 +5,11 @@ resolver send any ``*.localhost`` name to loopback, so no DNS or /etc/hosts setu
 needed.  Apps run in rootless podman containers exactly as on a real server.
 
 Usage:
-    pixi run -e dev python scripts/run_local_stack.py [--fresh] [--port 8080] [--default-apps]
+    pixi run -e dev python scripts/run_local_stack.py [--fresh] [--port N] [--default-apps]
 
-Then open http://home.localhost:8080/ in a browser.  On first run, /setup asks you to
-pick an owner password.  Deployed apps are served at http://<app>.home.localhost:8080/.
+A random port is picked unless --port says otherwise; the URLs to open are printed at startup.  On
+first run, /setup asks you to pick an owner password.  Deployed apps are served at
+http://<app>.home.localhost:<port>/.
 
 Data persists in --data-dir across restarts; use --fresh to start over.  App containers
 are not children of the router and keep running after it exits (the router re-adopts them
@@ -16,6 +17,7 @@ on restart); use ``podman ps`` / ``podman rm -f openhost-<app>`` to stop them ma
 """
 
 import argparse
+import random
 import shutil
 import subprocess
 import sys
@@ -33,7 +35,7 @@ from compute_space.tests.utils import write_first_boot_beside
 
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
-    parser.add_argument("--port", type=int, default=8080)
+    parser.add_argument("--port", type=int, default=None, help="default: a random port in [20000, 40000)")
     parser.add_argument("--zone-name", default="home", help="zone is <zone-name>.localhost:<port>")
     parser.add_argument("--data-dir", default="~/.openhost-local-stack")
     parser.add_argument("--fresh", action="store_true", help="wipe the data dir before starting")
@@ -43,6 +45,7 @@ def main() -> int:
         help="deploy the standard default apps (secrets, filestash, catalog, oauth, backup) at setup",
     )
     args = parser.parse_args()
+    port = args.port if args.port is not None else random.randrange(20000, 40000)
 
     # resolve() so symlinked paths like /tmp -> /private/tmp become the real path:
     # podman machine on macOS only shares resolved paths (/Users, /private, /var/folders)
@@ -54,7 +57,7 @@ def main() -> int:
 
     config = make_local_stack_config(
         data_root_dir=str(data_dir),
-        port=args.port,
+        port=port,
         zone_name=args.zone_name,
         default_apps=None if args.default_apps else [],
         # vendored builtins (e.g. file_browser in default_apps) live in the repo's apps/


### PR DESCRIPTION
- don't dump a juicefs failure when running locally on mac (bc the binaries are linux only). instead just raise a warning and set the archive backend state to an error message (is this right?). we could get mac binaries but seems like we'd want to handle unsupported platforms cleanly regardless so this seems good.
- allow running the compute space locally with justfile and by default run on a random port to avoid collisions.