### PR TITLE
Use Git HTTP/1.1 during provisioning

### DIFF
--- a/scripts/provision.sh
+++ b/scripts/provision.sh
@@ -135,6 +135,7 @@ fi
 echo "--- Installing ansible and git ---"
 apt-get update -qq
 apt-get install -y -qq ansible-core git > /dev/null 2>&1
+sudo git config --global http.version HTTP/1.1
 
 # ---- Clone the repo ----
 echo "--- Cloning Cloud in a Bottle ($BRANCH) ---"


### PR DESCRIPTION
Configures Git to use HTTP/1.1 after installation and before cloning the repository. 

This fixes an issue where git stuff didn't work. 