### PR TITLE
Dual-name env vars passed into apps: OPENHOST_ + BOTTLE_

### DIFF
--- a/compute_space/src/compute_space/core/containers.py
+++ b/compute_space/src/compute_space/core/containers.py
@@ -36,6 +36,30 @@ from compute_space.core.manifest import PortMapping
 
 CONTAINER_ROOT = "/data"
 
+# Env-var naming contract.  The project was renamed OpenHost -> Cloud in a
+# Bottle; every OPENHOST_* variable stamped into an app container is now also
+# exposed under BOTTLE_*.  The legacy names are kept indefinitely for backward
+# compatibility.
+LEGACY_ENV_PREFIX = "OPENHOST_"
+ENV_PREFIX = "BOTTLE_"
+
+
+def add_bottle_env_aliases(env: dict[str, str]) -> dict[str, str]:
+    """Return ``env`` with a ``BOTTLE_``-prefixed twin for every ``OPENHOST_`` var.
+
+    The rename from OpenHost to Cloud in a Bottle keeps the legacy
+    ``OPENHOST_*`` names for compatibility while exposing the same values
+    under ``BOTTLE_*``.  An already-present ``BOTTLE_*`` entry is never
+    clobbered, so an explicit new-style value wins over the auto-alias.
+    """
+    aliased = dict(env)
+    for key, value in env.items():
+        if key.startswith(LEGACY_ENV_PREFIX):
+            twin = ENV_PREFIX + key[len(LEGACY_ENV_PREFIX) :]
+            aliased.setdefault(twin, value)
+    return aliased
+
+
 # Dummy-interface IP that the host kernel accepts as local; the router (and a
 # container-facing CoreDNS view) bind here so pasta containers can reach host
 # services via ``host.containers.internal``.  Created by ansible as the
@@ -424,6 +448,11 @@ def run_container(
         # conflicts with other host services, so it should bind on this
         # allocated port instead.
         container_env["OPENHOST_LOCAL_PORT"] = str(local_port)
+
+    # Expose every var under both the legacy OPENHOST_ name and the new
+    # BOTTLE_ name.  Done here (after host->container path translation and
+    # after LOCAL_PORT is set) so the twins carry the final container values.
+    container_env = add_bottle_env_aliases(container_env)
 
     for key, value in container_env.items():
         cmd.extend(["-e", f"{key}={value}"])

--- a/compute_space/src/compute_space/tests/test_bottle_env_aliases.py
+++ b/compute_space/src/compute_space/tests/test_bottle_env_aliases.py
@@ -1,0 +1,39 @@
+"""OpenHost -> Cloud in a Bottle env-var rename.
+
+Every OPENHOST_* variable is kept for backward compatibility and also
+exposed under a BOTTLE_* twin.  These tests pin the alias helper that stamps
+the BOTTLE_* twins onto the env passed into app containers.
+"""
+
+from __future__ import annotations
+
+from compute_space.core.containers import add_bottle_env_aliases
+
+
+def test_alias_adds_bottle_twin_for_each_openhost_var() -> None:
+    aliased = add_bottle_env_aliases({"OPENHOST_APP_NAME": "myapp", "OPENHOST_APP_ID": "abc"})
+    # Legacy names preserved for compatibility.
+    assert aliased["OPENHOST_APP_NAME"] == "myapp"
+    assert aliased["OPENHOST_APP_ID"] == "abc"
+    # New names carry the same values.
+    assert aliased["BOTTLE_APP_NAME"] == "myapp"
+    assert aliased["BOTTLE_APP_ID"] == "abc"
+
+
+def test_alias_leaves_non_openhost_vars_untouched() -> None:
+    aliased = add_bottle_env_aliases({"PATH": "/usr/bin", "OPENHOST_APP_NAME": "myapp"})
+    assert aliased["PATH"] == "/usr/bin"
+    assert "BOTTLE_PATH" not in aliased
+
+
+def test_alias_does_not_clobber_existing_bottle_value() -> None:
+    # An explicit new-style value wins over the auto-generated alias.
+    aliased = add_bottle_env_aliases({"OPENHOST_APP_NAME": "legacy", "BOTTLE_APP_NAME": "explicit"})
+    assert aliased["BOTTLE_APP_NAME"] == "explicit"
+    assert aliased["OPENHOST_APP_NAME"] == "legacy"
+
+
+def test_alias_is_pure() -> None:
+    original = {"OPENHOST_APP_NAME": "myapp"}
+    add_bottle_env_aliases(original)
+    assert original == {"OPENHOST_APP_NAME": "myapp"}

--- a/compute_space/src/compute_space/tests/test_containers.py
+++ b/compute_space/src/compute_space/tests/test_containers.py
@@ -668,6 +668,29 @@ def test_run_container_app_archive_env_var_translated_to_container_path(
     assert archive_env[0] == f"OPENHOST_APP_ARCHIVE_DIR=/data/app_archive/{manifest.name}"
 
 
+def test_run_container_stamps_bottle_and_openhost_env_twins(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Every app env var is stamped under both the legacy OPENHOST_ name and
+    the new BOTTLE_ name (OpenHost -> Cloud in a Bottle rename).  The BOTTLE_
+    twin of a path var must carry the already-translated in-container value,
+    not the host path — i.e. aliasing happens after path translation."""
+    manifest = _basic_manifest(app_data=True, app_archive=True)
+    env_vars = {
+        "OPENHOST_APP_TOKEN": "tok123",
+        "OPENHOST_APP_ARCHIVE_DIR": "/some/host/archive/myapp",
+    }
+    argv = _run_and_capture(monkeypatch, manifest=manifest, tmp_path=tmp_path, env_vars=env_vars)
+
+    e_values = [arg for prev, arg in zip(argv, argv[1:], strict=False) if prev == "-e"]
+
+    # Non-path var: legacy + new twin, same value.
+    assert "OPENHOST_APP_TOKEN=tok123" in e_values
+    assert "BOTTLE_APP_TOKEN=tok123" in e_values
+
+    # Path var: the BOTTLE_ twin carries the translated container path.
+    assert f"OPENHOST_APP_ARCHIVE_DIR=/data/app_archive/{manifest.name}" in e_values
+    assert f"BOTTLE_APP_ARCHIVE_DIR=/data/app_archive/{manifest.name}" in e_values
+
+
 def test_run_container_port_mappings_bind_tcp_and_udp_on_all_interfaces(
     tmp_path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
Part 1 of splitting #315.

The project was renamed OpenHost -> Cloud in a Bottle. This is the **app-facing** slice: every env var stamped into an app container is now exposed under both the legacy `OPENHOST_` name and the new `BOTTLE_` name, so deployed apps can read either.

## What changed
- New dependency-free `core.env_aliases` module with `add_bottle_env_aliases`, which mirrors each `OPENHOST_*` var to a `BOTTLE_*` twin without clobbering an explicit `BOTTLE_*` value. Re-exported from `core.data` (the historical home of the mirror boundary).
- `run_container` applies it after host->container path translation and after `LOCAL_PORT` is set, so the twins carry the final in-container values (path vars get the translated container path, not the host path).

## Scope
Deliberately small and mergeable on its own. The internal daemon/agent config renames, the data-dir/updater env handling, `BOTTLE_ROUTER_CONFIG`, and the systemd-drop-in migration all live in the stacked follow-up PR.

Replaces #315 (to be closed).