### PR TITLE
Use provider-neutral deploy copy

### DIFF
--- a/compute_space/src/compute_space/web/templates/dashboard.html
+++ b/compute_space/src/compute_space/web/templates/dashboard.html
@@ -17,7 +17,7 @@
     {{ card("Browse the catalog", "One-click install ready-made apps.", "Explore catalog",
             cta_href=app_url(catalog_app_name) if catalog_installed else "/add_app",
             cta_new_tab=catalog_installed) }}
-    {{ card("Deploy your app", "From GitHub, or ask Claude to build it.", "Deploy app",
+    {{ card("Deploy your app", "From your preferred Git hosting provider.", "Deploy app",
             cta_href="/add_app") }}
     {{ card("Docs and setup", "Guides and GitHub repo.", "View docs",
             cta_href="/docs/") }}

--- a/compute_space/src/compute_space/web/templates/dashboard.html
+++ b/compute_space/src/compute_space/web/templates/dashboard.html
@@ -17,9 +17,9 @@
     {{ card("Browse the catalog", "One-click install ready-made apps.", "Explore catalog",
             cta_href=app_url(catalog_app_name) if catalog_installed else "/add_app",
             cta_new_tab=catalog_installed) }}
-    {{ card("Deploy your app", "From your preferred Git hosting provider.", "Deploy app",
+    {{ card("Deploy your app", "From your own repo.", "Deploy app",
             cta_href="/add_app") }}
-    {{ card("Docs and setup", "Guides and GitHub repo.", "View docs",
+    {{ card("Docs and setup", "Learn about your space and creating new apps.", "View docs",
             cta_href="/docs/") }}
   </div>
 </section>


### PR DESCRIPTION
Changes the dashboard deploy card to refer to the user's preferred Git hosting provider instead of GitHub and Claude.