### PR TITLE
Separate image builds from app launch

### DIFF
--- a/compute_space/src/compute_space/core/apps.py
+++ b/compute_space/src/compute_space/core/apps.py
@@ -29,7 +29,7 @@ from compute_space.core.containers import stop_app_process
 from compute_space.core.containers import stop_container
 from compute_space.core.data import deprovision_data
 from compute_space.core.data import deprovision_temp_data
-from compute_space.core.data import provision_data
+from compute_space.core.data import make_data_dirs_and_env_vars
 from compute_space.core.data import rmtree_with_sudo_fallback
 from compute_space.core.domains import Domain
 from compute_space.core.domains import primary_domain
@@ -327,7 +327,7 @@ def insert_and_deploy(
     # Resolve auto-assigned ports (host_port=0)
     resolved_mappings = resolve_port_mappings(mappings, db, config.port_range_start, config.port_range_end)
 
-    env_vars = provision_data(
+    env_vars = make_data_dirs_and_env_vars(
         app_id=app_id,
         app_name=app_name,
         manifest=manifest,
@@ -395,7 +395,7 @@ def insert_and_deploy(
     threading.Thread(
         target=deploy_app_background,
         args=(manifest, repo_path, config),
-        kwargs={"app_id": app_id, "app_name": app_name},
+        kwargs={"app_id": app_id, "app_name": app_name, "env_vars": env_vars},
         daemon=True,
     ).start()
 
@@ -408,6 +408,7 @@ def deploy_app_background(
     config: Config,
     app_id: str,
     app_name: str | None = None,
+    env_vars: dict[str, str] | None = None,
 ) -> None:
     """Build and start an app in a background thread."""
     if app_name is None:
@@ -419,35 +420,16 @@ def deploy_app_background(
     try:
         storage.check_before_deploy(config)
 
-        # Retry container builds for transient failures.  Cache-corrupt
-        # failures re-raise immediately — retrying can't fix them and
-        # the dashboard needs the marker to surface the remediation.
-        max_build_attempts = 3
-        image_tag = ""
-        for attempt in range(1, max_build_attempts + 1):
-            try:
-                image_tag = build_image(
-                    app_name,
-                    repo_path,
-                    manifest.container_image,
-                    temp_data_dir=config.temporary_data_dir,
-                    memory_mb=manifest.effective_build_memory_mb,
-                )
-                break
-            except RuntimeError as e:
-                if BUILD_CACHE_CORRUPT_MARKER in str(e):
-                    raise
-                if attempt == max_build_attempts:
-                    raise
-                logger.warning(
-                    "Container build attempt {}/{} for {} failed, retrying in {}s",
-                    attempt,
-                    max_build_attempts,
-                    app_name,
-                    attempt * 5,
-                )
-                time.sleep(attempt * 5)
-        launch_app_image(app_id, image_tag, manifest, db, config)
+        _build_then_run_app(
+            app_id,
+            app_name,
+            repo_path,
+            manifest,
+            db,
+            config,
+            max_build_attempts=3,
+            env_vars=env_vars,
+        )
     except Exception as e:
         logger.exception("Failed to deploy {}", app_name)
         db.execute(
@@ -488,14 +470,15 @@ def _load_port_mappings_from_db(app_id: str, db: sqlite3.Connection) -> list[Por
     return [PortMapping(label=r["label"], container_port=r["container_port"], host_port=r["host_port"]) for r in rows]
 
 
-def launch_app_image(
+def run_app_image(
     app_id: str,
     image_tag: str,
     manifest: AppManifest,
     db: sqlite3.Connection,
     config: Config,
+    env_vars: dict[str, str] | None = None,
 ) -> None:
-    """Prepare and launch an existing image using persisted runtime settings."""
+    """Prepare and run an existing image using persisted runtime settings."""
     app_row = db.execute("SELECT * FROM apps WHERE app_id = ?", (app_id,)).fetchone()
     if app_row is None:
         raise RuntimeError(f"No app found with id {app_id}")
@@ -505,18 +488,19 @@ def launch_app_image(
     container_id: str | None = None
     launch_started = False
     try:
-        env_vars = provision_data(
-            app_id=app_id,
-            app_name=app_name,
-            manifest=manifest,
-            data_dir=config.persistent_data_dir,
-            temp_data_dir=config.temporary_data_dir,
-            archive_dir=archive_backend.effective_archive_dir(config, db),
-            my_openhost_redirect_domain=config.my_openhost_redirect_domain,
-            zone_domain=primary_domain(db).name,
-            port=config.port,
-            owner_username=read_owner_username(db) or DEFAULT_OWNER_USERNAME,
-        )
+        if env_vars is None:
+            env_vars = make_data_dirs_and_env_vars(
+                app_id=app_id,
+                app_name=app_name,
+                manifest=manifest,
+                data_dir=config.persistent_data_dir,
+                temp_data_dir=config.temporary_data_dir,
+                archive_dir=archive_backend.effective_archive_dir(config, db),
+                my_openhost_redirect_domain=config.my_openhost_redirect_domain,
+                zone_domain=primary_domain(db).name,
+                port=config.port,
+                owner_username=read_owner_username(db) or DEFAULT_OWNER_USERNAME,
+            )
         app_token = env_vars.get("OPENHOST_APP_TOKEN")
         if app_token:
             db.execute(
@@ -713,14 +697,44 @@ def start_app_process(app_id: str, db: sqlite3.Connection, config: Config) -> No
     )
     db.commit()
 
-    image_tag = build_image(
-        app_name,
-        app_row["repo_path"],
-        manifest.container_image,
-        temp_data_dir=config.temporary_data_dir,
-        memory_mb=manifest.effective_build_memory_mb,
-    )
-    launch_app_image(app_id, image_tag, manifest, db, config)
+    _build_then_run_app(app_id, app_name, app_row["repo_path"], manifest, db, config)
+
+
+def _build_then_run_app(
+    app_id: str,
+    app_name: str,
+    repo_path: str,
+    manifest: AppManifest,
+    db: sqlite3.Connection,
+    config: Config,
+    *,
+    max_build_attempts: int = 1,
+    env_vars: dict[str, str] | None = None,
+) -> None:
+    """Build an app image, retrying transient failures, then run it."""
+    image_tag = ""
+    for attempt in range(1, max_build_attempts + 1):
+        try:
+            image_tag = build_image(
+                app_name,
+                repo_path,
+                manifest.container_image,
+                temp_data_dir=config.temporary_data_dir,
+                memory_mb=manifest.effective_build_memory_mb,
+            )
+            break
+        except RuntimeError as e:
+            if BUILD_CACHE_CORRUPT_MARKER in str(e) or attempt == max_build_attempts:
+                raise
+            logger.warning(
+                "Container build attempt {}/{} for {} failed, retrying in {}s",
+                attempt,
+                max_build_attempts,
+                app_name,
+                attempt * 5,
+            )
+            time.sleep(attempt * 5)
+    run_app_image(app_id, image_tag, manifest, db, config, env_vars=env_vars)
 
 
 def app_log_path(app_name: str, config: Config) -> str:

--- a/compute_space/src/compute_space/core/apps.py
+++ b/compute_space/src/compute_space/core/apps.py
@@ -26,6 +26,7 @@ from compute_space.core.containers import is_container_running
 from compute_space.core.containers import remove_image
 from compute_space.core.containers import run_container
 from compute_space.core.containers import stop_app_process
+from compute_space.core.containers import stop_container
 from compute_space.core.data import deprovision_data
 from compute_space.core.data import deprovision_temp_data
 from compute_space.core.data import provision_data
@@ -393,8 +394,8 @@ def insert_and_deploy(
 
     threading.Thread(
         target=deploy_app_background,
-        args=(manifest, repo_path, local_port, env_vars, config),
-        kwargs={"app_id": app_id, "app_name": app_name, "port_mappings": resolved_mappings},
+        args=(manifest, repo_path, config),
+        kwargs={"app_id": app_id, "app_name": app_name},
         daemon=True,
     ).start()
 
@@ -404,12 +405,9 @@ def insert_and_deploy(
 def deploy_app_background(
     manifest: AppManifest,
     repo_path: str,
-    local_port: int,
-    env_vars: dict[str, str],
     config: Config,
     app_id: str,
     app_name: str | None = None,
-    port_mappings: list[PortMapping] | None = None,
 ) -> None:
     """Build and start an app in a background thread."""
     if app_name is None:
@@ -449,39 +447,7 @@ def deploy_app_background(
                     attempt * 5,
                 )
                 time.sleep(attempt * 5)
-        db.execute(
-            "UPDATE apps SET status = 'starting' WHERE app_id = ?",
-            (app_id,),
-        )
-        db.commit()
-        container_id = run_container(
-            app_name,
-            image_tag,
-            manifest,
-            local_port,
-            env_vars,
-            config.persistent_data_dir,
-            config.temporary_data_dir,
-            archive_backend.effective_archive_dir(config, db),
-            port_mappings=port_mappings,
-        )
-        db.execute(
-            "UPDATE apps SET container_id = ? WHERE app_id = ?",
-            (container_id, app_id),
-        )
-        db.commit()
-
-        if wait_for_ready(local_port):
-            db.execute(
-                "UPDATE apps SET status = 'running' WHERE app_id = ?",
-                (app_id,),
-            )
-        else:
-            db.execute(
-                "UPDATE apps SET status = 'error', error_message = ? WHERE app_id = ?",
-                ("App started but not responding to HTTP", app_id),
-            )
-        db.commit()
+        launch_app_image(app_id, image_tag, manifest, db, config)
     except Exception as e:
         logger.exception("Failed to deploy {}", app_name)
         db.execute(
@@ -520,6 +486,103 @@ def _load_port_mappings_from_db(app_id: str, db: sqlite3.Connection) -> list[Por
         (app_id,),
     ).fetchall()
     return [PortMapping(label=r["label"], container_port=r["container_port"], host_port=r["host_port"]) for r in rows]
+
+
+def launch_app_image(
+    app_id: str,
+    image_tag: str,
+    manifest: AppManifest,
+    db: sqlite3.Connection,
+    config: Config,
+) -> None:
+    """Prepare and launch an existing image using persisted runtime settings."""
+    app_row = db.execute("SELECT * FROM apps WHERE app_id = ?", (app_id,)).fetchone()
+    if app_row is None:
+        raise RuntimeError(f"No app found with id {app_id}")
+
+    app_name = app_row["name"]
+    local_port = app_row["local_port"]
+    container_id: str | None = None
+    launch_started = False
+    try:
+        env_vars = provision_data(
+            app_id=app_id,
+            app_name=app_name,
+            manifest=manifest,
+            data_dir=config.persistent_data_dir,
+            temp_data_dir=config.temporary_data_dir,
+            archive_dir=archive_backend.effective_archive_dir(config, db),
+            my_openhost_redirect_domain=config.my_openhost_redirect_domain,
+            zone_domain=primary_domain(db).name,
+            port=config.port,
+            owner_username=read_owner_username(db) or DEFAULT_OWNER_USERNAME,
+        )
+        app_token = env_vars.get("OPENHOST_APP_TOKEN")
+        if app_token:
+            db.execute(
+                "INSERT OR REPLACE INTO app_tokens (app_id, token_hash) VALUES (?, ?)",
+                (app_id, hashlib.sha256(app_token.encode()).hexdigest()),
+            )
+        register_services_provided_by_app(app_id, manifest, db)
+        port_mappings = _load_port_mappings_from_db(app_id, db)
+
+        db.execute(
+            "UPDATE apps SET status = 'starting', error_message = NULL WHERE app_id = ?",
+            (app_id,),
+        )
+        db.commit()
+
+        launch_started = True
+        container_id = run_container(
+            app_name,
+            image_tag,
+            manifest,
+            local_port,
+            env_vars,
+            config.persistent_data_dir,
+            config.temporary_data_dir,
+            archive_backend.effective_archive_dir(config, db),
+            port_mappings=port_mappings,
+        )
+        db.execute(
+            "UPDATE apps SET container_id = ? WHERE app_id = ?",
+            (container_id, app_id),
+        )
+        db.commit()
+
+        if wait_for_ready(local_port):
+            db.execute(
+                "UPDATE apps SET status = 'running' WHERE app_id = ?",
+                (app_id,),
+            )
+        else:
+            db.execute(
+                "UPDATE apps SET status = 'error', error_message = ? WHERE app_id = ?",
+                ("App started but not responding to HTTP", app_id),
+            )
+        db.commit()
+    except Exception as e:
+        db.rollback()
+        cleanup_failed = False
+        if container_id is not None:
+            try:
+                stop_container(container_id)
+            except Exception:
+                cleanup_failed = True
+                logger.exception("Failed to clean up container {} after launch failure", container_id)
+        persisted_container_id = container_id if cleanup_failed else None
+        if not launch_started:
+            persisted_container_id = app_row["container_id"]
+        try:
+            db.execute(
+                "UPDATE apps SET status = 'error', error_message = ?, container_id = ? WHERE app_id = ?",
+                (str(e), persisted_container_id, app_id),
+            )
+            db.commit()
+        except sqlite3.Error:
+            db.rollback()
+            logger.exception("Failed to record launch failure for {}", app_id)
+        raise
 
 
 def _sync_port_mappings(
@@ -644,32 +707,6 @@ def start_app_process(app_id: str, db: sqlite3.Connection, config: Config) -> No
     app_name = app_row["name"]
 
     manifest = parse_manifest(app_row["repo_path"])
-    env_vars = provision_data(
-        app_id=app_id,
-        app_name=app_name,
-        manifest=manifest,
-        data_dir=config.persistent_data_dir,
-        temp_data_dir=config.temporary_data_dir,
-        archive_dir=archive_backend.effective_archive_dir(config, db),
-        my_openhost_redirect_domain=config.my_openhost_redirect_domain,
-        zone_domain=primary_domain(db).name,
-        port=config.port,
-        owner_username=read_owner_username(db) or DEFAULT_OWNER_USERNAME,
-    )
-
-    app_token = env_vars.get("OPENHOST_APP_TOKEN")
-    if app_token:
-        app_token_hash = hashlib.sha256(app_token.encode()).hexdigest()
-        db.execute(
-            "INSERT OR REPLACE INTO app_tokens (app_id, token_hash) VALUES (?, ?)",
-            (app_id, app_token_hash),
-        )
-
-    register_services_provided_by_app(app_id, manifest, db)
-
-    # Load resolved port mappings from DB (preserves host_port assignments)
-    port_mappings = _load_port_mappings_from_db(app_id, db)
-
     db.execute(
         "UPDATE apps SET status = 'starting', error_message = NULL WHERE app_id = ?",
         (app_id,),
@@ -683,34 +720,7 @@ def start_app_process(app_id: str, db: sqlite3.Connection, config: Config) -> No
         temp_data_dir=config.temporary_data_dir,
         memory_mb=manifest.effective_build_memory_mb,
     )
-    container_id = run_container(
-        app_name,
-        image_tag,
-        manifest,
-        app_row["local_port"],
-        env_vars,
-        config.persistent_data_dir,
-        config.temporary_data_dir,
-        archive_backend.effective_archive_dir(config, db),
-        port_mappings=port_mappings,
-    )
-    db.execute(
-        "UPDATE apps SET container_id = ? WHERE app_id = ?",
-        (container_id, app_id),
-    )
-    db.commit()
-
-    if wait_for_ready(app_row["local_port"]):
-        db.execute(
-            "UPDATE apps SET status = 'running' WHERE app_id = ?",
-            (app_id,),
-        )
-    else:
-        db.execute(
-            "UPDATE apps SET status = 'error', error_message = ? WHERE app_id = ?",
-            ("App started but not responding to HTTP", app_id),
-        )
-    db.commit()
+    launch_app_image(app_id, image_tag, manifest, db, config)
 
 
 def app_log_path(app_name: str, config: Config) -> str:

--- a/compute_space/src/compute_space/core/data.py
+++ b/compute_space/src/compute_space/core/data.py
@@ -74,7 +74,7 @@ def rmtree_with_sudo_fallback(path: str, *, raise_on_failure: bool = False) -> N
             raise
 
 
-def provision_data(
+def make_data_dirs_and_env_vars(
     app_id: str,
     app_name: str,
     manifest: AppManifest,
@@ -86,13 +86,15 @@ def provision_data(
     port: int,
     owner_username: str,
 ) -> dict[str, str]:
-    """Create data directories for an app based on manifest permissions.
-    Returns a dict of environment variable name -> value.
+    """Idempotently create app data directories and return fresh environment variables.
 
     By default, apps receive a permanent data directory (app_data defaults
     to True). Additional storage tiers must be explicitly requested via
     app_temp_data, app_archive, or access_all_app_data.
     SQLite entries also implicitly enable app_data.
+
+    Existing directories and their contents are preserved. Each call returns
+    newly assembled environment variables, including a newly generated app token.
     """
     app_data_dir = os.path.join(data_dir, "app_data", app_name)
     app_temp_dir = os.path.join(temp_data_dir, "app_temp_data", app_name)

--- a/compute_space/src/compute_space/tests/test_api_archive_backend.py
+++ b/compute_space/src/compute_space/tests/test_api_archive_backend.py
@@ -487,7 +487,7 @@ def test_reload_app_refuses_when_archive_unhealthy(
     cfg: Any, apps_client: TestClient[Litestar], cookies: dict[str, str]
 ) -> None:
     """An archive-using app cannot be reloaded while the JuiceFS mount is
-    unhealthy; without this guard, provision_data would write to the
+    unhealthy; without this guard, make_data_dirs_and_env_vars would write to the
     underlying empty mount-point and lose those writes once the mount
     came back."""
     archived_id = new_app_id()

--- a/compute_space/src/compute_space/tests/test_app_archive.py
+++ b/compute_space/src/compute_space/tests/test_app_archive.py
@@ -7,7 +7,7 @@ host-mounted POSIX filesystem).  Apps see the same in-container path
 either way.
 
 These tests cover the manifest opt-in plumbing that flows from
-``provision_data`` through ``deprovision_data``, plus the
+``make_data_dirs_and_env_vars`` through ``deprovision_data``, plus the
 ``Config.app_archive_dir`` resolution rules.
 """
 
@@ -17,7 +17,7 @@ import pytest
 
 from compute_space.config import DefaultConfig
 from compute_space.core.data import deprovision_data
-from compute_space.core.data import provision_data
+from compute_space.core.data import make_data_dirs_and_env_vars
 from compute_space.core.manifest import AppManifest
 
 
@@ -35,7 +35,7 @@ def _manifest(**kwargs) -> AppManifest:  # type: ignore[no-untyped-def]
     return AppManifest(**base)  # type: ignore[arg-type]
 
 
-def test_provision_data_creates_archive_subdir_when_opted_in(tmp_path) -> None:
+def test_make_data_dirs_and_env_vars_creates_archive_subdir_when_opted_in(tmp_path) -> None:
     """``app_archive=True`` should produce a per-app subdir under the
     operator-configured archive root and stamp
     ``OPENHOST_APP_ARCHIVE_DIR`` on the env-vars dict.
@@ -47,7 +47,7 @@ def test_provision_data_creates_archive_subdir_when_opted_in(tmp_path) -> None:
         d.mkdir()
 
     manifest = _manifest(app_data=True, app_archive=True)
-    env = provision_data(
+    env = make_data_dirs_and_env_vars(
         app_id="archiveapp-id",
         app_name=manifest.name,
         manifest=manifest,
@@ -65,7 +65,7 @@ def test_provision_data_creates_archive_subdir_when_opted_in(tmp_path) -> None:
     assert env["OPENHOST_APP_ARCHIVE_DIR"] == str(expected)
 
 
-def test_provision_data_skips_archive_when_not_opted_in(tmp_path) -> None:
+def test_make_data_dirs_and_env_vars_skips_archive_when_not_opted_in(tmp_path) -> None:
     """An app that doesn't ask for ``app_archive`` must NOT get the
     env var or a subdir created — apps that don't opt in shouldn't
     surface operator-configured backings to themselves."""
@@ -76,7 +76,7 @@ def test_provision_data_skips_archive_when_not_opted_in(tmp_path) -> None:
         d.mkdir()
 
     manifest = _manifest(app_data=True)
-    env = provision_data(
+    env = make_data_dirs_and_env_vars(
         app_id="archiveapp-id",
         app_name=manifest.name,
         manifest=manifest,
@@ -93,7 +93,7 @@ def test_provision_data_skips_archive_when_not_opted_in(tmp_path) -> None:
     assert not (archive_dir / manifest.name).exists()
 
 
-def test_provision_data_archive_subdir_under_access_all_app_data(tmp_path) -> None:
+def test_make_data_dirs_and_env_vars_archive_subdir_under_access_all_app_data(tmp_path) -> None:
     """Cross-app access still provisions the app's own stable archive path."""
     data_dir = tmp_path / "persistent"
     temp_dir = tmp_path / "temp"
@@ -102,7 +102,7 @@ def test_provision_data_archive_subdir_under_access_all_app_data(tmp_path) -> No
         d.mkdir()
 
     manifest = _manifest(access_all_app_data=True)
-    env = provision_data(
+    env = make_data_dirs_and_env_vars(
         app_id="archiveapp-id",
         app_name=manifest.name,
         manifest=manifest,
@@ -119,7 +119,7 @@ def test_provision_data_archive_subdir_under_access_all_app_data(tmp_path) -> No
     assert env["OPENHOST_APP_ARCHIVE_DIR"] == str(archive_dir / manifest.name)
 
 
-def test_provision_data_refuses_when_archive_dir_missing(tmp_path) -> None:
+def test_make_data_dirs_and_env_vars_refuses_when_archive_dir_missing(tmp_path) -> None:
     """When the configured archive root doesn't exist (e.g. the S3 backend's JuiceFS mount has dropped), provisioning must fail loudly rather than silently creating a local-disk ghost path that JuiceFS shadows when the mount eventually attaches."""
     data_dir = tmp_path / "persistent"
     temp_dir = tmp_path / "temp"
@@ -129,7 +129,7 @@ def test_provision_data_refuses_when_archive_dir_missing(tmp_path) -> None:
 
     manifest = _manifest(app_data=True, app_archive=True)
     with pytest.raises(RuntimeError, match="archive_dir"):
-        provision_data(
+        make_data_dirs_and_env_vars(
             app_id="archiveapp-id",
             app_name=manifest.name,
             manifest=manifest,
@@ -143,7 +143,7 @@ def test_provision_data_refuses_when_archive_dir_missing(tmp_path) -> None:
         )
 
 
-def test_provision_data_skips_archive_for_access_all_app_data_when_archive_dir_missing(tmp_path) -> None:
+def test_make_data_dirs_and_env_vars_skips_archive_for_access_all_app_data_when_archive_dir_missing(tmp_path) -> None:
     """Cross-app access is permissive when the archive mount is unavailable."""
     data_dir = tmp_path / "persistent"
     temp_dir = tmp_path / "temp"
@@ -152,7 +152,7 @@ def test_provision_data_skips_archive_for_access_all_app_data_when_archive_dir_m
     temp_dir.mkdir()
 
     manifest = _manifest(access_all_app_data=True)
-    env = provision_data(
+    env = make_data_dirs_and_env_vars(
         app_id="archiveapp-id",
         app_name=manifest.name,
         manifest=manifest,
@@ -169,7 +169,7 @@ def test_provision_data_skips_archive_for_access_all_app_data_when_archive_dir_m
     assert not archive_dir.exists()
 
 
-def test_provision_data_does_not_fail_when_archive_dir_missing_and_no_archive_opt_in(
+def test_make_data_dirs_and_env_vars_does_not_fail_when_archive_dir_missing_and_no_archive_opt_in(
     tmp_path,
 ) -> None:
     """Apps that don't ask for app_archive must NOT fail just
@@ -185,7 +185,7 @@ def test_provision_data_does_not_fail_when_archive_dir_missing_and_no_archive_op
     temp_dir.mkdir()
 
     manifest = _manifest(app_data=True)
-    provision_data(
+    make_data_dirs_and_env_vars(
         app_id="archiveapp-id",
         app_name=manifest.name,
         manifest=manifest,
@@ -199,8 +199,8 @@ def test_provision_data_does_not_fail_when_archive_dir_missing_and_no_archive_op
     )
 
 
-def test_provision_data_archive_idempotent_on_redeploy(tmp_path) -> None:
-    """Calling provision_data twice (the redeploy path) must succeed without complaining about the archive subdir already existing and must preserve data the first deploy wrote — same idempotency contract as app_data and app_temp_data."""
+def test_make_data_dirs_and_env_vars_archive_idempotent_on_redeploy(tmp_path) -> None:
+    """Repeated setup preserves data already written to the archive directory."""
     data_dir = tmp_path / "persistent"
     temp_dir = tmp_path / "temp"
     archive_dir = tmp_path / "archive"
@@ -208,7 +208,7 @@ def test_provision_data_archive_idempotent_on_redeploy(tmp_path) -> None:
         d.mkdir()
 
     manifest = _manifest(app_data=True, app_archive=True)
-    provision_data(
+    make_data_dirs_and_env_vars(
         app_id="archiveapp-id",
         app_name=manifest.name,
         manifest=manifest,
@@ -223,7 +223,7 @@ def test_provision_data_archive_idempotent_on_redeploy(tmp_path) -> None:
     marker = archive_dir / manifest.name / "marker.txt"
     marker.write_text("hello")
 
-    provision_data(
+    make_data_dirs_and_env_vars(
         app_id="archiveapp-id",
         app_name=manifest.name,
         manifest=manifest,

--- a/compute_space/src/compute_space/tests/test_app_image_launch.py
+++ b/compute_space/src/compute_space/tests/test_app_image_launch.py
@@ -10,7 +10,8 @@ import pytest
 
 from compute_space.core import apps as apps_mod
 from compute_space.core.apps import deploy_app_background
-from compute_space.core.apps import launch_app_image
+from compute_space.core.apps import insert_and_deploy
+from compute_space.core.apps import run_app_image
 from compute_space.core.apps import start_app_process
 from compute_space.core.manifest import PortMapping
 from compute_space.core.manifest import parse_manifest_from_string
@@ -62,7 +63,7 @@ def app_db(cfg: Any, tmp_path: Path) -> tuple[sqlite3.Connection, str, Path]:
         db.close()
 
 
-def test_launch_existing_image_prepares_fresh_runtime_from_persisted_app(
+def test_run_existing_image_prepares_fresh_runtime_from_persisted_app(
     cfg: Any,
     app_db: tuple[sqlite3.Connection, str, Path],
 ) -> None:
@@ -71,15 +72,15 @@ def test_launch_existing_image_prepares_fresh_runtime_from_persisted_app(
     runtime_env = {"OPENHOST_APP_TOKEN": "fresh-token", "CUSTOM": "value"}
 
     with (
-        mock.patch.object(apps_mod, "provision_data", return_value=runtime_env) as provision,
+        mock.patch.object(apps_mod, "make_data_dirs_and_env_vars", return_value=runtime_env) as prepare,
         mock.patch.object(apps_mod, "run_container", return_value="container-123") as run,
         mock.patch.object(apps_mod, "wait_for_ready", return_value=True),
         mock.patch.object(apps_mod, "build_image") as build,
     ):
-        launch_app_image(app_id, "registry.example/existing:sha", manifest, db, cfg)
+        run_app_image(app_id, "registry.example/existing:sha", manifest, db, cfg)
 
     build.assert_not_called()
-    provision.assert_called_once_with(
+    prepare.assert_called_once_with(
         app_id=app_id,
         app_name="launch-test",
         manifest=manifest,
@@ -108,7 +109,7 @@ def test_launch_existing_image_prepares_fresh_runtime_from_persisted_app(
     assert token["token_hash"] == hashlib.sha256(b"fresh-token").hexdigest()
 
 
-def test_launch_failure_removes_started_container_and_clears_db_reference(
+def test_run_failure_removes_started_container_and_clears_db_reference(
     cfg: Any,
     app_db: tuple[sqlite3.Connection, str, Path],
 ) -> None:
@@ -116,13 +117,13 @@ def test_launch_failure_removes_started_container_and_clears_db_reference(
     manifest = parse_manifest_from_string(MANIFEST_TEXT)
 
     with (
-        mock.patch.object(apps_mod, "provision_data", return_value={}),
+        mock.patch.object(apps_mod, "make_data_dirs_and_env_vars", return_value={}),
         mock.patch.object(apps_mod, "run_container", return_value="container-123"),
         mock.patch.object(apps_mod, "wait_for_ready", side_effect=RuntimeError("readiness crashed")),
         mock.patch.object(apps_mod, "stop_container") as stop,
         pytest.raises(RuntimeError, match="readiness crashed"),
     ):
-        launch_app_image(app_id, "existing:image", manifest, db, cfg)
+        run_app_image(app_id, "existing:image", manifest, db, cfg)
 
     stop.assert_called_once_with("container-123")
     row = db.execute("SELECT status, error_message, container_id FROM apps WHERE app_id = ?", (app_id,)).fetchone()
@@ -139,12 +140,12 @@ def test_runtime_preparation_failure_preserves_existing_container_reference(
     db.commit()
 
     with (
-        mock.patch.object(apps_mod, "provision_data", side_effect=RuntimeError("storage unavailable")),
+        mock.patch.object(apps_mod, "make_data_dirs_and_env_vars", side_effect=RuntimeError("storage unavailable")),
         mock.patch.object(apps_mod, "run_container") as run,
         mock.patch.object(apps_mod, "stop_container") as stop,
         pytest.raises(RuntimeError, match="storage unavailable"),
     ):
-        launch_app_image(app_id, "existing:image", manifest, db, cfg)
+        run_app_image(app_id, "existing:image", manifest, db, cfg)
 
     run.assert_not_called()
     stop.assert_not_called()
@@ -156,7 +157,7 @@ def test_runtime_preparation_failure_preserves_existing_container_reference(
     )
 
 
-def test_launch_failure_preserves_container_reference_when_cleanup_fails(
+def test_run_failure_preserves_container_reference_when_cleanup_fails(
     cfg: Any,
     app_db: tuple[sqlite3.Connection, str, Path],
 ) -> None:
@@ -164,20 +165,20 @@ def test_launch_failure_preserves_container_reference_when_cleanup_fails(
     manifest = parse_manifest_from_string(MANIFEST_TEXT)
 
     with (
-        mock.patch.object(apps_mod, "provision_data", return_value={}),
+        mock.patch.object(apps_mod, "make_data_dirs_and_env_vars", return_value={}),
         mock.patch.object(apps_mod, "run_container", return_value="container-123"),
         mock.patch.object(apps_mod, "wait_for_ready", side_effect=RuntimeError("readiness crashed")),
         mock.patch.object(apps_mod, "stop_container", side_effect=RuntimeError("podman unavailable")),
         pytest.raises(RuntimeError, match="readiness crashed"),
     ):
-        launch_app_image(app_id, "existing:image", manifest, db, cfg)
+        run_app_image(app_id, "existing:image", manifest, db, cfg)
 
     row = db.execute("SELECT status, container_id FROM apps WHERE app_id = ?", (app_id,)).fetchone()
     assert (row["status"], row["container_id"]) == ("error", "container-123")
 
 
 @pytest.mark.parametrize("entry_point", ["start", "deploy"])
-def test_existing_start_paths_build_before_launching_image(
+def test_existing_start_paths_build_before_running_image(
     entry_point: str,
     cfg: Any,
     app_db: tuple[sqlite3.Connection, str, Path],
@@ -190,13 +191,13 @@ def test_existing_start_paths_build_before_launching_image(
         events.append(("build", args[0]))
         return "newly-built:image"
 
-    def launch(launch_app_id: str, image: str, *args: Any) -> None:
-        assert launch_app_id == app_id
-        events.append(("launch", image))
+    def run(run_app_id: str, image: str, *args: Any, **kwargs: Any) -> None:
+        assert run_app_id == app_id
+        events.append(("run", image))
 
     with (
         mock.patch.object(apps_mod, "build_image", side_effect=build),
-        mock.patch.object(apps_mod, "launch_app_image", side_effect=launch),
+        mock.patch.object(apps_mod, "run_app_image", side_effect=run),
     ):
         if entry_point == "start":
             start_app_process(app_id, db, cfg)
@@ -204,4 +205,81 @@ def test_existing_start_paths_build_before_launching_image(
             db.close()
             deploy_app_background(manifest, str(repo), cfg, app_id, "launch-test")
 
-    assert events == [("build", "launch-test"), ("launch", "newly-built:image")]
+    assert events == [("build", "launch-test"), ("run", "newly-built:image")]
+
+
+def test_initial_deploy_reuses_prepared_environment(
+    cfg: Any,
+    tmp_path: Path,
+) -> None:
+    repo = tmp_path / "initial-repo"
+    repo.mkdir()
+    (repo / "cloudinabottle.toml").write_text(MANIFEST_TEXT)
+    manifest = parse_manifest_from_string(MANIFEST_TEXT)
+    prepared_env = {"OPENHOST_APP_TOKEN": "initial-token"}
+
+    class ImmediateThread:
+        def __init__(self, *, target: Any, args: tuple[Any, ...], kwargs: dict[str, Any], daemon: bool) -> None:
+            self.target = target
+            self.args = args
+            self.kwargs = kwargs
+
+        def start(self) -> None:
+            self.target(*self.args, **self.kwargs)
+
+    db = sqlite3.connect(cfg.db_path)
+    db.row_factory = sqlite3.Row
+    try:
+        with (
+            mock.patch.object(apps_mod, "make_data_dirs_and_env_vars", return_value=prepared_env) as prepare,
+            mock.patch.object(apps_mod.threading, "Thread", ImmediateThread),
+            mock.patch.object(apps_mod, "build_image", return_value="built:image"),
+            mock.patch.object(apps_mod, "run_app_image") as run,
+        ):
+            app_id = insert_and_deploy(manifest, str(repo), cfg, db)
+    finally:
+        db.close()
+
+    prepare.assert_called_once()
+    run.assert_called_once_with(app_id, "built:image", manifest, mock.ANY, cfg, env_vars=prepared_env)
+
+
+def test_deploy_retries_build_three_times_before_running(
+    cfg: Any,
+    app_db: tuple[sqlite3.Connection, str, Path],
+) -> None:
+    db, app_id, repo = app_db
+    manifest = parse_manifest_from_string(MANIFEST_TEXT)
+    db.close()
+
+    with (
+        mock.patch.object(
+            apps_mod,
+            "build_image",
+            side_effect=[RuntimeError("transient one"), RuntimeError("transient two"), "built:image"],
+        ) as build,
+        mock.patch.object(apps_mod.time, "sleep") as sleep,
+        mock.patch.object(apps_mod, "run_app_image") as run,
+    ):
+        deploy_app_background(manifest, str(repo), cfg, app_id, "launch-test")
+
+    assert build.call_count == 3
+    assert sleep.call_args_list == [mock.call(5), mock.call(10)]
+    run.assert_called_once_with(app_id, "built:image", manifest, mock.ANY, cfg, env_vars=None)
+
+
+def test_start_build_failure_is_not_retried(
+    cfg: Any,
+    app_db: tuple[sqlite3.Connection, str, Path],
+) -> None:
+    db, app_id, _ = app_db
+
+    with (
+        mock.patch.object(apps_mod, "build_image", side_effect=RuntimeError("build failed")) as build,
+        mock.patch.object(apps_mod, "run_app_image") as run,
+        pytest.raises(RuntimeError, match="build failed"),
+    ):
+        start_app_process(app_id, db, cfg)
+
+    build.assert_called_once()
+    run.assert_not_called()

--- a/compute_space/src/compute_space/tests/test_app_image_launch.py
+++ b/compute_space/src/compute_space/tests/test_app_image_launch.py
@@ -1,0 +1,207 @@
+from __future__ import annotations
+
+import hashlib
+import sqlite3
+from pathlib import Path
+from typing import Any
+from unittest import mock
+
+import pytest
+
+from compute_space.core import apps as apps_mod
+from compute_space.core.apps import deploy_app_background
+from compute_space.core.apps import launch_app_image
+from compute_space.core.apps import start_app_process
+from compute_space.core.manifest import PortMapping
+from compute_space.core.manifest import parse_manifest_from_string
+from compute_space.db.connection import init_db
+from compute_space.tests.conftest import _make_test_config
+
+MANIFEST_TEXT = """\
+[app]
+name = "launch-test"
+version = "1.0.0"
+
+[runtime.container]
+image = "Dockerfile"
+port = 8080
+
+[resources]
+memory_mb = 384
+cpu_cores = 1.5
+"""
+
+
+@pytest.fixture
+def cfg(tmp_path: Path) -> Any:
+    config = _make_test_config(tmp_path, port=20800)
+    init_db(config.db_path)
+    return config
+
+
+@pytest.fixture
+def app_db(cfg: Any, tmp_path: Path) -> tuple[sqlite3.Connection, str, Path]:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "cloudinabottle.toml").write_text(MANIFEST_TEXT)
+    app_id = "launch-test-id"
+    db = sqlite3.connect(cfg.db_path)
+    db.row_factory = sqlite3.Row
+    db.execute(
+        "INSERT INTO apps (app_id, name, version, repo_path, local_port, status) VALUES (?, ?, ?, ?, ?, ?)",
+        (app_id, "launch-test", "1.0.0", str(repo), 20801, "building"),
+    )
+    db.execute(
+        "INSERT INTO app_port_mappings (app_id, label, container_port, host_port) VALUES (?, ?, ?, ?)",
+        (app_id, "metrics", 9090, 22090),
+    )
+    db.commit()
+    try:
+        yield db, app_id, repo
+    finally:
+        db.close()
+
+
+def test_launch_existing_image_prepares_fresh_runtime_from_persisted_app(
+    cfg: Any,
+    app_db: tuple[sqlite3.Connection, str, Path],
+) -> None:
+    db, app_id, _ = app_db
+    manifest = parse_manifest_from_string(MANIFEST_TEXT)
+    runtime_env = {"OPENHOST_APP_TOKEN": "fresh-token", "CUSTOM": "value"}
+
+    with (
+        mock.patch.object(apps_mod, "provision_data", return_value=runtime_env) as provision,
+        mock.patch.object(apps_mod, "run_container", return_value="container-123") as run,
+        mock.patch.object(apps_mod, "wait_for_ready", return_value=True),
+        mock.patch.object(apps_mod, "build_image") as build,
+    ):
+        launch_app_image(app_id, "registry.example/existing:sha", manifest, db, cfg)
+
+    build.assert_not_called()
+    provision.assert_called_once_with(
+        app_id=app_id,
+        app_name="launch-test",
+        manifest=manifest,
+        data_dir=cfg.persistent_data_dir,
+        temp_data_dir=cfg.temporary_data_dir,
+        archive_dir=cfg.app_archive_dir,
+        my_openhost_redirect_domain=cfg.my_openhost_redirect_domain,
+        zone_domain="testzone.local",
+        port=cfg.port,
+        owner_username="owner",
+    )
+    run.assert_called_once_with(
+        "launch-test",
+        "registry.example/existing:sha",
+        manifest,
+        20801,
+        runtime_env,
+        cfg.persistent_data_dir,
+        cfg.temporary_data_dir,
+        cfg.app_archive_dir,
+        port_mappings=[PortMapping(label="metrics", container_port=9090, host_port=22090)],
+    )
+    row = db.execute("SELECT status, container_id FROM apps WHERE app_id = ?", (app_id,)).fetchone()
+    assert (row["status"], row["container_id"]) == ("running", "container-123")
+    token = db.execute("SELECT token_hash FROM app_tokens WHERE app_id = ?", (app_id,)).fetchone()
+    assert token["token_hash"] == hashlib.sha256(b"fresh-token").hexdigest()
+
+
+def test_launch_failure_removes_started_container_and_clears_db_reference(
+    cfg: Any,
+    app_db: tuple[sqlite3.Connection, str, Path],
+) -> None:
+    db, app_id, _ = app_db
+    manifest = parse_manifest_from_string(MANIFEST_TEXT)
+
+    with (
+        mock.patch.object(apps_mod, "provision_data", return_value={}),
+        mock.patch.object(apps_mod, "run_container", return_value="container-123"),
+        mock.patch.object(apps_mod, "wait_for_ready", side_effect=RuntimeError("readiness crashed")),
+        mock.patch.object(apps_mod, "stop_container") as stop,
+        pytest.raises(RuntimeError, match="readiness crashed"),
+    ):
+        launch_app_image(app_id, "existing:image", manifest, db, cfg)
+
+    stop.assert_called_once_with("container-123")
+    row = db.execute("SELECT status, error_message, container_id FROM apps WHERE app_id = ?", (app_id,)).fetchone()
+    assert (row["status"], row["error_message"], row["container_id"]) == ("error", "readiness crashed", None)
+
+
+def test_runtime_preparation_failure_preserves_existing_container_reference(
+    cfg: Any,
+    app_db: tuple[sqlite3.Connection, str, Path],
+) -> None:
+    db, app_id, _ = app_db
+    manifest = parse_manifest_from_string(MANIFEST_TEXT)
+    db.execute("UPDATE apps SET container_id = ? WHERE app_id = ?", ("existing-container", app_id))
+    db.commit()
+
+    with (
+        mock.patch.object(apps_mod, "provision_data", side_effect=RuntimeError("storage unavailable")),
+        mock.patch.object(apps_mod, "run_container") as run,
+        mock.patch.object(apps_mod, "stop_container") as stop,
+        pytest.raises(RuntimeError, match="storage unavailable"),
+    ):
+        launch_app_image(app_id, "existing:image", manifest, db, cfg)
+
+    run.assert_not_called()
+    stop.assert_not_called()
+    row = db.execute("SELECT status, error_message, container_id FROM apps WHERE app_id = ?", (app_id,)).fetchone()
+    assert (row["status"], row["error_message"], row["container_id"]) == (
+        "error",
+        "storage unavailable",
+        "existing-container",
+    )
+
+
+def test_launch_failure_preserves_container_reference_when_cleanup_fails(
+    cfg: Any,
+    app_db: tuple[sqlite3.Connection, str, Path],
+) -> None:
+    db, app_id, _ = app_db
+    manifest = parse_manifest_from_string(MANIFEST_TEXT)
+
+    with (
+        mock.patch.object(apps_mod, "provision_data", return_value={}),
+        mock.patch.object(apps_mod, "run_container", return_value="container-123"),
+        mock.patch.object(apps_mod, "wait_for_ready", side_effect=RuntimeError("readiness crashed")),
+        mock.patch.object(apps_mod, "stop_container", side_effect=RuntimeError("podman unavailable")),
+        pytest.raises(RuntimeError, match="readiness crashed"),
+    ):
+        launch_app_image(app_id, "existing:image", manifest, db, cfg)
+
+    row = db.execute("SELECT status, container_id FROM apps WHERE app_id = ?", (app_id,)).fetchone()
+    assert (row["status"], row["container_id"]) == ("error", "container-123")
+
+
+@pytest.mark.parametrize("entry_point", ["start", "deploy"])
+def test_existing_start_paths_build_before_launching_image(
+    entry_point: str,
+    cfg: Any,
+    app_db: tuple[sqlite3.Connection, str, Path],
+) -> None:
+    db, app_id, repo = app_db
+    manifest = parse_manifest_from_string(MANIFEST_TEXT)
+    events: list[tuple[str, str]] = []
+
+    def build(*args: Any, **kwargs: Any) -> str:
+        events.append(("build", args[0]))
+        return "newly-built:image"
+
+    def launch(launch_app_id: str, image: str, *args: Any) -> None:
+        assert launch_app_id == app_id
+        events.append(("launch", image))
+
+    with (
+        mock.patch.object(apps_mod, "build_image", side_effect=build),
+        mock.patch.object(apps_mod, "launch_app_image", side_effect=launch),
+    ):
+        if entry_point == "start":
+            start_app_process(app_id, db, cfg)
+        else:
+            db.close()
+            deploy_app_background(manifest, str(repo), cfg, app_id, "launch-test")
+
+    assert events == [("build", "launch-test"), ("launch", "newly-built:image")]

--- a/compute_space/src/compute_space/tests/test_integration.py
+++ b/compute_space/src/compute_space/tests/test_integration.py
@@ -20,7 +20,7 @@ import requests
 
 from compute_space import OPENHOST_PROJECT_DIR
 from compute_space.core.caddy import generate_caddyfile
-from compute_space.core.data import provision_data
+from compute_space.core.data import make_data_dirs_and_env_vars
 from compute_space.core.domains import Domain
 from compute_space.core.manifest import AppManifest
 from compute_space.tests.conftest import _make_config_and_env
@@ -54,7 +54,7 @@ def test_sqlite_provisioning():
             sqlite_dbs=["main", "cache"],
         )
 
-        env_vars = provision_data(
+        env_vars = make_data_dirs_and_env_vars(
             app_id="testapp-id",
             app_name="testapp",
             manifest=manifest,

--- a/compute_space/src/compute_space/tests/test_owner_username.py
+++ b/compute_space/src/compute_space/tests/test_owner_username.py
@@ -7,7 +7,7 @@ Covers the load-bearing pieces of the OPENHOST_OWNER_USERNAME feature:
      through the ``users`` table.  Pre-setup zones (no user row) must
      return None / raise ValueError respectively; the env-var plumbing
      keys on None to mean "use the default".
-  3. ``provision_data`` — env var stamped with the passed-in value.
+  3. ``make_data_dirs_and_env_vars`` - env var stamped with the passed-in value.
   4. The Litestar ``/api/settings/owner_username`` routes.
   5. The setup app's optional username form field.
   6. /login: the session minted on login resolves to the persisted
@@ -35,7 +35,7 @@ from compute_space.core.auth.auth import create_session
 from compute_space.core.auth.auth import read_owner_username
 from compute_space.core.auth.auth import update_owner_username
 from compute_space.core.auth.auth import validate_owner_username
-from compute_space.core.data import provision_data
+from compute_space.core.data import make_data_dirs_and_env_vars
 from compute_space.core.manifest import AppManifest
 from compute_space.db import provide_db
 from compute_space.db.connection import init_db
@@ -93,7 +93,7 @@ def _read_username_direct(db_path: str) -> str | None:
 
 
 def _bare_manifest() -> AppManifest:
-    """Minimal manifest with app_data enabled so provision_data runs."""
+    """Minimal manifest with app_data enabled so make_data_dirs_and_env_vars runs."""
     return AppManifest(  # type: ignore[call-arg]
         name="probe",
         version="1.0",
@@ -109,7 +109,7 @@ def _provision(tmp_path: Path, **kwargs: Any) -> dict[str, str]:
 
     archive_dir = tmp_path / "archive"
     archive_dir.mkdir(exist_ok=True)
-    return provision_data(
+    return make_data_dirs_and_env_vars(
         "test-app-id",
         "probe",
         _bare_manifest(),
@@ -292,11 +292,11 @@ def test_update_owner_username_raises_pre_setup(db: sqlite3.Connection) -> None:
 
 
 # ---------------------------------------------------------------------------
-# provision_data: OPENHOST_OWNER_USERNAME stamping
+# make_data_dirs_and_env_vars: OPENHOST_OWNER_USERNAME stamping
 # ---------------------------------------------------------------------------
 
 
-def test_provision_data_stamps_owner_username(tmp_path: Path) -> None:
+def test_make_data_dirs_and_env_vars_stamps_owner_username(tmp_path: Path) -> None:
     env = _provision(tmp_path, owner_username="alice")
     assert env["OPENHOST_OWNER_USERNAME"] == "alice"
     assert env["OPENHOST_APP_NAME"] == "probe"


### PR DESCRIPTION
Extracts existing-image app launch from image building while preserving current behavior. This is the first foundation for restart-driven primary-domain promotion by making fresh container creation reusable without rebuilding.