### PR TITLE
Reuse images for app restarts

### DIFF
--- a/compute_space/src/compute_space/core/apps.py
+++ b/compute_space/src/compute_space/core/apps.py
@@ -47,6 +47,7 @@ from compute_space.core.manifest import PermissionGrant
 from compute_space.core.manifest import PortMapping
 from compute_space.core.manifest import find_manifest_path
 from compute_space.core.manifest import parse_manifest
+from compute_space.core.manifest import parse_manifest_from_string
 from compute_space.core.oauth import OAuthRequired
 from compute_space.core.oauth import get_oauth_token
 from compute_space.core.ports import allocate_port
@@ -691,17 +692,17 @@ def stop_running_archive_apps(
 
 
 def start_apps_by_id(app_ids: list[str], db: sqlite3.Connection, config: Config) -> None:
-    """Start each app by id (best-effort).  Companion to
+    """Restart each app by id (best-effort).  Companion to
     ``stop_running_archive_apps`` for the migration quiesce/resume dance."""
     for app_id in app_ids:
         try:
-            start_app_process(app_id, db, config)
+            restart_app_process(app_id, db, config)
         except Exception:
             logger.exception("failed to restart app {} after archive migration remount", app_id)
 
 
 def start_app_process(app_id: str, db: sqlite3.Connection, config: Config) -> None:
-    """Start the process for an app. Updates DB with status and container id."""
+    """Build the current checkout and launch it for an app."""
     app_row = db.execute("SELECT * FROM apps WHERE app_id = ?", (app_id,)).fetchone()
     storage.check_before_deploy(config)
     app_name = app_row["name"]
@@ -721,6 +722,18 @@ def start_app_process(app_id: str, db: sqlite3.Connection, config: Config) -> No
         memory_mb=manifest.effective_build_memory_mb,
     )
     launch_app_image(app_id, image_tag, manifest, db, config)
+
+
+def restart_app_process(app_id: str, db: sqlite3.Connection, config: Config) -> None:
+    """Recreate an app container from its existing tagged image without building."""
+    app_row = db.execute("SELECT * FROM apps WHERE app_id = ?", (app_id,)).fetchone()
+    if app_row is None:
+        raise RuntimeError(f"No app found with id {app_id}")
+
+    storage.check_before_deploy(config)
+    manifest_raw = app_row["manifest_raw"]
+    manifest = parse_manifest_from_string(manifest_raw) if manifest_raw else parse_manifest(app_row["repo_path"])
+    launch_app_image(app_id, f"openhost-{app_row['name']}:latest", manifest, db, config)
 
 
 def app_log_path(app_name: str, config: Config) -> str:

--- a/compute_space/src/compute_space/core/apps.py
+++ b/compute_space/src/compute_space/core/apps.py
@@ -633,7 +633,7 @@ def stop_running_archive_apps(
     sync (that write would be lost when the volume re-points to S3), and
     ``systemctl stop openhost-juicefs`` cannot cleanly unmount while a
     container still has the mount open.  The caller restarts these apps once
-    the mount is back (via ``start_apps_by_id``).
+    the mount is back (via ``restart_apps_by_id``).
 
     ``stop_app_process`` stops the container but does NOT update the DB status
     and never raises, so we verify quiescence against the real container state
@@ -675,7 +675,7 @@ def stop_running_archive_apps(
     return recorded
 
 
-def start_apps_by_id(app_ids: list[str], db: sqlite3.Connection, config: Config) -> None:
+def restart_apps_by_id(app_ids: list[str], db: sqlite3.Connection, config: Config) -> None:
     """Restart each app by id (best-effort).  Companion to
     ``stop_running_archive_apps`` for the migration quiesce/resume dance."""
     for app_id in app_ids:

--- a/compute_space/src/compute_space/core/archive_backend.py
+++ b/compute_space/src/compute_space/core/archive_backend.py
@@ -1207,7 +1207,7 @@ def configure_backend(
     lost), and ``systemctl stop openhost-juicefs`` cannot unmount the FUSE
     filesystem while an app container holds it open (the unmount times out).
     The caller is responsible for RE-STARTING those apps afterwards (the web
-    route records the quiesced app ids and calls ``start_apps_by_id`` in a
+    route records the quiesced app ids and calls ``restart_apps_by_id`` in a
     ``finally``), which re-opens the now-migrated archive.
 
     FAIL-OPEN: if any step before the DB flip fails, the volume is left

--- a/compute_space/src/compute_space/core/containers.py
+++ b/compute_space/src/compute_space/core/containers.py
@@ -510,6 +510,19 @@ def remove_image(app_name: str) -> None:
     subprocess.run(["podman", "rmi", image_tag], capture_output=True, timeout=30)
 
 
+def image_exists(image_tag: str) -> bool:
+    """Return whether podman has a usable local image with this tag."""
+    try:
+        result = subprocess.run(
+            ["podman", "image", "exists", image_tag],
+            capture_output=True,
+            timeout=10,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return False
+    return result.returncode == 0
+
+
 def container_image_storage_bytes() -> tuple[int | None, int | None]:
     """Return ``(total, reclaimable)`` bytes from ``podman system df``; either value may be ``None``."""
     try:

--- a/compute_space/src/compute_space/core/startup.py
+++ b/compute_space/src/compute_space/core/startup.py
@@ -4,9 +4,11 @@ import threading
 import time
 
 from compute_space.config import Config
+from compute_space.core.apps import restart_app_process
 from compute_space.core.apps import start_app_process
 from compute_space.core.containers import BUILD_CACHE_CORRUPT_MARKER
 from compute_space.core.containers import drop_docker_build_cache
+from compute_space.core.containers import image_exists
 from compute_space.core.containers import is_container_running
 from compute_space.core.default_apps import deploy_default_apps
 from compute_space.core.logging import logger
@@ -25,22 +27,26 @@ def check_app_status(config: Config) -> None:
     (e.g. the service restarted mid-rebuild) those apps stay in 'starting'.
     Looking only at 'running' would strand them forever.
 
-    Apps that need rebuilding are restarted sequentially in a single background
-    thread to avoid concurrent image builds against the same containers-storage
-    instance.
+    Recovery runs sequentially in one background thread. Ordinary restarts reuse
+    the tagged image; interrupted builds and missing images rebuild safely.
     """
     db = sqlite3.connect(config.db_path)
     db.row_factory = sqlite3.Row
-    apps_to_restart: list[str] = []
+    apps_to_recover: list[tuple[str, bool]] = []
     try:
         rows = db.execute("SELECT * FROM apps WHERE status IN ('running', 'starting', 'building')").fetchall()
         for row in rows:
             alive = bool(row["container_id"]) and is_container_running(row["container_id"])
 
-            if alive:
-                # Container survived, or a prior sweep restarted it but the
-                # status never advanced past 'starting'/'building'. Heal it.
-                if row["status"] != "running":
+            # A newly inserted row belongs to this process's deploy thread. It
+            # is not durable restart intent yet, even if podman is already up.
+            if row["status"] == "starting" and row["created_at"] >= _PROCESS_START_UTC:
+                continue
+
+            if alive and row["status"] != "starting":
+                # A completed build may have reached podman before its final DB
+                # update. A durable starting state, however, is restart intent.
+                if row["status"] == "building":
                     db.execute(
                         "UPDATE apps SET status = 'running' WHERE app_id = ?",
                         (row["app_id"],),
@@ -48,11 +54,15 @@ def check_app_status(config: Config) -> None:
                 continue
 
             repo_path = row["repo_path"]
-            if not repo_path or not os.path.isdir(repo_path):
+            has_repo = bool(repo_path) and os.path.isdir(repo_path)
+            has_manifest = bool(row["manifest_raw"]) or has_repo
+            image_tag = f"openhost-{row['name']}:latest"
+            needs_build = row["status"] == "building" or not image_exists(image_tag)
+            if not has_manifest or (needs_build and not has_repo):
                 db.execute(
                     "UPDATE apps SET status = 'error', error_message = ? WHERE app_id = ?",
                     (
-                        f"Cannot restart: repo path missing ({repo_path})",
+                        f"Cannot recover: repo path missing ({repo_path})",
                         row["app_id"],
                     ),
                 )
@@ -75,20 +85,20 @@ def check_app_status(config: Config) -> None:
                 "UPDATE apps SET status = 'starting' WHERE app_id = ?",
                 (row["app_id"],),
             )
-            apps_to_restart.append(row["app_id"])
+            apps_to_recover.append((row["app_id"], needs_build))
 
         # Recover apps whose build corrupted containers-storage onto the same
         # serial rebuild path (which exists precisely to avoid that corruption).
-        apps_to_restart.extend(_recover_cache_corrupt_apps(db))
+        apps_to_recover.extend((app_id, True) for app_id in _recover_cache_corrupt_apps(db))
 
         db.commit()
     finally:
         db.close()
 
-    if apps_to_restart:
+    if apps_to_recover:
         threading.Thread(
             target=_restart_apps_sequential,
-            args=(apps_to_restart, config),
+            args=(apps_to_recover, config),
             daemon=True,
         ).start()
 
@@ -133,18 +143,21 @@ def _recover_cache_corrupt_apps(db: sqlite3.Connection) -> list[str]:
     return corrupt
 
 
-def _restart_apps_sequential(app_ids: list[str], config: Config) -> None:
-    """Rebuild and restart apps one at a time in a background thread."""
+def _restart_apps_sequential(apps: list[tuple[str, bool]], config: Config) -> None:
+    """Recover apps one at a time, rebuilding only when required."""
     db = sqlite3.connect(config.db_path, check_same_thread=False)
     db.row_factory = sqlite3.Row
     db.execute("PRAGMA journal_mode=WAL")
     try:
-        for app_id in app_ids:
+        for app_id, needs_build in apps:
             try:
-                start_app_process(app_id, db, config)
-                logger.info("Rebuilt and restarted app {}", app_id)
+                if needs_build:
+                    start_app_process(app_id, db, config)
+                else:
+                    restart_app_process(app_id, db, config)
+                logger.info("Recovered app {} ({})", app_id, "rebuilt" if needs_build else "restarted")
             except Exception as e:
-                logger.exception("Failed to rebuild app {}", app_id)
+                logger.exception("Failed to recover app {}", app_id)
                 db.execute(
                     "UPDATE apps SET status = 'error', error_message = ? WHERE app_id = ?",
                     (str(e), app_id),

--- a/compute_space/src/compute_space/tests/test_app_image_launch.py
+++ b/compute_space/src/compute_space/tests/test_app_image_launch.py
@@ -11,6 +11,7 @@ import pytest
 from compute_space.core import apps as apps_mod
 from compute_space.core.apps import deploy_app_background
 from compute_space.core.apps import launch_app_image
+from compute_space.core.apps import restart_app_process
 from compute_space.core.apps import start_app_process
 from compute_space.core.manifest import PortMapping
 from compute_space.core.manifest import parse_manifest_from_string
@@ -174,6 +175,29 @@ def test_launch_failure_preserves_container_reference_when_cleanup_fails(
 
     row = db.execute("SELECT status, container_id FROM apps WHERE app_id = ?", (app_id,)).fetchone()
     assert (row["status"], row["container_id"]) == ("error", "container-123")
+
+
+def test_restart_reuses_tagged_image_and_persisted_manifest_without_build(
+    cfg: Any,
+    app_db: tuple[sqlite3.Connection, str, Path],
+) -> None:
+    db, app_id, _ = app_db
+    db.execute(
+        "UPDATE apps SET manifest_raw = ?, container_id = ? WHERE app_id = ?",
+        (MANIFEST_TEXT, "old-container", app_id),
+    )
+    db.commit()
+
+    with (
+        mock.patch.object(apps_mod, "launch_app_image") as launch,
+        mock.patch.object(apps_mod, "build_image") as build,
+    ):
+        restart_app_process(app_id, db, cfg)
+
+    build.assert_not_called()
+    launch.assert_called_once()
+    assert launch.call_args.args[:2] == (app_id, "openhost-launch-test:latest")
+    assert launch.call_args.args[2].memory_mb == 384
 
 
 @pytest.mark.parametrize("entry_point", ["start", "deploy"])

--- a/compute_space/src/compute_space/tests/test_archive_backend.py
+++ b/compute_space/src/compute_space/tests/test_archive_backend.py
@@ -1331,7 +1331,7 @@ def test_stop_running_archive_apps_aborts_if_container_still_running(cfg, db):
 def test_start_apps_by_id_starts_each(cfg, db):
     """start_apps_by_id restarts every id it's given (companion to the quiesce)."""
     db.row_factory = sqlite3.Row
-    with mock.patch.object(apps_mod, "start_app_process") as start:
+    with mock.patch.object(apps_mod, "restart_app_process") as start:
         apps_mod.start_apps_by_id(["a", "b"], db, cfg)
     assert [c.args[0] for c in start.call_args_list] == ["a", "b"]
 
@@ -1339,6 +1339,6 @@ def test_start_apps_by_id_starts_each(cfg, db):
 def test_start_apps_by_id_continues_on_failure(cfg, db):
     """A failure starting one app must not block the others (best-effort)."""
     db.row_factory = sqlite3.Row
-    with mock.patch.object(apps_mod, "start_app_process", side_effect=[RuntimeError("boom"), None]) as start:
+    with mock.patch.object(apps_mod, "restart_app_process", side_effect=[RuntimeError("boom"), None]) as start:
         apps_mod.start_apps_by_id(["a", "b"], db, cfg)
     assert start.call_count == 2

--- a/compute_space/src/compute_space/tests/test_archive_backend.py
+++ b/compute_space/src/compute_space/tests/test_archive_backend.py
@@ -1273,7 +1273,7 @@ def test_storage_summary_cross_app_access_includes_every_tier(cfg, db, flag):
     assert s.requires_archive is False
 
 
-# --- stop_running_archive_apps / start_apps_by_id --------------------------
+# --- stop_running_archive_apps / restart_apps_by_id ------------------------
 
 
 def _seed_app(db, app_id, name, status, manifest_raw, port):
@@ -1328,17 +1328,17 @@ def test_stop_running_archive_apps_aborts_if_container_still_running(cfg, db):
     assert recorded == ["stubborn"]
 
 
-def test_start_apps_by_id_starts_each(cfg, db):
-    """start_apps_by_id restarts every id it's given (companion to the quiesce)."""
+def test_restart_apps_by_id_restarts_each(cfg, db):
+    """restart_apps_by_id restarts every id it's given (companion to the quiesce)."""
     db.row_factory = sqlite3.Row
     with mock.patch.object(apps_mod, "restart_app_process") as start:
-        apps_mod.start_apps_by_id(["a", "b"], db, cfg)
+        apps_mod.restart_apps_by_id(["a", "b"], db, cfg)
     assert [c.args[0] for c in start.call_args_list] == ["a", "b"]
 
 
-def test_start_apps_by_id_continues_on_failure(cfg, db):
+def test_restart_apps_by_id_continues_on_failure(cfg, db):
     """A failure starting one app must not block the others (best-effort)."""
     db.row_factory = sqlite3.Row
     with mock.patch.object(apps_mod, "restart_app_process", side_effect=[RuntimeError("boom"), None]) as start:
-        apps_mod.start_apps_by_id(["a", "b"], db, cfg)
+        apps_mod.restart_apps_by_id(["a", "b"], db, cfg)
     assert start.call_count == 2

--- a/compute_space/src/compute_space/tests/test_archive_backend_edge_cases.py
+++ b/compute_space/src/compute_space/tests/test_archive_backend_edge_cases.py
@@ -530,9 +530,9 @@ def test_stop_running_archive_apps_none_when_empty(db, cfg):
         assert apps_mod.stop_running_archive_apps(db, cfg) == []
 
 
-def test_start_apps_by_id_empty_noop(db, cfg):
+def test_restart_apps_by_id_empty_noop(db, cfg):
     with mock.patch.object(apps_mod, "restart_app_process") as start:
-        apps_mod.start_apps_by_id([], db, cfg)
+        apps_mod.restart_apps_by_id([], db, cfg)
     start.assert_not_called()
 
 

--- a/compute_space/src/compute_space/tests/test_archive_backend_edge_cases.py
+++ b/compute_space/src/compute_space/tests/test_archive_backend_edge_cases.py
@@ -531,7 +531,7 @@ def test_stop_running_archive_apps_none_when_empty(db, cfg):
 
 
 def test_start_apps_by_id_empty_noop(db, cfg):
-    with mock.patch.object(apps_mod, "start_app_process") as start:
+    with mock.patch.object(apps_mod, "restart_app_process") as start:
         apps_mod.start_apps_by_id([], db, cfg)
     start.assert_not_called()
 

--- a/compute_space/src/compute_space/tests/test_check_app_status.py
+++ b/compute_space/src/compute_space/tests/test_check_app_status.py
@@ -102,10 +102,11 @@ def _capture_restart_sweep(monkeypatch: Any) -> tuple[list[str], threading.Event
     restarted: list[str] = []
     done = threading.Event()
 
-    def fake_sequential(app_ids: list[str], config: Any) -> None:
-        restarted.extend(app_ids)
+    def fake_sequential(apps: list[tuple[str, bool]], config: Any) -> None:
+        restarted.extend(app_id for app_id, _needs_build in apps)
         done.set()
 
+    monkeypatch.setattr(startup, "image_exists", lambda image_tag: True)
     monkeypatch.setattr(startup, "_restart_apps_sequential", fake_sequential)
     return restarted, done
 
@@ -115,7 +116,16 @@ def test_starting_app_with_dead_container_is_restarted(tmp_path: Path, monkeypat
     init_db(cfg.db_path)
     repo = tmp_path / "repo"
     repo.mkdir()
-    app_id = _seed_app(cfg, name="stuck", status="starting", port=20210, container_id="deadbeef", repo_path=str(repo))
+    monkeypatch.setattr(startup, "_PROCESS_START_UTC", "2020-01-01 00:00:00")
+    app_id = _seed_app(
+        cfg,
+        name="stuck",
+        status="starting",
+        port=20210,
+        container_id="deadbeef",
+        repo_path=str(repo),
+        created_at="2019-12-31 23:59:59",
+    )
 
     monkeypatch.setattr(startup, "is_container_running", lambda cid: False)
     restarted, done = _capture_restart_sweep(monkeypatch)
@@ -144,19 +154,30 @@ def test_building_app_with_dead_container_is_restarted(tmp_path: Path, monkeypat
     assert app_id in restarted
 
 
-def test_starting_app_with_live_container_is_healed_to_running(tmp_path: Path, monkeypatch: Any) -> None:
+def test_starting_app_with_live_container_is_recreated(tmp_path: Path, monkeypatch: Any) -> None:
     cfg = _make_test_config(tmp_path, port=20300)
     init_db(cfg.db_path)
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    monkeypatch.setattr(startup, "_PROCESS_START_UTC", "2020-01-01 00:00:00")
     app_id = _seed_app(
-        cfg, name="live", status="starting", port=20310, container_id="livecontainer", repo_path="/nonexistent"
+        cfg,
+        name="live",
+        status="starting",
+        port=20310,
+        container_id="livecontainer",
+        repo_path=str(repo),
+        created_at="2019-12-31 23:59:59",
     )
 
     monkeypatch.setattr(startup, "is_container_running", lambda cid: True)
-    _capture_restart_sweep(monkeypatch)
+    restarted, done = _capture_restart_sweep(monkeypatch)
 
     startup.check_app_status(cfg)
 
-    assert _status(cfg, app_id) == "running"
+    assert done.wait(5)
+    assert restarted == [app_id]
+    assert _status(cfg, app_id) == "starting"
 
 
 def test_running_app_with_dead_container_is_restarted(tmp_path: Path, monkeypatch: Any) -> None:
@@ -566,3 +587,90 @@ def test_inflight_starting_from_current_process_is_not_restarted(tmp_path: Path,
     assert not done.is_set()
     assert app_id not in restarted
     assert _status(cfg, app_id) == "starting"
+
+
+def test_inflight_starting_with_live_container_is_not_restarted(tmp_path: Path, monkeypatch: Any) -> None:
+    cfg = _make_test_config(tmp_path, port=21420)
+    init_db(cfg.db_path)
+    repo = tmp_path / "repo-live"
+    repo.mkdir()
+    monkeypatch.setattr(startup, "_PROCESS_START_UTC", "2020-01-01 00:00:00")
+    app_id = _seed_app(
+        cfg,
+        name="inflight-live",
+        status="starting",
+        port=21430,
+        container_id="live-container",
+        repo_path=str(repo),
+        created_at="2020-01-01 00:00:05",
+    )
+
+    monkeypatch.setattr(startup, "is_container_running", lambda cid: True)
+    restarted, done = _capture_restart_sweep(monkeypatch)
+
+    startup.check_app_status(cfg)
+
+    assert not done.is_set()
+    assert app_id not in restarted
+    assert _status(cfg, app_id) == "starting"
+
+
+def test_running_app_without_image_falls_back_to_rebuild(tmp_path: Path, monkeypatch: Any) -> None:
+    cfg = _make_test_config(tmp_path, port=22100)
+    init_db(cfg.db_path)
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    app_id = _seed_app(
+        cfg, name="missing-image", status="running", port=22110, container_id="dead", repo_path=str(repo)
+    )
+    captured: list[tuple[str, bool]] = []
+    done = threading.Event()
+
+    monkeypatch.setattr(startup, "is_container_running", lambda cid: False)
+    monkeypatch.setattr(startup, "image_exists", lambda image_tag: False)
+
+    def fake_sequential(apps: list[tuple[str, bool]], config: Any) -> None:
+        captured.extend(apps)
+        done.set()
+
+    monkeypatch.setattr(startup, "_restart_apps_sequential", fake_sequential)
+    startup.check_app_status(cfg)
+
+    assert done.wait(5)
+    assert captured == [(app_id, True)]
+
+
+def test_recovery_worker_restarts_existing_images_and_rebuilds_only_fallbacks(
+    tmp_path: Path, monkeypatch: Any
+) -> None:
+    cfg = _make_test_config(tmp_path, port=22200)
+    init_db(cfg.db_path)
+    restarted: list[str] = []
+    rebuilt: list[str] = []
+
+    monkeypatch.setattr(startup, "restart_app_process", lambda app_id, db, config: restarted.append(app_id))
+    monkeypatch.setattr(startup, "start_app_process", lambda app_id, db, config: rebuilt.append(app_id))
+
+    startup._restart_apps_sequential([("reuse", False), ("fallback", True)], cfg)
+
+    assert restarted == ["reuse"]
+    assert rebuilt == ["fallback"]
+
+
+def test_recovery_worker_persists_restart_failure(tmp_path: Path, monkeypatch: Any) -> None:
+    cfg = _make_test_config(tmp_path, port=22300)
+    init_db(cfg.db_path)
+    repo = tmp_path / "repo-failure"
+    repo.mkdir()
+    app_id = _seed_app(
+        cfg, name="restart-failure", status="starting", port=22310, container_id="old", repo_path=str(repo)
+    )
+
+    def fail_restart(app_id: str, db: sqlite3.Connection, config: Any) -> None:
+        raise RuntimeError("replacement failed")
+
+    monkeypatch.setattr(startup, "restart_app_process", fail_restart)
+    startup._restart_apps_sequential([(app_id, False)], cfg)
+
+    assert _status(cfg, app_id) == "error"
+    assert _error_message(cfg, app_id) == "replacement failed"

--- a/compute_space/src/compute_space/tests/test_containers.py
+++ b/compute_space/src/compute_space/tests/test_containers.py
@@ -19,6 +19,7 @@ from compute_space.core.containers import DEFAULT_CAPABILITIES
 from compute_space.core.containers import _bind_mount_arg
 from compute_space.core.containers import build_image
 from compute_space.core.containers import get_docker_logs
+from compute_space.core.containers import image_exists
 from compute_space.core.containers import is_container_running
 from compute_space.core.containers import remove_image
 from compute_space.core.containers import run_container
@@ -785,6 +786,28 @@ def test_is_container_running_returns_false_on_failure(monkeypatch: pytest.Monke
 
     _patch_subprocess_run(monkeypatch, fake_run)
     assert is_container_running("bogus") is False
+
+
+@pytest.mark.parametrize("returncode, expected", [(0, True), (1, False)])
+def test_image_exists_uses_podman_exit_status(
+    monkeypatch: pytest.MonkeyPatch, returncode: int, expected: bool
+) -> None:
+    monkeypatch.setattr(
+        subprocess,
+        "run",
+        lambda *args, **kwargs: subprocess.CompletedProcess(args[0], returncode),
+    )
+
+    assert image_exists("openhost-notes:latest") is expected
+
+
+def test_image_exists_returns_false_when_podman_is_unavailable(monkeypatch: pytest.MonkeyPatch) -> None:
+    def unavailable(*args: object, **kwargs: object) -> subprocess.CompletedProcess[bytes]:
+        raise FileNotFoundError
+
+    monkeypatch.setattr(subprocess, "run", unavailable)
+
+    assert image_exists("openhost-notes:latest") is False
 
 
 def test_is_container_running_returns_true_when_podman_reports_running(

--- a/compute_space/src/compute_space/web/routes/api/archive_backend.py
+++ b/compute_space/src/compute_space/web/routes/api/archive_backend.py
@@ -282,7 +282,7 @@ async def configure_archive_backend(
             # has no data + no live mount, so it needs no quiesce.
             migrating = archive_backend.read_state(worker_db).backend in ("local", "s3")
             # Imported lazily to avoid a core<-web import cycle.
-            from compute_space.core.apps import start_apps_by_id  # noqa: PLC0415
+            from compute_space.core.apps import restart_apps_by_id  # noqa: PLC0415
             from compute_space.core.apps import stop_running_archive_apps  # noqa: PLC0415
 
             # For a migration the JuiceFS mount must be restarted (juicefs
@@ -326,7 +326,7 @@ async def configure_archive_backend(
                 # stopped is safe; attach_on_startup remounts and the operator
                 # restarts the apps (state_message tells them to).
                 if quiesced and archive_backend.is_mounted(archive_backend.juicefs_mount_dir(config)):
-                    start_apps_by_id(quiesced, worker_db, config)
+                    restart_apps_by_id(quiesced, worker_db, config)
         finally:
             worker_db.close()
 


### PR DESCRIPTION
Depends on #357.

Makes app restarts recreate containers from existing images with fresh runtime configuration, and makes startup resume durable restarts safely. This supplies the normal restart path that primary-domain promotion will use.