### PR TITLE
Backfill Git HTTP/1.1 configuration

### DIFF
--- a/ansible/tasks/sync_code.yml
+++ b/ansible/tasks/sync_code.yml
@@ -10,6 +10,31 @@
 # config.toml), so the ref checked out here must be new enough to read first_boot.toml — the
 # config/domains-consolidation change onward. Older refs boot with no domain. See ansible/readme.md.
 
+- name: Configure root Git to use HTTP/1.1 for updates
+  become: true
+  ansible.builtin.command:
+    argv:
+      - git
+      - config
+      - --global
+      - --replace-all
+      - http.version
+      - HTTP/1.1
+  environment:
+    HOME: /root
+  changed_when: false
+
+- name: Configure host Git to use HTTP/1.1
+  ansible.builtin.command:
+    argv:
+      - git
+      - config
+      - --global
+      - --replace-all
+      - http.version
+      - HTTP/1.1
+  changed_when: false
+
 - name: Clone or update openhost repo
   ansible.builtin.git:
     repo: https://github.com/cloud-in-a-bottle/cloud-in-a-bottle.git

--- a/openhost_system_agent/src/openhost_system_agent/migrations/registry.py
+++ b/openhost_system_agent/src/openhost_system_agent/migrations/registry.py
@@ -14,6 +14,7 @@ from openhost_system_agent.migrations.versions.v0007_seed_domains_and_scrub impo
 from openhost_system_agent.migrations.versions.v0008_restart_on_failure import Migration0008RestartOnFailure
 from openhost_system_agent.migrations.versions.v0009_swap_file import Migration0009SwapFile
 from openhost_system_agent.migrations.versions.v0010_journal_read_for_oom import Migration0010JournalReadForOom
+from openhost_system_agent.migrations.versions.v0011_git_http_version import Migration0011GitHttpVersion
 
 # Numbered migrations in apply order. Versions MUST start at 2 and be
 # contiguous. v1 is the baseline produced by ansible setup.yml.
@@ -27,6 +28,7 @@ REGISTRY: list[SystemMigration] = [
     Migration0008RestartOnFailure(),
     Migration0009SwapFile(),
     Migration0010JournalReadForOom(),
+    Migration0011GitHttpVersion(),
 ]
 
 

--- a/openhost_system_agent/src/openhost_system_agent/migrations/versions/v0011_git_http_version.py
+++ b/openhost_system_agent/src/openhost_system_agent/migrations/versions/v0011_git_http_version.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from openhost_system_agent.migrations.base import SystemMigration
+from openhost_system_agent.migrations.helpers import run
+
+
+class Migration0011GitHttpVersion(SystemMigration):
+    version = 11
+
+    def up(self) -> None:
+        # Self-update fetches run as root.
+        run(
+            "sudo",
+            "-u",
+            "root",
+            "-H",
+            "git",
+            "config",
+            "--global",
+            "--replace-all",
+            "http.version",
+            "HTTP/1.1",
+        )
+
+        # Migrations run as root; -H makes --global target /home/host/.gitconfig.
+        run(
+            "sudo",
+            "-u",
+            "host",
+            "-H",
+            "git",
+            "config",
+            "--global",
+            "--replace-all",
+            "http.version",
+            "HTTP/1.1",
+        )

--- a/openhost_system_agent/src/openhost_system_agent/tests/test_migration_container.py
+++ b/openhost_system_agent/src/openhost_system_agent/tests/test_migration_container.py
@@ -205,6 +205,15 @@ class TestApplyUpdateWalk:
         # quirk is test-only; the agent trusts the working repo on its own.
         _exec(c, "git", "config", "--global", "--add", "safe.directory", "/tmp/origin.git")
 
+        # Seed conflicting multi-valued settings so the migration has to
+        # converge both users to one value rather than merely append another.
+        _exec(c, "git", "config", "--global", "--add", "http.version", "HTTP/2")
+        _exec(c, "git", "config", "--global", "--add", "http.version", "HTTP/1.1")
+        _host_sh(
+            c,
+            "git config --global --add http.version HTTP/2 && git config --global --add http.version HTTP/1.1",
+        )
+
         # Precondition: the image ships the pre-migration pixi.
         before = _host_sh(c, f"{_PIXI} --version")
         assert "0.69.0" in before.stdout, f"unexpected starting pixi: {before.stdout!r}"
@@ -235,6 +244,11 @@ class TestApplyUpdateWalk:
         latest = latest_registry_version(REGISTRY)
         log = _exec(c, "cat", "/etc/openhost/migrations.jsonl")
         assert f'"version":{latest}' in log.stdout.replace(" ", ""), f"log did not reach v{latest}:\n{log.stdout}"
+
+        root_http_version = _exec(c, "git", "config", "--global", "--get-all", "http.version")
+        host_http_version = _host_sh(c, "git config --global --get-all http.version")
+        assert root_http_version.stdout.splitlines() == ["HTTP/1.1"]
+        assert host_http_version.stdout.splitlines() == ["HTTP/1.1"]
 
         # openhost was stopped for the walk and started again at the end; the
         # unit's ExecStopPost guarantees that even on a failure path.

--- a/openhost_system_agent/src/openhost_system_agent/tests/test_migration_git_http_version.py
+++ b/openhost_system_agent/src/openhost_system_agent/tests/test_migration_git_http_version.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import pytest
+
+from openhost_system_agent.migrations.versions import v0011_git_http_version
+from openhost_system_agent.migrations.versions.v0011_git_http_version import Migration0011GitHttpVersion
+
+
+def test_configures_git_http_version_for_root_and_host(monkeypatch: pytest.MonkeyPatch) -> None:
+    run_calls: list[tuple[str, ...]] = []
+
+    def fake_run(*cmd: str) -> None:
+        run_calls.append(cmd)
+
+    monkeypatch.setattr(v0011_git_http_version, "run", fake_run)
+
+    Migration0011GitHttpVersion().up()
+
+    assert run_calls == [
+        (
+            "sudo",
+            "-u",
+            "root",
+            "-H",
+            "git",
+            "config",
+            "--global",
+            "--replace-all",
+            "http.version",
+            "HTTP/1.1",
+        ),
+        (
+            "sudo",
+            "-u",
+            "host",
+            "-H",
+            "git",
+            "config",
+            "--global",
+            "--replace-all",
+            "http.version",
+            "HTTP/1.1",
+        ),
+    ]
+
+
+def test_migration_version_is_eleven() -> None:
+    assert Migration0011GitHttpVersion.version == 11

--- a/scripts/provision.sh
+++ b/scripts/provision.sh
@@ -135,7 +135,8 @@ fi
 echo "--- Installing ansible and git ---"
 apt-get update -qq
 apt-get install -y -qq ansible-core git > /dev/null 2>&1
-su host -c "git config --global http.version HTTP/1.1"
+HOME=/root git config --global --replace-all http.version HTTP/1.1
+su host -c "git config --global --replace-all http.version HTTP/1.1"
 
 # ---- Clone the repo ----
 echo "--- Cloning Cloud in a Bottle ($BRANCH) ---"


### PR DESCRIPTION
Adds a v11 migration that enforces HTTP/1.1 for root and host Git operations, aligns shell and Ansible provisioning, and adds unit and container coverage. The migration runs after the fetch that delivers it, so hosts unable to fetch this release still require manual configuration.