### PR TITLE
image: default baked swap to 4 GiB (was 2)

### DIFF
--- a/image/build.sh
+++ b/image/build.sh
@@ -55,7 +55,9 @@
 #                         filesystem to fill whatever disk it is installed onto
 #                         on first boot, so users pick the real size by sizing
 #                         the VM disk (or the physical disk on bare metal).
-#   --swap-size <gib>     Swap file size in GiB baked into the image (default: 2)
+#   --swap-size <gib>     Swap file size in GiB baked into the image (default: 4).
+#                         Tweak after install by SSHing in and resizing /swapfile
+#                         (or from the dashboard settings page).
 #   --mem <mb>            Build VM memory in MB (default: 4096)
 #   --cpus <n>            Build VM vCPUs (default: 2)
 #   --output-dir <dir>    Where artifacts land (default: image/out)
@@ -78,7 +80,7 @@ HOST_PASSWORD="openhost"
 SSH_PUBKEY_FILE=""
 VERSION=""
 DISK_SIZE="20G"
-SWAP_SIZE_GB="2"
+SWAP_SIZE_GB="4"
 MEM_MB="4096"
 CPUS="2"
 BUILD_TIMEOUT="1800"


### PR DESCRIPTION
## What

Bump the VM image's default swap file from **2 GiB to 4 GiB** (`SWAP_SIZE_GB` in `image/build.sh`).

Out-of-box instances get a little more headroom before the OOM killer fires under memory pressure. 4 GiB is a flat, predictable default (not memory-derived): simple, and easy for an owner to change.

## How it flows

The value threads through the existing, unchanged path:

`image/build.sh --swap-size` -> cloud-init seed (`__SWAP_SIZE_GB__`) -> `provision.sh --swap-size` -> `ansible/tasks/swap.yml` (`fallocate`/`mkswap`/`swapon` of `/swapfile`, persisted in `/etc/fstab`).

## Not touched

- The raw-ansible default (`swap_size_gb | default(16)`) used when provisioning a VPS/bare-metal box directly without `--swap-size`.
- The runtime `DEFAULT_SWAP_SIZE_GIB = 16` and 256 GiB max in `openhost_system_agent/swap.py` (settings-page resize + v0009 back-fill).

Only the VM image default changed.

## Overrides

- Build time: `image/build.sh --swap-size <gib>`.
- Running box: dashboard settings page (`resize_swapfile`, 0-256 GiB), or by hand over SSH (`swapoff` -> recreate -> `mkswap` -> `swapon`; fstab already persists it).

## Verification

Confirmed swap behaves correctly on a booted image (v0.1.4, so 2 GiB): idle `Swap 0B used`; under a 4.6 GiB allocation on a 3.8 GiB-RAM box, ~1.1 GiB spilled into `/swapfile` (`free` + `swapon --show`) instead of OOM-killing, and freed back afterward. This PR only raises the default size; the mechanism is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)