### PR TITLE
Only point containers at the gateway resolver when it exists

### DIFF
--- a/compute_space/src/compute_space/core/containers.py
+++ b/compute_space/src/compute_space/core/containers.py
@@ -29,6 +29,7 @@ from typing import NoReturn
 
 import attr
 
+from compute_space.core.ip import is_bindable
 from compute_space.core.logging import logger
 from compute_space.core.manifest import AppManifest
 from compute_space.core.manifest import PortMapping
@@ -348,21 +349,26 @@ def run_container(
                 # host.docker.internal kept for compatibility with existing apps.
                 f"--add-host={_DOCKER_COMPAT_HOST}:host-gateway",
                 f"--add-host={ROUTER_GATEWAY_HOST}:host-gateway",
-                # Point the container's resolver at the container-facing CoreDNS
-                # view bound on the gateway.  That view answers `*.zone_domain`
-                # with the gateway IP (where Caddy is reachable) and forwards
-                # everything else upstream.  This is what makes "hairpin" access
-                # to sibling apps' public HTTPS URLs work: pasta otherwise gives
-                # the container the host's public IP as a *local* address, so a
-                # connection to `app.zone` (public IP) never leaves the container
-                # netns and is refused.  Resolving to the gateway instead sends
-                # it to Caddy, which terminates the real zone cert by SNI and
-                # applies normal routing/auth.  network_host apps are excluded:
-                # they share the host netns and use the host's resolver directly.
-                "--dns",
-                CONTAINER_GATEWAY_IP,
             ]
         )
+        # Point the container's resolver at the container-facing CoreDNS view
+        # bound on the gateway.  That view answers `*.zone_domain` with the
+        # gateway IP (where Caddy is reachable) and forwards everything else
+        # upstream.  This is what makes "hairpin" access to sibling apps' public
+        # HTTPS URLs work: pasta otherwise gives the container the host's public
+        # IP as a *local* address, so a connection to `app.zone` (public IP)
+        # never leaves the container netns and is refused.  Resolving to the
+        # gateway instead sends it to Caddy, which terminates the real zone cert
+        # by SNI and applies normal routing/auth.  network_host apps are
+        # excluded: they share the host netns and use the host's resolver
+        # directly.
+        #
+        # Only when that view is actually being served, which is gated on the
+        # same probe (see start.py's _hairpin_gateway_ip).  In dev/CI, and on
+        # macOS, nothing creates the openhost0 dummy interface, and a container
+        # pointed at a resolver that isn't there has no DNS at all.
+        if is_bindable(CONTAINER_GATEWAY_IP):
+            cmd.extend(["--dns", CONTAINER_GATEWAY_IP])
 
     # max-file is not supported by podman's k8s-file driver; archiving is
     # handled by the reload route before run_container is called.

--- a/compute_space/src/compute_space/tests/test_containers.py
+++ b/compute_space/src/compute_space/tests/test_containers.py
@@ -440,10 +440,21 @@ def test_run_container_has_hardening_flags(tmp_path, monkeypatch: pytest.MonkeyP
 def test_run_container_points_dns_at_gateway_for_pasta_apps(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
     # Pasta apps resolve via the container-facing CoreDNS view on the gateway so
     # `<app>.<zone>` hairpins to Caddy instead of looping in the container netns.
+    monkeypatch.setattr(containers, "is_bindable", lambda ip: True)
     manifest = _basic_manifest()
     argv = _run_and_capture(monkeypatch, manifest=manifest, tmp_path=tmp_path)
     dns_idx = argv.index("--dns")
     assert argv[dns_idx + 1] == "10.200.0.1"
+
+
+def test_run_container_skips_dns_when_gateway_is_absent(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
+    # No openhost0 dummy interface (dev, CI, macOS) means no container-facing
+    # CoreDNS view to point at, and a container aimed at a resolver that isn't
+    # there gets no DNS at all — leave podman's default resolver in place.
+    monkeypatch.setattr(containers, "is_bindable", lambda ip: False)
+    manifest = _basic_manifest()
+    argv = _run_and_capture(monkeypatch, manifest=manifest, tmp_path=tmp_path)
+    assert "--dns" not in argv
 
 
 def test_run_container_network_host_app_gets_no_dns_override(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## The bug

`run_container` passes `--dns 10.200.0.1` to every non-`network_host` app. That
is where the container-facing CoreDNS view binds **on a real instance**, once
ansible has created the `openhost0` dummy interface. Nowhere else has that
address: not in dev, not in CI, and not on macOS, where the app test harness
runs the router on the host and containers inside the podman VM.

A container pointed at a resolver that isn't there has **no DNS at all**:

```
podman run --rm --dns 10.200.0.1 python:3.12-slim getent hosts pypi.org   # fails
podman run --rm                  python:3.12-slim getent hosts pypi.org   # resolves
```

Anything an app does over the internet breaks. Two we hit while testing
`imbue-hosted-spaces` locally:

- a Stripe call from the app container returned 500 with the log ending at the
  outbound request — the name lookup never completed
- vm-manager's entrypoint runs `uv run`, which reaches pypi, so the container
  never came up. The router reports this as `App started but not responding to
  HTTP`, which points nowhere near DNS.

It also silently breaks DNS for every app container on a developer's local
stack, not just test runs.

## The fix

Gate the flag on `is_bindable(CONTAINER_GATEWAY_IP)` — the same probe
`start.py`'s `_hairpin_gateway_ip` already uses to decide whether to *serve*
that view. The two sides now agree: we only point containers at the gateway
resolver when we're actually running one there. On a real instance nothing
changes; everywhere else containers keep podman's default resolver.

`start.py` already had the precedent, with the matching comment: *"Only add the
gateway bind if the interface actually exists (it won't in dev mode or CI where
openhost0 hasn't been created by ansible)."*

## Tests

`test_run_container_points_dns_at_gateway_for_pasta_apps` pins the probe True
(it would otherwise fail on any machine without `openhost0` — including CI), and
a new `test_run_container_skips_dns_when_gateway_is_absent` covers the other
branch. 90 passing across `test_containers.py` + `test_coredns.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)