### PR TITLE
Dual-name internal env vars + add BOTTLE_ROUTER_CONFIG migration

### DIFF
--- a/ansible/files/openhost.service.d/20-bottle-router-config.conf
+++ b/ansible/files/openhost.service.d/20-bottle-router-config.conf
@@ -1,0 +1,12 @@
+# Managed by OpenHost; do not edit by hand. Kept byte-identical between
+# ansible/files/openhost.service.d/20-bottle-router-config.conf and the
+# BOTTLE_ROUTER_CONFIG_DROPIN constant in openhost_system_agent's v0011 migration
+# (a test enforces this).
+#
+# OpenHost -> Cloud in a Bottle rename: advertise the router config-file path under
+# the new BOTTLE_ROUTER_CONFIG name. The main unit already sets the legacy
+# OPENHOST_ROUTER_CONFIG and the router reads either (BOTTLE_ preferred), so this is
+# additive — Environment= directives accumulate across drop-ins, layering the new
+# name on without touching the baseline unit.
+[Service]
+Environment=BOTTLE_ROUTER_CONFIG=/home/host/.openhost/local_compute_space/config.toml

--- a/ansible/tasks/install_openhost_units.yml
+++ b/ansible/tasks/install_openhost_units.yml
@@ -83,6 +83,15 @@
     mode: "0644"
   register: journal_dropin_file
 
+- name: Install openhost bottle-router-config drop-in
+  become: yes
+  become_user: root
+  copy:
+    src: files/openhost.service.d/20-bottle-router-config.conf
+    dest: /etc/systemd/system/openhost.service.d/20-bottle-router-config.conf
+    mode: "0644"
+  register: bottle_router_config_dropin_file
+
 # JuiceFS archive-tier mount: a dedicated systemd service with
 # Restart=always so the FUSE mount recovers automatically if the
 # JuiceFS process is OOM-killed or crashes.  Installed disabled;
@@ -102,7 +111,7 @@
   become_user: root
   systemd:
     daemon_reload: yes
-  when: service_file.changed or juicefs_service_file.changed or journal_dropin_file.changed
+  when: service_file.changed or juicefs_service_file.changed or journal_dropin_file.changed or bottle_router_config_dropin_file.changed
 
 # Enabling openhost is deliberately NOT done here — see the note at the top of
 # this file. It happens in tasks/restart_openhost_service.yml alongside the

--- a/compute_space/src/compute_space/config.py
+++ b/compute_space/src/compute_space/config.py
@@ -358,17 +358,38 @@ class DefaultConfig(Config):
     )
 
 
-def load_config() -> Config:
-    """Load config from OPENHOST_ prefixed env vars, env-selected TOML file, or default config, in that order.
+def router_config_path_from_env() -> str | None:
+    """Explicit router-config file path from the environment, or None if unset.
 
-    Prefer ``OPENHOST_ROUTER_CONFIG`` (new CLI name) and fall back to
-    ``OPENHOST_CONFIG`` for backward compatibility.
+    OpenHost -> Cloud in a Bottle rename: prefers the new ``BOTTLE_ROUTER_CONFIG``
+    and falls back to the legacy ``OPENHOST_ROUTER_CONFIG`` then ``OPENHOST_CONFIG``,
+    which are kept for backward compatibility.  Shared so every reader of the
+    config-file path (``load_config`` and ``first_boot``) agrees on precedence.
     """
-    path = os.environ.get("OPENHOST_ROUTER_CONFIG") or os.environ.get("OPENHOST_CONFIG")
-    if path:
-        return typed_settings.load(DefaultConfig, appname="openhost", config_files=[path])
-    else:
-        return typed_settings.load(DefaultConfig, appname="openhost")
+    return (
+        os.environ.get("BOTTLE_ROUTER_CONFIG")
+        or os.environ.get("OPENHOST_ROUTER_CONFIG")
+        or os.environ.get("OPENHOST_CONFIG")
+    )
+
+
+def load_config() -> Config:
+    """Load config from prefixed env vars, an env-selected TOML file, or the default config, in that order.
+
+    The project was renamed OpenHost -> Cloud in a Bottle.  Config env vars
+    are read under both the new ``BOTTLE_`` prefix and the legacy
+    ``OPENHOST_`` prefix; ``BOTTLE_`` wins when both name the same field.
+
+    The explicit config-file path prefers ``BOTTLE_ROUTER_CONFIG`` and falls
+    back to ``OPENHOST_ROUTER_CONFIG`` then ``OPENHOST_CONFIG``.
+    """
+    path = router_config_path_from_env()
+    config_files = [path] if path else []
+    # default_loaders gives [FileLoader, EnvLoader("OPENHOST_")].  Append a
+    # BOTTLE_ env loader last so BOTTLE_<FIELD> overrides OPENHOST_<FIELD>.
+    loaders = typed_settings.default_loaders(appname="openhost", config_files=config_files)
+    loaders.append(typed_settings.EnvLoader(prefix="BOTTLE_"))
+    return typed_settings.load_settings(DefaultConfig, loaders)
 
 
 _active_config: Config | None = None

--- a/compute_space/src/compute_space/core/first_boot.py
+++ b/compute_space/src/compute_space/core/first_boot.py
@@ -9,7 +9,6 @@ exactly once, after which the DB is authoritative.  Old instances (whose domain 
 
 from __future__ import annotations
 
-import os
 import sqlite3
 import tomllib
 from contextlib import closing
@@ -18,6 +17,7 @@ from pathlib import Path
 import attr
 
 from compute_space.config import Config
+from compute_space.config import router_config_path_from_env
 from compute_space.core import identity_store
 from compute_space.core import settings_store
 from compute_space.core.domains import Domain
@@ -44,7 +44,7 @@ class FirstBoot:
 
 def _config_dir() -> Path | None:
     """Directory of the router config file (``first_boot.toml`` lives beside it)."""
-    path = os.environ.get("OPENHOST_ROUTER_CONFIG") or os.environ.get("OPENHOST_CONFIG")
+    path = router_config_path_from_env()
     return Path(path).parent if path else None
 
 

--- a/compute_space/src/compute_space/core/system_agent/client.py
+++ b/compute_space/src/compute_space/core/system_agent/client.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import json
-import os
 import subprocess
 import time
 
@@ -13,7 +12,8 @@ from openhost_system_agent.protocol import DiffResult
 from openhost_system_agent.protocol import FetchResult
 from openhost_system_agent.protocol import MigrationStatus
 from openhost_system_agent.protocol import RemoteInfo
-from openhost_system_agent.updater.paths import DATA_DIR_ENV
+from openhost_system_agent.updater.paths import data_dir_env_value
+from openhost_system_agent.updater.paths import data_dir_setenv_pairs
 
 
 class SystemAgentError(Exception):
@@ -21,13 +21,14 @@ class SystemAgentError(Exception):
 
 
 # The agent resolves the shared updater paths (progress log, token, certs) from
-# OPENHOST_DATA_DIR, but sudo's env_reset strips it. Forward it explicitly (via
-# `sudo env`) so a non-default data_root_dir keeps compute_space and the agent
-# pointed at the same files instead of silently diverging to the agent's default.
+# the data-dir env var (BOTTLE_DATA_DIR, legacy OPENHOST_DATA_DIR), but sudo's
+# env_reset strips it. Forward it explicitly (via `sudo env`) so a non-default
+# data_root_dir keeps compute_space and the agent pointed at the same files
+# instead of silently diverging to the agent's default. Both names are forwarded.
 def _agent_argv(*args: str) -> list[str]:
-    data_dir = os.environ.get(DATA_DIR_ENV)
+    data_dir = data_dir_env_value()
     if data_dir:
-        return ["sudo", "env", f"{DATA_DIR_ENV}={data_dir}", "openhost_system_agent", *args]
+        return ["sudo", "env", *data_dir_setenv_pairs(data_dir), "openhost_system_agent", *args]
     return ["sudo", "openhost_system_agent", *args]
 
 

--- a/compute_space/src/compute_space/tests/test_bottle_env_aliases.py
+++ b/compute_space/src/compute_space/tests/test_bottle_env_aliases.py
@@ -1,12 +1,15 @@
 """OpenHost -> Cloud in a Bottle env-var rename.
 
 Every OPENHOST_* variable is kept for backward compatibility and also
-exposed under a BOTTLE_* twin.  These tests pin the alias helper that stamps
-the BOTTLE_* twins onto the env passed into app containers.
+exposed under a BOTTLE_* twin.  These tests pin the alias helper and the
+daemon config loader's dual-prefix precedence.
 """
 
 from __future__ import annotations
 
+import pytest
+
+from compute_space.config import load_config
 from compute_space.core.containers import add_bottle_env_aliases
 
 
@@ -37,3 +40,16 @@ def test_alias_is_pure() -> None:
     original = {"OPENHOST_APP_NAME": "myapp"}
     add_bottle_env_aliases(original)
     assert original == {"OPENHOST_APP_NAME": "myapp"}
+
+
+def test_load_config_prefers_bottle_over_openhost(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("OPENHOST_PORT", "9001")
+    assert load_config().port == 9001, "legacy OPENHOST_ override still works"
+
+    monkeypatch.setenv("BOTTLE_PORT", "9002")
+    assert load_config().port == 9002, "BOTTLE_ wins when both are set"
+
+
+def test_load_config_reads_field_from_bottle_prefix(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("BOTTLE_MY_OPENHOST_REDIRECT_DOMAIN", "bottle.example")
+    assert load_config().my_openhost_redirect_domain == "bottle.example"

--- a/compute_space/src/compute_space/tests/test_first_boot.py
+++ b/compute_space/src/compute_space/tests/test_first_boot.py
@@ -41,7 +41,23 @@ def _point_config_env(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
 def test_read_first_boot_none_without_env(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("OPENHOST_ROUTER_CONFIG", raising=False)
     monkeypatch.delenv("OPENHOST_CONFIG", raising=False)
+    monkeypatch.delenv("BOTTLE_ROUTER_CONFIG", raising=False)
     assert read_first_boot() is None
+
+
+def test_read_first_boot_honors_bottle_router_config(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    # OpenHost -> Cloud in a Bottle rename: first_boot resolves the config dir from
+    # BOTTLE_ROUTER_CONFIG too, not only the legacy OPENHOST_ names.
+    monkeypatch.delenv("OPENHOST_ROUTER_CONFIG", raising=False)
+    monkeypatch.delenv("OPENHOST_CONFIG", raising=False)
+    config_toml = tmp_path / "config.toml"
+    config_toml.write_text("")  # only its directory matters
+    monkeypatch.setenv("BOTTLE_ROUTER_CONFIG", str(config_toml))
+    (tmp_path / "first_boot.toml").write_text('domain = "bottle.example.com"\n')
+
+    first_boot = read_first_boot()
+    assert first_boot is not None
+    assert first_boot.domain == "bottle.example.com"
 
 
 def test_seed_prefers_first_boot(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/compute_space/src/compute_space/web/start.py
+++ b/compute_space/src/compute_space/web/start.py
@@ -48,7 +48,7 @@ from compute_space.db import get_db
 from compute_space.db import init_db
 from compute_space.web.app import create_app
 from compute_space.web.setup_app import create_setup_app
-from openhost_system_agent.updater.paths import DATA_DIR_ENV
+from openhost_system_agent.updater.paths import DATA_DIR_ENV_NAMES
 
 
 def _terminate_children(children: list[subprocess.Popen[bytes]]) -> None:
@@ -73,7 +73,9 @@ def _bootstrap(config: Config) -> None:
     # same shared module the agent, the apply unit and the updater use, and that
     # module resolves the directory from this variable so all four agree on one
     # path. Agent invocations forward it explicitly on top (see _agent_argv).
-    os.environ[DATA_DIR_ENV] = str(config.openhost_data_path)
+    # Set both the new BOTTLE_ and legacy OPENHOST_ names (rename compat).
+    for _data_dir_env in DATA_DIR_ENV_NAMES:
+        os.environ[_data_dir_env] = str(config.openhost_data_path)
     setup_file_logging(Path(os.path.dirname(config.db_path)) / "compute_space.log")
     load_keys(config.keys_dir)
     init_db(config.db_path)

--- a/openhost_system_agent/src/openhost_system_agent/detach.py
+++ b/openhost_system_agent/src/openhost_system_agent/detach.py
@@ -18,11 +18,16 @@ import time
 
 from loguru import logger
 
-from openhost_system_agent.updater.paths import DATA_DIR_ENV
+from openhost_system_agent.updater.paths import data_dir_env_value
+from openhost_system_agent.updater.paths import data_dir_setenv_pairs
 
 OPENHOST_UNIT = "openhost.service"
 APPLY_UNIT = "openhost-apply.service"
+# OpenHost -> Cloud in a Bottle rename: mark a detached apply under the new
+# BOTTLE_ name and the legacy OPENHOST_ name. Set both; read either.
 DETACHED_ENV = "OPENHOST_APPLY_DETACHED"
+DETACHED_ENV_NEW = "BOTTLE_APPLY_DETACHED"
+DETACHED_ENV_NAMES = (DETACHED_ENV_NEW, DETACHED_ENV)
 
 _WAIT_TIMEOUT_SECONDS = 3600.0
 _RUNTIME_MAX_SECONDS = 3600
@@ -45,7 +50,7 @@ def _systemctl(*args: str, timeout: int = 120) -> subprocess.CompletedProcess[st
 
 
 def is_detached() -> bool:
-    return os.environ.get(DETACHED_ENV) == "1"
+    return any(os.environ.get(name) == "1" for name in DETACHED_ENV_NAMES)
 
 
 def apply_is_running() -> bool:
@@ -92,14 +97,15 @@ def detach_apply() -> None:
         # start, including this failsafe, which is when it matters most.
         f'--property=ExecStopPost=/bin/sh -c "{systemctl} reset-failed {OPENHOST_UNIT}; '
         f'{systemctl} start --no-block {OPENHOST_UNIT}"',
+        f"--setenv={DETACHED_ENV_NEW}=1",
         f"--setenv={DETACHED_ENV}=1",
         # Transient units get no HOME, and git needs one (root's safe.directory
         # lives in $HOME/.gitconfig), or the walk dies on its first git call.
         f"--setenv=HOME={os.environ.get('HOME') or '/root'}",
     ]
-    data_dir = os.environ.get(DATA_DIR_ENV)
+    data_dir = data_dir_env_value()
     if data_dir:
-        cmd.append(f"--setenv={DATA_DIR_ENV}={data_dir}")
+        cmd += [f"--setenv={pair}" for pair in data_dir_setenv_pairs(data_dir)]
     cmd += [sys.executable, "-c", _ENTRYPOINT]
 
     try:

--- a/openhost_system_agent/src/openhost_system_agent/migrations/README.md
+++ b/openhost_system_agent/src/openhost_system_agent/migrations/README.md
@@ -51,6 +51,32 @@ class Migration{NNNN}{Name}(SystemMigration):
 
 4. Versions must be **contiguous** starting at 2 (v1 is the ansible baseline).
 
+## Never edit a landed migration — only add new ones
+
+A migration is **write-once, edit-never.** Once a `v{NNNN}` migration has landed, its behavior is frozen: hosts run
+only the migrations they haven't seen yet to catch up, so a host at v10 will *never* re-run an edited v2. If you change
+what an old migration does, two hosts reporting the "same" version can end up in different states, and the stepping-stone
+guarantee breaks. To change or fix host state, **add the next migration** — never touch an existing one. (This also
+applies to shared helpers a migration calls: editing a builder that an old migration invokes is editing that migration.
+Freeze it and add a new migration instead.)
+
+### Changing a systemd unit: use an additive drop-in
+
+Do **not** change host-level state by rewriting the main `openhost.service` unit from a shared builder and re-applying
+it in a new migration — that pattern requires editing the builder, which lives in the v0002 baseline migration, so it
+edits an old migration. Instead, layer the change on with an **additive systemd drop-in** under
+`/etc/systemd/system/openhost.service.d/NN-*.conf` and `systemctl daemon-reload`:
+
+- Ship the identical drop-in from ansible (`ansible/files/openhost.service.d/NN-*.conf`, installed by
+  `install_openhost_units.yml`) so fresh hosts and self-updating hosts converge to the same state. A test keeps the
+  migration constant and the ansible copy byte-identical.
+- `Environment=` and other list directives accumulate across drop-ins (good for *adding* a var); single-value
+  directives (`Restart=`, etc.) are overridden by the highest-numbered drop-in. Either way the baseline unit — and the
+  v0002 migration that builds it — stays frozen.
+
+See `v0010_journal_read_for_oom` (adds `SupplementaryGroups=`) and `v0011_bottle_router_config_env` (adds
+`Environment=BOTTLE_ROUTER_CONFIG=`) for the canonical shape.
+
 ## The stepping-stone guarantee
 
 The tag walk ensures a host that has been offline for a long time can catch up safely by walking through each

--- a/openhost_system_agent/src/openhost_system_agent/migrations/registry.py
+++ b/openhost_system_agent/src/openhost_system_agent/migrations/registry.py
@@ -14,6 +14,7 @@ from openhost_system_agent.migrations.versions.v0007_seed_domains_and_scrub impo
 from openhost_system_agent.migrations.versions.v0008_restart_on_failure import Migration0008RestartOnFailure
 from openhost_system_agent.migrations.versions.v0009_swap_file import Migration0009SwapFile
 from openhost_system_agent.migrations.versions.v0010_journal_read_for_oom import Migration0010JournalReadForOom
+from openhost_system_agent.migrations.versions.v0011_bottle_router_config_env import Migration0011BottleRouterConfigEnv
 
 # Numbered migrations in apply order. Versions MUST start at 2 and be
 # contiguous. v1 is the baseline produced by ansible setup.yml.
@@ -27,6 +28,7 @@ REGISTRY: list[SystemMigration] = [
     Migration0008RestartOnFailure(),
     Migration0009SwapFile(),
     Migration0010JournalReadForOom(),
+    Migration0011BottleRouterConfigEnv(),
 ]
 
 

--- a/openhost_system_agent/src/openhost_system_agent/migrations/versions/v0011_bottle_router_config_env.py
+++ b/openhost_system_agent/src/openhost_system_agent/migrations/versions/v0011_bottle_router_config_env.py
@@ -1,0 +1,60 @@
+"""Add a systemd drop-in advertising the router config path under BOTTLE_ROUTER_CONFIG.
+
+The project was renamed OpenHost -> Cloud in a Bottle.  The router reads the
+config-file path from ``BOTTLE_ROUTER_CONFIG`` (preferred), falling back to the
+legacy ``OPENHOST_ROUTER_CONFIG``/``OPENHOST_CONFIG``.  The baseline unit already
+sets ``OPENHOST_ROUTER_CONFIG``, so the router already resolves its config; this
+drop-in additionally exposes the same value under the new name.
+
+Rather than rewrite the main unit — or the shared ``build_openhost_service_unit``
+builder, which lives in the v0002 baseline migration and so must not change — this
+adds the new name through an additive systemd drop-in, the same file ansible
+installs on fresh hosts (kept byte-identical; a test enforces it).  ``Environment=``
+directives accumulate across drop-ins, so the new name layers on alongside the
+legacy one without touching the baseline unit or any existing migration.  This is
+the same pattern as v0010's journal-read drop-in, and it is the expected way to
+change the unit going forward (see migrations/README.md, "Changing a systemd unit").
+
+This migration writes the drop-in and reloads systemd so hosts provisioned before
+the rename expose ``BOTTLE_ROUTER_CONFIG`` on their next self-update.  It does NOT
+restart openhost: ``daemon-reload`` makes the drop-in authoritative for the next
+start, and the apply walk restarts the service at the end anyway.  Idempotent:
+writing the same file and reloading is safe to repeat.
+"""
+
+from __future__ import annotations
+
+from openhost_system_agent.migrations.base import SystemMigration
+from openhost_system_agent.migrations.helpers import run
+from openhost_system_agent.migrations.helpers import write_file
+
+BOTTLE_ROUTER_CONFIG_DROPIN_PATH = "/etc/systemd/system/openhost.service.d/20-bottle-router-config.conf"
+
+# Additive drop-in: it layers a second ``Environment=`` (the new BOTTLE_ROUTER_CONFIG
+# name) onto openhost.service without rewriting the main unit. Kept byte-identical
+# with the ansible copy at ansible/files/openhost.service.d/20-bottle-router-config.conf
+# (a test enforces this).
+BOTTLE_ROUTER_CONFIG_DROPIN = """\
+# Managed by OpenHost; do not edit by hand. Kept byte-identical between
+# ansible/files/openhost.service.d/20-bottle-router-config.conf and the
+# BOTTLE_ROUTER_CONFIG_DROPIN constant in openhost_system_agent's v0011 migration
+# (a test enforces this).
+#
+# OpenHost -> Cloud in a Bottle rename: advertise the router config-file path under
+# the new BOTTLE_ROUTER_CONFIG name. The main unit already sets the legacy
+# OPENHOST_ROUTER_CONFIG and the router reads either (BOTTLE_ preferred), so this is
+# additive — Environment= directives accumulate across drop-ins, layering the new
+# name on without touching the baseline unit.
+[Service]
+Environment=BOTTLE_ROUTER_CONFIG=/home/host/.openhost/local_compute_space/config.toml
+"""
+
+
+class Migration0011BottleRouterConfigEnv(SystemMigration):
+    version = 11
+
+    def up(self) -> None:
+        write_file(BOTTLE_ROUTER_CONFIG_DROPIN_PATH, BOTTLE_ROUTER_CONFIG_DROPIN, mode=0o644)
+        # Make the drop-in authoritative for the next start. The apply walk restarts
+        # openhost at the end, so we don't restart here.
+        run("systemctl", "daemon-reload")

--- a/openhost_system_agent/src/openhost_system_agent/tests/test_data_dir_env.py
+++ b/openhost_system_agent/src/openhost_system_agent/tests/test_data_dir_env.py
@@ -1,0 +1,39 @@
+"""OpenHost -> Cloud in a Bottle rename: the data-dir override env var is read
+under the new BOTTLE_ name (preferred) and the legacy OPENHOST_ name, and writers
+export both.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from openhost_system_agent.updater import paths
+
+
+def test_prefers_bottle_over_legacy(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(paths.DATA_DIR_ENV, "/legacy")
+    monkeypatch.setenv(paths.DATA_DIR_ENV_NEW, "/bottle")
+    assert paths.data_dir_env_value() == "/bottle"
+    assert paths.data_dir() == Path("/bottle")
+
+
+def test_falls_back_to_legacy(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv(paths.DATA_DIR_ENV_NEW, raising=False)
+    monkeypatch.setenv(paths.DATA_DIR_ENV, "/legacy")
+    assert paths.data_dir_env_value() == "/legacy"
+
+
+def test_none_when_unset(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv(paths.DATA_DIR_ENV_NEW, raising=False)
+    monkeypatch.delenv(paths.DATA_DIR_ENV, raising=False)
+    assert paths.data_dir_env_value() is None
+    # data_dir() falls back to the shared default rather than raising.
+    assert str(paths.data_dir()).endswith("/persistent_data/openhost")
+
+
+def test_setenv_pairs_covers_both_names() -> None:
+    pairs = paths.data_dir_setenv_pairs("/some/dir")
+    assert f"{paths.DATA_DIR_ENV_NEW}=/some/dir" in pairs
+    assert f"{paths.DATA_DIR_ENV}=/some/dir" in pairs

--- a/openhost_system_agent/src/openhost_system_agent/tests/test_detach.py
+++ b/openhost_system_agent/src/openhost_system_agent/tests/test_detach.py
@@ -105,6 +105,10 @@ def test_detach_launches_a_transient_unit_with_everything_it_needs(monkeypatch: 
     assert "--setenv=HOME=/root" in cmd
     # Without this the detached walk resolves a different progress log and token.
     assert f"--setenv={updater_paths.DATA_DIR_ENV}=/custom/data" in cmd
+    # OpenHost -> Cloud in a Bottle rename: both env-var names are exported so the
+    # detached walk resolves them whichever it reads.
+    assert f"--setenv={detach_mod.DETACHED_ENV_NEW}=1" in cmd
+    assert f"--setenv={updater_paths.DATA_DIR_ENV_NEW}=/custom/data" in cmd
     # A wedged walk would otherwise hold the instance down indefinitely.
     assert f"--property=RuntimeMaxSec={detach_mod._RUNTIME_MAX_SECONDS}" in cmd
 

--- a/openhost_system_agent/src/openhost_system_agent/tests/test_migration_bottle_router_config_env.py
+++ b/openhost_system_agent/src/openhost_system_agent/tests/test_migration_bottle_router_config_env.py
@@ -1,0 +1,61 @@
+"""Tests for the v11 migration that advertises the router config path under the
+new BOTTLE_ROUTER_CONFIG name (OpenHost -> Cloud in a Bottle env-var rename).
+
+The migration installs an additive systemd drop-in — it does NOT rewrite the main
+unit or the shared ``build_openhost_service_unit`` builder (which lives in the
+v0002 baseline migration and must not change).  So hosts provisioned before the
+rename expose ``BOTTLE_ROUTER_CONFIG`` on their next self-update; we drive the
+migration through fakes to assert exactly that.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from openhost_system_agent.migrations.versions import v0011_bottle_router_config_env
+from openhost_system_agent.migrations.versions.v0011_bottle_router_config_env import BOTTLE_ROUTER_CONFIG_DROPIN
+from openhost_system_agent.migrations.versions.v0011_bottle_router_config_env import BOTTLE_ROUTER_CONFIG_DROPIN_PATH
+from openhost_system_agent.migrations.versions.v0011_bottle_router_config_env import Migration0011BottleRouterConfigEnv
+
+_PREFIX = "openhost_system_agent.migrations.versions.v0011_bottle_router_config_env"
+
+
+def test_writes_additive_dropin_and_reloads(monkeypatch: pytest.MonkeyPatch) -> None:
+    written: dict[str, Any] = {}
+    run_calls: list[tuple[str, ...]] = []
+
+    def fake_write_file(path: str, content: str, *, mode: int = 0o600) -> None:
+        written["path"] = path
+        written["content"] = content
+        written["mode"] = mode
+
+    def fake_run(*cmd: str) -> None:
+        run_calls.append(cmd)
+
+    monkeypatch.setattr(f"{_PREFIX}.write_file", fake_write_file)
+    monkeypatch.setattr(f"{_PREFIX}.run", fake_run)
+
+    Migration0011BottleRouterConfigEnv().up()
+
+    # World-readable drop-in at the canonical path — NOT the main unit path, so the
+    # baseline unit (and the v0002 migration that builds it) is left untouched.
+    assert written["path"] == BOTTLE_ROUTER_CONFIG_DROPIN_PATH
+    assert written["path"].endswith("openhost.service.d/20-bottle-router-config.conf")
+    assert written["mode"] == 0o644
+    assert written["content"] == BOTTLE_ROUTER_CONFIG_DROPIN
+    # The drop-in only adds the new name; it must not set the legacy directive
+    # (the baseline unit already does). A comment may mention the legacy name.
+    assert "Environment=BOTTLE_ROUTER_CONFIG=" in written["content"]
+    assert "Environment=OPENHOST_ROUTER_CONFIG=" not in written["content"]
+
+    # systemd is reloaded so the drop-in is authoritative for the next start.
+    assert ("systemctl", "daemon-reload") in run_calls
+    # It must NOT restart openhost itself — the apply walk does that at the end;
+    # a mid-migration restart would kill the running apply process.
+    assert not any(c[:2] == ("systemctl", "restart") for c in run_calls)
+
+
+def test_migration_version_is_eleven() -> None:
+    assert v0011_bottle_router_config_env.Migration0011BottleRouterConfigEnv.version == 11

--- a/openhost_system_agent/src/openhost_system_agent/tests/test_service_unit.py
+++ b/openhost_system_agent/src/openhost_system_agent/tests/test_service_unit.py
@@ -11,6 +11,7 @@ from openhost_system_agent.migrations.versions.v0002_baseline import RECLAIM_SCR
 from openhost_system_agent.migrations.versions.v0002_baseline import RECLAIM_SCRIPT_PATH
 from openhost_system_agent.migrations.versions.v0002_baseline import build_openhost_service_unit
 from openhost_system_agent.migrations.versions.v0010_journal_read_for_oom import JOURNAL_READ_DROPIN
+from openhost_system_agent.migrations.versions.v0011_bottle_router_config_env import BOTTLE_ROUTER_CONFIG_DROPIN
 
 
 def _effective_directives(unit_text: str) -> list[str]:
@@ -47,6 +48,17 @@ def test_journal_read_dropin_matches_ansible_copy_byte_for_byte() -> None:
     assert "SupplementaryGroups=systemd-journal\n" in JOURNAL_READ_DROPIN
 
 
+def test_bottle_router_config_dropin_matches_ansible_copy_byte_for_byte() -> None:
+    """The migration-written drop-in and the ansible-installed drop-in must be
+    identical so a host advertises BOTTLE_ROUTER_CONFIG the same way however it was
+    set up. The new name lives in this additive drop-in, not the main unit, so no
+    existing migration (or the shared builder) has to change to add it."""
+    repo_root = Path(__file__).resolve().parents[4]
+    ansible_copy = repo_root / "ansible" / "files" / "openhost.service.d" / "20-bottle-router-config.conf"
+    assert ansible_copy.read_text() == BOTTLE_ROUTER_CONFIG_DROPIN
+    assert "Environment=BOTTLE_ROUTER_CONFIG=" in BOTTLE_ROUTER_CONFIG_DROPIN
+
+
 class TestOpenhostServiceUnit:
     def test_reclaim_execstartpre_runs_script_as_root_best_effort(self) -> None:
         unit = build_openhost_service_unit(1001)
@@ -66,6 +78,16 @@ class TestOpenhostServiceUnit:
         # The exact ExecStartPre line is a module constant so migrations that
         # rewrite the unit stay byte-identical with the baseline.
         assert RECLAIM_EXEC_START_PRE in build_openhost_service_unit(1234)
+
+    def test_baseline_unit_sets_only_the_legacy_router_config_name(self) -> None:
+        # OpenHost -> Cloud in a Bottle rename: the new BOTTLE_ROUTER_CONFIG name is
+        # added by an additive drop-in (see v0011 / the byte-for-byte test below),
+        # NOT by the baseline unit. The baseline still sets only the legacy name, so
+        # the shared builder — and the v0002 migration that owns it — stay frozen.
+        unit = build_openhost_service_unit(1001)
+        cfg = "/home/host/.openhost/local_compute_space/config.toml"
+        assert f"Environment=OPENHOST_ROUTER_CONFIG={cfg}\n" in unit
+        assert "BOTTLE_ROUTER_CONFIG" not in unit
 
     def test_host_uid_is_substituted(self) -> None:
         unit = build_openhost_service_unit(4242)

--- a/openhost_system_agent/src/openhost_system_agent/updater/launcher.py
+++ b/openhost_system_agent/src/openhost_system_agent/updater/launcher.py
@@ -4,7 +4,6 @@
 
 from __future__ import annotations
 
-import os
 import shutil
 import subprocess
 import sys
@@ -12,7 +11,8 @@ import time
 
 from loguru import logger
 
-from openhost_system_agent.updater.paths import DATA_DIR_ENV
+from openhost_system_agent.updater.paths import data_dir_env_value
+from openhost_system_agent.updater.paths import data_dir_setenv_pairs
 from openhost_system_agent.updater.paths import ready_marker_path
 
 _UPDATER_UNIT = "openhost-updater.service"
@@ -73,10 +73,10 @@ def launch_updater() -> bool:
         "--property=RestartSec=1",
     ]
     # The updater must resolve the same on-disk paths (token, progress, certs) as
-    # this process; forward the data-dir override when one is in effect.
-    data_dir = os.environ.get(DATA_DIR_ENV)
+    # this process; forward the data-dir override (both env names) when one is in effect.
+    data_dir = data_dir_env_value()
     if data_dir:
-        cmd.append(f"--setenv={DATA_DIR_ENV}={data_dir}")
+        cmd += [f"--setenv={pair}" for pair in data_dir_setenv_pairs(data_dir)]
     cmd += [
         sys.executable,
         # `-c` rather than `-m`: under -m the module loads as __main__ and cappa's

--- a/openhost_system_agent/src/openhost_system_agent/updater/paths.py
+++ b/openhost_system_agent/src/openhost_system_agent/updater/paths.py
@@ -8,11 +8,36 @@ from pathlib import Path
 # compute_space sets it for itself at boot and forwards it on every agent call
 # (`sudo env`) and into the detached updater (`systemd-run --setenv`).
 _DEFAULT_DATA_DIR = "/home/host/.openhost/local_compute_space/persistent_data/openhost"
+# OpenHost -> Cloud in a Bottle rename: the data-dir override is read under the
+# new BOTTLE_ name (preferred) and the legacy OPENHOST_ name (kept for compat).
+# Order matters — BOTTLE_ wins. Writers set BOTH names so a reader on either side
+# of a version-skewed self-update still finds it.
 DATA_DIR_ENV = "OPENHOST_DATA_DIR"
+DATA_DIR_ENV_NEW = "BOTTLE_DATA_DIR"
+DATA_DIR_ENV_NAMES = (DATA_DIR_ENV_NEW, DATA_DIR_ENV)
+
+
+def data_dir_env_value() -> str | None:
+    """The configured data-dir override from the environment, or None if unset.
+
+    Prefers ``BOTTLE_DATA_DIR`` over the legacy ``OPENHOST_DATA_DIR``.
+    """
+    for name in DATA_DIR_ENV_NAMES:
+        value = os.environ.get(name)
+        if value:
+            return value
+    return None
+
+
+def data_dir_setenv_pairs(value: str) -> list[str]:
+    """``NAME=value`` assignments for every data-dir env name, for ``env`` /
+    ``systemd-run --setenv`` so both the new and legacy names are exported."""
+    return [f"{name}={value}" for name in DATA_DIR_ENV_NAMES]
 
 
 def data_dir() -> Path:
-    return Path(os.environ.get(DATA_DIR_ENV, _DEFAULT_DATA_DIR))
+    value = data_dir_env_value()
+    return Path(value) if value else Path(_DEFAULT_DATA_DIR)
 
 
 def updater_dir() -> Path:

--- a/routerd_cli/src/self_host_cli/up.py
+++ b/routerd_cli/src/self_host_cli/up.py
@@ -183,6 +183,8 @@ def run_up(args: argparse.Namespace) -> None:
     )
 
     env = os.environ.copy()
+    # New BOTTLE_ name plus the legacy OPENHOST_ name for backward compat.
+    env["BOTTLE_ROUTER_CONFIG"] = config_path
     env["OPENHOST_ROUTER_CONFIG"] = config_path
 
     cmd = [


### PR DESCRIPTION
Part 2 of splitting #315. **Stacked on #322** (base = `kilo/sculptor/bottle-app-env-vars`) — review/merge #322 first.

Completes the OpenHost -> Cloud in a Bottle env-var rename beyond the app-facing surface. Daemon/agent config and path env vars are read under the new `BOTTLE_` name (preferred), keeping the legacy `OPENHOST_` names for backward compatibility, and both are exported wherever we set them.

## What changed
- **`config.load_config`**: append a `BOTTLE_` `EnvLoader` so `BOTTLE_<FIELD>` overrides `OPENHOST_<FIELD>`. `router_config_path_from_env()` shared by `load_config` and `first_boot` (`BOTTLE_ROUTER_CONFIG` > `OPENHOST_ROUTER_CONFIG` > `OPENHOST_CONFIG`).
- **`updater.paths`**: `DATA_DIR_ENV_NEW` / `data_dir_env_value()` / `data_dir_setenv_pairs()`; `detach`, `launcher`, `system_agent.client` and `web/start` export both names (and forward both via `sudo env` / `systemd-run --setenv`).
- **`detach`**: `DETACHED_ENV` twin (`BOTTLE_APPLY_DETACHED`); read either.
- **`routerd` up.py**: set `BOTTLE_ROUTER_CONFIG` alongside the legacy name.
- **v0011 migration + ansible drop-in**: advertise `BOTTLE_ROUTER_CONFIG` via an *additive* systemd drop-in so the baseline unit and the v0002 builder stay frozen (a test keeps the migration constant and the ansible copy byte-identical). `migrations/README` documents the never-edit-a-landed-migration rule.
- Adds the `load_config` dual-prefix tests to `test_bottle_env_aliases.py`.

Replaces #315 (to be closed).