### PR TITLE
Raise reclaim chown timeout 120s -> 300s to stop CI flake

### DIFF
--- a/openhost_system_agent/src/openhost_system_agent/reclaim.py
+++ b/openhost_system_agent/src/openhost_system_agent/reclaim.py
@@ -50,8 +50,14 @@ def reclaim_host_ownership() -> None:
         # -R to cover the whole tree; -h so symlinks are chowned in place
         # rather than followed. check=True: a failure here means a tree may
         # still be broken, so surface it rather than silently continuing.
+        #
+        # timeout: this chown -R walks (and rewrites) every inode under the
+        # host trees -- the repo, its .git, and the .pixi env, easily 100k+
+        # files. On slower hosts that legitimately approaches the old 120s cap,
+        # which was flaking CI. Raised to 300s as a stopgap; the real fix is to
+        # walk fewer files (e.g. only chown misowned ones), tracked separately.
         subprocess.run(
             ["chown", "-Rh", f"{HOST_USER}:{HOST_USER}", path],
             check=True,
-            timeout=120,
+            timeout=300,
         )


### PR DESCRIPTION
## What

Bumps the `subprocess` timeout in `reclaim_host_ownership()` from **120s → 300s**.

## Why

`reclaim_host_ownership()` runs `chown -Rh` over the whole host tree (`/home/host/openhost` and `/home/host/.pixi`) — the repo, its `.git`, and the `.pixi` env, easily 100k+ files. This was broadened in 5cacb94a ("Broaden reclaim to the whole /home/host/openhost tree"). On slower hosts that recursive walk legitimately approaches the old 120s cap, which has been intermittently failing CI (notably during the v0005 migration and the root update walk).

## Scope / caveats

- **Stopgap, not the fix.** It buys headroom without changing behavior.
- Deliberately does **not** touch the shell/boot copy's `timeout 80` (the `ExecStartPre` reclaim script). That one is kept under systemd's default 90s `TimeoutStartSec`; raising it past 90s would also need a `TimeoutStartSec=` on the unit, which is a separate decision.
- The proper fix is to stop rewriting every inode — e.g. only chown files that are actually misowned via `find ! -user/-group ... -exec chown` — but the size of that win depends on the underlying filesystem (`/home/host` is asserted to be ext4/xfs/btrfs, not overlay, so there's no copy-up to avoid). Worth measuring before committing to it. Tracking that separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)