### PR TITLE
image: distributable VM image + release workflow for easy self-host installs (OH-275)

### DIFF
--- a/.github/workflows/image-release.yml
+++ b/.github/workflows/image-release.yml
@@ -84,8 +84,9 @@ jobs:
           - \`*.qcow2\` — QEMU/KVM/libvirt (and most cloud importers)
           - \`*.ova\` — VirtualBox / VMware
 
-          Boot it, then reach the dashboard at \`http://<vm-ip>:8080\`.
-          See \`image/build.sh\` and \`docs/\` for defaults (claim token, console login)."
+          Boot it, then reach the dashboard at \`http://<vm-ip>:8080\` and claim it
+          (claiming is open by default — the image is private behind NAT).
+          See \`image/build.sh\` for defaults (console login, disk sizing)."
           )
           if [ "${{ inputs.draft }}" = "true" ]; then
             create_args+=(--draft)

--- a/.github/workflows/image-release.yml
+++ b/.github/workflows/image-release.yml
@@ -1,0 +1,94 @@
+name: image-release
+
+# Build the OpenHost VM images (qcow2 + optional VirtualBox OVA) for a chosen
+# git tag and publish them as a GitHub release. Manually triggered for now —
+# run it from the Actions tab once the version tag has been pushed.
+#
+# The build recipe (image/build.sh) boots the tag's provision.sh once under
+# QEMU/KVM and freezes the result; the app code baked into the image is cloned
+# from this repo at the same tag (build.sh --branch also accepts a tag ref).
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Git tag to build and release (e.g. v0.1.4). Must already exist and be pushed."
+        required: true
+        type: string
+      make_ova:
+        description: "Also build the VirtualBox OVA alongside the qcow2"
+        required: false
+        type: boolean
+        default: true
+      draft:
+        description: "Publish the release as a draft (review before it goes public)"
+        required: false
+        type: boolean
+        default: true
+
+# gh release create needs write access to create the release and upload assets.
+permissions:
+  contents: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    # The build boots a VM and provisions it end to end; give it plenty of room.
+    # build.sh has its own 30-min boot timeout inside this budget.
+    timeout-minutes: 90
+    steps:
+      - name: Check out the release tag
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.tag }}
+          fetch-depth: 0
+
+      - name: Install image build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y qemu-system-x86 qemu-utils cloud-image-utils
+
+      - name: Report KVM availability
+        run: |
+          if [ -w /dev/kvm ]; then
+            echo "KVM is available — build will use hardware acceleration."
+          else
+            echo "::warning::/dev/kvm not writable; build falls back to slow TCG emulation."
+          fi
+
+      - name: Build VM images
+        run: |
+          args=(--branch "${{ inputs.tag }}" --version "${{ inputs.tag }}")
+          if [ "${{ inputs.make_ova }}" != "true" ]; then
+            args+=(--no-ova)
+          fi
+          image/build.sh "${args[@]}"
+
+      - name: List built artifacts
+        run: ls -lh image/out/
+
+      - name: Publish GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          assets=(image/out/openhost-*.qcow2)
+          for ova in image/out/openhost-*.ova; do
+            [ -e "$ova" ] && assets+=("$ova")
+          done
+
+          create_args=(
+            "${{ inputs.tag }}"
+            --title "OpenHost ${{ inputs.tag }}"
+            --notes "OpenHost VM images for ${{ inputs.tag }}.
+
+          - \`*.qcow2\` — QEMU/KVM/libvirt (and most cloud importers)
+          - \`*.ova\` — VirtualBox / VMware
+
+          Boot it, then reach the dashboard at \`http://<vm-ip>:8080\`.
+          See \`image/build.sh\` and \`docs/\` for defaults (claim token, console login)."
+          )
+          if [ "${{ inputs.draft }}" = "true" ]; then
+            create_args+=(--draft)
+          fi
+
+          gh release create "${create_args[@]}" "${assets[@]}"

--- a/ansible/templates/config.toml.j2
+++ b/ansible/templates/config.toml.j2
@@ -19,7 +19,7 @@ acme_directory_url = "{{ acme_directory_url }}"
 coredns_enabled = {{ 'false' if http_only else 'true' }}
 public_ip = "{{ public_ip | default(inventory_hostname) }}"
 start_caddy = {{ 'false' if http_only else 'true' }}
-claim_token_required = true
+claim_token_required = {{ 'true' if (claim_token_required | default(true) | bool) else 'false' }}
 data_root_dir = "/home/host/.openhost/local_compute_space"
 apps_dir_override = "/home/host/openhost/apps"
 {% if cert_provider is defined and cert_provider == 'cert_api' %}

--- a/image/.gitignore
+++ b/image/.gitignore
@@ -1,0 +1,3 @@
+# Build artifacts and the cached Ubuntu base image.
+out/
+cache/

--- a/image/build.sh
+++ b/image/build.sh
@@ -1,0 +1,381 @@
+#!/usr/bin/env bash
+# build.sh — Build a bootable OpenHost VM image from the Ubuntu 24.04 cloud image.
+#
+# The recipe is deliberately plain: take Ubuntu's official cloud-image qcow2,
+# boot it once under QEMU with a cloud-init seed that runs our existing,
+# tested provision.sh, let it power itself off, then freeze the resulting disk.
+# No Packer, no autoinstall ISO dance — just the exact code path a real deploy
+# uses. Output is a QEMU qcow2 and (optionally) a VirtualBox OVA.
+#
+# The image comes up out of the box in HTTP-only mode bound to 0.0.0.0, so the
+# dashboard is reachable at http://<vm-ip>:8080 with a known claim token and a
+# default console password. No domain, DNS, or TLS setup required to try it.
+#
+# Usage (run on a Linux host with KVM):
+#   image/build.sh [options]
+#
+# Options:
+#   --branch <branch>     Git branch of openhost app code to clone (default: main)
+#   --repo <url>          Git repo URL to clone app code from
+#                         (default: imbue-openhost/openhost)
+#   --provision-script <path>
+#                         provision.sh to embed and run in the build VM
+#                         (default: this repo's scripts/provision.sh). Embedded
+#                         from the working tree, so the branch need not be pushed.
+#   --domain <domain>     App subdomain-routing domain baked in (default: lvh.me)
+#   --claim-token <tok>   Claim token baked in (default: openhost)
+#   --password <pw>       Default console password for the `host` user
+#                         (default: openhost)
+#   --ssh-pubkey <path>   Optional SSH public key file to authorize for `host`
+#                         (SSH is key-only; without this, access is console-only)
+#   --version <v>         Version string used in artifact filenames
+#                         (default: `git describe` or "dev")
+#   --disk-size <size>    Virtual disk size baked into the image — the default
+#                         floor only (default: 20G). The image grows its root
+#                         filesystem to fill whatever disk it is installed onto
+#                         on first boot, so users pick the real size by sizing
+#                         the VM disk (or the physical disk on bare metal).
+#   --swap-size <gib>     Swap file size in GiB baked into the image (default: 2)
+#   --mem <mb>            Build VM memory in MB (default: 4096)
+#   --cpus <n>            Build VM vCPUs (default: 2)
+#   --output-dir <dir>    Where artifacts land (default: image/out)
+#   --no-ova              Skip the VirtualBox OVA; produce only the qcow2
+#   --timeout <sec>       Max seconds to wait for the build boot (default: 1800)
+#   -h, --help            Show this help
+#
+# Requirements: qemu-system-x86_64, qemu-img, cloud-localds (cloud-image-utils)
+# or genisoimage/xorriso, curl, tar. KVM (/dev/kvm) strongly recommended —
+# without it the build boot falls back to slow TCG emulation.
+
+set -euo pipefail
+
+# ---- Defaults ----
+BRANCH="main"
+REPO_URL="https://github.com/imbue-openhost/openhost.git"
+DOMAIN="lvh.me"
+CLAIM_TOKEN="openhost"
+HOST_PASSWORD="openhost"
+SSH_PUBKEY_FILE=""
+VERSION=""
+DISK_SIZE="20G"
+SWAP_SIZE_GB="2"
+MEM_MB="4096"
+CPUS="2"
+BUILD_TIMEOUT="1800"
+MAKE_OVA="true"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+OUTPUT_DIR="$SCRIPT_DIR/out"
+CACHE_DIR="$SCRIPT_DIR/cache"
+PROVISION_SCRIPT="$SCRIPT_DIR/../scripts/provision.sh"
+
+CLOUD_IMG_URL="https://cloud-images.ubuntu.com/noble/current/noble-server-cloudimg-amd64.img"
+
+# Print the leading comment block (everything from line 2 up to the first
+# non-comment line), stripped of the leading "# ".
+usage() { sed -n '2,/^[^#]/{/^#/s/^# \{0,1\}//p;}' "${BASH_SOURCE[0]}"; }
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --branch)       BRANCH="$2"; shift 2 ;;
+        --repo)         REPO_URL="$2"; shift 2 ;;
+        --provision-script) PROVISION_SCRIPT="$2"; shift 2 ;;
+        --domain)       DOMAIN="$2"; shift 2 ;;
+        --claim-token)  CLAIM_TOKEN="$2"; shift 2 ;;
+        --password)     HOST_PASSWORD="$2"; shift 2 ;;
+        --ssh-pubkey)   SSH_PUBKEY_FILE="$2"; shift 2 ;;
+        --version)      VERSION="$2"; shift 2 ;;
+        --disk-size)    DISK_SIZE="$2"; shift 2 ;;
+        --swap-size)    SWAP_SIZE_GB="$2"; shift 2 ;;
+        --mem)          MEM_MB="$2"; shift 2 ;;
+        --cpus)         CPUS="$2"; shift 2 ;;
+        --output-dir)   OUTPUT_DIR="$2"; shift 2 ;;
+        --no-ova)       MAKE_OVA="false"; shift ;;
+        --timeout)      BUILD_TIMEOUT="$2"; shift 2 ;;
+        -h|--help)      usage; exit 0 ;;
+        *)              echo "Unknown option: $1" >&2; usage; exit 1 ;;
+    esac
+done
+
+# ---- Portable helpers ----
+file_size() { stat -c%s "$1" 2>/dev/null || stat -f%z "$1"; }
+
+need() {
+    command -v "$1" >/dev/null 2>&1 || { echo "Error: '$1' not found. $2" >&2; exit 1; }
+}
+
+# ---- Dependency checks ----
+need qemu-img       "Install qemu-utils."
+need qemu-system-x86_64 "Install qemu-system-x86."
+need curl           "Install curl."
+need tar            "Install tar."
+
+# Seed-ISO builder: prefer cloud-localds, fall back to xorriso/genisoimage.
+SEED_TOOL=""
+if command -v cloud-localds >/dev/null 2>&1; then
+    SEED_TOOL="cloud-localds"
+elif command -v xorriso >/dev/null 2>&1; then
+    SEED_TOOL="xorriso"
+elif command -v genisoimage >/dev/null 2>&1; then
+    SEED_TOOL="genisoimage"
+else
+    echo "Error: need one of cloud-localds (cloud-image-utils), xorriso, or genisoimage." >&2
+    exit 1
+fi
+
+if [ -z "$VERSION" ]; then
+    VERSION="$(git -C "$SCRIPT_DIR" describe --tags --always --dirty 2>/dev/null || echo dev)"
+fi
+
+if [ ! -f "$PROVISION_SCRIPT" ]; then
+    echo "Error: provision script not found: $PROVISION_SCRIPT" >&2
+    exit 1
+fi
+
+mkdir -p "$OUTPUT_DIR" "$CACHE_DIR"
+WORK_DIR="$(mktemp -d)"
+trap 'rm -rf "$WORK_DIR"' EXIT
+
+echo "=== OpenHost VM image build ==="
+echo "  Version:      $VERSION"
+echo "  Repo/branch:  $REPO_URL @ $BRANCH"
+echo "  provision.sh: $PROVISION_SCRIPT (embedded)"
+echo "  Domain:       $DOMAIN   (HTTP-only, bound 0.0.0.0)"
+echo "  Claim token:  $CLAIM_TOKEN"
+echo "  Disk size:    $DISK_SIZE"
+echo "  Output dir:   $OUTPUT_DIR"
+echo ""
+
+# ---- 1. Fetch the Ubuntu cloud base image (cached) ----
+BASE_IMG="$CACHE_DIR/noble-server-cloudimg-amd64.img"
+if [ ! -f "$BASE_IMG" ]; then
+    echo "--- Downloading Ubuntu 24.04 cloud image ---"
+    curl -fSL "$CLOUD_IMG_URL" -o "$BASE_IMG.tmp"
+    mv "$BASE_IMG.tmp" "$BASE_IMG"
+else
+    echo "--- Using cached base image: $BASE_IMG ---"
+fi
+
+# ---- 2. Working disk = copy of base, grown to the target size ----
+DISK="$WORK_DIR/disk.qcow2"
+echo "--- Preparing working disk ($DISK_SIZE) ---"
+qemu-img convert -O qcow2 "$BASE_IMG" "$DISK"
+qemu-img resize "$DISK" "$DISK_SIZE"
+
+# ---- 3. Render cloud-init user-data and build the seed ISO ----
+echo "--- Building cloud-init seed ---"
+SSH_KEY_CONTENT=""
+if [ -n "$SSH_PUBKEY_FILE" ]; then
+    SSH_KEY_CONTENT="$(cat "$SSH_PUBKEY_FILE")"
+fi
+
+# Embed provision.sh and seal.sh as single-line base64 blobs. The base64
+# alphabet is [A-Za-z0-9+/=] — none of which collide with sed's '|' delimiter.
+PROVISION_B64="$(base64 -w0 "$PROVISION_SCRIPT")"
+SEAL_B64="$(base64 -w0 "$SCRIPT_DIR/seal.sh")"
+
+USER_DATA="$WORK_DIR/user-data"
+# Use a non-/ delimiter for sed since URLs contain slashes.
+sed \
+    -e "s|__REPO_URL__|$REPO_URL|g" \
+    -e "s|__BRANCH__|$BRANCH|g" \
+    -e "s|__DOMAIN__|$DOMAIN|g" \
+    -e "s|__CLAIM_TOKEN__|$CLAIM_TOKEN|g" \
+    -e "s|__HOST_PASSWORD__|$HOST_PASSWORD|g" \
+    -e "s|__SSH_AUTHORIZED_KEY__|$SSH_KEY_CONTENT|g" \
+    -e "s|__SWAP_SIZE_GB__|$SWAP_SIZE_GB|g" \
+    -e "s|__PROVISION_B64__|$PROVISION_B64|g" \
+    -e "s|__SEAL_B64__|$SEAL_B64|g" \
+    "$SCRIPT_DIR/cloud-init/user-data.tmpl" > "$USER_DATA"
+
+SEED_ISO="$WORK_DIR/seed.iso"
+case "$SEED_TOOL" in
+    cloud-localds)
+        cloud-localds "$SEED_ISO" "$USER_DATA" "$SCRIPT_DIR/cloud-init/meta-data"
+        ;;
+    xorriso)
+        xorriso -as genisoimage -output "$SEED_ISO" -volid cidata -joliet -rock \
+            "$USER_DATA" "$SCRIPT_DIR/cloud-init/meta-data"
+        ;;
+    genisoimage)
+        genisoimage -output "$SEED_ISO" -volid cidata -joliet -rock \
+            "$USER_DATA" "$SCRIPT_DIR/cloud-init/meta-data"
+        ;;
+esac
+
+# ---- 4. Boot once under QEMU: cloud-init provisions, then powers off ----
+echo "--- Provisioning (booting build VM; this takes a while) ---"
+# Persist the guest serial console (kernel + cloud-init + our sentinels) in the
+# output dir so a failed build is diagnosable after WORK_DIR is cleaned up.
+CONSOLE_LOG="$OUTPUT_DIR/build-console.log"
+: > "$CONSOLE_LOG"
+echo "  (guest console -> $CONSOLE_LOG)"
+
+KVM_ARGS=()
+if [ -e /dev/kvm ] && [ -w /dev/kvm ]; then
+    KVM_ARGS=(-enable-kvm -cpu host)
+else
+    echo "  (no writable /dev/kvm — falling back to slow TCG emulation)"
+    KVM_ARGS=(-cpu max)
+fi
+
+# -display none -monitor none: no VGA, no monitor on stdio (nothing waits on
+# stdin). The guest's ttyS0 console is captured to CONSOLE_LOG.
+set +e
+timeout "$BUILD_TIMEOUT" qemu-system-x86_64 \
+    "${KVM_ARGS[@]}" \
+    -m "$MEM_MB" \
+    -smp "$CPUS" \
+    -display none \
+    -monitor none \
+    -serial "file:$CONSOLE_LOG" \
+    -drive "file=$DISK,if=virtio,format=qcow2" \
+    -drive "file=$SEED_ISO,if=virtio,format=raw" \
+    -netdev user,id=n0 \
+    -device virtio-net-pci,netdev=n0 \
+    -no-reboot
+QEMU_RC=$?
+set -e
+
+if [ $QEMU_RC -eq 124 ]; then
+    echo "Error: build VM timed out after ${BUILD_TIMEOUT}s. Last console output:" >&2
+    tail -n 40 "$CONSOLE_LOG" >&2 || true
+    exit 1
+fi
+
+if grep -q "OPENHOST_IMAGE_BUILD_SUCCESS" "$CONSOLE_LOG"; then
+    echo "  Provisioning succeeded."
+elif grep -q "OPENHOST_IMAGE_BUILD_FAILED" "$CONSOLE_LOG"; then
+    echo "Error: provisioning reported failure. Last console output:" >&2
+    tail -n 60 "$CONSOLE_LOG" >&2 || true
+    exit 1
+else
+    echo "Error: no build sentinel found (VM powered off unexpectedly?). Console:" >&2
+    tail -n 60 "$CONSOLE_LOG" >&2 || true
+    exit 1
+fi
+
+# ---- 5. Compact the qcow2 (drop freed blocks) ----
+echo "--- Finalizing qcow2 ---"
+QCOW2_OUT="$OUTPUT_DIR/openhost-$VERSION-amd64.qcow2"
+qemu-img convert -O qcow2 -c "$DISK" "$QCOW2_OUT"
+
+echo ""
+echo "  QEMU image:   $QCOW2_OUT"
+
+# ---- 6. VirtualBox OVA (qcow2 -> streamOptimized VMDK -> OVF -> tar) ----
+if [ "$MAKE_OVA" = "true" ]; then
+    echo "--- Building VirtualBox OVA ---"
+    OVA_STAGE="$WORK_DIR/ova"
+    mkdir -p "$OVA_STAGE"
+    VMDK="$OVA_STAGE/openhost-$VERSION-amd64.vmdk"
+    qemu-img convert -O vmdk -o subformat=streamOptimized,adapter_type=lsilogic \
+        "$DISK" "$VMDK"
+
+    CAPACITY_BYTES="$(qemu-img info --output=json "$DISK" | sed -n 's/.*"virtual-size": *\([0-9]*\).*/\1/p' | head -n1)"
+    VMDK_BYTES="$(file_size "$VMDK")"
+    OVF="$OVA_STAGE/openhost-$VERSION-amd64.ovf"
+    VMDK_NAME="$(basename "$VMDK")"
+
+    cat > "$OVF" <<OVF_EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<Envelope xmlns="http://schemas.dmtf.org/ovf/envelope/1"
+          xmlns:ovf="http://schemas.dmtf.org/ovf/envelope/1"
+          xmlns:rasd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData"
+          xmlns:vssd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_VirtualSystemSettingData"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <References>
+    <File ovf:href="$VMDK_NAME" ovf:id="file1" ovf:size="$VMDK_BYTES"/>
+  </References>
+  <DiskSection>
+    <Info>Virtual disk information</Info>
+    <Disk ovf:capacity="$CAPACITY_BYTES" ovf:diskId="vmdisk1" ovf:fileRef="file1"
+          ovf:format="http://www.vmware.com/interfaces/specifications/vmdk.html#streamOptimized"/>
+  </DiskSection>
+  <NetworkSection>
+    <Info>Logical networks</Info>
+    <Network ovf:name="NAT">
+      <Description>NAT network</Description>
+    </Network>
+  </NetworkSection>
+  <VirtualSystem ovf:id="openhost-$VERSION">
+    <Info>OpenHost $VERSION</Info>
+    <Name>openhost-$VERSION</Name>
+    <OperatingSystemSection ovf:id="94">
+      <Info>Ubuntu 24.04 (64-bit)</Info>
+      <Description>Ubuntu_64</Description>
+    </OperatingSystemSection>
+    <VirtualHardwareSection>
+      <Info>Virtual hardware requirements</Info>
+      <System>
+        <vssd:ElementName>Virtual Hardware Family</vssd:ElementName>
+        <vssd:InstanceID>0</vssd:InstanceID>
+        <vssd:VirtualSystemType>virtualbox-2.2</vssd:VirtualSystemType>
+      </System>
+      <Item>
+        <rasd:Caption>$CPUS virtual CPU(s)</rasd:Caption>
+        <rasd:Description>Number of virtual CPUs</rasd:Description>
+        <rasd:ElementName>$CPUS virtual CPU(s)</rasd:ElementName>
+        <rasd:InstanceID>1</rasd:InstanceID>
+        <rasd:ResourceType>3</rasd:ResourceType>
+        <rasd:VirtualQuantity>$CPUS</rasd:VirtualQuantity>
+      </Item>
+      <Item>
+        <rasd:AllocationUnits>MegaBytes</rasd:AllocationUnits>
+        <rasd:Caption>$MEM_MB MB of memory</rasd:Caption>
+        <rasd:Description>Memory Size</rasd:Description>
+        <rasd:ElementName>$MEM_MB MB of memory</rasd:ElementName>
+        <rasd:InstanceID>2</rasd:InstanceID>
+        <rasd:ResourceType>4</rasd:ResourceType>
+        <rasd:VirtualQuantity>$MEM_MB</rasd:VirtualQuantity>
+      </Item>
+      <Item>
+        <rasd:Address>0</rasd:Address>
+        <rasd:Caption>sataController0</rasd:Caption>
+        <rasd:Description>SATA Controller</rasd:Description>
+        <rasd:ElementName>sataController0</rasd:ElementName>
+        <rasd:InstanceID>3</rasd:InstanceID>
+        <rasd:ResourceSubType>AHCI</rasd:ResourceSubType>
+        <rasd:ResourceType>20</rasd:ResourceType>
+      </Item>
+      <Item>
+        <rasd:AddressOnParent>0</rasd:AddressOnParent>
+        <rasd:Caption>disk1</rasd:Caption>
+        <rasd:Description>Disk Image</rasd:Description>
+        <rasd:ElementName>disk1</rasd:ElementName>
+        <rasd:HostResource>/disk/vmdisk1</rasd:HostResource>
+        <rasd:InstanceID>4</rasd:InstanceID>
+        <rasd:Parent>3</rasd:Parent>
+        <rasd:ResourceType>17</rasd:ResourceType>
+      </Item>
+      <Item>
+        <rasd:AutomaticAllocation>true</rasd:AutomaticAllocation>
+        <rasd:Caption>Ethernet adapter on 'NAT'</rasd:Caption>
+        <rasd:Connection>NAT</rasd:Connection>
+        <rasd:ElementName>Ethernet adapter on 'NAT'</rasd:ElementName>
+        <rasd:InstanceID>5</rasd:InstanceID>
+        <rasd:ResourceType>10</rasd:ResourceType>
+      </Item>
+    </VirtualHardwareSection>
+  </VirtualSystem>
+</Envelope>
+OVF_EOF
+
+    OVA_OUT="$OUTPUT_DIR/openhost-$VERSION-amd64.ova"
+    # OVA spec: the .ovf must be the first entry in the tar, disk(s) after.
+    tar -C "$OVA_STAGE" -cf "$OVA_OUT" "$(basename "$OVF")" "$VMDK_NAME"
+    echo "  VirtualBox:   $OVA_OUT"
+fi
+
+echo ""
+echo "=== Build complete ==="
+echo ""
+echo "Disk:   ships as ${DISK_SIZE} (floor). To install with more, size the VM's"
+echo "        virtual disk larger before first boot (or write to a bigger"
+echo "        physical disk) — the root filesystem grows to fill it on boot."
+echo ""
+echo "Boot it, then reach the dashboard at:  http://<vm-ip>:8080"
+echo "Claim URL:                             http://<vm-ip>:8080/setup?claim=$CLAIM_TOKEN"
+echo "Console login:                         user 'host', password '$HOST_PASSWORD'"
+echo ""
+echo "Find <vm-ip> from the VM console (\`ip addr\`) or your hypervisor's NAT/DHCP."

--- a/image/build.sh
+++ b/image/build.sh
@@ -8,8 +8,10 @@
 # uses. Output is a QEMU qcow2 and (optionally) a VirtualBox OVA.
 #
 # The image comes up out of the box in HTTP-only mode bound to 0.0.0.0, so the
-# dashboard is reachable at http://<vm-ip>:8080 with a known claim token and a
-# default console password. No domain, DNS, or TLS setup required to try it.
+# dashboard is reachable at http://<vm-ip>:8080 with a default console password.
+# No domain, DNS, or TLS setup required to try it. Claiming is open by default
+# (no token) since the image is private behind NAT and a shipped default token
+# would be a public non-secret; pass --claim-token to bake one instead.
 #
 # Usage (run on a Linux host with KVM):
 #   image/build.sh [options]
@@ -23,7 +25,10 @@
 #                         (default: this repo's scripts/provision.sh). Embedded
 #                         from the working tree, so the branch need not be pushed.
 #   --domain <domain>     App subdomain-routing domain baked in (default: lvh.me)
-#   --claim-token <tok>   Claim token baked in (default: openhost)
+#   --claim-token <tok>   Bake in a claim token gating /setup. Default: none —
+#                         claiming is open (claim_token_required=false), since
+#                         the image is private behind NAT. Set this to require a
+#                         token (e.g. for a customized image you distribute).
 #   --password <pw>       Default console password for the `host` user
 #                         (default: openhost)
 #   --ssh-pubkey <path>   Optional SSH public key file to authorize for `host`
@@ -53,7 +58,7 @@ set -euo pipefail
 BRANCH="main"
 REPO_URL="https://github.com/imbue-openhost/openhost.git"
 DOMAIN="lvh.me"
-CLAIM_TOKEN="openhost"
+CLAIM_TOKEN=""   # empty => open claim (no token required); set to bake a token
 HOST_PASSWORD="openhost"
 SSH_PUBKEY_FILE=""
 VERSION=""
@@ -141,7 +146,7 @@ echo "  Version:      $VERSION"
 echo "  Repo/branch:  $REPO_URL @ $BRANCH"
 echo "  provision.sh: $PROVISION_SCRIPT (embedded)"
 echo "  Domain:       $DOMAIN   (HTTP-only, bound 0.0.0.0)"
-echo "  Claim token:  $CLAIM_TOKEN"
+echo "  Claim:        ${CLAIM_TOKEN:+token '$CLAIM_TOKEN'}${CLAIM_TOKEN:-open (no token required)}"
 echo "  Disk size:    $DISK_SIZE"
 echo "  Output dir:   $OUTPUT_DIR"
 echo ""
@@ -169,6 +174,14 @@ if [ -n "$SSH_PUBKEY_FILE" ]; then
     SSH_KEY_CONTENT="$(cat "$SSH_PUBKEY_FILE")"
 fi
 
+# Claim mode: with no --claim-token, claiming is open (no token). Otherwise bake
+# the given token. This becomes the provision.sh argument in the seed.
+if [ -n "$CLAIM_TOKEN" ]; then
+    CLAIM_ARG="--claim-token \"$CLAIM_TOKEN\""
+else
+    CLAIM_ARG="--open-claim"
+fi
+
 # Embed provision.sh and seal.sh as single-line base64 blobs. The base64
 # alphabet is [A-Za-z0-9+/=] — none of which collide with sed's '|' delimiter.
 PROVISION_B64="$(base64 -w0 "$PROVISION_SCRIPT")"
@@ -180,7 +193,7 @@ sed \
     -e "s|__REPO_URL__|$REPO_URL|g" \
     -e "s|__BRANCH__|$BRANCH|g" \
     -e "s|__DOMAIN__|$DOMAIN|g" \
-    -e "s|__CLAIM_TOKEN__|$CLAIM_TOKEN|g" \
+    -e "s|__CLAIM_ARG__|$CLAIM_ARG|g" \
     -e "s|__HOST_PASSWORD__|$HOST_PASSWORD|g" \
     -e "s|__SSH_AUTHORIZED_KEY__|$SSH_KEY_CONTENT|g" \
     -e "s|__SWAP_SIZE_GB__|$SWAP_SIZE_GB|g" \
@@ -375,7 +388,11 @@ echo "        virtual disk larger before first boot (or write to a bigger"
 echo "        physical disk) — the root filesystem grows to fill it on boot."
 echo ""
 echo "Boot it, then reach the dashboard at:  http://<vm-ip>:8080"
-echo "Claim URL:                             http://<vm-ip>:8080/setup?claim=$CLAIM_TOKEN"
+if [ -n "$CLAIM_TOKEN" ]; then
+    echo "Claim URL:                             http://<vm-ip>:8080/setup?claim=$CLAIM_TOKEN"
+else
+    echo "Claim:                                 open — go to /setup (no token)"
+fi
 echo "Console login:                         user 'host', password '$HOST_PASSWORD'"
 echo ""
 echo "Find <vm-ip> from the VM console (\`ip addr\`) or your hypervisor's NAT/DHCP."

--- a/image/cloud-init/meta-data
+++ b/image/cloud-init/meta-data
@@ -1,0 +1,2 @@
+instance-id: openhost-image-build
+local-hostname: openhost

--- a/image/cloud-init/user-data.tmpl
+++ b/image/cloud-init/user-data.tmpl
@@ -1,0 +1,73 @@
+#cloud-config
+# cloud-init config baked into the seed ISO that drives the image build.
+# build.sh renders the __PLACEHOLDER__ values and hands this to a throwaway
+# QEMU boot: cloud-init runs provision.sh, we set a default console password,
+# then the VM powers itself off and its disk becomes the distributed image.
+#
+# Nothing here is user-facing at runtime — it only shapes the golden image.
+
+hostname: openhost
+manage_etc_hosts: true
+
+# SSH stays key-only: provision.sh's ansible hardening disables password auth.
+# The default password below is for CONSOLE login only (VM window / virsh
+# console), which is what makes the image usable with zero customization.
+ssh_pwauth: false
+
+write_files:
+  # provision.sh copies /root/.ssh/authorized_keys onto the `host` user with
+  # remote_src, which errors if the file is absent. Ubuntu cloud images only
+  # create it when a key is injected, so we always write it here. If the image
+  # builder passed --ssh-pubkey, its value lands here and grants `host` SSH
+  # access; otherwise it's empty and access is console-password-only.
+  - path: /root/.ssh/authorized_keys
+    permissions: '0600'
+    owner: root:root
+    content: |
+      __SSH_AUTHORIZED_KEY__
+
+  # The provisioner itself, embedded (base64) straight from the build host's
+  # working tree rather than fetched from GitHub. This means the image is built
+  # from exactly the checked-out provision.sh — no need to push the branch
+  # first. The openhost app code is still cloned from __REPO_URL__ @ __BRANCH__
+  # by provision.sh below.
+  - path: /root/provision.sh
+    permissions: '0755'
+    owner: root:root
+    encoding: b64
+    content: __PROVISION_B64__
+
+  # Seal (generalize) the golden image: strip build-VM identity so every install
+  # is unique, and install a boot-time service that grows root to fill the
+  # target disk. Embedded (base64) from image/seal.sh in the working tree.
+  - path: /root/seal.sh
+    permissions: '0755'
+    owner: root:root
+    encoding: b64
+    content: __SEAL_B64__
+
+runcmd:
+  # Provision, then seal. The SUCCESS sentinel only reaches the serial console
+  # if BOTH succeeded (cloud-init's runcmd does not stop on error on its own),
+  # so a green build is a provisioned AND generalized image. build.sh greps the
+  # captured console log for these sentinels to decide whether the build worked.
+  - |
+    set -x
+    chmod 700 /root/.ssh
+    ( bash /root/provision.sh \
+             --domain "__DOMAIN__" \
+             --repo "__REPO_URL__" \
+             --branch "__BRANCH__" \
+             --local-http-only \
+             --bind-host 0.0.0.0 \
+             --claim-token "__CLAIM_TOKEN__" \
+             --swap-size "__SWAP_SIZE_GB__" \
+        && echo 'host:__HOST_PASSWORD__' | chpasswd \
+        && bash /root/seal.sh \
+        && echo "OPENHOST_IMAGE_BUILD_SUCCESS" > /dev/console ) \
+      || echo "OPENHOST_IMAGE_BUILD_FAILED" > /dev/console
+  # Explicit, deterministic poweroff (both on success and failure) so build.sh's
+  # QEMU wait returns. We do this here rather than via cloud-init's power_state
+  # module because seal.sh above runs `cloud-init clean`, which tears down the
+  # very state that module relies on.
+  - poweroff

--- a/image/cloud-init/user-data.tmpl
+++ b/image/cloud-init/user-data.tmpl
@@ -60,7 +60,7 @@ runcmd:
              --branch "__BRANCH__" \
              --local-http-only \
              --bind-host 0.0.0.0 \
-             --claim-token "__CLAIM_TOKEN__" \
+             __CLAIM_ARG__ \
              --swap-size "__SWAP_SIZE_GB__" \
         && echo 'host:__HOST_PASSWORD__' | chpasswd \
         && bash /root/seal.sh \

--- a/image/seal.sh
+++ b/image/seal.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# seal.sh — Generalize the golden image at the end of the build boot.
+#
+# Runs once, as root, inside the build VM (invoked from cloud-init runcmd) after
+# provisioning succeeds. It strips build-VM identity so every install is unique,
+# and installs a boot-time service that grows the root filesystem to fill
+# whatever disk the image is installed onto.
+#
+# Why a systemd service instead of cloud-init: a distributed appliance boots
+# with NO cloud-init datasource (no seed ISO), so cloud-init does not run — its
+# growpart/ssh-keygen modules never fire. We must do this ourselves.
+
+set -euo pipefail
+
+# growpart lives in cloud-guest-utils. Present on Ubuntu cloud images, but make
+# sure — the boot service below depends on it. Network is up during the build.
+if ! command -v growpart >/dev/null 2>&1; then
+    apt-get update -qq
+    apt-get install -y -qq cloud-guest-utils
+fi
+
+# ---- boot-time prepare script: grow root + ensure SSH host keys ----
+install -d /usr/local/sbin
+cat > /usr/local/sbin/openhost-prepare <<'PREP'
+#!/usr/bin/env bash
+# Grow the root filesystem to fill its disk and regenerate SSH host keys if the
+# (generalized) image shipped without them. Idempotent — safe every boot.
+set -uo pipefail
+
+root_src=$(findmnt -no SOURCE / || true)          # /dev/vda1, /dev/sda1, /dev/nvme0n1p1, ...
+if [ -n "${root_src:-}" ] && [ -b "$root_src" ]; then
+    dev=$(basename "$root_src")                    # vda1
+    disk=$(lsblk -no PKNAME "$root_src" 2>/dev/null | head -n1)          # vda
+    partnum=$(cat "/sys/class/block/$dev/partition" 2>/dev/null || true) # 1
+    if [ -n "$disk" ] && [ -n "$partnum" ]; then
+        # growpart grows the (last) partition into free space; resize2fs then
+        # grows the mounted filesystem. Both no-op when already full.
+        growpart "/dev/$disk" "$partnum" || true
+        resize2fs "$root_src" || true
+    fi
+fi
+
+# The generalized image ships with no SSH host keys; make a unique set on first
+# boot so every install has its own server identity (and sshd can start).
+if ! ls /etc/ssh/ssh_host_*_key >/dev/null 2>&1; then
+    ssh-keygen -A || true
+fi
+PREP
+chmod 0755 /usr/local/sbin/openhost-prepare
+
+# ---- unit: run it early, before sshd and openhost come up ----
+cat > /etc/systemd/system/openhost-prepare.service <<'UNIT'
+[Unit]
+Description=Grow root filesystem and ensure SSH host keys
+After=local-fs.target
+Before=ssh.service openhost.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/local/sbin/openhost-prepare
+
+[Install]
+WantedBy=multi-user.target
+UNIT
+systemctl enable openhost-prepare.service
+
+# ---- strip build-VM identity ----
+# Unique machine-id per install: systemd regenerates an empty file on boot
+# (this path does not depend on cloud-init).
+truncate -s 0 /etc/machine-id
+rm -f /var/lib/dbus/machine-id
+
+# Never ship the build VM's SSH host keys — openhost-prepare regenerates them.
+rm -f /etc/ssh/ssh_host_*
+
+# Drop build-time cloud-init instance data + logs. Hygiene only; cloud-init
+# won't run on the distributed image anyway (no datasource).
+cloud-init clean --logs --seed || true
+
+# The embedded provisioner has done its job.
+rm -f /root/provision.sh

--- a/scripts/provision.sh
+++ b/scripts/provision.sh
@@ -28,6 +28,7 @@ LOCAL_HTTP_ONLY="false"
 BIND_HOST=""
 CLAIM_TOKEN=""
 SWAP_SIZE_GB=""
+OPEN_CLAIM="false"
 
 usage() {
     echo "Usage: $0 --domain <domain> [--branch <branch>] [--repo <repo-url>] [--local-http-only]"
@@ -49,6 +50,12 @@ usage() {
     echo "                      distributable image with a predictable claim URL."
     echo "  --swap-size         Swap file size in GiB (default: playbook default,"
     echo "                      16). Smaller values suit constrained local VMs."
+    echo "  --open-claim        Don't require a claim token at /setup"
+    echo "                      (claim_token_required = false). For a private,"
+    echo "                      unexposed instance (e.g. the distributed VM image"
+    echo "                      behind NAT) where a shipped default token would be"
+    echo "                      a public non-secret. Re-enable via config if you"
+    echo "                      later expose the instance on a network."
 }
 
 while [[ $# -gt 0 ]]; do
@@ -60,6 +67,7 @@ while [[ $# -gt 0 ]]; do
         --bind-host)        BIND_HOST="$2"; shift 2 ;;
         --claim-token)      CLAIM_TOKEN="$2"; shift 2 ;;
         --swap-size)        SWAP_SIZE_GB="$2"; shift 2 ;;
+        --open-claim)       OPEN_CLAIM="true"; shift ;;
         -h|--help)          usage; exit 0 ;;
         *)                  echo "Unknown option: $1"; usage; exit 1 ;;
     esac
@@ -138,6 +146,9 @@ if [ -n "$CLAIM_TOKEN" ]; then
 fi
 if [ -n "$SWAP_SIZE_GB" ]; then
     EXTRA_VARS+=(-e "swap_size_gb=$SWAP_SIZE_GB")
+fi
+if [ "$OPEN_CLAIM" = "true" ]; then
+    EXTRA_VARS+=(-e "claim_token_required=false")
 fi
 
 ansible-playbook ansible/local_setup.yml \

--- a/scripts/provision.sh
+++ b/scripts/provision.sh
@@ -25,6 +25,9 @@ BRANCH="main"
 REPO_URL="https://github.com/imbue-openhost/openhost.git"
 OPENHOST_DIR="/home/host/openhost"
 LOCAL_HTTP_ONLY="false"
+BIND_HOST=""
+CLAIM_TOKEN=""
+SWAP_SIZE_GB=""
 
 usage() {
     echo "Usage: $0 --domain <domain> [--branch <branch>] [--repo <repo-url>] [--local-http-only]"
@@ -37,6 +40,15 @@ usage() {
     echo "  --local-http-only   HTTP-only localhost mode: no TLS, CoreDNS, or Caddy."
     echo "                      For bringing an instance up before a public domain +"
     echo "                      DNS are ready.  Reach it via an SSH tunnel to :8080."
+    echo "  --bind-host         Router bind address (default: config default,"
+    echo "                      127.0.0.1). Pass 0.0.0.0 to reach :8080 over the LAN"
+    echo "                      (used by the VM image build so the dashboard is"
+    echo "                      reachable from the host machine)."
+    echo "  --claim-token       Fixed claim token to bake in (default: random,"
+    echo "                      printed at the end). Set a known value for a"
+    echo "                      distributable image with a predictable claim URL."
+    echo "  --swap-size         Swap file size in GiB (default: playbook default,"
+    echo "                      16). Smaller values suit constrained local VMs."
 }
 
 while [[ $# -gt 0 ]]; do
@@ -45,6 +57,9 @@ while [[ $# -gt 0 ]]; do
         --branch)           BRANCH="$2"; shift 2 ;;
         --repo)             REPO_URL="$2"; shift 2 ;;
         --local-http-only)  LOCAL_HTTP_ONLY="true"; shift ;;
+        --bind-host)        BIND_HOST="$2"; shift 2 ;;
+        --claim-token)      CLAIM_TOKEN="$2"; shift 2 ;;
+        --swap-size)        SWAP_SIZE_GB="$2"; shift 2 ;;
         -h|--help)          usage; exit 0 ;;
         *)                  echo "Unknown option: $1"; usage; exit 1 ;;
     esac
@@ -111,12 +126,27 @@ echo "  Public IP: ${PUBLIC_IP:-unknown}"
 # ---- Run ansible (but skip the service start — we need ACME key first) ----
 echo "--- Running setup playbook ---"
 cd "$OPENHOST_DIR"
+
+# Optional passthrough vars. Only add the -e when set, so we don't override the
+# config template's defaults (e.g. bind_host defaults to 127.0.0.1) with empties.
+EXTRA_VARS=()
+if [ -n "$BIND_HOST" ]; then
+    EXTRA_VARS+=(-e "bind_host=$BIND_HOST")
+fi
+if [ -n "$CLAIM_TOKEN" ]; then
+    EXTRA_VARS+=(-e "claim_token=$CLAIM_TOKEN")
+fi
+if [ -n "$SWAP_SIZE_GB" ]; then
+    EXTRA_VARS+=(-e "swap_size_gb=$SWAP_SIZE_GB")
+fi
+
 ansible-playbook ansible/local_setup.yml \
     -e "domain=$DOMAIN" \
     -e "public_ip=${PUBLIC_IP:-127.0.0.1}" \
     -e "acme_directory_url=https://acme-v02.api.letsencrypt.org/directory" \
     -e "local_http_only=$LOCAL_HTTP_ONLY" \
     -e "skip_service_start=true" \
+    "${EXTRA_VARS[@]}" \
     --connection=local \
     -i "localhost,"
 


### PR DESCRIPTION
Linear: [OH-275](https://linear.app/imbue/issue/OH-275/build-vm-image-that-we-can-distribute-for-easy-self-host-installs)

Combines the VM-image build and the GitHub release workflow into one PR.

## `image/` — the image builder

`image/build.sh` boots the Ubuntu 24.04 cloud image once under KVM with a cloud-init seed that runs the existing, tested `scripts/provision.sh`, then freezes the disk into a **qcow2** (QEMU) and **OVA** (VirtualBox), x86_64. No Packer — it exercises the real deploy path, not an offline-chroot approximation.

**Zero-config first boot:** HTTP-only, bound `0.0.0.0` — no TLS/CoreDNS/Caddy, **no domain required**. Boot → dashboard at `http://<vm-ip>:8080`.

**Open claiming by default (no token).** A fixed token baked into every image is a public non-secret — friction without protection. Since the image is private behind NAT (nothing reaches `:8080` without the user's own port-forward), the image sets `claim_token_required=false`. `claim_token_required` is now a config var (default `true`, so **no change for any existing deploy**); pass `--claim-token` to bake one for a customized image.

**No SSH key baked in.** Access is console-only until the owner adds their own key (`--ssh-pubkey` is opt-in for custom builds).

**Grow-to-fill.** `image/seal.sh` installs `openhost-prepare.service`, a systemd oneshot that grows the root filesystem to fill whatever disk the image is installed onto (device auto-detected → works on QEMU `vda` and VirtualBox `sda`). "Install size" = the disk you give the VM; default floor 20G. Done with systemd, not cloud-init, because a datasource-less appliance never runs cloud-init. It also generalizes the image: fresh machine-id and regenerated SSH host keys per install.

`scripts/provision.sh` gains `--bind-host`, `--claim-token`, `--swap-size`, and `--open-claim` passthroughs so the build reuses the single tested provisioning path.

## `.github/workflows/image-release.yml` — the release flow

Manually-triggered (`workflow_dispatch`) job: takes a git tag, runs `image/build.sh` for it, and publishes the qcow2 + OVA as a GitHub release (draft by default). Shells straight out to the build script — no separate recipe.

> Note: GitHub-hosted `ubuntu-latest` may not expose `/dev/kvm`; the workflow warns and falls back to TCG, which is much slower. Worth confirming KVM availability (or a larger/self-hosted runner) on the first real run.

## Verification (on a KVM host, booting the produced image fresh)

| Check | 60G disk (resized) | 20G native floor |
|---|---|---|
| Root FS grew | 58G ✅ | 19G (no-op) ✅ |
| `openhost-prepare` | success ✅ | success ✅ |
| SSH host keys regenerated | ✅ | ✅ |
| Fresh machine-id | ✅ | ✅ |
| Dashboard health | 200 ✅ | 200 ✅ |

Open-claim verified through the real ansible render: unset → `claim_token_required = true`, `-e claim_token_required=false` → `false`.

## Not included (intentional)

- No binary artifacts committed — the release workflow publishes versioned, downloadable images.
- macOS HVF build path and the app-subdomain DNS/UX polish are follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)