### PR TITLE
docs: Cloudflare Tunnel setup for exposing a home instance

### DIFF
--- a/docs/src/setup/home_network.md
+++ b/docs/src/setup/home_network.md
@@ -12,7 +12,90 @@ HTTP tunnels are cheap to provide, because instead of having a dedicated IPv4 pe
 
 This isn't ideal, because there are some non-HTTP protocols that we would like Cloud in a Bottle should be able to receive inbound traffic on, eg SMTP (email). We're working on a better alternative (see below). That said, most apps only use HTTP and will work fine. Just remember that any apps specifying non-standard `[[ports]]` in the manifest won't work properly.
 
-TODO: include instructions on how to actually set this up.
+### Cloudflare Tunnel setup
+
+These steps assume you already have a running OpenHost instance — stand one up first via the [dedicated machine](./dedicated_machine.md) or [shared machine](./shared_machine.md) guide. They then work the same on the VM image, a `provision.sh` install, or bare metal: every instance ends up as a plain-HTTP router listening on `127.0.0.1:8080`, and `cloudflared` reverse-tunnels public traffic to it. Cloudflare terminates TLS at its edge, so OpenHost itself runs in HTTP-only mode — no Caddy, CoreDNS, ACME, or open inbound ports on your side.
+
+> **Claim your instance before the tunnel goes live.** The VM image and any `--local-http-only` bring-up assume the instance is private behind NAT, so claiming may be open (no token). A tunnel makes `/setup` reachable by anyone, so claim it immediately — or bake in a claim token first (`--claim-token` when building the image) so nobody can race you to it.
+
+A couple of limitations to know going in:
+
+- **HTTP(s) only.** Apps using a custom `[[ports]]` entry or a non-HTTP protocol (e.g. SMTP) won't work over the tunnel.
+- **Cloudflare free-plan limits.** Request bodies are capped at 100 MB and origin responses time out after ~100 s, so large uploads and long-lived streaming connections may be cut.
+
+**Prerequisites**
+
+- A domain whose DNS is managed by Cloudflare (nameservers delegated to Cloudflare — the free plan is enough).
+- **Always Use HTTPS** enabled on the zone (Cloudflare dashboard: **SSL/TLS → Edge Certificates**). The local hop from `cloudflared` to the router is plain HTTP, so an app that builds an absolute URL from the forwarded scheme could occasionally emit an `http://` link; this setting upgrades those at the edge. (The dashboard itself already builds `https://` links correctly from the `X-Forwarded-Proto` header Cloudflare sends.)
+
+**1. Point OpenHost at your domain, in HTTP-only mode.** Edit `/home/host/.openhost/local_compute_space/config.toml`:
+
+```toml
+zone_domain = "example.com"
+host = "127.0.0.1"
+tls_enabled = false
+start_caddy = false
+coredns_enabled = false
+acquire_tls_cert_if_missing = false
+```
+
+Then `sudo systemctl restart openhost`. Note there's no `:8080` in the domain (unlike the Tailscale HTTP option) — the browser reaches Cloudflare on 443, and Cloudflare forwards to your local `:8080`. Binding to `127.0.0.1` (rather than the image's default `0.0.0.0`) is good hygiene — `cloudflared` reaches the router over loopback, so nothing needs to be exposed on your LAN.
+
+Prefer a domain used at its apex (`example.com`, so apps land at `<app>.example.com`). Cloudflare's free Universal SSL certificate covers the apex and a *first-level* wildcard (`example.com` and `*.example.com`) — but nothing deeper. If you nest OpenHost under `bottle.example.com`, app hostnames like `<app>.bottle.example.com` are a second label deep and browsers will show certificate warnings unless you pay for [Advanced Certificate Manager](https://developers.cloudflare.com/ssl/edge-certificates/advanced-certificate-manager/). The examples here use `example.com` at the apex.
+
+**2. Install `cloudflared`** (Ubuntu):
+
+```bash
+sudo mkdir -p --mode=0755 /usr/share/keyrings
+curl -fsSL https://pkg.cloudflare.com/cloudflare-main.gpg \
+  | sudo tee /usr/share/keyrings/cloudflare-main.gpg >/dev/null
+echo "deb [signed-by=/usr/share/keyrings/cloudflare-main.gpg] https://pkg.cloudflare.com/cloudflared any main" \
+  | sudo tee /etc/apt/sources.list.d/cloudflared.list
+sudo apt-get update && sudo apt-get install -y cloudflared
+```
+
+**3. Create the tunnel.** `login` prints a URL — open it in a browser (on any machine) and authorize the zone. `create` writes a credentials file to `~/.cloudflared/<UUID>.json` and prints the tunnel's UUID.
+
+```bash
+cloudflared tunnel login
+cloudflared tunnel create openhost
+```
+
+**4. Route DNS to the tunnel** — one record for the dashboard, one wildcard that gives every app its own subdomain. Quote the wildcard so your shell doesn't glob-expand it (zsh otherwise fails with `no matches found: *.example.com`):
+
+```bash
+cloudflared tunnel route dns openhost example.com
+cloudflared tunnel route dns openhost '*.example.com'
+```
+
+Each creates a **proxied** CNAME to `<UUID>.cfargotunnel.com`. (Proxied wildcard records used to be Enterprise-only, but work on all plans now.) You can also add them by hand in the Cloudflare dashboard under **DNS → Records** if you prefer.
+
+**5. Write the tunnel config** with a wildcard ingress rule so all app subdomains flow to the one router. Put both the config and credentials under `/etc/cloudflared/` so the system service can read them:
+
+```bash
+sudo mkdir -p /etc/cloudflared
+sudo cp ~/.cloudflared/<UUID>.json /etc/cloudflared/
+```
+
+`/etc/cloudflared/config.yml`:
+
+```yaml
+tunnel: <UUID>
+credentials-file: /etc/cloudflared/<UUID>.json
+ingress:
+  - hostname: example.com
+    service: http://127.0.0.1:8080
+  - hostname: "*.example.com"
+    service: http://127.0.0.1:8080
+  - service: http_status:404
+```
+
+**6. Run it as a service:**
+
+```bash
+sudo cloudflared service install
+sudo systemctl enable --now cloudflared
+```
 
 ## Tailscale: HTTP or HTTPS
 


### PR DESCRIPTION
## What

Fills in the long-standing `TODO: include instructions on how to actually set this up.` under **HTTP(s) tunnel services** in `docs/src/setup/home_network.md` with an end-to-end [Cloudflare Tunnel](https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/) walkthrough.

## Approach

**No code changes** — this leans entirely on config knobs OpenHost already has. Tunnel mode is just the existing `--local-http-only` mode (router serves plain HTTP on `127.0.0.1:8080`; no Caddy/CoreDNS/ACME) with `cloudflared` reverse-tunneling to it. Cloudflare terminates TLS at the edge. The router is already reverse-proxy aware (honors `X-Forwarded-Proto`/`X-Forwarded-Host`), so dashboard URLs come out `https://` correctly.

Because it bottoms out on "an OpenHost instance serving HTTP on `127.0.0.1:8080`", the guide is **environment-agnostic**: identical steps for the VM image, a `provision.sh` install, or bare metal.

## The walkthrough

1. Point OpenHost at your domain in HTTP-only mode (`config.toml`).
2. Install `cloudflared`.
3. Create a named tunnel.
4. Route apex + wildcard DNS (`cloudflared tunnel route dns openhost '*.example.com'`).
5. Write the tunnel config with a wildcard ingress rule.
6. Run it as a systemd service.

## Gotchas documented

- **Claim before exposing.** The VM image ships with claiming open (assumes private-behind-NAT); a public tunnel makes `/setup` reachable, so claim immediately or bake a claim token.
- **Universal SSL depth.** Free certs cover the apex + first-level wildcard only, so the guide recommends using the domain at its apex (apps at `<app>.example.com`); deeper nesting needs Advanced Certificate Manager.
- **Wildcard DNS + shell globbing.** The `route dns` CLI *does* accept wildcards (verified against cloudflared source); the real trap is the shell expanding an unquoted `*.example.com` — hence the quoting note.
- HTTP(s)-only (custom `[[ports]]`/non-HTTP apps won't tunnel); Cloudflare free-plan 100 MB body / ~100 s timeout limits.

Draft while we decide whether we also want a pre-baked `cloudflared` binary in the image build (a small, separate follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)