### PR TITLE
ansible: silence INJECT_FACTS_AS_VARS deprecation warnings

### DIFF
--- a/ansible/tasks/containers.yml
+++ b/ansible/tasks/containers.yml
@@ -206,7 +206,7 @@
 - name: Write v1 system migration baseline
   copy:
     content: |
-      {"version":1,"timestamp":"{{ ansible_date_time.iso8601 }}","success":true,"error":null}
+      {"version":1,"timestamp":"{{ ansible_facts['date_time']['iso8601'] }}","success":true,"error":null}
     dest: /etc/openhost/migrations.jsonl
     mode: "0644"
   when: not _migration_log.stat.exists

--- a/ansible/tasks/coredns.yml
+++ b/ansible/tasks/coredns.yml
@@ -9,7 +9,7 @@
 - name: Pin CoreDNS release
   set_fact:
     coredns_version: "1.14.4"
-    coredns_arch: "{{ 'arm64' if ansible_architecture in ['aarch64', 'arm64'] else 'amd64' }}"
+    coredns_arch: "{{ 'arm64' if ansible_facts['architecture'] in ['aarch64', 'arm64'] else 'amd64' }}"
     coredns_sha256:
       amd64: "5b0e6a6a8b97bdcaec65baa70e83ca88ce03ab852355c656e3f7953405cfe36e"
       arm64: "b3491ed0fbe530a549640a4073d90037ffafa483f007936e1943c1ae0def7325"

--- a/openhost_system_agent/src/openhost_system_agent/tests/test_ansible_no_deprecated_facts.py
+++ b/openhost_system_agent/src/openhost_system_agent/tests/test_ansible_no_deprecated_facts.py
@@ -1,0 +1,142 @@
+"""Guard against re-introducing top-level injected ansible facts.
+
+Ansible's ``INJECT_FACTS_AS_VARS`` default (``True``) auto-injects every
+gathered fact as a top-level ``ansible_<fact>`` variable (e.g.
+``ansible_architecture``, ``ansible_date_time``).  That default is deprecated
+and is being removed in ansible-core 2.24, after which those references
+silently resolve to *undefined*.  The supported spelling is the accessor form,
+``ansible_facts['<fact>']``.
+
+We don't pin ansible-core in this repo (it's installed via ``apt`` in
+scripts/provision.sh and ``pipx`` in e2e, both unversioned), so we can't rely
+on a fixed toolchain to warn us.  A test that actually ran a playbook and
+scraped stderr for ``[DEPRECATION WARNING]`` would be worse than useless here:
+these warnings only fire at task runtime against a real host (not in
+``--syntax-check``), and any future ansible release could emit a brand-new,
+unrelated deprecation that breaks the suite with no change on our side.
+
+So instead this test statically enforces the one rule behind this class of
+warning: no bare ``ansible_<fact>`` references anywhere under ``ansible/`` --
+use ``ansible_facts[...]``.  It is deterministic, needs no ansible install or
+host, and is immune to ansible version drift.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+# ``ansible_*`` variables that are connection/behavioral/runtime "magic" vars
+# rather than gathered facts.  These are NOT injected by INJECT_FACTS_AS_VARS
+# and are always safe as top-level references.  If a legitimate new one trips
+# this test, add it here (and confirm it's genuinely a magic var, not a fact --
+# facts appear under ``ansible_facts`` in ``ansible -m setup``).
+_ALLOWED_MAGIC_VARS = frozenset(
+    {
+        # connection
+        "ansible_connection",
+        "ansible_host",
+        "ansible_port",
+        "ansible_user",
+        "ansible_password",
+        "ansible_ssh_host",
+        "ansible_ssh_port",
+        "ansible_ssh_user",
+        "ansible_ssh_pass",
+        "ansible_ssh_private_key_file",
+        "ansible_ssh_common_args",
+        "ansible_ssh_extra_args",
+        "ansible_ssh_pipelining",
+        "ansible_ssh_executable",
+        "ansible_ssh_transfer_method",
+        "ansible_sftp_extra_args",
+        "ansible_scp_extra_args",
+        "ansible_paramiko_pty",
+        "ansible_pipelining",
+        # privilege escalation
+        "ansible_become",
+        "ansible_become_method",
+        "ansible_become_user",
+        "ansible_become_pass",
+        "ansible_become_password",
+        "ansible_become_exe",
+        "ansible_become_flags",
+        # interpreter / shell
+        "ansible_python_interpreter",
+        "ansible_shell_type",
+        "ansible_shell_executable",
+        # runtime / play introspection
+        "ansible_check_mode",
+        "ansible_diff_mode",
+        "ansible_verbosity",
+        "ansible_forks",
+        "ansible_version",
+        "ansible_managed",
+        "ansible_config_file",
+        "ansible_playbook_python",
+        "ansible_play_hosts",
+        "ansible_play_hosts_all",
+        "ansible_play_batch",
+        "ansible_play_name",
+        "ansible_play_role_names",
+        "ansible_role_names",
+        "ansible_role_name",
+        "ansible_dependent_role_names",
+        "ansible_parent_role_names",
+        "ansible_parent_role_paths",
+        "ansible_collection_name",
+        "ansible_loop",
+        "ansible_loop_var",
+        "ansible_index_var",
+        "ansible_search_path",
+        "ansible_inventory_sources",
+        "ansible_limit",
+        "ansible_run_tags",
+        "ansible_skip_tags",
+        "ansible_module_name",
+    }
+)
+
+# Matches ``ansible_foo`` / ``ansible_foo_bar`` tokens.  ``ansible_facts`` (the
+# blessed accessor) is filtered out below rather than via the regex so the
+# failure message can point specifically at the offending fact name.
+_ANSIBLE_VAR_RE = re.compile(r"\bansible_[a-z0-9]+(?:_[a-z0-9]+)*\b")
+
+
+def _repo_root() -> Path:
+    """Walk up until we find the checkout root (the dir holding ``ansible/``)."""
+    here = Path(__file__).resolve()
+    for parent in here.parents:
+        if (parent / "ansible").is_dir() and (parent / "pyproject.toml").is_file():
+            return parent
+    raise RuntimeError("could not locate repo root (no ansible/ + pyproject.toml above this test)")
+
+
+def _ansible_source_files() -> list[Path]:
+    root = _repo_root() / "ansible"
+    # Playbooks/tasks (``.yml``/``.yaml``) and Jinja templates (``.j2``); the
+    # ``template`` module injects facts the same way ``set_fact``/inline
+    # templating does, so both surfaces are subject to the deprecation.
+    files = [p for ext in ("*.yml", "*.yaml", "*.j2") for p in root.rglob(ext)]
+    assert files, f"no ansible source files found under {root}"
+    return files
+
+
+def test_no_top_level_injected_facts() -> None:
+    root = _repo_root()
+    offenders: list[str] = []
+
+    for path in _ansible_source_files():
+        for lineno, line in enumerate(path.read_text().splitlines(), start=1):
+            for match in _ANSIBLE_VAR_RE.finditer(line):
+                var = match.group(0)
+                if var == "ansible_facts" or var in _ALLOWED_MAGIC_VARS:
+                    continue
+                rel = path.relative_to(root)
+                offenders.append(f"  {rel}:{lineno}: {var}")
+
+    assert not offenders, (
+        "Top-level ansible fact references found. These break once "
+        "INJECT_FACTS_AS_VARS defaults to False (ansible-core 2.24). "
+        "Use ansible_facts['<name>'] instead:\n" + "\n".join(offenders)
+    )


### PR DESCRIPTION
## What

Fix two ansible deprecation warnings by switching top-level fact references
to the `ansible_facts[...]` accessor form:

- `ansible/tasks/coredns.yml` — `ansible_architecture` → `ansible_facts['architecture']`
- `ansible/tasks/containers.yml` — `ansible_date_time.iso8601` → `ansible_facts['date_time']['iso8601']`

## Why

`INJECT_FACTS_AS_VARS` defaults to `True` today, which auto-injects facts as
top-level `ansible_*` vars. That default is deprecated and will be removed in
ansible-core 2.24, at which point these references would silently resolve to
undefined. The `ansible_facts[...]` form is stable across that change and
resolves to identical values today.

These were the only two top-level fact usages in the ansible tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)