### PR TITLE
Clarify local HTTP domain wording

### DIFF
--- a/compute_space/src/compute_space/tests/test_dashboard_title.py
+++ b/compute_space/src/compute_space/tests/test_dashboard_title.py
@@ -144,6 +144,10 @@ def test_settings_renders_domains_section(cfg: Any) -> None:
     assert settings_resp.status_code == 200
     assert ">Domains</h2>" in settings_resp.text
     assert 'onclick="addDomain()"' in settings_resp.text
+    assert "Local (HTTP)" in settings_resp.text
+    assert "Local mDNS" not in settings_resp.text
+    assert "Arrange name resolution for local domains" in settings_resp.text
+    assert "<th>Domain</th><th>Scheme</th><th>Type</th>" in settings_resp.text
     assert "js/domains.js" in settings_resp.text
 
 

--- a/compute_space/src/compute_space/tests/test_domains_api.py
+++ b/compute_space/src/compute_space/tests/test_domains_api.py
@@ -216,7 +216,7 @@ def test_add_mdns_with_tls_rejected(cfg: Any, client: TestClient[Litestar]) -> N
     client.cookies.update(_auth_cookie(cfg.db_path))
     resp = client.post("/api/domains", json={"name": "myhost.local", "tls": True, "mdns": True})
     assert resp.status_code == 400
-    assert resp.json()["detail"] == "mDNS (.local) domains are served over http; set tls=false"
+    assert resp.json()["detail"] == "Local domains are served over HTTP; set tls=false"
 
 
 # --- remove -------------------------------------------------------------------------

--- a/compute_space/src/compute_space/web/routes/api/domains.py
+++ b/compute_space/src/compute_space/web/routes/api/domains.py
@@ -151,7 +151,7 @@ def _validate_new_domain(config: Config, name: str, tls: bool, mdns: bool, db: s
     if not _DOMAIN_RE.match(name):
         return "invalid domain name"
     if mdns and tls:
-        return "mDNS (.local) domains are served over http; set tls=false"
+        return "Local domains are served over HTTP; set tls=false"
     if any(d.name_no_port == name for d in effective_domains(db)):
         return "domain is already configured"
     return None

--- a/compute_space/src/compute_space/web/static/js/domains.js
+++ b/compute_space/src/compute_space/web/static/js/domains.js
@@ -51,7 +51,7 @@ function renderDomains(domains) {
         d.is_primary ? dom.el('span', {class: 'muted', text: ' (primary)'}) : null,
       ]),
       dom.el('td', {text: d.scheme}),
-      dom.el('td', {text: d.mdns ? 'mDNS (.local)' : 'Public DNS'}),
+      dom.el('td', {text: d.tls ? 'Public' : 'Local'}),
       dom.el('td', null, domainCertCell(d)),
       dom.el('td', {class: 'col-actions'}, d.is_primary
         ? dom.el('span', {class: 'muted', text: '—'})

--- a/compute_space/src/compute_space/web/templates/settings.html
+++ b/compute_space/src/compute_space/web/templates/settings.html
@@ -98,8 +98,9 @@
   <div class="panel">
     <p class="hint">Hostnames this instance answers on. The primary is set at provisioning. Add a
       secondary <strong>public</strong> domain (its DNS must be delegated to this instance — it then
-      acquires a TLS certificate automatically) or a local <code>.local</code> name served over plain
-      HTTP. Removing a domain takes effect immediately; the primary can't be removed.</p>
+      acquires a TLS certificate automatically) or a hostname served locally over plain HTTP, such
+      as a <code>.local</code> or tailnet-only name. Arrange name resolution for local domains
+      separately. Removing a domain takes effect immediately; the primary can't be removed.</p>
 
     <div class="field-row field-row--add">
       <label class="field" for="domain-name">
@@ -110,7 +111,7 @@
         <span>Type</span>
         <select id="domain-type">
           <option value="public">Public (HTTPS)</option>
-          <option value="mdns">Local mDNS (.local, HTTP)</option>
+          <option value="mdns">Local (HTTP)</option>
         </select>
       </label>
       {{ button("Add domain", variant="primary", id="add-domain-btn", onclick="addDomain()", disabled=true) }}
@@ -120,7 +121,7 @@
     <div class="table-scroll" id="domains-table-wrap" hidden>
       <table>
         <thead><tr>
-          <th>Domain</th><th>Scheme</th><th>Discovery</th><th>Certificate</th>
+          <th>Domain</th><th>Scheme</th><th>Type</th><th>Certificate</th>
           <th class="col-actions">Actions</th>
         </tr></thead>
         <tbody id="domains-body"></tbody>


### PR DESCRIPTION
Replaces reductive mDNS labels with the consistent Local (HTTP) wording, renders non-TLS domains as Local, and clarifies that operators arrange local name resolution. Internal mdns behavior is unchanged.