### PR TITLE
better tailscale docs

### DIFF
--- a/docs/src/setup/home_network.md
+++ b/docs/src/setup/home_network.md
@@ -18,6 +18,8 @@ TODO: include instructions on how to actually set this up.
 
 These steps assume you have already provisioned an instance in HTTP-only mode by following one of the preceding home server setup guides and can access its dashboard.
 
+This approach does not make the instance publicly accessible. It makes the instance available only to devices on your tailnet, wherever those devices are connected to the internet.
+
 ### 1. Install and connect Tailscale
 
 First, install Tailscale on the instance:

--- a/docs/src/setup/home_network.md
+++ b/docs/src/setup/home_network.md
@@ -53,13 +53,13 @@ Using your existing connection to the dashboard, open **Settings → Domains** a
 
 Choose **Local (HTTP)** and click **Add domain**.
 
-Run `tailscale ip -4`, then edit `/home/host/.openhost/local_compute_space/config.toml` and set `host` under `[openhost]` to the address it prints:
+Check `host` under `[openhost]` in `/home/host/.openhost/local_compute_space/config.toml`. If it is set to `127.0.0.1`, run `tailscale ip -4` and replace the value with the address it prints:
 
 ```toml
 host = "100.x.y.z"
 ```
 
-Restart the instance:
+If `host` is already `0.0.0.0` or the Tailscale IP, no change is needed. If you changed it, restart the instance:
 
 ```bash
 sudo systemctl restart openhost

--- a/docs/src/setup/home_network.md
+++ b/docs/src/setup/home_network.md
@@ -22,6 +22,12 @@ First, install Tailscale on the instance:
 sudo snap install tailscale --classic
 ```
 
+Then log in to Tailscale:
+
+```bash
+sudo tailscale up
+```
+
 Choose a domain you control the DNS for. We'll use `bottle.example.com` for this purpose. Point both that domain and `*.bottle.example.com` at the server's Tailscale IPv4 address (`tailscale ip -4`). The wildcard record gives every app its own working subdomain.
 
 ### Option 1: HTTP

--- a/docs/src/setup/home_network.md
+++ b/docs/src/setup/home_network.md
@@ -55,18 +55,6 @@ Using your existing connection to the dashboard, open **Settings → Domains** a
 
 Choose **Local (HTTP)** and click **Add domain**.
 
-Check `host` under `[openhost]` in `/home/host/.openhost/local_compute_space/config.toml`. If it is set to `127.0.0.1`, run `tailscale ip -4` and replace the value with the address it prints:
-
-```toml
-host = "100.x.y.z"
-```
-
-If `host` is already `0.0.0.0` or the Tailscale IP, no change is needed. If you changed it, restart the instance:
-
-```bash
-sudo systemctl restart openhost
-```
-
 The dashboard uses `http://bottle.example.com:8080` and apps use `http://<app>.bottle.example.com:8080`.
 
 #### Public (HTTPS)
@@ -90,7 +78,7 @@ sudo chmod 0644 "$CERT_DIR/$DOMAIN.pem"
 sudo chmod 0600 "$CERT_DIR/$DOMAIN.key"
 ```
 
-In `/home/host/.openhost/local_compute_space/config.toml`, set `host = "127.0.0.1"`, `start_caddy = true`, `coredns_enabled = false`, and `acquire_tls_cert_if_missing = false`, then restart the service. The dashboard then uses `https://bottle.example.com`, apps use `https://<app>.bottle.example.com`, and acme.sh renews and installs the certificate through the same DNS API.
+The dashboard then uses `https://bottle.example.com`, apps use `https://<app>.bottle.example.com`, and acme.sh renews and installs the certificate through the same DNS API.
 
 ## IPv4 tunnel service
 

--- a/docs/src/setup/home_network.md
+++ b/docs/src/setup/home_network.md
@@ -16,6 +16,8 @@ TODO: include instructions on how to actually set this up.
 
 ## Tailscale: HTTP or HTTPS
 
+These steps assume you have already provisioned an instance in HTTP-only mode by following one of the preceding home server setup guides.
+
 First, install Tailscale on the instance:
 
 ```bash
@@ -34,16 +36,21 @@ Choose a domain you control the DNS for. We'll use `bottle.example.com` for this
 
 ### Option 1: HTTP
 
-Provision a fresh instance in HTTP-only mode, including port 8080 in the domain because the browser connects directly to the router:
+Using your existing connection to the dashboard, open **Settings → Domains**, enter `bottle.example.com`, choose **Local (HTTP)**, and click **Add domain**.
 
-```bash
-TAILSCALE_IP=$(tailscale ip -4)
-test -n "$TAILSCALE_IP"
-curl -fsSL https://raw.githubusercontent.com/cloud-in-a-bottle/cloud-in-a-bottle/main/scripts/provision.sh \
-  | sudo bash -s -- --domain bottle.example.com:8080 --local-http-only --bind-host "$TAILSCALE_IP"
+Run `tailscale ip -4`, then edit `/home/host/.openhost/local_compute_space/config.toml` and set `host` under `[openhost]` to the address it prints:
+
+```toml
+host = "100.x.y.z"
 ```
 
-Open the Claim URL printed by the installer. The dashboard uses `http://bottle.example.com:8080` and apps use `http://<app>.bottle.example.com:8080`.
+Restart the instance:
+
+```bash
+sudo systemctl restart openhost
+```
+
+The dashboard uses `http://bottle.example.com:8080` and apps use `http://<app>.bottle.example.com:8080`.
 
 ### Option 2: HTTPS
 
@@ -51,22 +58,22 @@ Use the same DNS records, then use [acme.sh](https://github.com/acmesh-official/
 
 ```bash
 DOMAIN=bottle.example.com
-CERT_DIR=/home/host/.openhost/local_compute_space/persistent_data/openhost
-sudo install -d "$CERT_DIR"
+CERT_DIR=/home/host/.openhost/local_compute_space/persistent_data/openhost/certs
+sudo install -d -o host -g host "$CERT_DIR"
 curl -fsSL https://get.acme.sh | sh -s email=you@example.com
 # Export the credentials required by your DNS provider's plugin first.
 ~/.acme.sh/acme.sh --issue --server letsencrypt --dns dns_yourprovider \
   -d "$DOMAIN" -d "*.$DOMAIN"
 ~/.acme.sh/acme.sh --install-cert -d "$DOMAIN" \
-  --fullchain-file "$CERT_DIR/openhost-tls-cert.pem" \
-  --key-file "$CERT_DIR/openhost-tls-key.pem" \
+  --fullchain-file "$CERT_DIR/$DOMAIN.pem" \
+  --key-file "$CERT_DIR/$DOMAIN.key" \
   --reloadcmd "sudo systemctl restart openhost"
-sudo chown host:host "$CERT_DIR/openhost-tls-cert.pem" "$CERT_DIR/openhost-tls-key.pem"
-sudo chmod 0644 "$CERT_DIR/openhost-tls-cert.pem"
-sudo chmod 0600 "$CERT_DIR/openhost-tls-key.pem"
+sudo chown host:host "$CERT_DIR/$DOMAIN.pem" "$CERT_DIR/$DOMAIN.key"
+sudo chmod 0644 "$CERT_DIR/$DOMAIN.pem"
+sudo chmod 0600 "$CERT_DIR/$DOMAIN.key"
 ```
 
-In `/home/host/.openhost/local_compute_space/config.toml`, set `host = "127.0.0.1"`, `start_caddy = true`, `coredns_enabled = true`, and `acquire_tls_cert_if_missing = false`. Mark the primary domain as HTTPS, remove `:8080` from its name, and restart the service. The dashboard then uses `https://bottle.example.com`, apps use `https://<app>.bottle.example.com`, and acme.sh renews and installs the certificate through the same DNS API.
+Using your existing connection to the dashboard, open **Settings → Domains**, enter `bottle.example.com`, leave the type as **Public (HTTPS)**, and click **Add domain**. In `/home/host/.openhost/local_compute_space/config.toml`, set `host = "127.0.0.1"`, `start_caddy = true`, `coredns_enabled = false`, and `acquire_tls_cert_if_missing = false`, then restart the service. The dashboard then uses `https://bottle.example.com`, apps use `https://<app>.bottle.example.com`, and acme.sh renews and installs the certificate through the same DNS API.
 
 ## IPv4 tunnel service
 

--- a/docs/src/setup/home_network.md
+++ b/docs/src/setup/home_network.md
@@ -57,8 +57,6 @@ Using your existing connection to the dashboard, open **Settings → Domains** a
 
 Choose **Local (HTTP)** and click **Add domain**.
 
-The dashboard uses `http://bottle.example.com:8080` and apps use `http://<app>.bottle.example.com:8080`.
-
 #### Public (HTTPS)
 
 Choose **Public (HTTPS)** and click **Add domain**. The initial automatic certificate attempt may fail because this setup keeps DNS at your provider rather than delegating it to the instance. Use [acme.sh](https://github.com/acmesh-official/acme.sh) with your DNS provider's [DNS API plugin](https://github.com/acmesh-official/acme.sh/wiki/dnsapi) to complete the DNS-01 challenge and issue a wildcard certificate:

--- a/docs/src/setup/home_network.md
+++ b/docs/src/setup/home_network.md
@@ -16,7 +16,7 @@ TODO: include instructions on how to actually set this up.
 
 ## Tailscale: HTTP or HTTPS
 
-These steps assume you have already provisioned an instance in HTTP-only mode by following one of the preceding home server setup guides and can access its dashboard.
+These steps assume you have already provisioned an instance and can access its dashboard.
 
 This approach does not make the instance publicly accessible. It makes the instance available only to devices on your tailnet, wherever those devices are connected to the internet.
 

--- a/docs/src/setup/home_network.md
+++ b/docs/src/setup/home_network.md
@@ -16,6 +16,12 @@ TODO: include instructions on how to actually set this up.
 
 ## Tailscale: HTTP or HTTPS
 
+First, install Tailscale on the instance:
+
+```bash
+sudo snap install tailscale --classic
+```
+
 Choose a domain you control the DNS for. We'll use `bottle.example.com` for this purpose. Point both that domain and `*.bottle.example.com` at the server's Tailscale IPv4 address (`tailscale ip -4`). The wildcard record gives every app its own working subdomain.
 
 ### Option 1: HTTP

--- a/docs/src/setup/home_network.md
+++ b/docs/src/setup/home_network.md
@@ -28,6 +28,8 @@ Then log in to Tailscale:
 sudo tailscale up
 ```
 
+For a long-running server, you may also want to disable key expiry for this machine in the Tailscale admin console so it does not require periodic reauthentication.
+
 Choose a domain you control the DNS for. We'll use `bottle.example.com` for this purpose. Point both that domain and `*.bottle.example.com` at the server's Tailscale IPv4 address (`tailscale ip -4`). The wildcard record gives every app its own working subdomain.
 
 ### Option 1: HTTP

--- a/docs/src/setup/home_network.md
+++ b/docs/src/setup/home_network.md
@@ -22,6 +22,8 @@ This approach does not make the instance publicly accessible. It makes the insta
 
 ### 1. Install and connect Tailscale
 
+Run the commands in this guide from the terminal in the Cloud in a Bottle dashboard or over SSH to the instance.
+
 First, install Tailscale on the instance:
 
 ```bash

--- a/docs/src/setup/home_network.md
+++ b/docs/src/setup/home_network.md
@@ -16,7 +16,9 @@ TODO: include instructions on how to actually set this up.
 
 ## Tailscale: HTTP or HTTPS
 
-These steps assume you have already provisioned an instance in HTTP-only mode by following one of the preceding home server setup guides.
+These steps assume you have already provisioned an instance in HTTP-only mode by following one of the preceding home server setup guides and can access its dashboard.
+
+### 1. Install and connect Tailscale
 
 First, install Tailscale on the instance:
 
@@ -32,11 +34,24 @@ sudo tailscale up
 
 For a long-running server, you may also want to disable key expiry for this machine in the Tailscale admin console so it does not require periodic reauthentication.
 
-Choose a domain you control the DNS for. We'll use `bottle.example.com` for this purpose. Point both that domain and `*.bottle.example.com` at the server's Tailscale IPv4 address (`tailscale ip -4`). The wildcard record gives every app its own working subdomain.
+### 2. Point a domain to the Tailscale IP
 
-### Option 1: HTTP
+Choose a domain you control the DNS for. We'll use `bottle.example.com`. Run `tailscale ip -4` on the instance, then create these records at your DNS provider using the address it prints:
 
-Using your existing connection to the dashboard, open **Settings → Domains**, enter `bottle.example.com`, choose **Local (HTTP)**, and click **Add domain**.
+| Type | Name                   | Value                |
+|------|------------------------|----------------------|
+| `A`  | `bottle.example.com`   | `<tailscale-ip>`     |
+| `A`  | `*.bottle.example.com` | `<tailscale-ip>`     |
+
+The wildcard record gives every app its own working subdomain.
+
+### 3. Add the domain
+
+Using your existing connection to the dashboard, open **Settings → Domains** and enter `bottle.example.com`. Choose **Local (HTTP)** to continue serving plain HTTP on port 8080, or **Public (HTTPS)** to serve the domain with a certificate.
+
+#### Local (HTTP)
+
+Choose **Local (HTTP)** and click **Add domain**.
 
 Run `tailscale ip -4`, then edit `/home/host/.openhost/local_compute_space/config.toml` and set `host` under `[openhost]` to the address it prints:
 
@@ -52,9 +67,9 @@ sudo systemctl restart openhost
 
 The dashboard uses `http://bottle.example.com:8080` and apps use `http://<app>.bottle.example.com:8080`.
 
-### Option 2: HTTPS
+#### Public (HTTPS)
 
-Use the same DNS records, then use [acme.sh](https://github.com/acmesh-official/acme.sh) with your DNS provider's [DNS API plugin](https://github.com/acmesh-official/acme.sh/wiki/dnsapi) to complete the DNS-01 challenge and issue a wildcard certificate:
+Choose **Public (HTTPS)** and click **Add domain**. The initial automatic certificate attempt may fail because this setup keeps DNS at your provider rather than delegating it to the instance. Use [acme.sh](https://github.com/acmesh-official/acme.sh) with your DNS provider's [DNS API plugin](https://github.com/acmesh-official/acme.sh/wiki/dnsapi) to complete the DNS-01 challenge and issue a wildcard certificate:
 
 ```bash
 DOMAIN=bottle.example.com
@@ -73,7 +88,7 @@ sudo chmod 0644 "$CERT_DIR/$DOMAIN.pem"
 sudo chmod 0600 "$CERT_DIR/$DOMAIN.key"
 ```
 
-Using your existing connection to the dashboard, open **Settings → Domains**, enter `bottle.example.com`, leave the type as **Public (HTTPS)**, and click **Add domain**. In `/home/host/.openhost/local_compute_space/config.toml`, set `host = "127.0.0.1"`, `start_caddy = true`, `coredns_enabled = false`, and `acquire_tls_cert_if_missing = false`, then restart the service. The dashboard then uses `https://bottle.example.com`, apps use `https://<app>.bottle.example.com`, and acme.sh renews and installs the certificate through the same DNS API.
+In `/home/host/.openhost/local_compute_space/config.toml`, set `host = "127.0.0.1"`, `start_caddy = true`, `coredns_enabled = false`, and `acquire_tls_cert_if_missing = false`, then restart the service. The dashboard then uses `https://bottle.example.com`, apps use `https://<app>.bottle.example.com`, and acme.sh renews and installs the certificate through the same DNS API.
 
 ## IPv4 tunnel service
 

--- a/docs/src/setup/home_network.md
+++ b/docs/src/setup/home_network.md
@@ -51,15 +51,15 @@ The wildcard record gives every app its own working subdomain.
 
 ### 3. Add the domain
 
-Using your existing connection to the dashboard, open **Settings → Domains** and enter `bottle.example.com`. Choose **Local (HTTP)** to continue serving plain HTTP, or **Public (HTTPS)** to serve the domain with a certificate.
+Using your existing connection to the dashboard, open **Settings → Domains** and enter `bottle.example.com`. Choose **HTTP** to continue serving plain HTTP, or **HTTPS** to serve the domain with a certificate.
 
-#### Local (HTTP)
+#### HTTP
 
-Choose **Local (HTTP)** and click **Add domain**.
+Choose **HTTP** and click **Add domain**.
 
-#### Public (HTTPS)
+#### HTTPS
 
-Choose **Public (HTTPS)** and click **Add domain**. The initial automatic certificate attempt may fail because this setup keeps DNS at your provider rather than delegating it to the instance. Use [acme.sh](https://github.com/acmesh-official/acme.sh) with your DNS provider's [DNS API plugin](https://github.com/acmesh-official/acme.sh/wiki/dnsapi) to complete the DNS-01 challenge and issue a wildcard certificate:
+Choose **HTTPS** and click **Add domain**. The initial automatic certificate attempt may fail because this setup keeps DNS at your provider rather than delegating it to the instance. Use [acme.sh](https://github.com/acmesh-official/acme.sh) with your DNS provider's [DNS API plugin](https://github.com/acmesh-official/acme.sh/wiki/dnsapi) to complete the DNS-01 challenge and issue a wildcard certificate:
 
 ```bash
 DOMAIN=bottle.example.com

--- a/docs/src/setup/home_network.md
+++ b/docs/src/setup/home_network.md
@@ -51,7 +51,7 @@ The wildcard record gives every app its own working subdomain.
 
 ### 3. Add the domain
 
-Using your existing connection to the dashboard, open **Settings → Domains** and enter `bottle.example.com`. Choose **Local (HTTP)** to continue serving plain HTTP on port 8080, or **Public (HTTPS)** to serve the domain with a certificate.
+Using your existing connection to the dashboard, open **Settings → Domains** and enter `bottle.example.com`. Choose **Local (HTTP)** to continue serving plain HTTP, or **Public (HTTPS)** to serve the domain with a certificate.
 
 #### Local (HTTP)
 


### PR DESCRIPTION
Updates the Tailscale guide for an already-provisioned HTTP-only instance. Documents installation, login, DNS and domain setup, optional key expiry guidance, and that access remains private to the user's tailnet.