### PR TITLE
Make e2e instance provisioning fail over instead of hanging

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,3 +1,13 @@
 [defaults]
 host_key_checking = false
 retry_files_enabled = false
+
+[ssh_connection]
+# Keep the control connection alive through long silent tasks.  A dist-upgrade or a big apt
+# install sends nothing over the SSH channel for minutes, and an idle TCP connection through an
+# AWS security group is reaped at ~350s, which surfaces as an UNREACHABLE mid-play rather than as
+# a task failure.  The keepalives give the connection traffic so it never looks idle; the count
+# allows ~10 minutes of genuine unresponsiveness before ansible gives up on the host.
+# ControlMaster/ControlPersist/-C are ansible's own defaults, repeated because setting ssh_args
+# replaces them wholesale.
+ssh_args = -C -o ControlMaster=auto -o ControlPersist=60s -o ServerAliveInterval=15 -o ServerAliveCountMax=40

--- a/tests/providers/gcp.sh
+++ b/tests/providers/gcp.sh
@@ -15,6 +15,7 @@
 #   GCP_SSH_KEY      — path to SSH private key
 #   GCP_SSH_USER     — SSH user (default: ubuntu)
 #   GCP_DISK_SIZE    — boot disk GB (default: 30)
+#   GCP_CREATE_TIMEOUT — seconds to wait for one zone's instance create (default: 120)
 
 : "${GCP_PROJECT:?GCP_PROJECT is required}"
 : "${GCP_NETWORK_TAG:?GCP_NETWORK_TAG is required}"
@@ -23,6 +24,10 @@ GCP_MACHINE_TYPE="${GCP_MACHINE_TYPE:-e2-standard-4}"
 GCP_IMAGE_FAMILY="${GCP_IMAGE_FAMILY:-ubuntu-2404-lts-amd64}"
 GCP_SSH_USER="${GCP_SSH_USER:-ubuntu}"
 GCP_DISK_SIZE="${GCP_DISK_SIZE:-30}"
+# A healthy zone creates in ~15s.  gcloud's own deadline is 1800s, so a single wedged zone burns
+# half an hour before the fallback list is even reached; cap it well below that but leave enough
+# headroom that a merely slow zone isn't abandoned.
+GCP_CREATE_TIMEOUT="${GCP_CREATE_TIMEOUT:-120}"
 
 # Internal state set by provider_create
 _GCP_INSTANCE_NAME=""
@@ -58,7 +63,8 @@ provider_create() {
     local created=false
     for zone in "${unique_zones[@]}"; do
         echo "  Trying zone: $zone" >&2
-        if gcloud compute instances create "$_GCP_INSTANCE_NAME" \
+        local rc=0
+        timeout "$GCP_CREATE_TIMEOUT" gcloud compute instances create "$_GCP_INSTANCE_NAME" \
             --project="$GCP_PROJECT" \
             --zone="$zone" \
             --machine-type="$GCP_MACHINE_TYPE" \
@@ -69,10 +75,20 @@ provider_create() {
             --tags="$GCP_NETWORK_TAG" \
             --metadata="ssh-keys=${GCP_SSH_USER}:${ssh_pub_key}" \
             --format=json \
-            --quiet >&2 2>&1; then
+            --quiet >&2 2>&1 || rc=$?
+
+        if [ "$rc" -eq 0 ]; then
             created=true
             _GCP_ACTUAL_ZONE="$zone"
             break
+        fi
+
+        if [ "$rc" -eq 124 ]; then
+            # Timed out rather than refused, so the create may still land remotely and would then
+            # be nobody's to delete: the env file only ever names the zone we settled on.
+            echo "  Zone $zone did not create within ${GCP_CREATE_TIMEOUT}s, trying next..." >&2
+            gcloud compute instances delete "$_GCP_INSTANCE_NAME" \
+                --project="$GCP_PROJECT" --zone="$zone" --quiet >/dev/null 2>&1 || true
         else
             echo "  Zone $zone unavailable, trying next..." >&2
         fi


### PR DESCRIPTION
Both e2e legs have been burning whole CI jobs on provisioning problems that never reach the actual tests.

## GCP: a wedged zone costs 30 minutes

`gcloud compute instances create` polls against its own 1800s deadline. On [run 33899115112](https://github.com/cloud-in-a-bottle/cloud-in-a-bottle/actions/runs/33899115112) it sat in `us-central1-a` for the full 30 minutes:

```
Did not create the following resources within 1800s:
.../zones/us-central1-a/instances/openhost-e2e-887de4c5
```

then fell through to `us-central1-b`, which created in 13 seconds. The zone fallback list already existed; it just never got reached in time.

Each attempt is now capped at `GCP_CREATE_TIMEOUT` (default 120s, tunable via env). A healthy zone creates in ~15s, so that is ~8x headroom while failing over 15x faster.

On timeout specifically we also issue a best-effort delete for that zone. gcloud's own message notes the operation "may still be underway remotely and may still succeed", and the env file only ever names the zone we settled on, so an instance created after we moved on would be nobody's to tear down. The 6-hourly `e2e-cleanup` sweep is the backstop, not the first line.

## EC2: UNREACHABLE partway through the play

The ec2 leg has been dying mid-play, at whichever long apt task it happens to be on:

- `Update apt cache`, 6m07s then UNREACHABLE
- `Update apt cache`, 12m then UNREACHABLE
- `Install rootless container support packages`, 4m20s then UNREACHABLE

The instance is still `running` when teardown reaches it, so this is the connection dying, not the host. A big apt operation sends nothing over the SSH channel for minutes, and an idle TCP connection through a security group is reaped at around 350s, which matches the 6m07s case closely.

`ansible.cfg` set no keepalives, so this adds them. `ControlMaster`/`ControlPersist`/`-C` are repeated because setting `ssh_args` replaces ansible's defaults wholesale.

## Confidence

The GCP change is a direct fix for a diagnosed cause: the log states the deadline and the fallback zone succeeded immediately afterwards.

The EC2 change is a hypothesis. The idle-reap theory fits the symptom (connection dies, host survives, always during a long silent task) and the ~350s timing, but I could not reproduce it without launching instances, and CI is the only place it can be confirmed. If ec2 still goes UNREACHABLE with keepalives in place, the next suspect is the host itself rather than the connection, and the console output of a failed instance would be the thing to capture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)