### PR TITLE
VM-image setup docs + public/TLS image builds

### DIFF
--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -7,6 +7,7 @@
 
 - [Deploying on a dedicated machine](setup/dedicated_machine.md)
 - [Deploying on a shared machine](setup/shared_machine.md)
+- [Building your own VM image](setup/building_a_vm_image.md)
 - [Exposing a server with a static IP](setup/static_ip.md)
 - [Exposing a home server](setup/home_network.md)
 

--- a/docs/src/setup/building_a_vm_image.md
+++ b/docs/src/setup/building_a_vm_image.md
@@ -1,0 +1,72 @@
+# Building your own VM image
+
+The [release images](./shared_machine.md#part-1-download-and-run-the-vm-image) are produced by `image/build.sh` in the [Cloud in a Bottle repo](https://github.com/cloud-in-a-bottle/cloud-in-a-bottle). Build your own to bake in a custom branch, an SSH key, or a claim token — or, with `--public`, [a TLS image for your own domain](#building-a-public-tls-image). The output is the same qcow2 + OVA pair the releases ship, which you then boot and claim exactly as in [Deploying on a shared machine](./shared_machine.md#part-1-download-and-run-the-vm-image).
+
+## What you need
+
+**To build the image**, a Linux host with:
+
+- `qemu-system-x86_64` and `qemu-img` (the `qemu-system-x86` and `qemu-utils` packages).
+- A seed-ISO builder: `cloud-localds` (from `cloud-image-utils`), or `xorriso`, or `genisoimage`.
+- `curl` and `tar`.
+- (recommended) KVM (`/dev/kvm`) — without it the build boot falls back to slow TCG emulation.
+
+**To run the image it produces** (this applies to the release images too):
+
+- About 8 GB of RAM and 4 cores.
+- Free disk - we recommend at least 20G.
+
+## Build it
+
+Run from a checkout of the openhost repo, on the Linux/KVM host:
+
+```bash
+image/build.sh
+```
+
+With no options this builds `main` into `image/out/openhost-<version>-amd64.qcow2` and a matching `.ova`, in HTTP-only mode on `lvh.me`, with open claiming and a default console password. The build boots a VM and runs the full provisioning, so it takes a while; the guest console is streamed to `image/out/build-console.log` so a failed build is diagnosable.
+
+### Common options
+
+These customize the image in any mode:
+
+| Option | Purpose |
+| --- | --- |
+| `--domain <domain>` | subdomain-routing domain baked in (default `lvh.me`) |
+| `--claim-token <tok>` | bake in a specific `/setup` token instead of the default |
+| `--ssh-pubkey <path>` | authorize an SSH key for `host` (SSH is key-only; otherwise console-only) |
+
+Run `image/build.sh --help` for the full set — repo and branch, disk and resource sizing, output paths, and more. For example, a custom HTTP-only image from a branch, with your SSH key:
+
+```bash
+image/build.sh \
+  --branch my-feature \
+  --ssh-pubkey ~/.ssh/id_ed25519.pub
+```
+
+### Building a public (TLS) image
+
+By default the image is HTTP-only — the easy, behind-NAT on-ramp. Pass `--public` to bake a TLS image instead: one provisioned with CoreDNS, Caddy, and Let's Encrypt for `--domain`, ready to serve at `https://<domain>` once it's on the network.
+
+| Option | Purpose |
+| --- | --- |
+| `--public` | build a TLS image (claiming is token-gated) |
+| `--public-ip <ip>` | your public IPv4, baked in for the DNS records CoreDNS serves (**required** with `--public`) |
+| `--acme-key <path>` | a pre-registered ACME account key to bake in (optional) |
+| `--acme-email <email>` | email for the account the build registers, when you don't pass `--acme-key` |
+
+Without `--acme-key`, the build generates and registers a fresh Let's Encrypt account key. Open claiming is refused on a reachable instance, so a public image is always token-gated — pass `--claim-token` for a known value, or let the build print a random one.
+
+```bash
+image/build.sh \
+  --public \
+  --domain host.example.com \
+  --public-ip 203.0.113.4 \
+  --ssh-pubkey ~/.ssh/id_ed25519.pub
+```
+
+The build validates provisioning, but the TLS certificate is issued later, at your site — the build VM has no DNS pointing at it. Boot the image where its domain resolves to `--public-ip`, [delegate DNS and open ports 53 / 80 / 443](./shared_machine.md#part-2-taking-it-public), and the instance acquires its wildcard certificate and comes up at `https://host.example.com/`.
+
+## Run it
+
+Boot the resulting qcow2 (QEMU / KVM / libvirt) or `.ova` (VirtualBox). An HTTP-only image is reached and claimed exactly like a release image — see [Deploying on a shared machine](./shared_machine.md#part-1-download-and-run-the-vm-image). A `--public` image instead follows [taking it public](./shared_machine.md#part-2-taking-it-public): delegate DNS, open the ports, then claim at `https://<domain>`. Either way, the build prints the dashboard URL, the claim mode, and the console login when it finishes.

--- a/docs/src/setup/building_a_vm_image.md
+++ b/docs/src/setup/building_a_vm_image.md
@@ -48,6 +48,8 @@ image/build.sh \
 
 By default the image is HTTP-only and not suitable for exposing publicly. Pass `--public` to bake a TLS image instead: one provisioned with CoreDNS, Caddy, and Let's Encrypt for `--domain`, ready to serve at `https://<domain>` once it's on the network.
 
+You don't have to build a public image to go public — you can take an HTTP-only instance public in place by adding your domain from the dashboard, per [Exposing a server with a static IP](./static_ip.md). The reason to build with `--public` is that it provisions for your domain from the start, so that domain is the instance's **primary** — whereas converting a running HTTP-only instance leaves the install-time domain as the primary.
+
 | Option | Purpose |
 | --- | --- |
 | `--public` | build a TLS image (claiming is token-gated) |

--- a/docs/src/setup/building_a_vm_image.md
+++ b/docs/src/setup/building_a_vm_image.md
@@ -24,7 +24,7 @@ Run from a checkout of the openhost repo, on the Linux/KVM host:
 image/build.sh
 ```
 
-With no options this builds `main` into `image/out/openhost-<version>-amd64.qcow2` and a matching `.ova`, in HTTP-only mode on `lvh.me`, with open claiming and a default console password. The build boots a VM and runs the full provisioning, so it takes a while; the guest console is streamed to `image/out/build-console.log` so a failed build is diagnosable.
+With no options this builds `main` into `image/out/openhost-<version>-amd64.qcow2` and a matching `.ova`, in HTTP-only mode on `lvh.me`, with no claim token and a default console password. The build boots a VM and runs the full provisioning, so it takes a while; Logs go into `image/out/build-console.log`.
 
 ### Common options
 
@@ -46,7 +46,7 @@ image/build.sh \
 
 ### Building a public (TLS) image
 
-By default the image is HTTP-only — the easy, behind-NAT on-ramp. Pass `--public` to bake a TLS image instead: one provisioned with CoreDNS, Caddy, and Let's Encrypt for `--domain`, ready to serve at `https://<domain>` once it's on the network.
+By default the image is HTTP-only and not suitable for exposing publicly. Pass `--public` to bake a TLS image instead: one provisioned with CoreDNS, Caddy, and Let's Encrypt for `--domain`, ready to serve at `https://<domain>` once it's on the network.
 
 | Option | Purpose |
 | --- | --- |
@@ -65,8 +65,8 @@ image/build.sh \
   --ssh-pubkey ~/.ssh/id_ed25519.pub
 ```
 
-The build validates provisioning, but the TLS certificate is issued later, at your site — the build VM has no DNS pointing at it. Boot the image where its domain resolves to `--public-ip`, [delegate DNS and open ports 53 / 80 / 443](./shared_machine.md#part-2-taking-it-public), and the instance acquires its wildcard certificate and comes up at `https://host.example.com/`.
+The build does not get a TLS certificate issued - That can only happen once it's running and has DNS pointing at it. Once it boots with the right public ip `--public-ip`, delegate DNS and open ports 53 / 80 / 443 to it — see [Exposing a server with a static IP](./static_ip.md) or [Exposing a home server](./home_network.md) — and the instance will acquire its wildcard certificate and start serving at `https://host.example.com/`.
 
 ## Run it
 
-Boot the resulting qcow2 (QEMU / KVM / libvirt) or `.ova` (VirtualBox). An HTTP-only image is reached and claimed exactly like a release image — see [Deploying on a shared machine](./shared_machine.md#part-1-download-and-run-the-vm-image). A `--public` image instead follows [taking it public](./shared_machine.md#part-2-taking-it-public): delegate DNS, open the ports, then claim at `https://<domain>`. Either way, the build prints the dashboard URL, the claim mode, and the console login when it finishes.
+Boot the resulting qcow2 (QEMU / KVM / libvirt) or `.ova` (VirtualBox). An HTTP-only image is reached and claimed exactly like a release image — see [Deploying on a shared machine](./shared_machine.md#part-1-download-and-run-the-vm-image). A `--public` image instead needs its networking in place first (delegate DNS, open the ports, as above), then you claim at `https://<domain>`. Either way, the build prints the dashboard URL, the claim mode, and the console login when it finishes.

--- a/docs/src/setup/building_a_vm_image.md
+++ b/docs/src/setup/building_a_vm_image.md
@@ -62,12 +62,12 @@ Without `--acme-key`, the build generates and registers a fresh Let's Encrypt ac
 ```bash
 image/build.sh \
   --public \
-  --domain host.example.com \
+  --domain mycooldomain.com \
   --public-ip 203.0.113.4 \
   --ssh-pubkey ~/.ssh/id_ed25519.pub
 ```
 
-The build does not get a TLS certificate issued - That can only happen once it's running and has DNS pointing at it. Once it boots with the right public ip `--public-ip`, delegate DNS and open ports 53 / 80 / 443 to it — see [Exposing a server with a static IP](./static_ip.md) or [Exposing a home server](./home_network.md) — and the instance will acquire its wildcard certificate and start serving at `https://host.example.com/`.
+The build does not get a TLS certificate issued - That can only happen once it's running and has DNS pointing at it. Once it boots with the right public ip `--public-ip`, delegate DNS and open ports 53 / 80 / 443 to it — see [Exposing a server with a static IP](./static_ip.md) or [Exposing a home server](./home_network.md) — and the instance will acquire its wildcard certificate and start serving at `https://mycooldomain.com/`.
 
 ## Run it
 

--- a/docs/src/setup/shared_machine.md
+++ b/docs/src/setup/shared_machine.md
@@ -11,8 +11,8 @@ This page is in two parts. Part 1 gets a working instance running inside a VM fr
 The release image is a self-contained Ubuntu 24.04 appliance with Cloud in a Bottle already provisioned by the same `scripts/provision.sh` a production deploy uses. It is deliberately configured for the easy on-ramp:
 
 - **HTTP only, no domain required.** The router binds `0.0.0.0:8080` with no TLS, CoreDNS, or Caddy in front of it. Boot the VM and the dashboard is at `http://<vm-ip>:8080/`.
-- **Open claiming.** There is no claim token to copy around — the first person to reach the dashboard claims the instance. This is safe precisely *because* the appliance sits behind your NAT: nothing reaches `:8080` unless you forward a port to it yourself.
-- **No baked-in SSH key.** Access is console-only until you add your own key. The image ships no credentials shared across every download.
+- **No claim token** There is no claim token to copy around — the first person to reach the dashboard claims the instance. This is safe only because the VM sits behind your NAT: nothing reaches `:8080` unless you forward a port to it yourself.
+- **No baked-in SSH key.** Access is console-only until you add your own key. The image ships no shared credentials.
 - **Grow-to-fill disk.** On first boot a systemd oneshot (`openhost-prepare.service`) expands the root filesystem to fill whatever disk you gave the VM (20 GB floor), regenerates the SSH host keys, and assigns a fresh machine-id — so every install is distinct.
 
 Two formats are published per release, both x86_64:

--- a/docs/src/setup/shared_machine.md
+++ b/docs/src/setup/shared_machine.md
@@ -4,245 +4,57 @@ Use this path when installing on a machine that you don't necessarily want to de
 
 Cloud in a Bottle wants to install directly on the host. It runs various system services, sets system-level configuration, and expects to be able to manage the system ongoing. So instead of installing on the host, you give it its own Ubuntu VM to live inside. Everything it does stays inside the VM's disk image, and it can't access your host system. If you want to install on a dedicated machine, [see this guide instead](./dedicated_machine.md).
 
-This guide starts by setting up a local-network-only instance. The local instance lives at `http://lvh.me:8080`, with apps at `http://<app>.lvh.me:8080`. `lvh.me` is a public DNS name that resolves to `127.0.0.1`, wildcard subdomains included. Cloud in a Bottle routes apps by subdomain, so this gives you working app URLs with no DNS setup on your part.
+This page is in two parts. Part 1 gets a working instance running inside a VM from our pre-built image. [Part 2](#part-2-taking-it-public) covers the networking and config needed to put it on the public internet at your own domain.
 
-When you're ready to take your instance public, see [going public](#going-public) at the end of this doc.
+## Part 1: download and run the VM image
 
-## What the VM needs
+The release image is a self-contained Ubuntu 24.04 appliance with Cloud in a Bottle already provisioned by the same `scripts/provision.sh` a production deploy uses. It is deliberately configured for the easy on-ramp:
 
-Cloud in a Bottle does not care which hypervisor you use. QEMU, UTM, VirtualBox, VMware, Hyper-V, libvirt/virt-manager, Multipass, and Proxmox all work. The VM just has to provide:
+- **HTTP only, no domain required.** The router binds `0.0.0.0:8080` with no TLS, CoreDNS, or Caddy in front of it. Boot the VM and the dashboard is at `http://<vm-ip>:8080/`.
+- **Open claiming.** There is no claim token to copy around — the first person to reach the dashboard claims the instance. This is safe precisely *because* the appliance sits behind your NAT: nothing reaches `:8080` unless you forward a port to it yourself.
+- **No baked-in SSH key.** Access is console-only until you add your own key. The image ships no credentials shared across every download.
+- **Grow-to-fill disk.** On first boot a systemd oneshot (`openhost-prepare.service`) expands the root filesystem to fill whatever disk you gave the VM (20 GB floor), regenerates the SSH host keys, and assigns a fresh machine-id — so every install is distinct.
 
-- Ubuntu 24.04.
-- Key-based SSH from your machine, as a user with sudo.
-- The VM's port 8080 reachable at `127.0.0.1:8080` on your machine, via a port forward in the VM host's NAT config or an SSH tunnel.
-- About 8 GB of RAM, 4 cores, and 40 GB of disk.
-- An ext4, xfs, or btrfs root filesystem. App containers need idmapped mounts, and install fails early with a clear error otherwise.
+Two formats are published per release, both x86_64:
 
-[Part 1](#part-1-build-an-ubuntu-vm-with-qemu) is a QEMU recipe you can follow verbatim if you do not already have a preferred way to make VMs. Otherwise build the VM however you like and skip to [Part 2](#part-2-install-cloud-in-a-bottle-into-the-vm).
+| File     | Use with                                |
+| -------- | --------------------------------------- |
+| `.qcow2` | QEMU / KVM / libvirt (`virt-manager`)   |
+| `.ova`   | VirtualBox (and most other hypervisors) |
 
-## On your machine
+### Download
 
-- Ansible: `uv tool install ansible-core`, or `pipx install ansible-core`. It runs on your machine, never inside the VM.
-- A checkout of Cloud in a Bottle, for the playbooks: `git clone https://github.com/cloud-in-a-bottle/cloud-in-a-bottle.git ~/openhost`
-- An SSH keypair. Make one if you do not have one: `ssh-keygen -t ed25519 -f ~/.ssh/id_ed25519 -N ""`
+Grab the latest `.qcow2` or `.ova` from the [releases page](https://github.com/cloud-in-a-bottle/cloud-in-a-bottle/releases). Pick the format that matches your hypervisor.
 
-## Settings
+### Boot it
 
-Set these once in your shell. Every command below reads them, so this is the only place you fill in values.
+Give the VM at least **2 vCPU, 4 GB RAM**, and a disk of the size you want your instance to have — the root filesystem grows to fill it on first boot, so a 60 GB disk yields ~58 GB of usable space. The 20 GB floor is the minimum; go bigger if you plan to run several apps.
 
-```bash
-# --- how to reach the VM ---
-export VM_HOST=127.0.0.1               # or the VM's IP, if it has one of its own
-export SSH_PORT=2222                   # 22 if you're connecting to the VM directly
-export HTTP_PORT=8080                  # port on your machine that reaches VM :8080
-export VM_USER=ubuntu                  # a sudo-capable login in the VM
-export SSH_KEY=~/.ssh/id_ed25519       # your SSH private key ($SSH_KEY.pub must exist)
+- **VirtualBox:** *File → Import Appliance…*, select the `.ova`, adjust CPU/RAM/disk, and start it.
+- **QEMU / libvirt:** import the `.qcow2` as the VM's disk (e.g. `virt-manager`'s "Import existing disk image"), or boot it directly with `qemu-system-x86_64`.
 
-# --- Cloud in a Bottle ---
-export DOMAIN=lvh.me:8080              # zone domain for app routing (see step 2.2)
-export OPENHOST_REPO=~/openhost        # your checkout of the repo
-```
+First boot runs `openhost-prepare.service` before the dashboard comes up; give it a minute. If you need a shell, log in on the VM console and add your SSH public key to `~/.ssh/authorized_keys`.
 
-## Part 1: build an Ubuntu VM with QEMU
+### Claim it
 
-Skip this if you already have a VM meeting the requirements above.
+Point a browser at `http://<vm-ip>:8080/`. Claiming is open, so the dashboard lets you claim the instance immediately — no token. Create your owner account and you're in.
 
-### QEMU settings
+> Keep the VM behind your NAT/firewall until you've claimed it. Open claiming means anyone who can reach `:8080` before you do can take the instance. Don't port-forward `:8080` to the public internet on an unclaimed appliance.
 
-The defaults target an Apple Silicon (arm64) Mac. See [other hosts](#other-hosts-x86_64-linux) for x86_64 and Linux substitutions.
+### Reaching your apps (subdomains without a domain)
+
+Cloud in a Bottle routes to apps **by subdomain** — an app named `foo` lives at `foo.<domain>`. The appliance has no real domain, so it uses [`lvh.me`](https://lvh.me), a public convenience domain where both `lvh.me` and `*.lvh.me` resolve to `127.0.0.1`. That gives you working wildcard subdomains without registering anything.
+
+Forward the appliance's `:8080` to a local port over SSH (once you've added your key):
 
 ```bash
-export VM_DIR=~/openhost-vm            # holds the disk, firmware vars, seed
-export DISK_SIZE=40G
-export RAM_MB=8192
-export CPUS=4
-
-export UBUNTU_IMG_URL="https://cloud-images.ubuntu.com/releases/24.04/release/ubuntu-24.04-server-cloudimg-arm64.img"
-export QEMU=qemu-system-aarch64
-export ACCEL=hvf                       # macOS accelerator; Linux: kvm
-export EFI_CODE=/opt/homebrew/share/qemu/edk2-aarch64-code.fd
-export EFI_VARS_TEMPLATE=/opt/homebrew/share/qemu/edk2-arm-vars.fd
+ssh -L 8088:localhost:8080 host@<vm-ip>
 ```
 
-Install QEMU with `brew install qemu` on macOS, or `sudo apt install qemu-system-arm qemu-system-x86 qemu-utils` on Debian/Ubuntu.
+Then browse to the dashboard at `http://lvh.me:8088/` and an app named `foo` at `http://foo.lvh.me:8088/`. The router carries the tunnel port through every absolute link and redirect it builds, so the `/login` bounce and the app links land on `lvh.me:8088` rather than dropping back to `:80`. You can pick whatever local port you like.
 
-### 1.1 Create the disk
+## Part 2: taking it public
 
-Ubuntu's cloud image is a prebuilt qcow2 that configures itself from cloud-init on first boot, so there is no interactive installer. Download it as the VM's disk and grow it:
+The released images are HTTP-only; To serve an instance at your own domain from a VM, you will need to **build your own image** with the domain baked in and HTTPS turned on — see [Building your own VM image](./building_a_vm_image.md).
 
-```bash
-mkdir -p "$VM_DIR"
-curl -L -o "$VM_DIR/disk.qcow2" "$UBUNTU_IMG_URL"
-qemu-img resize "$VM_DIR/disk.qcow2" "$DISK_SIZE"   # cloud-init grows the rootfs to fill it
-cp "$EFI_VARS_TEMPLATE" "$VM_DIR/efi-vars.fd"       # writable UEFI variable store
-```
-
-### 1.2 Build the cloud-init seed
-
-Cloud-init reads a `user-data` and `meta-data` pair off a small ISO labelled `CIDATA`. This one creates `$VM_USER`, imports your SSH key, and sets a sudo password. The password defaults to `ubuntu` and you hand it to Ansible later. Change it here if you like.
-
-```bash
-cat > "$VM_DIR/user-data" <<EOF
-#cloud-config
-users:
-  - name: $VM_USER
-    groups: [sudo]
-    shell: /bin/bash
-    sudo: ALL=(ALL) ALL
-    lock_passwd: false
-    ssh_authorized_keys:
-      - $(cat "$SSH_KEY.pub")
-chpasswd:
-  expire: false
-  users:
-    - {name: $VM_USER, password: ubuntu, type: text}
-ssh_pwauth: false
-EOF
-: > "$VM_DIR/meta-data"        # must exist, but stays empty
-
-# Pack them into a CIDATA seed ISO.
-# macOS:
-hdiutil makehybrid -iso -joliet -default-volume-name CIDATA \
-  -o "$VM_DIR/seed.iso" "$VM_DIR/user-data" "$VM_DIR/meta-data"
-# Linux (needs cloud-image-utils):
-# cloud-localds "$VM_DIR/seed.iso" "$VM_DIR/user-data" "$VM_DIR/meta-data"
-```
-
-### 1.3 Boot it
-
-Boot headless, with the seed attached and two ports forwarded in from your machine: SSH, and the dashboard. Leave this running in its own terminal, or a `tmux` window, and use a second terminal for Part 2. First boot takes a minute while cloud-init runs.
-
-```bash
-"$QEMU" \
-  -machine virt,accel=$ACCEL -cpu host -smp $CPUS -m $RAM_MB \
-  -drive if=pflash,format=raw,readonly=on,file="$EFI_CODE" \
-  -drive if=pflash,format=raw,file="$VM_DIR/efi-vars.fd" \
-  -device virtio-rng-pci \
-  -netdev user,id=n0,hostfwd=tcp::$SSH_PORT-:22,hostfwd=tcp::$HTTP_PORT-:8080 \
-  -device virtio-net-pci,netdev=n0 \
-  -drive if=none,file="$VM_DIR/disk.qcow2",format=qcow2,id=hd0 -device virtio-blk-pci,drive=hd0 \
-  -drive if=none,file="$VM_DIR/seed.iso",format=raw,readonly=on,id=cd0 -device virtio-blk-pci,drive=cd0 \
-  -nographic
-```
-
-This is also the restart command later. The seed ISO is harmless to leave attached, since cloud-init only applies it once per VM.
-
-`-nographic` wires the VM's serial console to this terminal. Quit QEMU with `Ctrl-A` then `X`, not `Ctrl-C`.
-
-Confirm SSH works from your second terminal. Accept the host key, and retry for a few seconds if cloud-init is still finishing.
-
-```bash
-ssh -p "$SSH_PORT" "$VM_USER@$VM_HOST" 'lsb_release -ds && echo SSH_OK'
-```
-
-### Other hosts (x86_64, Linux)
-
-The settings above assume an arm64 Mac. On an x86_64 host:
-
-- `QEMU=qemu-system-x86_64`, and swap `-machine virt` for `-machine q35`.
-- `ACCEL=kvm` on Linux, `ACCEL=hvf` on an Intel Mac.
-- Use OVMF firmware instead of arm EDK2: `EFI_CODE=/usr/share/OVMF/OVMF_CODE.fd` and `EFI_VARS_TEMPLATE=/usr/share/OVMF/OVMF_VARS.fd`. On Debian/Ubuntu, install `ovmf`.
-- Use the amd64 cloud image, and build the seed with `cloud-localds`.
-
-On arm64 Linux keep `-machine virt`, but use `EFI_CODE=/usr/share/AAVMF/AAVMF_CODE.fd` and the matching `AAVMF_VARS.fd`.
-
-## Part 2: install Cloud in a Bottle into the VM
-
-Run these from your machine, not inside the VM, with the VM running.
-
-### 2.1 Run the playbook
-
-```bash
-cd "$OPENHOST_REPO"
-
-ANSIBLE_HOST_KEY_CHECKING=False \
-ansible-playbook ansible/setup.yml \
-  -i "$VM_HOST," \
-  -e ansible_connection=ssh \
-  -e ansible_port=$SSH_PORT \
-  -e initial_user=$VM_USER \
-  -e domain=$DOMAIN \
-  -e local_http_only=true \
-  -e bind_host=0.0.0.0 \
-  -e public_ip=127.0.0.1 \
-  -e skip_apt_upgrade=true \
-  --private-key=$SSH_KEY \
-  --ask-become-pass          # the VM user's sudo password
-```
-
-This installs rootless Podman and pixi inside the VM, clones Cloud in a Bottle from GitHub, writes its config, and starts it as a systemd service. It takes several minutes the first time.
-
-Two flags matter. `local_http_only=true` puts the instance in HTTP-only mode: no TLS, no CoreDNS, no Caddy, just the router serving plain HTTP on port 8080. `bind_host=0.0.0.0` makes it listen on the VM's network interface instead of only loopback, which is what a NAT port forward connects to. If you are reaching the VM over an SSH tunnel instead, you can leave `bind_host` at its `127.0.0.1` default.
-
-### 2.2 Why `DOMAIN=lvh.me:8080`
-
-Apps are routed by subdomain (`<app>.<domain>`), so the zone domain has to be something whose subdomains resolve. `localhost` does not qualify. `lvh.me` and `*.lvh.me` both resolve to `127.0.0.1` in public DNS, so `http://myapp.lvh.me:8080` reaches the router with nothing to configure. Any other wildcard-to-loopback domain works too, including one you run yourself.
-
-Include the `:8080`. The router builds absolute login and redirect URLs from this value, and without the port they point at `:80` and dead-end.
-
-### 2.3 Claim it
-
-The playbook prints a claim URL at the end:
-
-```
-Claim URL: http://lvh.me:8080/setup?claim=<token>
-```
-
-Open it and set the owner username and password. Before it is claimed, every request redirects to a gated `/setup`.
-
-If you lose the token, re-run the playbook, which is idempotent, or read it out of the VM:
-
-```bash
-ssh -p $SSH_PORT $VM_USER@$VM_HOST \
-  'sudo cat /home/host/.openhost/local_compute_space/first_boot.toml'
-```
-
-## Verify and manage
-
-```bash
-curl http://localhost:$HTTP_PORT/health         # -> {"status":"ok"}
-
-ssh -p $SSH_PORT $VM_USER@$VM_HOST 'sudo systemctl status openhost'
-ssh -p $SSH_PORT $VM_USER@$VM_HOST 'sudo journalctl -u openhost -f'
-```
-
-- Stop the VM: shut it down however your VM host does it, or `ssh -p $SSH_PORT $VM_USER@$VM_HOST sudo poweroff`. Under QEMU you can also press `Ctrl-A` then `X` in its terminal.
-- Restart the VM: Cloud in a Bottle comes back up on its own. Under QEMU, re-run the boot command from [step 1.3](#13-boot-it).
-- Throw it away: delete the VM. Under QEMU that is `rm -rf "$VM_DIR"`, and nothing was installed on your machine except QEMU itself.
-- Upgrade Cloud in a Bottle: use the update button on the dashboard's settings page.
-
-The systemd service, logs and diagnostics are in [Debugging](../operation/debugging.md).
-
-## Going public
-
-An instance in a VM is a real deployment, not just a test rig. Serving it on the internet takes three things beyond the walkthrough above.
-
-**Networking.** Delegate a DNS zone to your public IPv4 and get ports 53, 80, and 443 through to the VM. On a home connection that means dynamic DNS plus forwarding rules on both your router and the VM host. See [Exposing a home server](./home_network.md).
-
-**An ACME account key**, so the instance can get its own certificates. Generate one on your machine:
-
-```bash
-cd "$OPENHOST_REPO"
-pixi run python scripts/generate_acme_key.py ansible/secrets/certbot_private_key.json --email you@example.com
-```
-
-**A playbook run with TLS on.** Use your real zone domain, pass your public IPv4, and drop `local_http_only` and `bind_host`. Caddy terminates TLS on port 443 and proxies to the router over loopback, so the router does not need to listen on the VM's interface anymore.
-
-```bash
-ansible-playbook ansible/setup.yml \
-  -i "$VM_HOST," \
-  -e ansible_connection=ssh \
-  -e ansible_port=$SSH_PORT \
-  -e initial_user=$VM_USER \
-  -e domain=mycooldomain.com \
-  -e public_ip=<your public IPv4> \
-  -e acme_directory_url=https://acme-v02.api.letsencrypt.org/directory \
-  --private-key=$SSH_KEY \
-  --ask-become-pass
-```
-
-Set `acme_directory_url` to Let's Encrypt, which is what the key you just generated is registered with. The built-in default is Google Trust Services, which needs an account binding you have to request separately.
-
-The instance gets a wildcard certificate covering `mycooldomain.com` and `*.mycooldomain.com` over DNS-01, and comes up at `https://mycooldomain.com/`.
-
-Easiest is to do this from the start, on a VM you have not claimed yet. Converting an instance you already claimed at `lvh.me` is more work: the playbook preserves an existing config, so you have to re-run it with `-e overwrite_existing=true` to switch the instance out of HTTP-only mode, and the primary domain is fixed in the database at claim time, so you add the public domain from the dashboard's domain settings rather than replacing it.
+From there, putting it on the internet is the same networking as any install: delegate a DNS zone to the VM's public IP and open ports 53, 80, and 443 to it. See [Exposing a server with a static IP](./static_ip.md) for a VPS/static-IP host, or [Exposing a home server](./home_network.md) for a home connection.

--- a/docs/src/setup/shared_machine.md
+++ b/docs/src/setup/shared_machine.md
@@ -55,6 +55,6 @@ Then browse to the dashboard at `http://lvh.me:8088/` and an app named `foo` at 
 
 ## Part 2: taking it public
 
-The released images are HTTP-only; To serve an instance at your own domain from a VM, you will need to **build your own image** with the domain baked in and HTTPS turned on — see [Building your own VM image](./building_a_vm_image.md).
+A VM is just a machine, so taking it public works the same as any install: expose it on the internet and add your domain. Delegate a DNS zone to the VM's public IP, open ports 53, 80, and 443, and add the domain from the dashboard — follow [Exposing a server with a static IP](./static_ip.md) for a VPS/static-IP host, or [Exposing a home server](./home_network.md) for a home connection.
 
-From there, putting it on the internet is the same networking as any install: delegate a DNS zone to the VM's public IP and open ports 53, 80, and 443 to it. See [Exposing a server with a static IP](./static_ip.md) for a VPS/static-IP host, or [Exposing a home server](./home_network.md) for a home connection.
+One wrinkle when you take a *downloaded* image public this way: the domain you add is served, but the instance's primary domain stays `lvh.me` (the dashboard can't repoint the primary). Your apps and dashboard work at the new domain — only things that build outbound links from the primary keep pointing at `lvh.me`. If you want your domain to be the primary, which is the cleaner setup for a real public instance, [build your own image](./building_a_vm_image.md) with it baked in instead.

--- a/docs/src/setup/static_ip.md
+++ b/docs/src/setup/static_ip.md
@@ -52,17 +52,21 @@ sudo -u host bash -c "cd /home/host/openhost && /home/host/.pixi/bin/pixi run py
 sudo chmod 600 "$KEY"
 ```
 
-Then edit `/home/host/.openhost/local_compute_space/config.toml`. Under `[openhost]`, flip three settings and add three more:
+Then edit `/home/host/.openhost/local_compute_space/config.toml`. Under `[openhost]`, flip three settings on, add the three ACME settings, and make sure `public_ip` is your server's real public IPv4 — CoreDNS answers every app subdomain with it:
 
 ```toml
 acquire_tls_cert_if_missing = true
 coredns_enabled = true
 start_caddy = true
 
+public_ip = "203.0.113.10"
+
 acme_account_key_path = "/home/host/openhost/ansible/secrets/certbot_private_key.json"
 acme_email = "openhost@mycooldomain.com"
 acme_directory_url = "https://acme-v02.api.letsencrypt.org/directory"
 ```
+
+`public_ip` is already in the file. A normal install detected it correctly at install time, but a downloaded VM image ships with a placeholder from the build machine, so set it to this server's address.
 
 Restart:
 

--- a/image/build.sh
+++ b/image/build.sh
@@ -13,6 +13,11 @@
 # (no token) since the image is private behind NAT and a shipped default token
 # would be a public non-secret; pass --claim-token to bake one instead.
 #
+# Pass --public (with --public-ip) to bake a TLS image instead: it provisions
+# with CoreDNS + Caddy + Let's Encrypt for --domain, ready to serve publicly
+# once you delegate DNS and open ports 53/80/443. Claiming is token-gated in
+# this mode (open claiming is refused on a reachable instance).
+#
 # Usage (run on a Linux host with KVM):
 #   image/build.sh [options]
 #
@@ -24,7 +29,17 @@
 #                         provision.sh to embed and run in the build VM
 #                         (default: this repo's scripts/provision.sh). Embedded
 #                         from the working tree, so the branch need not be pushed.
-#   --domain <domain>     App subdomain-routing domain baked in (default: lvh.me)
+#   --domain <domain>     App subdomain-routing domain baked in (default: lvh.me).
+#                         With --public this is the real domain served over TLS.
+#   --public              Build a TLS image (CoreDNS + Caddy + Let's Encrypt for
+#                         --domain) instead of the default HTTP-only image.
+#                         Requires --public-ip.
+#   --public-ip <ip>      Public IPv4 baked into the config for DNS records
+#                         (required with --public).
+#   --acme-key <path>     Pre-registered ACME account key to bake in (--public).
+#                         Default: the build generates and registers one.
+#   --acme-email <email>  Email for the generated ACME account (--public, when
+#                         no --acme-key is given).
 #   --claim-token <tok>   Bake in a claim token gating /setup. Default: none —
 #                         claiming is open (claim_token_required=false), since
 #                         the image is private behind NAT. Set this to require a
@@ -68,6 +83,10 @@ MEM_MB="4096"
 CPUS="2"
 BUILD_TIMEOUT="1800"
 MAKE_OVA="true"
+PUBLIC="false"
+PUBLIC_IP=""
+ACME_KEY_FILE=""
+ACME_EMAIL=""
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 OUTPUT_DIR="$SCRIPT_DIR/out"
@@ -97,10 +116,29 @@ while [[ $# -gt 0 ]]; do
         --output-dir)   OUTPUT_DIR="$2"; shift 2 ;;
         --no-ova)       MAKE_OVA="false"; shift ;;
         --timeout)      BUILD_TIMEOUT="$2"; shift 2 ;;
+        --public)       PUBLIC="true"; shift ;;
+        --public-ip)    PUBLIC_IP="$2"; shift 2 ;;
+        --acme-key)     ACME_KEY_FILE="$2"; shift 2 ;;
+        --acme-email)   ACME_EMAIL="$2"; shift 2 ;;
         -h|--help)      usage; exit 0 ;;
         *)              echo "Unknown option: $1" >&2; usage; exit 1 ;;
     esac
 done
+
+# ---- Validate --public flags ----
+if [ "$PUBLIC" = "true" ]; then
+    if [ -z "$PUBLIC_IP" ]; then
+        echo "Error: --public requires --public-ip <ip> (baked in for DNS records)." >&2
+        exit 1
+    fi
+elif [ -n "$PUBLIC_IP" ] || [ -n "$ACME_KEY_FILE" ] || [ -n "$ACME_EMAIL" ]; then
+    echo "Error: --public-ip / --acme-key / --acme-email require --public." >&2
+    exit 1
+fi
+if [ -n "$ACME_KEY_FILE" ] && [ ! -f "$ACME_KEY_FILE" ]; then
+    echo "Error: --acme-key file not found: $ACME_KEY_FILE" >&2
+    exit 1
+fi
 
 # ---- Portable helpers ----
 file_size() { stat -c%s "$1" 2>/dev/null || stat -f%z "$1"; }
@@ -145,8 +183,15 @@ echo "=== OpenHost VM image build ==="
 echo "  Version:      $VERSION"
 echo "  Repo/branch:  $REPO_URL @ $BRANCH"
 echo "  provision.sh: $PROVISION_SCRIPT (embedded)"
-echo "  Domain:       $DOMAIN   (HTTP-only, bound 0.0.0.0)"
-echo "  Claim:        ${CLAIM_TOKEN:+token '$CLAIM_TOKEN'}${CLAIM_TOKEN:-open (no token required)}"
+if [ "$PUBLIC" = "true" ]; then
+    echo "  Domain:       $DOMAIN   (public, TLS via Let's Encrypt)"
+    echo "  Public IP:    $PUBLIC_IP"
+    echo "  ACME key:     ${ACME_KEY_FILE:-generated during build}"
+    echo "  Claim:        ${CLAIM_TOKEN:+token '$CLAIM_TOKEN'}${CLAIM_TOKEN:-token-gated (random, printed on first boot)}"
+else
+    echo "  Domain:       $DOMAIN   (HTTP-only, bound 0.0.0.0)"
+    echo "  Claim:        ${CLAIM_TOKEN:+token '$CLAIM_TOKEN'}${CLAIM_TOKEN:-open (no token required)}"
+fi
 echo "  Disk size:    $DISK_SIZE"
 echo "  Output dir:   $OUTPUT_DIR"
 echo ""
@@ -174,18 +219,35 @@ if [ -n "$SSH_PUBKEY_FILE" ]; then
     SSH_KEY_CONTENT="$(cat "$SSH_PUBKEY_FILE")"
 fi
 
-# Claim mode: with no --claim-token, claiming is open (no token). Otherwise bake
-# the given token. This becomes the provision.sh argument in the seed.
+# Claim mode. An explicit --claim-token always wins. Otherwise HTTP-only images
+# ship open-claim (safe behind NAT); --public images can't (open claiming on a
+# reachable instance is refused), so they fall through to provision.sh's default
+# random, printed, token-gated claim. This becomes provision.sh args in the seed.
 if [ -n "$CLAIM_TOKEN" ]; then
     CLAIM_ARG="--claim-token \"$CLAIM_TOKEN\""
+elif [ "$PUBLIC" = "true" ]; then
+    CLAIM_ARG=""
 else
     CLAIM_ARG="--open-claim"
 fi
 
-# Embed provision.sh and seal.sh as single-line base64 blobs. The base64
-# alphabet is [A-Za-z0-9+/=] — none of which collide with sed's '|' delimiter.
+# Mode args passed to provision.sh: HTTP-only + LAN bind by default, or TLS with
+# the baked public IP (and optional ACME account key / email) under --public.
+if [ "$PUBLIC" = "true" ]; then
+    MODE_ARGS="--public-ip \"$PUBLIC_IP\""
+    [ -n "$ACME_KEY_FILE" ] && MODE_ARGS="$MODE_ARGS --acme-key /root/acme_account_key.json"
+    [ -n "$ACME_EMAIL" ]    && MODE_ARGS="$MODE_ARGS --acme-email \"$ACME_EMAIL\""
+else
+    MODE_ARGS="--local-http-only --bind-host 0.0.0.0"
+fi
+
+# Embed provision.sh and seal.sh (and, for --public --acme-key, the account key)
+# as single-line base64 blobs. The base64 alphabet is [A-Za-z0-9+/=] — none of
+# which collide with sed's '|' delimiter.
 PROVISION_B64="$(base64 -w0 "$PROVISION_SCRIPT")"
 SEAL_B64="$(base64 -w0 "$SCRIPT_DIR/seal.sh")"
+ACME_KEY_B64=""
+[ -n "$ACME_KEY_FILE" ] && ACME_KEY_B64="$(base64 -w0 "$ACME_KEY_FILE")"
 
 USER_DATA="$WORK_DIR/user-data"
 # Use a non-/ delimiter for sed since URLs contain slashes.
@@ -193,12 +255,14 @@ sed \
     -e "s|__REPO_URL__|$REPO_URL|g" \
     -e "s|__BRANCH__|$BRANCH|g" \
     -e "s|__DOMAIN__|$DOMAIN|g" \
+    -e "s|__MODE_ARGS__|$MODE_ARGS|g" \
     -e "s|__CLAIM_ARG__|$CLAIM_ARG|g" \
     -e "s|__HOST_PASSWORD__|$HOST_PASSWORD|g" \
     -e "s|__SSH_AUTHORIZED_KEY__|$SSH_KEY_CONTENT|g" \
     -e "s|__SWAP_SIZE_GB__|$SWAP_SIZE_GB|g" \
     -e "s|__PROVISION_B64__|$PROVISION_B64|g" \
     -e "s|__SEAL_B64__|$SEAL_B64|g" \
+    -e "s|__ACME_KEY_B64__|$ACME_KEY_B64|g" \
     "$SCRIPT_DIR/cloud-init/user-data.tmpl" > "$USER_DATA"
 
 SEED_ISO="$WORK_DIR/seed.iso"
@@ -387,12 +451,23 @@ echo "Disk:   ships as ${DISK_SIZE} (floor). To install with more, size the VM's
 echo "        virtual disk larger before first boot (or write to a bigger"
 echo "        physical disk) — the root filesystem grows to fill it on boot."
 echo ""
-echo "Boot it, then reach the dashboard at:  http://<vm-ip>:8080"
-if [ -n "$CLAIM_TOKEN" ]; then
-    echo "Claim URL:                             http://<vm-ip>:8080/setup?claim=$CLAIM_TOKEN"
+if [ "$PUBLIC" = "true" ]; then
+    echo "Public image for: $DOMAIN"
+    echo "Before it can serve, delegate DNS to $PUBLIC_IP and open ports 53, 80, 443"
+    echo "to the VM. Then the dashboard comes up at:  https://$DOMAIN"
+    if [ -n "$CLAIM_TOKEN" ]; then
+        echo "Claim URL:                                  https://$DOMAIN/setup?claim=$CLAIM_TOKEN"
+    else
+        echo "Claim:                                      token-gated; the random token prints"
+        echo "                                            to the instance console on first boot."
+    fi
 else
-    echo "Claim:                                 open — go to /setup (no token)"
+    echo "Boot it, then reach the dashboard at:  http://<vm-ip>:8080"
+    if [ -n "$CLAIM_TOKEN" ]; then
+        echo "Claim URL:                             http://<vm-ip>:8080/setup?claim=$CLAIM_TOKEN"
+    else
+        echo "Claim:                                 open — go to /setup (no token)"
+    fi
+    echo "Find <vm-ip> from the VM console (\`ip addr\`) or your hypervisor's NAT/DHCP."
 fi
 echo "Console login:                         user 'host', password '$HOST_PASSWORD'"
-echo ""
-echo "Find <vm-ip> from the VM console (\`ip addr\`) or your hypervisor's NAT/DHCP."

--- a/image/cloud-init/user-data.tmpl
+++ b/image/cloud-init/user-data.tmpl
@@ -46,6 +46,16 @@ write_files:
     encoding: b64
     content: __SEAL_B64__
 
+  # Optional pre-registered ACME account key for a --public build (base64 from
+  # --acme-key; empty otherwise). provision.sh is told to use it via --acme-key
+  # only when one was supplied, so an empty file here is simply never read.
+  - path: /root/acme_account_key.json
+    permissions: '0600'
+    owner: root:root
+    encoding: b64
+    content: |
+      __ACME_KEY_B64__
+
 runcmd:
   # Provision, then seal. The SUCCESS sentinel only reaches the serial console
   # if BOTH succeeded (cloud-init's runcmd does not stop on error on its own),
@@ -58,8 +68,7 @@ runcmd:
              --domain "__DOMAIN__" \
              --repo "__REPO_URL__" \
              --branch "__BRANCH__" \
-             --local-http-only \
-             --bind-host 0.0.0.0 \
+             __MODE_ARGS__ \
              __CLAIM_ARG__ \
              --swap-size "__SWAP_SIZE_GB__" \
         && echo 'host:__HOST_PASSWORD__' | chpasswd \

--- a/scripts/provision.sh
+++ b/scripts/provision.sh
@@ -29,6 +29,9 @@ BIND_HOST=""
 CLAIM_TOKEN=""
 SWAP_SIZE_GB=""
 OPEN_CLAIM="false"
+PUBLIC_IP_OVERRIDE=""
+ACME_KEY_SRC=""
+ACME_EMAIL=""
 
 usage() {
     echo "Usage: $0 --domain <domain> [--branch <branch>] [--repo <repo-url>] [--local-http-only]"
@@ -53,6 +56,14 @@ usage() {
     echo "                      distributable image with a predictable claim URL."
     echo "  --swap-size         Swap file size in GiB (default: playbook default,"
     echo "                      16). Smaller values suit constrained local VMs."
+    echo "  --public-ip         Public IPv4 to bake into the config for DNS records,"
+    echo "                      overriding auto-detection. Use when the box running"
+    echo "                      provision.sh isn't the box that'll serve the domain"
+    echo "                      (e.g. building a distributable image)."
+    echo "  --acme-key          Path to a pre-registered ACME account key to install"
+    echo "                      instead of generating one (TLS mode only)."
+    echo "  --acme-email        Email for the generated ACME account (TLS mode, when"
+    echo "                      no --acme-key is given)."
     echo "  --open-claim        Leave /setup ungated (claim_token_required = false), so you"
     echo "                      can claim the instance without a token. For a private,"
     echo "                      unexposed instance (e.g. the distributed VM image behind"
@@ -72,6 +83,9 @@ while [[ $# -gt 0 ]]; do
         --bind-host)        BIND_HOST="$2"; shift 2 ;;
         --claim-token)      CLAIM_TOKEN="$2"; shift 2 ;;
         --swap-size)        SWAP_SIZE_GB="$2"; shift 2 ;;
+        --public-ip)        PUBLIC_IP_OVERRIDE="$2"; shift 2 ;;
+        --acme-key)         ACME_KEY_SRC="$2"; shift 2 ;;
+        --acme-email)       ACME_EMAIL="$2"; shift 2 ;;
         --open-claim)       OPEN_CLAIM="true"; shift ;;
         -h|--help)          usage; exit 0 ;;
         *)                  echo "Unknown option: $1"; usage; exit 1 ;;
@@ -134,11 +148,13 @@ else
 fi
 chown -R host:host "$OPENHOST_DIR"
 
-# ---- Detect public IP ----
-PUBLIC_IP=""
-PUBLIC_IP=$(hostname -I 2>/dev/null | awk '{print $1}' || true)
-if [ -z "$PUBLIC_IP" ] || echo "$PUBLIC_IP" | grep -qE '^(10\.|172\.(1[6-9]|2[0-9]|3[01])\.|192\.168\.)'; then
-    PUBLIC_IP=$(curl -sf --max-time 5 https://ifconfig.me 2>/dev/null || true)
+# ---- Public IP (explicit override, else auto-detect) ----
+PUBLIC_IP="$PUBLIC_IP_OVERRIDE"
+if [ -z "$PUBLIC_IP" ]; then
+    PUBLIC_IP=$(hostname -I 2>/dev/null | awk '{print $1}' || true)
+    if [ -z "$PUBLIC_IP" ] || echo "$PUBLIC_IP" | grep -qE '^(10\.|172\.(1[6-9]|2[0-9]|3[01])\.|192\.168\.)'; then
+        PUBLIC_IP=$(curl -sf --max-time 5 https://ifconfig.me 2>/dev/null || true)
+    fi
 fi
 echo "  Public IP: ${PUBLIC_IP:-unknown}"
 
@@ -172,13 +188,23 @@ ansible-playbook ansible/local_setup.yml \
     --connection=local \
     -i "localhost,"
 
-# ---- Generate ACME account key if missing (TLS mode only) ----
+# ---- ACME account key (TLS mode only): install the provided one, else generate ----
 if [ "$LOCAL_HTTP_ONLY" != "true" ]; then
     ACME_KEY_PATH="$OPENHOST_DIR/ansible/secrets/certbot_private_key.json"
-    if [ ! -f "$ACME_KEY_PATH" ]; then
+    ACME_KEY_DIR="$(dirname "$ACME_KEY_PATH")"
+    if [ -n "$ACME_KEY_SRC" ]; then
+        echo "--- Installing provided ACME account key ---"
+        mkdir -p "$ACME_KEY_DIR"
+        cp "$ACME_KEY_SRC" "$ACME_KEY_PATH"
+        chmod 600 "$ACME_KEY_PATH"
+        chown host:host "$ACME_KEY_PATH"
+    elif [ ! -f "$ACME_KEY_PATH" ]; then
         echo "--- Generating ACME account key ---"
-        mkdir -p "$(dirname "$ACME_KEY_PATH")"
-        su host -c "cd $OPENHOST_DIR && /home/host/.pixi/bin/pixi run python3 scripts/generate_acme_key.py $ACME_KEY_PATH"
+        mkdir -p "$ACME_KEY_DIR"
+        chown host:host "$ACME_KEY_DIR"
+        gen="/home/host/.pixi/bin/pixi run python3 scripts/generate_acme_key.py $ACME_KEY_PATH"
+        [ -n "$ACME_EMAIL" ] && gen="$gen --email $ACME_EMAIL"
+        su host -c "cd $OPENHOST_DIR && $gen"
         chmod 600 "$ACME_KEY_PATH"
         chown host:host "$ACME_KEY_PATH"
     fi


### PR DESCRIPTION
## Summary

Reworks the VM-image setup docs and adds a **public (TLS) build mode** to `image/build.sh`, so someone who wants a publicly-reachable instance can build an image with their domain and HTTPS baked in — the released images stay HTTP-only, as the easy on-ramp.

## Docs (`docs/src/setup/`)

- **Deploying on a shared machine** — reworked around the released VM image. Part 1 downloads / boots / claims the HTTP-only appliance (incl. the `lvh.me` tunnel for apps); Part 2 covers taking it public.
- **Building your own VM image** (new) — documents `image/build.sh`, its common options, and the new public/TLS build.
- Wired into `SUMMARY.md`.

## Public/TLS image builds

- `build.sh` gains `--public` / `--public-ip` / `--acme-key` / `--acme-email` to bake a TLS image (CoreDNS + Caddy + Let's Encrypt for `--domain`) instead of the default HTTP-only one. Public images are token-gated (open claiming is refused on a reachable instance). Validation requires `--public-ip` with `--public`.
- `provision.sh` gains `--public-ip` (override IP auto-detection — the build VM's NAT IP is wrong for a distributable image), `--acme-key` (install a pre-registered account key instead of generating one), and `--acme-email`.
- `user-data.tmpl` renders the mode args and embeds an optional ACME key.

The TLS certificate is issued **at the deploy site**, not at build time — the build VM has no DNS pointing at the domain. The instance acquires its cert once DNS is delegated and ports 53/80/443 are open.

## Testing

- `bash -n` on `build.sh` and `provision.sh`; flag validation and `--help` exercised.
- Rendered `user-data` seed validated as YAML in both modes (empty ACME content → `""`; a passed key round-trips through the base64 embed).
- ⚠️ **Not yet run through an actual KVM build.** A `--public` build boots the router in TLS mode inside the build VM (no DNS); this assumes cert acquisition is asynchronous so `systemctl enable --now openhost` still succeeds. Worth confirming on a KVM host before relying on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
