### PR TITLE
Add deploy redirect landing page

### DIFF
--- a/compute_space/src/compute_space/tests/test_add_app_page.py
+++ b/compute_space/src/compute_space/tests/test_add_app_page.py
@@ -18,6 +18,7 @@ from compute_space.db import provide_db
 from compute_space.db.connection import init_db
 from compute_space.web.app import _template_globals
 from compute_space.web.routes.pages.apps import add_app
+from compute_space.web.routes.pages.apps import redirect_deploy
 
 from ._litestar_helpers import auth_cookie
 from .conftest import _make_test_config
@@ -44,7 +45,7 @@ def _build_app(cfg: Any) -> Litestar:
             engine.engine.globals.update(_template_globals(cfg, web_dir / "static"))
 
     return Litestar(
-        route_handlers=[add_app],
+        route_handlers=[add_app, redirect_deploy],
         template_config=template_config,
         dependencies={
             "config": Provide(provide_config, sync_to_thread=False),
@@ -94,3 +95,31 @@ def test_callout_offers_install_when_catalog_missing(cfg: Any) -> None:
     assert "Install the catalog" in resp.text
     assert "https://github.com/cloud-in-a-bottle/app-catalog" in resp.text
     assert f"http://catalog.{primary_of(cfg).name}/" not in resp.text
+
+
+def test_redirect_deploy_prefills_repo_without_cloning(cfg: Any) -> None:
+    set_active_config(cfg)
+    cookie = auth_cookie(cfg)
+
+    with TestClient(app=_build_app(cfg)) as client:
+        client.cookies.update(cookie)
+        resp = client.get(
+            "/redirect/deploy",
+            params={"repo": "https://github.com/cloud-in-a-bottle/bottled-paperless-ngx"},
+        )
+
+    assert resp.status_code == 200
+    assert '"initialRepo": "https://github.com/cloud-in-a-bottle/bottled-paperless-ngx"' in resp.text
+    assert '"autoClone": false' in resp.text
+
+
+def test_add_app_repo_still_clones_automatically(cfg: Any) -> None:
+    set_active_config(cfg)
+    cookie = auth_cookie(cfg)
+
+    with TestClient(app=_build_app(cfg)) as client:
+        client.cookies.update(cookie)
+        resp = client.get("/add_app", params={"repo": "https://github.com/example/app"})
+
+    assert resp.status_code == 200
+    assert '"autoClone": true' in resp.text

--- a/compute_space/src/compute_space/web/routes/pages/apps.py
+++ b/compute_space/src/compute_space/web/routes/pages/apps.py
@@ -201,10 +201,7 @@ async def _resolve_edit_app(
     return {"mode": "service", "action": action, "repo": base_url, "ref": ref}
 
 
-@get("/add_app", guards=[require_owner_auth])
-async def add_app(
-    db: NamedDependency[sqlite3.Connection], repo: FromQuery[str] = "", next: FromQuery[str] = ""
-) -> Template:
+def _add_app_page(db: sqlite3.Connection, *, repo: str, next_url: str, auto_clone: bool) -> Template:
     catalog_installed = db.execute("SELECT 1 FROM apps WHERE name = ?", (CATALOG_APP_NAME,)).fetchone() is not None
     return Template(
         template_name="add_app.html",
@@ -213,9 +210,23 @@ async def add_app(
             "catalog_app_name": CATALOG_APP_NAME,
             "catalog_repo_url": CATALOG_REPO_URL,
             "initial_repo": repo,
-            "next_url": next,
+            "next_url": next_url,
+            "auto_clone": auto_clone,
         },
     )
+
+
+@get("/add_app", guards=[require_owner_auth])
+async def add_app(
+    db: NamedDependency[sqlite3.Connection], repo: FromQuery[str] = "", next: FromQuery[str] = ""
+) -> Template:
+    return _add_app_page(db, repo=repo, next_url=next, auto_clone=True)
+
+
+@get("/redirect/deploy", guards=[require_owner_auth])
+async def redirect_deploy(db: NamedDependency[sqlite3.Connection], repo: FromQuery[str] = "") -> Template:
+    """Side-effect-free landing page for public deploy links."""
+    return _add_app_page(db, repo=repo, next_url="", auto_clone=False)
 
 
 @get(
@@ -240,5 +251,5 @@ async def update_review(app_name: FromPath[str], db: NamedDependency[sqlite3.Con
 
 pages_apps_routes = Router(
     path="/",
-    route_handlers=[dashboard, app_detail, add_app, update_review],
+    route_handlers=[dashboard, app_detail, add_app, redirect_deploy, update_review],
 )

--- a/compute_space/src/compute_space/web/static/js/add-app.js
+++ b/compute_space/src/compute_space/web/static/js/add-app.js
@@ -1,5 +1,6 @@
 var config = JSON.parse(document.getElementById('page-config').textContent);
 const initialRepo = config.initialRepo;
+const autoClone = config.autoClone;
 const nextUrl = config.nextUrl;
 let cloneDir = null;
 let repoUrl = null;
@@ -12,7 +13,7 @@ if (initialRepo) {
   // Programmatic value set doesn't fire 'input', so sync the button here.
   document.getElementById('repo-url').value = initialRepo;
   document.getElementById('deploy-btn').disabled = false;
-  cloneApp(initialRepo);
+  if (autoClone) cloneApp(initialRepo);
 }
 
 function showError(msg) {

--- a/compute_space/src/compute_space/web/templates/add_app.html
+++ b/compute_space/src/compute_space/web/templates/add_app.html
@@ -79,6 +79,7 @@
 <script id="page-config" type="application/json">
 {
   "initialRepo": {{ initial_repo | tojson }},
+  "autoClone": {{ auto_clone | tojson }},
   "nextUrl": {{ next_url | tojson }}
 }
 </script>


### PR DESCRIPTION
Adds an authenticated, side-effect-free /redirect/deploy landing page that prefills a repository without cloning it until the owner clicks Deploy. Existing /add_app prefill behavior remains unchanged. This enables portable deploy links through my.cloudinabottle.org.

Validation: targeted pytest (4 passed); Ruff check and format; git diff --check; two vet passes with no issues.