### PR TITLE
Remove app access to VM data

### DIFF
--- a/compute_space/src/compute_space/core/containers.py
+++ b/compute_space/src/compute_space/core/containers.py
@@ -267,7 +267,6 @@ def run_container(
     app_data_dir = os.path.join(data_dir, "app_data", app_name)
     app_temp_dir = os.path.join(temp_data_dir, "app_temp_data", app_name)
     app_archive_dir = os.path.join(archive_dir, app_name)
-    vm_data_dir = os.path.join(data_dir, "vm_data")
     container_name = f"openhost-{app_name}"
 
     wants_all_app_data = manifest.access_all_app_data
@@ -276,12 +275,10 @@ def run_container(
     has_app_data = manifest.app_data or manifest.sqlite_dbs or wants_all_app_data
     has_app_temp = manifest.app_temp_data or wants_all_app_data
     has_app_archive = manifest.app_archive or wants_all_archive
-    has_vm_data = manifest.access_vm_data or wants_all_app_data
 
     c_app_data = f"{CONTAINER_ROOT}/app_data/{app_name}"
     c_app_temp = f"{CONTAINER_ROOT}/app_temp_data/{app_name}"
     c_app_archive = f"{CONTAINER_ROOT}/app_archive/{app_name}"
-    c_vm_data = f"{CONTAINER_ROOT}/vm_data"
 
     # Translate host paths in env vars to their in-container equivalents.
     container_env = {}
@@ -380,17 +377,11 @@ def run_container(
                 ),
             ]
         )
-        # vm_data is rw under wants_all_app_data (admin-level access).
-        os.makedirs(vm_data_dir, exist_ok=True)
-        cmd.extend(["-v", _bind_mount_arg(vm_data_dir, c_vm_data)])
     else:
         if has_app_data:
             cmd.extend(["-v", _bind_mount_arg(app_data_dir, c_app_data)])
         if has_app_temp:
             cmd.extend(["-v", _bind_mount_arg(app_temp_dir, c_app_temp)])
-        if has_vm_data:
-            os.makedirs(vm_data_dir, exist_ok=True)
-            cmd.extend(["-v", _bind_mount_arg(vm_data_dir, c_vm_data, read_only=True)])
 
     if wants_all_archive:
         # access_all_archive is permissive — skip the archive mount when

--- a/compute_space/src/compute_space/core/manifest.py
+++ b/compute_space/src/compute_space/core/manifest.py
@@ -199,7 +199,6 @@ class AppManifest:
     app_data: Annotated[bool, SettingLabel("Data", "Permanent data")] = True
     app_temp_data: Annotated[bool, SettingLabel("Data", "Temporary data")] = False
     app_archive: Annotated[bool, SettingLabel("Data", "Archive data")] = False
-    access_vm_data: Annotated[bool, SettingLabel("Data", "Access VM data")] = False
     # Granular cross-app data flags (preferred):
     access_all_app_data: Annotated[bool, SettingLabel("Data", "Access all app data")] = False
     access_all_archive: Annotated[bool, SettingLabel("Data", "Access all archive")] = False
@@ -498,7 +497,6 @@ def parse_manifest_from_string(raw_text: str) -> AppManifest:
         app_data=data_section.get("app_data", True),
         app_temp_data=data_section.get("app_temp_data", False),
         app_archive=data_section.get("app_archive", False),
-        access_vm_data=data_section.get("access_vm_data", False),
         access_all_data=_compat_all_data,
         access_all_app_data=data_section.get("access_all_app_data", False) or _compat_all_data,
         access_all_archive=data_section.get("access_all_archive", False) or _compat_all_data,

--- a/compute_space/src/compute_space/tests/test_api_archive_backend.py
+++ b/compute_space/src/compute_space/tests/test_api_archive_backend.py
@@ -404,7 +404,6 @@ def _archive_manifest(name: str, *, app_archive: bool, access_all_archive: bool 
         app_data=True,
         app_archive=app_archive,
         access_all_archive=access_all_archive,
-        access_vm_data=False,
         app_temp_data=False,
         public_paths=["/"],
         capabilities=[],

--- a/compute_space/src/compute_space/tests/test_containers.py
+++ b/compute_space/src/compute_space/tests/test_containers.py
@@ -25,6 +25,7 @@ from compute_space.core.containers import run_container
 from compute_space.core.containers import stop_container
 from compute_space.core.manifest import AppManifest
 from compute_space.core.manifest import PortMapping
+from compute_space.core.manifest import parse_manifest_from_string
 
 
 class _FakeCompleted:
@@ -454,7 +455,7 @@ def test_run_container_network_host_app_gets_no_dns_override(tmp_path, monkeypat
 
 
 def test_run_container_mounts_use_idmap_option(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
-    manifest = _basic_manifest(app_data=True, app_temp_data=True, access_vm_data=True)
+    manifest = _basic_manifest(app_data=True, app_temp_data=True, app_archive=True)
     argv = _run_and_capture(monkeypatch, manifest=manifest, tmp_path=tmp_path)
     # Every -v argument value should have :idmap (or :ro,idmap) as its
     # options suffix so container-root writes land on disk under the host
@@ -532,20 +533,27 @@ def test_run_container_adds_manifest_devices(tmp_path, monkeypatch: pytest.Monke
         )
 
 
-def test_run_container_access_vm_data_mounts_vm_data_read_only(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
-    """access_vm_data (without access_all_app_data) grants only a read-only
-    view of /data/vm_data.  The distinction matters: this is what lets
-    apps read shared state without being able to corrupt it, and a
-    regression swapping in rw here would turn a security-critical mount
-    into a write-through channel.
-    """
-    manifest = _basic_manifest(access_vm_data=True)
+def test_run_container_removed_access_vm_data_flag_does_not_mount_vm_data(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    manifest = parse_manifest_from_string(
+        """\
+[app]
+name = "myapp"
+version = "0.1.0"
+
+[runtime.container]
+image = "Dockerfile"
+port = 8080
+
+[data]
+access_vm_data = true
+"""
+    )
     argv = _run_and_capture(monkeypatch, manifest=manifest, tmp_path=tmp_path)
 
     volume_args = [arg for prev, arg in zip(argv, argv[1:], strict=False) if prev == "-v"]
-    vm_mounts = [v for v in volume_args if "/data/vm_data" in v]
-    assert len(vm_mounts) == 1, vm_mounts
-    assert vm_mounts[0].endswith(":ro,idmap"), vm_mounts[0]
+    assert not any("/data/vm_data" in v for v in volume_args)
 
 
 def test_run_container_app_archive_mounts_per_app_subdir(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -629,11 +637,30 @@ def test_run_container_access_all_app_data_mounts_parent_dirs(tmp_path, monkeypa
     targets = [v.rsplit(":", 2)[1] for v in volume_args]
     assert "/data/app_data" in targets
     assert "/data/app_temp_data" in targets
-    # vm_data must be rw under access_all_app_data.
-    vm_mount = next(v for v in volume_args if v.endswith(":/data/vm_data:idmap"))
-    assert "ro" not in vm_mount.rsplit(":", 1)[1]
+    assert "/data/vm_data" not in targets
     # No per-app subdir.
     assert f"/data/app_data/{manifest.name}" not in targets
+
+
+def test_run_container_access_all_data_does_not_mount_vm_data(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
+    manifest = parse_manifest_from_string(
+        """\
+[app]
+name = "myapp"
+version = "0.1.0"
+
+[runtime.container]
+image = "Dockerfile"
+port = 8080
+
+[data]
+access_all_data = true
+"""
+    )
+    argv = _run_and_capture(monkeypatch, manifest=manifest, tmp_path=tmp_path)
+
+    volume_args = [arg for prev, arg in zip(argv, argv[1:], strict=False) if prev == "-v"]
+    assert not any("/data/vm_data" in v for v in volume_args)
 
 
 def test_run_container_access_all_app_data_does_not_mount_archive(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/compute_space/src/compute_space/tests/test_manifest.py
+++ b/compute_space/src/compute_space/tests/test_manifest.py
@@ -59,7 +59,6 @@ class TestDefaults:
         assert manifest.app_data is True  # default on
         assert manifest.app_temp_data is False
         assert manifest.app_archive is False
-        assert manifest.access_vm_data is False
         assert manifest.access_all_app_data is False
         assert manifest.access_all_archive is False
         assert manifest.access_all_data is False

--- a/compute_space/src/compute_space/web/static/js/add-app.js
+++ b/compute_space/src/compute_space/web/static/js/add-app.js
@@ -101,19 +101,18 @@ function renderManifest(m, url, storage) {
   const wantsAllData = m.access_all_data;
   const wantsAllAppData = m.access_all_app_data;
   const wantsAllArchive = m.access_all_archive;
-  const hasFs = m.app_data || m.app_temp_data || m.access_vm_data || m.access_all_data || m.access_all_app_data || m.access_all_archive || m.app_archive || m.sqlite_dbs.length;
+  const hasFs = m.app_data || m.app_temp_data || m.access_all_data || m.access_all_app_data || m.access_all_archive || m.app_archive || m.sqlite_dbs.length;
   if (hasFs) {
     section('Filesystem Permissions', '#fff3cd');
     if (wantsAllData) {
-      row('Full data access', 'Read/write to ALL apps\u2019 permanent data, temporary data, VM data, and archive data (rw)');
+      row('Full data access', 'Read/write to ALL apps\u2019 permanent data, temporary data, and archive data');
     } else {
       if (wantsAllAppData) {
-        row('Full app data access', 'Read/write to ALL apps\u2019 permanent data, temporary data, and VM data (rw)');
+        row('Full app data access', 'Read/write to ALL apps\u2019 permanent and temporary data');
       } else {
         if (m.app_data || m.sqlite_dbs.length)
           row('Permanent data', "Read/write to app's own permanent data directory");
         if (m.app_temp_data) row('Temporary data', "Read/write to app's own temporary data directory");
-        if (m.access_vm_data) row('VM data', 'Read-only access to VM shared data');
       }
       if (wantsAllArchive) {
         row('Full archive access', 'Read/write to ALL apps\u2019 archive (bulk) data');

--- a/docs/src/creating_an_app.md
+++ b/docs/src/creating_an_app.md
@@ -137,8 +137,7 @@ Apps receive a persistent data directory by default. You can opt out or request 
 - **`sqlite = ["db_name"]`** — Provisions a SQLite database. Access the file at `OPENHOST_SQLITE_<NAME>`.
 - **`app_temp_data = true`** — mounts a temporary directory at `/data/app_temp_data/{app_name}/`. Not backed up, can be recreated.
 - **`app_archive = true`** — mounts an archive directory for bulk content at `/data/app_archive/{app_name}/`. Always available: local-disk backed by default, upgradable to S3 (JuiceFS) by the operator. No operator setup required to install.
-- **`access_vm_data = true`** — read-only access to the VM's shared data at `/data/vm_data/`.
-- **`access_all_app_data = true`** — full rw access to all apps' persistent and temp data parent directories, plus rw vm_data. For admin tools like file browsers.
+- **`access_all_app_data = true`** — full rw access to all apps' persistent and temp data parent directories. For admin tools like file browsers.
 - **`access_all_archive = true`** — full access to all apps' archive parent directory. Permissive: silently skipped if the archive mount is transiently unavailable. For backup tools.
 - **`access_all_data = true`** — convenience shorthand for `access_all_app_data = true` + `access_all_archive = true`.
 

--- a/docs/src/data.md
+++ b/docs/src/data.md
@@ -13,7 +13,7 @@
         - Durability: on the `local` backend JuiceFS's objects live under `persistent_data_dir` and ARE included in backups, but have no off-instance copy.  On the `s3` backend durability is tied to the operator's S3 provider (and the mountpoint is deliberately excluded from restic backups because the bytes already live in the bucket).
     - **temporary data (`app_temp_data`)** — local disk scratch, not backed up, recreatable on demand.
         - examples: low-res thumbnails generated from source photos, transcoding work files, in-flight upload chunks.
-- there’s also VM-level / router data (eg the sqlite database used by the router). apps see this in-container as `/data/vm_data/` (only with the `access_vm_data` permission); on the host the router db lives at `persistent_data/openhost/router.db`.
+- VM-level / router data (such as the router's SQLite database) is host-only and is not mounted into app containers.
 - where do app build artifacts go? probably in app temp data?
 - folder structure (as seen inside containers, mounted at `/data/`)
     - /data/
@@ -23,7 +23,6 @@
             - app_name/
         - app_archive/
             - app_name/
-        - vm_data/          # VM-level / router shared data (only with access_vm_data)
 - regardless of permissions, apps should see the same folder structure, just only with folders they have access to. that way the structure doesn't change if the permissions change. without any special permissions, apps will just have basically `/data/app_data/APP_NAME` and `/data/app_temp_data/APP_NAME` (and `/data/app_archive/APP_NAME` if requested).
 
 ### Why three tiers, not two
@@ -57,7 +56,7 @@ The same `sync` + `config` mechanism also drives an `s3` → `s3` migration (rot
 
 ### permissions
 
-- apps can request access to the entire data dir, or to specific apps, and/or to the router’s data.
+- apps can request access to all app data or to specific apps' data, but not to router data.
 - there should also be a permission explicitly requesting access to the app's own POSIX file system - some apps won't need this at all.
   - separate permissions for permanent and temp data dirs, too.
 - this probably gives access just to the “permanent data”. idk that we need cross-app access to temp data.
@@ -71,5 +70,4 @@ The same `sync` + `config` mechanism also drives an `s3` → `s3` migration (rot
 
 ## Router-level data
 
-the router stores its own state (database, TLS certs, etc.) in the configured data directory alongside app data.
-
+the router stores its own state (database, TLS certs, etc.) in the configured data directory alongside app data. This state is only accessible through the terminal or SSH, not from app containers.

--- a/docs/src/manifest_spec.md
+++ b/docs/src/manifest_spec.md
@@ -69,8 +69,7 @@ User-facing links the app advertises for paths on its own URL that aren't the ba
 | `app_temp_data` | boolean | no | false | Request access to temporary filesystem directory (not backed up) |
 | `app_archive` | boolean | no | false | Request access to the archive directory for bulk content. Always available: backed by local disk by default, upgradable to S3 (via JuiceFS) by the operator. Apps with this flag install on any zone; on a local-backed zone the operator sees an install-time notice that the data is on non-durable local disk. |
 | `sqlite` | string[] | no | [] | SQLite database names to provision (implicitly enables `app_data`) |
-| `access_vm_data` | boolean | no | false | Whether the app can access the VM's shared data directory (read-only) |
-| `access_all_app_data` | boolean | no | false | Mount all apps' permanent data and temp data parent directories (rw). Also grants rw access to vm_data. For admin tools like file browsers. |
+| `access_all_app_data` | boolean | no | false | Mount all apps' permanent data and temp data parent directories (rw). For admin tools like file browsers. |
 | `access_all_archive` | boolean | no | false | Mount all apps' archive parent directory. Permissive: silently skipped if the archive mount is transiently unavailable. For backup tools. |
 | `access_all_data` | boolean | no | false | Convenience shorthand for `access_all_app_data = true` + `access_all_archive = true`. |
 
@@ -82,7 +81,6 @@ Apps have three storage areas, each with different durability + size + latency t
 - **Permanent data** (`/data/app_data/{app_name}/`) — local disk. Small, fast, backed up. Enabled by `app_data = true` or by requesting `sqlite` entries. **SQLite databases must live here**, not in `app_archive`: the archive tier may be backed by a network FS with close-to-open consistency that corrupts SQLite WAL.
 - **Temporary data** (`/data/app_temp_data/{app_name}/`) — local disk scratch. Not backed up, recreatable. Enabled by `app_temp_data = true`.
 - **Archive data** (`/data/app_archive/{app_name}/`) — bulk content storage. Always available. Backed by **local disk** by default (kept under `persistent_data_dir`, survives rebuilds, included in backups). The operator can upgrade the zone to **S3** (JuiceFS) from the dashboard for elastic, durable object storage; existing local archive data is migrated into the bucket. Higher-latency on uncached reads once on S3, durability then tied to the provider's SLA. Intended for bulk content (videos, photos, attachments). Enabled by `app_archive = true`.
-- **VM data** (`/data/vm_data/`) — router database and VM-level shared data. Only accessible if `access_vm_data = true`.
 
 The archive tier defaults to local-disk backing and is always available. The operator can upgrade a zone to S3 one-shot from the dashboard, supplying S3 credentials and a per-zone prefix; archive bytes then route through a JuiceFS mount of the operator-supplied bucket (and any existing local archive data is migrated into it). Apps see `/data/app_archive/<app>/` as a normal POSIX directory and don't need to know which backing is in use.
 


### PR DESCRIPTION
Removes the access_vm_data manifest permission and prevents access_all_app_data and access_all_data from mounting router or VM data into app containers. Updates deployment permission copy, documentation, and regression coverage.