### PR TITLE
Replace stale OpenHost documentation examples

### DIFF
--- a/docs/internal/building_a_vm_image.md
+++ b/docs/internal/building_a_vm_image.md
@@ -18,7 +18,7 @@ The [release images](../src/setup/shared_homeserver.md#part-1-download-and-run-t
 
 ## Build it
 
-Run from a checkout of the openhost repo, on the Linux/KVM host:
+Run from a checkout of the Cloud in a Bottle repo, on the Linux/KVM host:
 
 ```bash
 image/build.sh

--- a/docs/internal/user_identity.md
+++ b/docs/internal/user_identity.md
@@ -34,7 +34,7 @@ Nothing wraps this on the app side yet (no client library, no worked example, no
 
 - eventually this will become a new DID method, so let's keep close to that setup
 - i want a new hybrid method - public key / DID is the source of truth, but the domain is the human-readable advisory ID. anytime you really need to ensure the domain shortname is valid, you’ll hit the domain and verify it still controls its private key. and the user can refer to themselves by their domain - eg to create a login - with the assumption that if the user thinks they control their domain, it’s probably safe to assume that is true for the next ~5 mins or whatever. so you can hit their domain and fetch their public key.
-- openhost-specific context
+- Cloud in a Bottle-specific context
   - each user has a Cloud in a Bottle space, accessable at a specific domain (user.host.imbue.com or whatever).
   - their userspaces all run a copy of an identity provider service that handles to the challenges+flows discussed in this doc.
   - a Cloud in a Bottle app (owned/hosted by user A) can give access to other Cloud in a Bottle users (user B) by the following flow
@@ -56,7 +56,7 @@ Nothing wraps this on the app side yet (no client library, no worked example, no
         - then you say “i will share this with user xyz”
         - when user xyz accesses your space/app, the app is like “tell me who you are”.
             - the user can maybe manually enter their PGP identity?
-            - but better is some way that we redirect to my.openhost.imbue.com/sso, which redirects to the user’s space, and is like “hey do you wanna log in to this app”. if you say yes, then it’ll redirect back with whatever crypographic challenge response is needed to provide the identity.
+            - but better is some way that we redirect through my.cloudinabottle.org, which redirects to the user’s space and asks whether they want to log in to this app. if they say yes, it redirects back with whatever cryptographic challenge response is needed to provide the identity.
 - existing implementations of this / standards. generally called “decentralized/federated identity”
     - indieauth
         - your domain name is your identity

--- a/docs/src/creating_an_app/cross_app_services.md
+++ b/docs/src/creating_an_app/cross_app_services.md
@@ -54,7 +54,7 @@ version = "0.1.0"
 endpoint = "/api/"
 ```
 
-Service requests land rooted at `endpoint` in the provider app, ie `app_name.openhost_space.com/<endpoint>/<whatever_api_route>`.
+Service requests land rooted at `endpoint` in the provider app, ie `app-name.your-domain.com/<endpoint>/<whatever_api_route>`.
 
 ### Consumer apps
 
@@ -261,6 +261,5 @@ Provider apps should verify permissions attached to inbound requests. A simple p
   }
   reverse_proxy localhost:3000
 }```
-
 
 

--- a/docs/src/creating_an_app/manifest_spec.md
+++ b/docs/src/creating_an_app/manifest_spec.md
@@ -70,14 +70,14 @@ Multiple apps requesting the same host port can't be installed at the same time,
 
 ### `[[links]]` (optional, repeatable)
 
-A convenience feature to display additional links to the instance owner on the app detail page. By default we just link to your app's root at `{app_name}.{zone_url}`. This feature allows additional links to be displayed, eg to an admin console at `/_openhost/admin`. The `path` is taken at face value and is not verified in any way.
+A convenience feature to display additional links to the instance owner on the app detail page. By default we just link to your app's root at `{app_name}.{zone_url}`. This feature allows additional links to be displayed, eg to an admin console at `/admin`. The `path` is taken at face value and is not verified in any way.
 
 In general it's better to expose these links from within your app; this is mainly a convenience feature for supporting existing apps where we want to add a Cloud in a Bottle specific admin page that isn't exposed in the upstream app. This feature may be removed in the future.
 
 | Field | Type | Required | Default | Description |
 |-------|------|----------|---------|-------------|
 | `name` | string | yes | - | Display name for the link (e.g., `"admin"`) |
-| `path` | string | yes | - | Path on the app's URL (e.g., `"/_openhost/admin"`) |
+| `path` | string | yes | - | Path on the app's URL (e.g., `"/admin"`) |
 
 ### `[resources]` (optional)
 
@@ -173,5 +173,5 @@ port = 3000
 
 [[links]]
 name = "admin"
-path = "/_openhost/admin"
+path = "/admin"
 ```

--- a/docs/src/creating_an_app/manifest_spec.md
+++ b/docs/src/creating_an_app/manifest_spec.md
@@ -70,14 +70,14 @@ Multiple apps requesting the same host port can't be installed at the same time,
 
 ### `[[links]]` (optional, repeatable)
 
-A convenience feature to display additional links to the instance owner on the app detail page. By default we just link to your app's root at `{app_name}.{zone_url}`. This feature allows additional links to be displayed, eg to an admin console at `/admin`. The `path` is taken at face value and is not verified in any way.
+A convenience feature to display additional links to the instance owner on the app detail page. By default we just link to your app's root at `{app_name}.{zone_url}`. This feature allows additional links to be displayed, eg to an admin console at `/_openhost/admin`. The `path` is taken at face value and is not verified in any way.
 
 In general it's better to expose these links from within your app; this is mainly a convenience feature for supporting existing apps where we want to add a Cloud in a Bottle specific admin page that isn't exposed in the upstream app. This feature may be removed in the future.
 
 | Field | Type | Required | Default | Description |
 |-------|------|----------|---------|-------------|
 | `name` | string | yes | - | Display name for the link (e.g., `"admin"`) |
-| `path` | string | yes | - | Path on the app's URL (e.g., `"/admin"`) |
+| `path` | string | yes | - | Path on the app's URL (e.g., `"/_openhost/admin"`) |
 
 ### `[resources]` (optional)
 
@@ -173,5 +173,5 @@ port = 3000
 
 [[links]]
 name = "admin"
-path = "/admin"
+path = "/_openhost/admin"
 ```

--- a/docs/src/how_it_works/data.md
+++ b/docs/src/how_it_works/data.md
@@ -10,7 +10,7 @@ Each app gets its own directories, mounted into its container under `/data/`. Ap
 | Temporary | `/data/app_temp_data/<app>` | Local disk | Not guaranteed | Thumbnails, transcodes, build artifacts, anything recreatable |
 | Archive | `/data/app_archive/<app>` | JuiceFS, local or S3 | See below | Bulk content: photos, video, attachments, model weights |
 
-Apps get permanent data by default and request the other two in their manifest (`app_temp_data`, `app_archive`). They should read the paths from `OPENHOST_APP_DATA_DIR`, `OPENHOST_APP_TEMP_DIR` and `OPENHOST_APP_ARCHIVE_DIR` rather than hardcoding them. See [Creating an App](../creating_an_app/overview.md#data-storage) for the app author's view.
+Apps get permanent data by default and request the other two in their manifest (`app_temp_data`, `app_archive`). They should read the paths from `BOTTLE_APP_DATA_DIR`, `BOTTLE_APP_TEMP_DIR` and `BOTTLE_APP_ARCHIVE_DIR` rather than hardcoding them. See [Creating an App](../creating_an_app/overview.md#data-storage) for the app author's view.
 
 The split between permanent and archive matters more than it looks. Permanent data is local disk with real `fsync` and strict POSIX semantics, which is what an embedded database needs: SQLite, LMDB, RocksDB and friends belong there and nowhere else. The archive tier is a network-shaped filesystem: fine for whole files, wrong for a write-ahead log or for `fcntl` locks used for correctness. An app that stores bulk content normally uses both, keeping its index in permanent data and the bytes in the archive.
 

--- a/docs/src/how_it_works/overview.md
+++ b/docs/src/how_it_works/overview.md
@@ -34,7 +34,7 @@ There are three ways a request can authenticate:
 |---|---|---|
 | Session cookie | Browsers | `session_token`, set at login. Opaque and stored in the router's database, so it can be revoked. Valid four weeks, and scoped to the domain, so one login covers the dashboard and every app on it. |
 | API token | The `bottle` CLI, scripts, agents | `Authorization: Bearer <token>`. Created and revoked in the dashboard or with `bottle tokens`. |
-| App token | App containers | `OPENHOST_APP_TOKEN`, injected into each container and used to authenticate [cross-app service calls](../creating_an_app/cross_app_services.md). |
+| App token | App containers | `BOTTLE_APP_TOKEN`, injected into each container and used to authenticate [cross-app service calls](../creating_an_app/cross_app_services.md). |
 
 Apps can open up specific routes by listing them in `public_paths` in their manifest. Those routes are proxied without authentication, and it is then the app's job to decide who may do what. To help, the router sets `X-OpenHost-Is-Owner: true` on requests that do carry a valid owner session, so an app can serve a public page and still show the owner an edit button. Any `X-OpenHost-*` header supplied by the client is stripped before the app sees it.
 

--- a/docs/src/setup/static_ip.md
+++ b/docs/src/setup/static_ip.md
@@ -64,7 +64,7 @@ start_caddy = true
 public_ip = "203.0.113.10"
 
 acme_account_key_path = "/home/host/openhost/ansible/secrets/certbot_private_key.json"
-acme_email = "openhost@mycooldomain.com"
+acme_email = "admin@mycooldomain.com"
 acme_directory_url = "https://acme-v02.api.letsencrypt.org/directory"
 ```
 


### PR DESCRIPTION
Updates the manual to teach canonical BOTTLE app variables and removes obsolete OpenHost-only example names and URLs. Retains current systemd units, filesystem paths, headers, service identifiers, and compatibility aliases.