### PR TITLE
Redirect localhost to the primary domain instead of serving "null"

### DIFF
--- a/compute_space/src/compute_space/tests/test_multidomain_proxy_integration.py
+++ b/compute_space/src/compute_space/tests/test_multidomain_proxy_integration.py
@@ -157,6 +157,47 @@ async def test_unknown_external_host_still_404s(wrapped_app: Any) -> None:
     assert r.status_code == 404
 
 
+@pytest.mark.asyncio
+async def test_unmatched_host_404_body_is_not_null(wrapped_app: Any) -> None:
+    # Regression: the 404 used to render the JSON literal "null" (content=None on the
+    # default JSON media type), which surfaced as a page reading "null".
+    async with _client(wrapped_app) as c:
+        r = await c.get("http://evil.example.org/health")
+    assert r.status_code == 404
+    assert r.text == ""
+
+
+# --- localhost & friends redirect to the primary domain instead of 404ing -----------
+
+
+@pytest.mark.asyncio
+async def test_localhost_redirects_to_primary_domain(wrapped_app: Any) -> None:
+    # `localhost` isn't a configured domain, but instead of a bare 404 we bounce the browser
+    # onto the canonical primary domain (over its own scheme — https here).
+    async with _client(wrapped_app) as c:
+        r = await c.get("http://localhost/")
+    assert r.status_code == 302
+    assert r.headers["location"] == "https://host.example.com/"
+
+
+@pytest.mark.asyncio
+async def test_localhost_redirect_preserves_port_path_and_query(wrapped_app: Any) -> None:
+    # A tunnelled browser hits localhost on a forwarded port; the redirect must keep the port,
+    # path, and query so the user lands exactly where they meant to on the canonical domain.
+    async with _client(wrapped_app) as c:
+        r = await c.get("http://localhost:18090/setup?next=%2Fapps&x=1")
+    assert r.status_code == 302
+    assert r.headers["location"] == "https://host.example.com:18090/setup?next=%2Fapps&x=1"
+
+
+@pytest.mark.asyncio
+async def test_localhost_localdomain_also_redirects(wrapped_app: Any) -> None:
+    async with _client(wrapped_app) as c:
+        r = await c.get("http://localhost.localdomain/health")
+    assert r.status_code == 302
+    assert r.headers["location"] == "https://host.example.com/health"
+
+
 # --- Phase 2: unauthenticated login redirect stays on the ARRIVING domain ----------
 
 

--- a/compute_space/src/compute_space/web/middleware/subdomain_proxy.py
+++ b/compute_space/src/compute_space/web/middleware/subdomain_proxy.py
@@ -7,6 +7,7 @@ from litestar import WebSocket
 from litestar.connection import ASGIConnection
 from litestar.enums import ScopeType
 from litestar.exceptions import NotAuthorizedException
+from litestar.response import Redirect
 from litestar.types import ASGIApp
 from litestar.types import Receive
 from litestar.types import Scope
@@ -19,6 +20,8 @@ from compute_space.core.apps import get_app_from_hostname
 from compute_space.core.apps import is_public_path
 from compute_space.core.containers import ROUTER_INTERNAL_HOSTS
 from compute_space.core.domains import Domain
+from compute_space.core.domains import host_with_request_port
+from compute_space.core.domains import primary_domain_or_none
 from compute_space.core.logging import logger
 from compute_space.core.proxy_target import LocalPort
 from compute_space.db import get_db
@@ -35,6 +38,14 @@ IS_OWNER_HEADER = ("X-OpenHost-Is-Owner", "true")
 # X-Forwarded-For it sets; any other peer (e.g. a container reaching us via the
 # 10.200.0.1 gateway) is untrusted and can't dictate the chain.
 _LOOPBACK_HOSTS = frozenset({"127.0.0.1", "::1"})
+
+# Bare-host aliases that mean "this machine" but are never a configured domain.  A browser
+# pointed at one of these — typically over an SSH tunnel or a local port-forward — would
+# otherwise miss every domain and get a 404.  We redirect it onto the primary domain instead
+# (see _redirect_to_primary) so the whole session stays on the one canonical hostname rather
+# than splitting cookies/login across host aliases.  127.0.0.1 is intentionally absent: it's a
+# ROUTER_INTERNAL_HOST used by the container->host gateway and is handled before we get here.
+_LOCAL_ALIAS_HOSTS = frozenset({"localhost", "localhost.localdomain"})
 
 
 def _resolve_forwarded_for(connection: ASGIConnection[Any, Any, Any, Any]) -> str | None:
@@ -90,10 +101,28 @@ async def _send_not_found(scope: Scope, receive: Receive, send: Send) -> None:
     """404 (HTTP) / close (WS) — for a host or app-subdomain this router doesn't serve."""
     if scope["type"] == ScopeType.HTTP:
         request: Request[Any, Any, Any] = Request(scope, receive, send)
-        response: Response[Any] = Response(content=None, status_code=404)
+        # Empty text/plain body: a bare ``content=None`` renders as the JSON literal ``null``
+        # (the default media type serializes None), which surfaces as a page reading "null".
+        response: Response[Any] = Response(content="", media_type="text/plain", status_code=404)
         await response.to_asgi_response(app=None, request=request)(scope, receive, send)
     else:
         await send(WebSocketCloseEvent(type="websocket.close", code=4404, reason="not found"))
+
+
+async def _redirect_to_primary(primary: Domain, scope: Scope, receive: Receive, send: Send) -> None:
+    """302 a local-alias host (e.g. ``localhost``) onto the primary domain, preserving path,
+    query, and the port the request arrived on so a tunnelled browser lands on the canonical
+    dashboard instead of a 404.  HTTP only — a websocket can't be redirected, so it 404s."""
+    if scope["type"] != ScopeType.HTTP:
+        await _send_not_found(scope, receive, send)
+        return
+    request: Request[Any, Any, Any] = Request(scope, receive, send)
+    target = host_with_request_port(primary.name_no_port, request.url.netloc)
+    location = f"{primary.scheme}://{target}{request.url.path}"
+    if request.url.query:
+        location = f"{location}?{request.url.query}"
+    response: Response[Any] = Redirect(path=location, status_code=302)
+    await response.to_asgi_response(app=None, request=request)(scope, receive, send)
 
 
 class SubdomainProxyMiddleware:
@@ -146,11 +175,21 @@ class SubdomainProxyMiddleware:
             looks_like_app = zone is not None and app is None and zone.is_app_subdomain(netloc)
 
         if zone is None:
-            if netloc.split(":")[0].lower() in ROUTER_INTERNAL_HOSTS:
+            bare_host = netloc.split(":")[0].lower()
+            if bare_host in ROUTER_INTERNAL_HOSTS:
                 # App→router service-proxy calls arrive here via OPENHOST_ROUTER_URL (the container→host
                 # gateway), which isn't a configured domain.  Defer to Litestar; those routes are auth-gated.
                 await self.app(scope, receive, send)
                 return
+            if bare_host in _LOCAL_ALIAS_HOSTS:
+                # ``localhost`` & friends aren't configured domains, so they'd 404 with no obvious cause.
+                # Bounce them to the primary domain (when one exists) so a tunnelled browser reaches the
+                # dashboard on the canonical hostname.  If no primary is configured yet, fall through to 404.
+                with closing(get_db()) as db:
+                    primary = primary_domain_or_none(db)
+                if primary is not None:
+                    await _redirect_to_primary(primary, scope, receive, send)
+                    return
             # Unmatched host — not a configured domain or one of its subdomains.  Don't serve it (no
             # fallback to the primary).  Public traffic always arrives via Caddy with the original
             # domain Host, so this only rejects direct-by-IP / unknown-Host requests to the full app.


### PR DESCRIPTION
## What & why

Browsing the router on a bare **`localhost`** (e.g. over an SSH tunnel / local port-forward) matched no configured domain and fell through to a 404 whose body was the JSON literal **`null`** — the default media type serializes `content=None`, so the page just reads `null`. Meanwhile `127.0.0.1` (a `ROUTER_INTERNAL_HOST`) and the primary domain both work — a confusing asymmetry.

Found while smoke-testing the **v0.1.4** image (primary domain `lvh.me`): `http://localhost:<port>/` → `null`.

## Change

- Redirect local-alias hosts (`localhost`, `localhost.localdomain`) in `SubdomainProxyMiddleware` to the **primary domain**, preserving **path, query, and the request's port** (reusing `host_with_request_port`). A tunnelled browser lands on the canonical dashboard and the session stays on one hostname — no cookie/login split across host aliases. Falls through to 404 if no primary is configured yet.
- Give genuinely-unmatched hosts a clean **empty 404 body** instead of `null`.

`127.0.0.1` is deliberately left alone — it's a router-internal gateway host handled earlier. No redirect-loop risk: a `localhost` *primary* matches as a zone before ever reaching the redirect branch.

## Tests

Added to `test_multidomain_proxy_integration.py` (drives the real middleware end-to-end):
- `localhost` → 302 to the primary domain
- port + path + query preserved on the redirect
- `localhost.localdomain` redirects too
- unmatched host 404 body is empty (not `null`)

All green; `test_multidomain_*`, `test_subdomain_proxy`, `test_domains`, `test_websocket_proxy` still pass; ruff + mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)