### PR TITLE
Fix loguru %-style placeholders in memory_guard logging

### DIFF
--- a/compute_space/src/compute_space/core/memory_guard.py
+++ b/compute_space/src/compute_space/core/memory_guard.py
@@ -200,7 +200,7 @@ class _MemoryGuard:
             kill = _parse_journal_oom(line)
             if kill is not None:
                 logger.warning(
-                    "TODO: make this a notification — the host OOM killer killed process %d (%s); "
+                    "TODO: make this a notification — the host OOM killer killed process {} ({}); "
                     "the machine is out of memory",
                     kill.pid,
                     kill.comm,
@@ -244,8 +244,8 @@ class _MemoryGuard:
             row = by_container.get(kill.container_id)
             if row is not None:
                 logger.warning(
-                    "TODO: make this a notification — app %s was killed by the OOM killer "
-                    "(exceeded its %sMB memory limit)",
+                    "TODO: make this a notification — app {} was killed by the OOM killer "
+                    "(exceeded its {}MB memory limit)",
                     row["name"],
                     row["memory_mb"],
                 )
@@ -254,7 +254,7 @@ class _MemoryGuard:
                 # back to the container name from the event so the kill still
                 # surfaces rather than being dropped.
                 logger.warning(
-                    "TODO: make this a notification — container %s was killed by the OOM killer (out of memory)",
+                    "TODO: make this a notification — container {} was killed by the OOM killer (out of memory)",
                     kill.container_name,
                 )
 
@@ -281,8 +281,8 @@ class _MemoryGuard:
             self._pressure_notified.add(app_id)
             usage = format_bytes(resources.memory_usage_bytes) if resources.memory_usage_bytes is not None else "?"
             logger.warning(
-                "TODO: make this a notification — app %s is at %.0f%% of its memory limit "
-                "(%s of %sMB); it may be OOM-killed if usage keeps climbing",
+                "TODO: make this a notification — app {} is at {:.0f}% of its memory limit "
+                "({} of {}MB); it may be OOM-killed if usage keeps climbing",
                 row["name"],
                 percent,
                 usage,


### PR DESCRIPTION
## What

`memory_guard.py` uses the loguru logger (via `compute_space.core.logging`), which interpolates with `{}` placeholders, **not** printf-style `%`. Four `logger.warning` calls still used `%d`/`%s`/`%.0f`, so at runtime they logged the raw format string and silently dropped their arguments — e.g.:

```
WARNING | ... | TODO: make this a notification — the host OOM killer killed process %d (%s); the machine is out of memory
```

## Why this file specifically

PR #296 (`andrew/fix-loguru-log-placeholders`) fixed this same class of bug across the rest of `compute_space`, but predated this newer file and so missed it. This is the only remaining loguru `%`-placeholder site on `main` (verified with a multi-line-aware scan of all loguru-backed modules).

## Changes

Converted the 4 calls to loguru's `{}` form:
- `%s`, `%d` → `{}`
- `%.0f%%` → `{:.0f}%` (the `%%` literal collapses to a single `%` under `.format()`)

Placeholder/arg counts verified to match (loguru raises on mismatch at log time, unlike the old silently-broken form).

## Testing

- `pytest compute_space/.../test_memory_guard.py` — 21 passed
- `ruff` + `mypy` clean (pre-commit hooks pass)
- Runtime smoke test confirms real interpolation and that `%` renders as a literal single `%`

🤖 Generated with [Claude Code](https://claude.com/claude-code)