### PR TITLE
docs: put grant_url inside required_grant in the 403 example

### DIFF
--- a/docs/src/cross_app_services.md
+++ b/docs/src/cross_app_services.md
@@ -139,9 +139,9 @@ HTTP 403
   "error": "permission_required",
   "required_grant": {
     "grant": { ... },
-    "scope": "app"
-  },
-  "grant_url": GRANT_URL
+    "scope": "app",
+    "grant_url": GRANT_URL
+  }
 }
 ```
 


### PR DESCRIPTION
`docs/src/cross_app_services.md` shows the app-scoped `permission_required` body with `grant_url` as a sibling of `required_grant`. Every implementation nests it inside:

| Source | Shape |
|---|---|
| `compute_space/web/routes/services_v2.py:142` | `required_grant["grant_url"] = _approve_grant_url(...)` |
| `compute_space/web/routes/services_v2.py:560-563` (installer's own 403) | `"required_grant": {"grant":…, "scope":…, "grant_url":…}` |
| `tests/test_services_e2e.py:112` | `body["required_grant"]["grant_url"]` |
| `services/oauth/openapi.yaml:327` | `required_grant.required: [grant_payload, scope, grant_url]` |
| `apps/oauth_provider/.../permissions.py:82-88` | `RequiredGrant(grant=…, scope="app", grant_url=…)` |
| `apps/oauth_demo/.../oauth.py:111-112` | `data["required_grant"].get("grant_url")` |
| `apps/oauth_demo/static/oauth.js:66` | `data.required_grant.grant_url` |

Nothing is generated from or validated against the prose example, so the divergence went unnoticed. `grant_url` is a browser redirect target — a provider written from the doc emits a key no consumer reads, and the owner never reaches the consent page.

Docs only, no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)