### PR TITLE
Give test_docs its own DB so it can run standalone

### DIFF
--- a/compute_space/src/compute_space/tests/test_docs.py
+++ b/compute_space/src/compute_space/tests/test_docs.py
@@ -41,6 +41,7 @@ from litestar.testing import TestClient
 import compute_space.web.routes.docs as docs_routes
 from compute_space.config import set_active_config
 from compute_space.core.apps import RESERVED_PATHS
+from compute_space.db import init_db
 from compute_space.tests._litestar_helpers import make_test_app
 from compute_space.web.routes.docs import docs_routes as docs_router
 
@@ -59,6 +60,14 @@ def _clear_render_cache() -> Iterator[None]:
     docs_routes._render_cache.clear()
     yield
     docs_routes._render_cache.clear()
+
+
+@pytest.fixture(autouse=True)
+def _db(tmp_path: Path) -> None:
+    """The test app's zone-stashing middleware calls get_db() on every request, so the module
+    needs its own DB.  Without this the file only passes when some earlier test module happens to
+    have initialized the global connection first."""
+    init_db(str(tmp_path / "docs-test.db"))
 
 
 def _populate_fake_docs(src_dir: Path) -> None:


### PR DESCRIPTION
**Stack 1/11** — standalone, no dependencies. Unrelated to the DNS work; split out because it was blocking me while working on that.

`test_docs.py` fails with 18 errors when run on its own:

```
pytest compute_space/src/compute_space/tests/test_docs.py
→ 18 failed, 10 passed
```

Every request-making test returns 500. The cause is `_full_app_bootstrap`'s zone-stashing middleware calling `get_db()` on every request, while the module never calls `init_db()`. It only passes in a full-suite run because an earlier module has already initialised the global connection.

One autouse fixture giving the module its own temp DB.

**Verified:** `test_docs.py` alone → 28 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)