### PR TITLE
ci: enable KVM on the image-release runner (OH-275)

### DIFF
--- a/.github/workflows/image-release.yml
+++ b/.github/workflows/image-release.yml
@@ -48,13 +48,29 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y qemu-system-x86 qemu-utils cloud-image-utils
 
-      - name: Report KVM availability
+      - name: Enable KVM access
         run: |
-          if [ -w /dev/kvm ]; then
-            echo "KVM is available — build will use hardware acceleration."
-          else
-            echo "::warning::/dev/kvm not writable; build falls back to slow TCG emulation."
+          # GitHub's 2-vCPU+ Linux runners (incl. ubuntu-latest) ship /dev/kvm,
+          # but it's root:kvm 0660 — not writable by the runner user. Grant
+          # access via udev so build.sh uses hardware acceleration instead of
+          # the (much slower) TCG fallback. Same rule android-emulator-runner
+          # uses. See https://github.com/actions/runner-images/issues/7541.
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' \
+            | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+
+      - name: Require KVM
+        run: |
+          ls -l /dev/kvm || true
+          if [ ! -w /dev/kvm ]; then
+            echo "::error::/dev/kvm is not usable. The build needs KVM; a TCG"
+            echo "fallback would exceed the boot timeout, so failing fast. If this"
+            echo "persists, the runner may lack nested virtualization — use a"
+            echo "larger runner or a self-hosted KVM runner."
+            exit 1
           fi
+          echo "KVM available — build will use hardware acceleration."
 
       - name: Build VM images
         run: |


### PR DESCRIPTION
Follow-up to #333.

The `image-release` workflow ran under slow TCG emulation because `/dev/kvm` on GitHub's Linux runners is `root:kvm 0660` — **present but not writable by the runner user**. Under TCG the full provision (apt + pixi + podman) would exceed `build.sh`'s 30-min boot timeout and never produce an image.

Fix: add a udev rule to grant KVM access before the build (the same rule [ReactiveCircus/android-emulator-runner](https://github.com/ReactiveCircus/android-emulator-runner) uses), and **fail fast** with a clear message if KVM still isn't usable rather than grinding under TCG until the timeout.

GitHub's 2-vCPU+ Linux runners have provided `/dev/kvm` since the [2024-04-02 hardware-acceleration change](https://github.blog/changelog/2024-04-02-github-actions-hardware-accelerated-android-virtualization-now-available/); the device is there, it just needs the permission grant (same root cause we hit on the local build box). Ref: [actions/runner-images#7541](https://github.com/actions/runner-images/issues/7541).

🤖 Generated with [Claude Code](https://claude.com/claude-code)