### PR TITLE
ci: manual workflow to build VM images + cut a release (OH-275)

### DIFF
--- a/.github/workflows/image-release.yml
+++ b/.github/workflows/image-release.yml
@@ -1,0 +1,94 @@
+name: image-release
+
+# Build the OpenHost VM images (qcow2 + optional VirtualBox OVA) for a chosen
+# git tag and publish them as a GitHub release. Manually triggered for now —
+# run it from the Actions tab once the version tag has been pushed.
+#
+# The build recipe (image/build.sh) boots the tag's provision.sh once under
+# QEMU/KVM and freezes the result; the app code baked into the image is cloned
+# from this repo at the same tag (build.sh --branch also accepts a tag ref).
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Git tag to build and release (e.g. v0.1.4). Must already exist and be pushed."
+        required: true
+        type: string
+      make_ova:
+        description: "Also build the VirtualBox OVA alongside the qcow2"
+        required: false
+        type: boolean
+        default: true
+      draft:
+        description: "Publish the release as a draft (review before it goes public)"
+        required: false
+        type: boolean
+        default: true
+
+# gh release create needs write access to create the release and upload assets.
+permissions:
+  contents: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    # The build boots a VM and provisions it end to end; give it plenty of room.
+    # build.sh has its own 30-min boot timeout inside this budget.
+    timeout-minutes: 90
+    steps:
+      - name: Check out the release tag
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.tag }}
+          fetch-depth: 0
+
+      - name: Install image build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y qemu-system-x86 qemu-utils cloud-image-utils
+
+      - name: Report KVM availability
+        run: |
+          if [ -w /dev/kvm ]; then
+            echo "KVM is available — build will use hardware acceleration."
+          else
+            echo "::warning::/dev/kvm not writable; build falls back to slow TCG emulation."
+          fi
+
+      - name: Build VM images
+        run: |
+          args=(--branch "${{ inputs.tag }}" --version "${{ inputs.tag }}")
+          if [ "${{ inputs.make_ova }}" != "true" ]; then
+            args+=(--no-ova)
+          fi
+          image/build.sh "${args[@]}"
+
+      - name: List built artifacts
+        run: ls -lh image/out/
+
+      - name: Publish GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          assets=(image/out/openhost-*.qcow2)
+          for ova in image/out/openhost-*.ova; do
+            [ -e "$ova" ] && assets+=("$ova")
+          done
+
+          create_args=(
+            "${{ inputs.tag }}"
+            --title "OpenHost ${{ inputs.tag }}"
+            --notes "OpenHost VM images for ${{ inputs.tag }}.
+
+          - \`*.qcow2\` — QEMU/KVM/libvirt (and most cloud importers)
+          - \`*.ova\` — VirtualBox / VMware
+
+          Boot it, then reach the dashboard at \`http://<vm-ip>:8080\`.
+          See \`image/build.sh\` and \`docs/\` for defaults (claim token, console login)."
+          )
+          if [ "${{ inputs.draft }}" = "true" ]; then
+            create_args+=(--draft)
+          fi
+
+          gh release create "${create_args[@]}" "${assets[@]}"


### PR DESCRIPTION
Stacked on #? (the VM image build PR, branch `kilo/sculptor/sepia-lion`).

Adds `.github/workflows/image-release.yml` — a `workflow_dispatch` (manually
triggered) action that:

1. Checks out a chosen, already-pushed git tag.
2. Builds the OpenHost VM images for that tag via `image/build.sh` (qcow2 +
   optional VirtualBox OVA) on a KVM-capable `ubuntu-latest` runner.
3. Publishes a GitHub release for the tag with the images attached.

### Inputs
- `tag` (required) — git tag to build and release, e.g. `v0.1.4`. Baked into the
  image as both `--branch` (app code cloned at that ref) and `--version`.
- `make_ova` (default `true`) — also build the VirtualBox OVA.
- `draft` (default `true`) — publish the release as a draft so it can be reviewed
  before going public.

### Notes
- Uses the built-in `GITHUB_TOKEN` with `contents: write`; no extra secrets.
- `timeout-minutes: 90` wraps `build.sh`'s own 30-min boot timeout.
- "Manually triggered for now" — a future change could add `on: push: tags:` to
  auto-run on tag pushes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)